### PR TITLE
feat: implement swarm list command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ thiserror = "2"
 # Utils
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,6 +1,90 @@
+use std::path::Path;
+
+use crate::core::agent::Agent;
+
 pub async fn execute(
-    _tags: Option<Vec<String>>,
-    _stack: Option<String>,
+    tags: Option<Vec<String>>,
+    stack: Option<String>,
 ) -> anyhow::Result<()> {
-    todo!("list command")
+    let agents_dir = Path::new("agents");
+    let mut agents = Agent::load_all(agents_dir)?;
+
+    if agents.is_empty() {
+        println!("No agents found in {}/", agents_dir.display());
+        println!("Create one with: swarm new --template basic <name>");
+        return Ok(());
+    }
+
+    // Apply filters
+    if let Some(ref tags) = tags {
+        agents.retain(|a| a.matches_tags(tags));
+    }
+    if let Some(ref stack) = stack {
+        agents.retain(|a| a.matches_stack(stack));
+    }
+
+    if agents.is_empty() {
+        println!("No agents match the given filters.");
+        return Ok(());
+    }
+
+    // Compute column widths
+    let name_w = agents
+        .iter()
+        .map(|a| a.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let provider_w = agents
+        .iter()
+        .map(|a| a.metadata.provider.len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let model_w = agents
+        .iter()
+        .map(|a| a.model_display().len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+
+    // Header
+    println!(
+        "  {:<name_w$}  {:<provider_w$}  {:<model_w$}  {}  {}",
+        "NAME", "PROVIDER", "MODEL", "TAGS", "STACKS",
+    );
+    println!(
+        "  {:<name_w$}  {:<provider_w$}  {:<model_w$}  {}  {}",
+        "-".repeat(name_w),
+        "-".repeat(provider_w),
+        "-".repeat(model_w),
+        "----",
+        "------",
+    );
+
+    // Rows
+    for agent in &agents {
+        let tags_str = if agent.metadata.tags.is_empty() {
+            "-".to_string()
+        } else {
+            agent.metadata.tags.join(", ")
+        };
+        let stacks_str = if agent.metadata.stacks.is_empty() {
+            "-".to_string()
+        } else {
+            agent.metadata.stacks.join(", ")
+        };
+
+        println!(
+            "  {:<name_w$}  {:<provider_w$}  {:<model_w$}  {}  {}",
+            agent.name,
+            agent.metadata.provider,
+            agent.model_display(),
+            tags_str,
+            stacks_str,
+        );
+    }
+
+    println!("\n  {} agent(s) found.", agents.len());
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Implement `swarm list` — first end-to-end flow connecting the markdown parser to the CLI
- Recursive agent loading from `agents/` directory (including subdirectories like `agents/examples/`)
- Formatted table display: name, provider, model, tags, stacks
- `--tags` and `--stack` filters

## Changes
- `src/core/agent.rs`: recursive `load_all()`, `matches_tags()`, `matches_stack()`, `model_display()`
- `src/cli/list.rs`: full implementation with dynamic column widths
- `src/parser/markdown.rs`: fix list item boundary handling + 7 unit tests
- `Cargo.toml`: add `tempfile` dev-dependency

## Test plan
- [x] `cargo test` — 7 tests pass
- [x] `swarm list` — displays all 4 agents
- [x] `swarm list --tags dev` — filters to 3 agents
- [x] `swarm list --stack sh` — filters to 1 agent
- [x] Empty directory handled gracefully

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)