### PR TITLE
feat: implement swarm new, inspect and validate commands

### DIFF
--- a/src/cli/inspect.rs
+++ b/src/cli/inspect.rs
@@ -1,3 +1,105 @@
-pub async fn execute(_agent: String) -> anyhow::Result<()> {
-    todo!("inspect command")
+use std::path::Path;
+
+use crate::core::agent::Agent;
+use crate::parser::parse_agent_file;
+
+pub async fn execute(agent_name: String) -> anyhow::Result<()> {
+    let agents_dir = Path::new("agents");
+
+    let path = Agent::find_file(agents_dir, &agent_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Agent '{agent_name}' not found in {}/ (looked for {agent_name}.md)",
+            agents_dir.display()
+        )
+    })?;
+
+    let agent = parse_agent_file(&path)?;
+
+    // Header
+    println!("Agent: {}", agent.name);
+    println!("Source: {}", agent.source.display());
+    println!();
+
+    // Metadata table
+    println!("## Metadata");
+    println!("  Provider:       {}", agent.metadata.provider);
+
+    if let Some(ref model) = agent.metadata.model {
+        println!("  Model:          {model}");
+    }
+    if let Some(ref command) = agent.metadata.command {
+        println!("  Command:        {command}");
+    }
+    if let Some(ref args) = agent.metadata.args {
+        println!("  Args:           [{}]", args.join(", "));
+    }
+
+    println!("  Temperature:    {}", agent.metadata.temperature);
+
+    if let Some(max) = agent.metadata.max_tokens {
+        println!("  Max tokens:     {max}");
+    }
+    if let Some(timeout) = agent.metadata.timeout {
+        println!("  Timeout:        {timeout}s");
+    }
+    if !agent.metadata.tags.is_empty() {
+        println!("  Tags:           [{}]", agent.metadata.tags.join(", "));
+    }
+    if !agent.metadata.stacks.is_empty() {
+        println!("  Stacks:         [{}]", agent.metadata.stacks.join(", "));
+    }
+    if let Some(cost) = agent.metadata.cost_limit {
+        println!("  Cost limit:     ${cost:.2}");
+    }
+    if let Some(ref rate) = agent.metadata.rate_limit {
+        println!("  Rate limit:     {rate}");
+    }
+    if let Some(ctx) = agent.metadata.context_window {
+        println!("  Context window: {ctx}");
+    }
+
+    // System prompt
+    println!();
+    println!("## System Prompt");
+    for line in agent.system_prompt.lines() {
+        println!("  {line}");
+    }
+
+    // Instructions
+    if let Some(ref instructions) = agent.instructions {
+        println!();
+        println!("## Instructions");
+        for line in instructions.lines() {
+            println!("  {line}");
+        }
+    }
+
+    // Output format
+    if let Some(ref format) = agent.output_format {
+        println!();
+        println!("## Output Format");
+        for line in format.lines() {
+            println!("  {line}");
+        }
+    }
+
+    // Pipeline
+    if let Some(ref pipeline) = agent.pipeline {
+        println!();
+        println!("## Pipeline");
+        for next in &pipeline.next {
+            println!("  -> {next}");
+        }
+    }
+
+    // Context
+    if let Some(ref context) = agent.context {
+        println!();
+        println!("## Context");
+        for line in context.lines() {
+            println!("  {line}");
+        }
+    }
+
+    Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,6 +35,12 @@ pub enum Command {
         /// Template to use
         #[arg(long, short, default_value = "basic")]
         template: String,
+        /// Tech stack (replaces {{stack}} placeholder)
+        #[arg(long, short)]
+        stack: Option<String>,
+        /// Agent description (replaces {{description}} placeholder)
+        #[arg(long, short)]
+        description: Option<String>,
     },
     /// List available agents
     List {
@@ -90,7 +96,12 @@ pub enum Command {
 pub async fn handle(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Command::Run { agent, input, pipe } => run::execute(agent, input, pipe).await,
-        Command::New { name, template } => new::execute(name, template).await,
+        Command::New {
+            name,
+            template,
+            stack,
+            description,
+        } => new::execute(name, template, stack, description).await,
         Command::List { tags, stack } => list::execute(tags, stack).await,
         Command::Inspect { agent } => inspect::execute(agent).await,
         Command::Validate { agent } => validate::execute(agent).await,

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -1,3 +1,146 @@
-pub async fn execute(_name: String, _template: String) -> anyhow::Result<()> {
-    todo!("new command")
+use std::path::Path;
+
+pub async fn execute(
+    name: String,
+    template: String,
+    stack: Option<String>,
+    description: Option<String>,
+) -> anyhow::Result<()> {
+    let templates_dir = Path::new("templates");
+    let agents_dir = Path::new("agents");
+
+    // Load template
+    let template_path = templates_dir.join(format!("{template}.md"));
+    if !template_path.exists() {
+        eprintln!("Template '{template}' not found.\n");
+        list_templates(templates_dir)?;
+        anyhow::bail!("Use --template <name> with one of the templates above");
+    }
+
+    // Check for duplicate
+    let output_path = agents_dir.join(format!("{name}.md"));
+    if output_path.exists() {
+        anyhow::bail!(
+            "Agent '{}' already exists at {}",
+            name,
+            output_path.display()
+        );
+    }
+
+    // Read and replace placeholders
+    let mut content = std::fs::read_to_string(&template_path)?;
+
+    // Convert name to title case for the H1 heading
+    let title = name
+        .split('-')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(c) => format!("{}{}", c.to_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    content = content.replace("{{name}}", &title);
+
+    if let Some(ref desc) = description {
+        content = content.replace("{{description}}", desc);
+    }
+    if let Some(ref s) = stack {
+        content = content.replace("{{stack}}", s);
+    }
+
+    // Check for remaining placeholders
+    let remaining: Vec<&str> = content
+        .match_indices("{{")
+        .filter_map(|(start, _)| {
+            content[start..]
+                .find("}}")
+                .map(|end| &content[start..start + end + 2])
+        })
+        .collect();
+
+    // Ensure agents directory exists
+    std::fs::create_dir_all(agents_dir)?;
+
+    // Write the agent file
+    std::fs::write(&output_path, &content)?;
+
+    println!("Agent created: {}", output_path.display());
+    println!("  Template: {template}");
+    println!("  Name: {title}");
+
+    if !remaining.is_empty() {
+        let unique: Vec<&str> = {
+            let mut seen = std::collections::HashSet::new();
+            remaining.into_iter().filter(|p| seen.insert(*p)).collect()
+        };
+        println!("\n  Note: the following placeholders need to be filled in manually:");
+        for p in &unique {
+            println!("    - {p}");
+        }
+    }
+
+    Ok(())
+}
+
+fn list_templates(templates_dir: &Path) -> anyhow::Result<()> {
+    println!("Available templates:");
+    if !templates_dir.exists() {
+        println!("  (no templates directory found)");
+        return Ok(());
+    }
+
+    let mut found = false;
+    for entry in std::fs::read_dir(templates_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "md")
+            && let Some(stem) = path.file_stem()
+        {
+            println!("  - {}", stem.to_string_lossy());
+            found = true;
+        }
+    }
+
+    if !found {
+        println!("  (no templates found)");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    #[tokio::test]
+    async fn new_basic_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let templates = dir.path().join("templates");
+        let agents = dir.path().join("agents");
+        fs::create_dir_all(&templates).unwrap();
+
+        fs::write(
+            templates.join("basic.md"),
+            "# {{name}}\n\n## Metadata\n- provider: anthropic\n\n## System Prompt\n\n{{description}}\n",
+        )
+        .unwrap();
+
+        // We need to work from the temp dir, so test the logic directly
+        let template_path = templates.join("basic.md");
+        let output_path = agents.join("my-agent.md");
+        let mut content = fs::read_to_string(&template_path).unwrap();
+        content = content.replace("{{name}}", "My Agent");
+        content = content.replace("{{description}}", "A test agent");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(&output_path, &content).unwrap();
+
+        let result = fs::read_to_string(&output_path).unwrap();
+        assert!(result.contains("# My Agent"));
+        assert!(result.contains("A test agent"));
+        assert!(!result.contains("{{name}}"));
+    }
 }

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -1,3 +1,94 @@
-pub async fn execute(_agent: Option<String>) -> anyhow::Result<()> {
-    todo!("validate command")
+use std::path::Path;
+
+use crate::core::agent::Agent;
+use crate::parser;
+
+pub async fn execute(agent_name: Option<String>) -> anyhow::Result<()> {
+    let agents_dir = Path::new("agents");
+
+    match agent_name {
+        Some(name) => validate_one(agents_dir, &name),
+        None => validate_all(agents_dir),
+    }
+}
+
+fn validate_one(agents_dir: &Path, name: &str) -> anyhow::Result<()> {
+    let path = Agent::find_file(agents_dir, name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Agent '{name}' not found in {}/ (looked for {name}.md)",
+            agents_dir.display()
+        )
+    })?;
+
+    match parser::validate_agent(&path) {
+        Ok(agent) => {
+            println!("  OK  {}", agent.name);
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("  FAIL  {name} ({})", path.display());
+            eprintln!("        {e}");
+            anyhow::bail!("Validation failed");
+        }
+    }
+}
+
+fn validate_all(agents_dir: &Path) -> anyhow::Result<()> {
+    if !agents_dir.exists() {
+        anyhow::bail!("No agents directory found at {}/", agents_dir.display());
+    }
+
+    let mut files = Vec::new();
+    collect_md_files(agents_dir, &mut files)?;
+    files.sort();
+
+    if files.is_empty() {
+        println!("No agent files found in {}/", agents_dir.display());
+        return Ok(());
+    }
+
+    let mut passed = 0;
+    let mut failed = 0;
+
+    for path in &files {
+        let display_name = path.strip_prefix(agents_dir).unwrap_or(path).display();
+
+        match parser::validate_agent(path) {
+            Ok(agent) => {
+                println!("  OK    {:<30}  ({})", agent.name, display_name);
+                passed += 1;
+            }
+            Err(e) => {
+                eprintln!("  FAIL  {:<30}  ({})", display_name, e);
+                failed += 1;
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "  {} agent(s) checked: {} passed, {} failed.",
+        passed + failed,
+        passed,
+        failed
+    );
+
+    if failed > 0 {
+        anyhow::bail!("{failed} agent(s) failed validation");
+    }
+
+    Ok(())
+}
+
+fn collect_md_files(dir: &Path, files: &mut Vec<std::path::PathBuf>) -> anyhow::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_md_files(&path, files)?;
+        } else if path.extension().is_some_and(|e| e == "md") {
+            files.push(path);
+        }
+    }
+    Ok(())
 }

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -67,7 +67,6 @@ pub fn parse_metadata(raw: &str) -> anyhow::Result<AgentMetadata> {
 }
 
 /// Validate metadata fields for consistency.
-#[allow(dead_code)]
 pub fn validate_metadata(metadata: &AgentMetadata) -> anyhow::Result<()> {
     match metadata.provider.as_str() {
         "cli" => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,7 +8,6 @@ use crate::core::agent::Agent;
 pub use markdown::parse_agent_file;
 
 /// Validate an agent definition without loading providers.
-#[allow(dead_code)]
 pub fn validate_agent(path: &Path) -> anyhow::Result<Agent> {
     let agent = parse_agent_file(path)?;
     metadata::validate_metadata(&agent.metadata)?;


### PR DESCRIPTION
## Summary
- **swarm new** (#10): create agents from templates with `{{placeholder}}` replacement, duplicate detection, template listing on error
- **swarm inspect** (#11): display fully parsed agent config (metadata, system prompt, instructions, pipeline, etc.)
- **swarm validate** (#12): dry-run validation of agent configs — single agent or all at once, with pass/fail reporting and exit codes
- Adds `Agent::find_file()` helper for recursive name-to-path resolution

## Test plan
- [x] `swarm new my-agent --template basic --description "test"` creates `agents/my-agent.md` with replaced placeholders
- [x] `swarm new my-agent` on existing agent shows duplicate error
- [x] `swarm new test --template nonexistent` lists available templates
- [x] `swarm inspect code-reviewer` shows full parsed config
- [x] `swarm inspect nonexistent` shows clear error
- [x] `swarm validate` checks all 4 agents (OK)
- [x] `swarm validate code-reviewer` checks single agent (OK)
- [x] 8 unit tests pass
- [x] clippy clean, fmt clean
- [ ] CI passes

Closes #10, closes #11, closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)