### PR TITLE
docs: update README and add wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,21 @@ swarm run my-assistant "Explain how async/await works in Rust"
 
 ## Usage
 
-```
-swarm run <agent> [input]           Run an agent
-swarm run --pipe <a> <b> [input]    Chain agents in a pipeline
-swarm new --template <tpl> <name>   Create an agent from a template
-swarm list [--tags t] [--stack s]   List available agents
-swarm inspect <agent>               Show parsed agent config
-swarm validate [agent]              Dry-run validation (no API calls)
-swarm history [--agent a]           View execution history
-swarm history --replay <id>         Replay a past execution
-swarm costs [--agent a] [--from d]  View cost tracking
-swarm config providers              Manage provider configs
-swarm config secrets init           Initialize SOPS + age
-swarm tui                           Launch the TUI dashboard
-swarm up                            Start infra (Docker Compose)
-swarm down                          Stop infra
-```
+| Command | Description | Status |
+|---|---|---|
+| `swarm list [--tags t] [--stack s]` | List available agents | Done |
+| `swarm new --template <tpl> <name>` | Create an agent from a template | Done |
+| `swarm inspect <agent>` | Show parsed agent config | Done |
+| `swarm validate [agent]` | Dry-run validation (no API calls) | Done |
+| `swarm run <agent> [input]` | Run an agent | Planned |
+| `swarm run --pipe <a> <b> [input]` | Chain agents in a pipeline | Planned |
+| `swarm history [--agent a]` | View execution history | Planned |
+| `swarm history --replay <id>` | Replay a past execution | Planned |
+| `swarm costs [--agent a] [--from d]` | View cost tracking | Planned |
+| `swarm config providers` | Manage provider configs | Planned |
+| `swarm config secrets init` | Initialize SOPS + age | Planned |
+| `swarm tui` | Launch the TUI dashboard | Planned |
+| `swarm up / down` | Start/stop infra (Docker Compose) | Done |
 
 ## Agent Format
 
@@ -126,6 +125,18 @@ You are an expert code reviewer...
 Structured review: bugs, security, performance, style.
 ```
 
+### Available sections
+
+| Section | Required | Description |
+|---|---|---|
+| `# Title` (H1) | Yes | Agent name |
+| `## Metadata` | Yes | Provider, model, temperature, tags, stacks, etc. |
+| `## System Prompt` | Yes | System prompt sent to the model |
+| `## Instructions` | No | Step-by-step execution instructions |
+| `## Output Format` | No | Expected output format description |
+| `## Pipeline` | No | List of agents to chain after this one |
+| `## Context` | No | Additional context injected at runtime |
+
 ### Using CLI tools as providers
 
 ```markdown
@@ -140,6 +151,22 @@ Structured review: bugs, security, performance, style.
 ## System Prompt
 
 You are a versatile development assistant.
+```
+
+## Templates
+
+| Template | Description |
+|---|---|
+| `basic` | General-purpose agent |
+| `dev-review` | Code review specialist |
+| `dev-test` | Test generation specialist |
+| `cli-generic` | Wrapper for any CLI tool |
+
+Create an agent from a template:
+
+```bash
+swarm new my-reviewer --template dev-review --stack rust
+swarm new my-tool --template cli-generic
 ```
 
 ## Architecture
@@ -159,14 +186,28 @@ HOST MACHINE
     └── litellm     :4000
 ```
 
-## Templates
+### Cargo Feature Flags
 
-| Template | Description |
-|---|---|
-| `basic` | General-purpose agent |
-| `dev-review` | Code review specialist |
-| `dev-test` | Test generation specialist |
-| `cli-generic` | Wrapper for any CLI tool |
+Heavy dependencies are gated behind optional feature flags for faster compilation:
+
+| Feature | Default | Description |
+|---|---|---|
+| `tui` | Yes | TUI dashboard (ratatui + crossterm) |
+| `storage` | Yes* | SurrealDB with in-memory backend |
+| `storage-rocksdb` | Yes | SurrealDB with persistent RocksDB backend |
+
+\* Implied by `storage-rocksdb`.
+
+```bash
+# Full build (all features)
+cargo build --release
+
+# Lightweight build (no SurrealDB, no TUI)
+cargo build --release --no-default-features
+
+# CLI + storage (no TUI)
+cargo build --release --no-default-features --features storage
+```
 
 ## Development
 
@@ -211,6 +252,15 @@ refactor(providers): extract common HTTP logic
 ```
 
 Changelogs are generated automatically via `cz bump`.
+
+## Wiki
+
+Detailed documentation is available in [`docs/wiki/`](docs/wiki/):
+
+- [Getting Started](docs/wiki/getting-started.md) — installation, first agent, first run
+- [Agent Format](docs/wiki/agent-format.md) — complete reference for agent Markdown files
+- [Providers](docs/wiki/providers.md) — configuring API, CLI, and proxy providers
+- [Templates](docs/wiki/templates.md) — using and creating agent templates
 
 ## License
 

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -1,0 +1,153 @@
+# Agent Format
+
+Agents are defined as Markdown files in the `agents/` directory. Each file represents one specialized agent.
+
+## File Structure
+
+```markdown
+# Agent Name          ← H1: required, becomes the agent's display name
+
+## Metadata           ← H2: required, key-value configuration
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.3
+
+## System Prompt      ← H2: required, the system prompt sent to the model
+
+Your role and behavior description here.
+
+## Instructions       ← H2: optional, step-by-step execution guidance
+
+1. Step one
+2. Step two
+
+## Output Format      ← H2: optional, expected output structure
+
+Description of the expected output format.
+
+## Pipeline           ← H2: optional, agents to chain after this one
+- next-agent-a
+- next-agent-b
+
+## Context            ← H2: optional, additional runtime context
+
+Extra context injected at execution time.
+```
+
+## Sections Reference
+
+### Metadata (required)
+
+Key-value pairs configuring the agent's technical behavior.
+
+| Key | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `provider` | string | Yes | — | Provider type: `anthropic`, `openai`, `google`, `cli`, `proxy` |
+| `model` | string | API providers | — | Model identifier (e.g. `claude-sonnet-4-5-20250929`) |
+| `command` | string | CLI provider | — | CLI command to execute |
+| `args` | list | No | — | CLI arguments: `["-p", "--model", "sonnet"]` |
+| `temperature` | float | No | `0.7` | Sampling temperature (0.0 - 2.0) |
+| `max_tokens` | int | No | — | Maximum output tokens |
+| `timeout` | int | No | — | Execution timeout in seconds |
+| `tags` | list | No | `[]` | Tags for filtering: `[dev, review]` |
+| `stacks` | list | No | `[]` | Tech stacks: `[rust, typescript]` |
+| `cost_limit` | float | No | — | Max cost per execution in USD |
+| `rate_limit` | string | No | — | Rate limit: `"10/min"` |
+| `context_window` | int | No | — | Context window size override |
+
+### System Prompt (required)
+
+The system prompt sent to the model. This defines the agent's identity, role, and behavioral boundaries.
+
+### Instructions (optional)
+
+Step-by-step instructions for how the agent should process input. Useful for complex multi-step tasks.
+
+### Output Format (optional)
+
+Description of the expected output structure. Helps the model produce consistent, parseable results.
+
+### Pipeline (optional)
+
+List of agent names to chain after this agent. Each agent receives the previous agent's output as input.
+
+```markdown
+## Pipeline
+- test-writer
+- doc-generator
+```
+
+### Context (optional)
+
+Additional context injected at runtime. Can include project-specific information, coding standards, etc.
+
+## Provider Types
+
+### API Providers (`anthropic`, `openai`, `google`)
+
+Send requests to LLM APIs. Require `model` field.
+
+```markdown
+## Metadata
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.3
+- max_tokens: 4096
+```
+
+### CLI Provider (`cli`)
+
+Execute any command-line tool. Require `command` field.
+
+```markdown
+## Metadata
+- provider: cli
+- command: claude
+- args: ["-p", "--output-format", "json"]
+- timeout: 300
+```
+
+### Proxy Provider (`proxy`)
+
+Route through an OpenAI-compatible proxy (LiteLLM, OpenRouter).
+
+```markdown
+## Metadata
+- provider: proxy
+- model: anthropic/claude-sonnet-4-5-20250929
+```
+
+## File Organization
+
+Agents can be organized in subdirectories:
+
+```
+agents/
+├── _coordinator.md       ← Hub agent (prefixed with _ for sorting)
+├── code-reviewer.md
+├── test-writer.md
+├── examples/
+│   ├── doc-generator.md
+│   └── simple-chat.md
+└── team-specific/
+    └── deploy-checker.md
+```
+
+All `.md` files in `agents/` and subdirectories are loaded recursively.
+
+## Validation
+
+Validate agent configurations without making API calls:
+
+```bash
+# Validate all agents
+swarm validate
+
+# Validate a specific agent
+swarm validate code-reviewer
+```
+
+Validation checks:
+- Presence of required sections (H1 title, Metadata, System Prompt)
+- Provider type consistency (API providers need `model`, CLI needs `command`)
+- Temperature range (0.0 - 2.0)

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -1,0 +1,79 @@
+# Getting Started
+
+## Installation
+
+### From source
+
+```bash
+git clone https://github.com/Dr0drigues/swarm-festai.git
+cd swarm-festai
+cargo build --release
+```
+
+The binary is at `target/release/swarm`. Add it to your `PATH`:
+
+```bash
+# Option 1: symlink
+ln -s $(pwd)/target/release/swarm ~/.local/bin/swarm
+
+# Option 2: cargo install
+cargo install --path .
+```
+
+### Prerequisites
+
+| Tool | Required | Purpose |
+|---|---|---|
+| Rust 1.86+ | Yes | Build from source |
+| Docker | No | Infrastructure services (SurrealDB, LiteLLM) |
+| SOPS + age | No | Encrypted secret management |
+
+## First Agent
+
+Create your first agent from a template:
+
+```bash
+swarm new my-assistant --template basic --description "general-purpose coding assistant"
+```
+
+This creates `agents/my-assistant.md`. Open it and customize the system prompt to your needs.
+
+## Verify Setup
+
+```bash
+# List all available agents
+swarm list
+
+# Validate all agent configurations
+swarm validate
+
+# Inspect a specific agent
+swarm inspect my-assistant
+```
+
+## Configure Providers
+
+Before running agents, configure your API keys:
+
+```bash
+# Quick setup (unencrypted, gitignored)
+cat > config/providers.secret.yaml << 'EOF'
+providers:
+  anthropic:
+    api_key: sk-ant-your-key-here
+EOF
+```
+
+For production use, see the [Providers](providers.md) page for SOPS + age encrypted configuration.
+
+## Run an Agent
+
+```bash
+swarm run my-assistant "Explain the builder pattern in Rust"
+```
+
+## Next Steps
+
+- [Agent Format](agent-format.md) — full reference for agent Markdown files
+- [Providers](providers.md) — configure API, CLI, and proxy providers
+- [Templates](templates.md) — available templates and how to create your own

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -1,0 +1,142 @@
+# Providers
+
+swarm-festai supports three types of providers for executing agents.
+
+## API Providers
+
+Direct HTTP calls to LLM APIs.
+
+### Anthropic
+
+```markdown
+## Metadata
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.3
+- max_tokens: 4096
+```
+
+Available models: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`
+
+### OpenAI
+
+```markdown
+## Metadata
+- provider: openai
+- model: gpt-4o
+- temperature: 0.7
+```
+
+Available models: `gpt-4o`, `gpt-4o-mini`, `o1`
+
+### Google
+
+```markdown
+## Metadata
+- provider: google
+- model: gemini-2.0-flash
+- temperature: 0.7
+```
+
+## CLI Provider
+
+Execute any command-line tool as an agent. The input is passed as the last argument to the command, and stdout is captured as the output.
+
+```markdown
+## Metadata
+- provider: cli
+- command: claude
+- args: ["-p", "--model", "sonnet", "--output-format", "json"]
+- timeout: 300
+```
+
+### Examples
+
+**Claude Code:**
+```markdown
+- provider: cli
+- command: claude
+- args: ["-p"]
+- timeout: 600
+```
+
+**aider:**
+```markdown
+- provider: cli
+- command: aider
+- args: ["--message"]
+- timeout: 300
+```
+
+**Custom script:**
+```markdown
+- provider: cli
+- command: ./scripts/my-tool.sh
+- args: ["--format", "json"]
+- timeout: 60
+```
+
+## Proxy Provider
+
+Route requests through an OpenAI-compatible proxy like LiteLLM or OpenRouter.
+
+```markdown
+## Metadata
+- provider: proxy
+- model: anthropic/claude-sonnet-4-5-20250929
+```
+
+### Setting up LiteLLM
+
+Start the proxy with Docker Compose:
+
+```bash
+swarm up
+```
+
+This starts LiteLLM on port 4000 (configured in `docker-compose.yml`).
+
+## Secret Management
+
+API keys are stored in `config/providers.sops.yaml` (encrypted) or `config/providers.secret.yaml` (unencrypted, gitignored).
+
+### Quick setup (unencrypted)
+
+```yaml
+# config/providers.secret.yaml
+providers:
+  anthropic:
+    api_key: sk-ant-your-key
+  openai:
+    api_key: sk-your-key
+  google:
+    api_key: AIza-your-key
+```
+
+### Production setup (SOPS + age)
+
+```bash
+# Initialize encryption
+swarm config secrets init
+
+# Edit encrypted file
+sops config/providers.sops.yaml
+```
+
+See the [SOPS documentation](https://github.com/getsops/sops) for details on the encryption workflow.
+
+## Provider Configuration
+
+Global provider settings are in `config/providers.yaml`:
+
+```yaml
+providers:
+  anthropic:
+    base_url: https://api.anthropic.com
+    default_model: claude-sonnet-4-5-20250929
+  openai:
+    base_url: https://api.openai.com/v1
+    default_model: gpt-4o
+  proxy:
+    base_url: http://localhost:4000
+```

--- a/docs/wiki/templates.md
+++ b/docs/wiki/templates.md
@@ -1,0 +1,85 @@
+# Templates
+
+Templates are Markdown files in the `templates/` directory that serve as starting points for new agents.
+
+## Available Templates
+
+### basic
+
+General-purpose agent with Anthropic provider.
+
+```bash
+swarm new my-agent --template basic --description "what this agent does"
+```
+
+### dev-review
+
+Code review specialist. Produces structured reviews with severity levels.
+
+```bash
+swarm new rust-reviewer --template dev-review --stack rust
+```
+
+### dev-test
+
+Test generation specialist. Writes unit tests for given code.
+
+```bash
+swarm new test-gen --template dev-test --stack typescript
+```
+
+### cli-generic
+
+Wrapper for any CLI tool (claude, aider, custom scripts).
+
+```bash
+swarm new my-tool --template cli-generic
+```
+
+Then edit `agents/my-tool.md` to set the `command` and `args` fields.
+
+## Placeholders
+
+Templates use `{{placeholder}}` syntax for customizable values:
+
+| Placeholder | CLI Flag | Description |
+|---|---|---|
+| `{{name}}` | positional `<name>` | Agent display name (auto title-cased from the slug) |
+| `{{description}}` | `--description` / `-d` | Agent description for the system prompt |
+| `{{stack}}` | `--stack` / `-s` | Tech stack (rust, typescript, java, etc.) |
+| `{{command}}` | — | CLI command (edit manually) |
+| `{{args}}` | — | CLI arguments (edit manually) |
+| `{{tags}}` | — | Agent tags (edit manually) |
+
+Placeholders not replaced by CLI flags remain in the output file. The command lists them so you know what to fill in manually.
+
+## Creating Custom Templates
+
+Add a `.md` file to the `templates/` directory following the [agent format](agent-format.md):
+
+```markdown
+# {{name}}
+
+## Metadata
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.5
+- tags: [{{tags}}]
+- stacks: [{{stack}}]
+
+## System Prompt
+
+You are an expert at {{description}} for {{stack}} projects.
+
+## Instructions
+
+1. Analyze the input
+2. Apply domain expertise
+3. Produce structured output
+
+## Output Format
+
+Clear, actionable response with examples.
+```
+
+Use any `{{placeholder}}` name — only `{{name}}`, `{{description}}`, and `{{stack}}` are auto-replaced by CLI flags. Others are left for manual editing.


### PR DESCRIPTION
## Summary
- Update README with command implementation status table (Done/Planned), Cargo feature flags section, available agent sections reference, and wiki links
- Create `docs/wiki/` directory with 4 documentation pages for future public wiki:
  - **getting-started.md** — installation, first agent, provider config, first run
  - **agent-format.md** — complete reference for all agent Markdown sections and metadata fields
  - **providers.md** — API, CLI, proxy providers with examples and secret management
  - **templates.md** — available templates, placeholders, creating custom templates

## Test plan
- [x] No code changes — fmt/clippy/tests unaffected
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)