### PR TITLE
feat: add Anthropic API provider and enhance CLI provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1404,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1687,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1912,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1897,6 +1942,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,9 +1975,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2598,6 +2661,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2889,50 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -3546,17 +3670,22 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3567,6 +3696,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3905,6 +4035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +4090,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4521,6 +4683,7 @@ dependencies = [
  "crossterm",
  "pulldown-cmark",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yml",
@@ -4588,6 +4751,27 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4836,6 +5020,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5651,6 +5845,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ name = "swarm"
 path = "src/main.rs"
 
 [features]
-default = ["tui", "storage-rocksdb"]
+default = ["tui", "storage-rocksdb", "providers-api"]
 tui = ["dep:ratatui", "dep:crossterm"]
 storage = ["dep:surrealdb"]
 storage-rocksdb = ["storage", "surrealdb/kv-rocksdb"]
+providers-api = ["dep:reqwest"]
 
 [dependencies]
 # Async runtime
@@ -27,6 +28,9 @@ clap = { version = "4", features = ["derive"] }
 # TUI (optional — enable with `tui` feature)
 ratatui = { version = "0.30", optional = true }
 crossterm = { version = "0.29", optional = true }
+
+# HTTP (optional — enable with `providers-api` feature)
+reqwest = { version = "0.12", features = ["json", "stream"], optional = true }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/src/providers/api/anthropic.rs
+++ b/src/providers/api/anthropic.rs
@@ -1,10 +1,17 @@
 use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio_stream::StreamExt;
 
 use crate::providers::traits::*;
 
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
 pub struct AnthropicProvider {
-    pub api_key: String,
-    pub base_url: String,
+    api_key: String,
+    pub(crate) base_url: String,
+    client: Client,
 }
 
 impl AnthropicProvider {
@@ -12,18 +19,221 @@ impl AnthropicProvider {
         Self {
             api_key,
             base_url: "https://api.anthropic.com/v1".to_string(),
+            client: Client::new(),
         }
     }
 }
 
+// --- API request/response types ---
+
+#[derive(Serialize)]
+struct ApiRequest {
+    model: String,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    messages: Vec<ApiMessage>,
+    temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct ApiMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    content: Vec<ContentBlock>,
+    model: String,
+    usage: ApiUsage,
+}
+
+#[derive(Deserialize)]
+struct ContentBlock {
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct ApiUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct ApiError {
+    error: ApiErrorDetail,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorDetail {
+    message: String,
+}
+
+// --- Cost calculation ---
+
+fn cost_for_model(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
+    let (input_rate, output_rate) = match model {
+        m if m.contains("opus") => (15.0, 75.0),
+        m if m.contains("haiku") => (0.80, 4.0),
+        _ => (3.0, 15.0), // sonnet pricing as default
+    };
+    (input_tokens as f64 * input_rate + output_tokens as f64 * output_rate) / 1_000_000.0
+}
+
+// --- SSE parsing ---
+
+fn parse_sse_text_delta(data: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(data).ok()?;
+    let event_type = value.get("type")?.as_str()?;
+    if event_type == "content_block_delta" {
+        return value.get("delta")?.get("text")?.as_str().map(String::from);
+    }
+    None
+}
+
 #[async_trait]
 impl Provider for AnthropicProvider {
-    async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
-        todo!("Anthropic completion")
+    async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        let body = ApiRequest {
+            model: request.model.clone(),
+            max_tokens: request.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+            system: if request.system_prompt.is_empty() {
+                None
+            } else {
+                Some(request.system_prompt)
+            },
+            messages: request
+                .messages
+                .into_iter()
+                .map(|m| ApiMessage {
+                    role: m.role,
+                    content: m.content,
+                })
+                .collect(),
+            temperature: request.temperature,
+            stream: None,
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/messages", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            let msg = serde_json::from_str::<ApiError>(&text)
+                .map(|e| e.error.message)
+                .unwrap_or(text);
+            anyhow::bail!("Anthropic API error ({status}): {msg}");
+        }
+
+        let api_resp: ApiResponse = response.json().await?;
+        let content = api_resp
+            .content
+            .into_iter()
+            .map(|b| b.text)
+            .collect::<Vec<_>>()
+            .join("");
+
+        let cost = cost_for_model(
+            &api_resp.model,
+            api_resp.usage.input_tokens,
+            api_resp.usage.output_tokens,
+        );
+
+        Ok(CompletionResponse {
+            content,
+            model: api_resp.model,
+            tokens_in: api_resp.usage.input_tokens,
+            tokens_out: api_resp.usage.output_tokens,
+            cost,
+        })
     }
 
-    async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
-        todo!("Anthropic streaming")
+    async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
+        let body = ApiRequest {
+            model: request.model.clone(),
+            max_tokens: request.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+            system: if request.system_prompt.is_empty() {
+                None
+            } else {
+                Some(request.system_prompt)
+            },
+            messages: request
+                .messages
+                .into_iter()
+                .map(|m| ApiMessage {
+                    role: m.role,
+                    content: m.content,
+                })
+                .collect(),
+            temperature: request.temperature,
+            stream: Some(true),
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/messages", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            let msg = serde_json::from_str::<ApiError>(&text)
+                .map(|e| e.error.message)
+                .unwrap_or(text);
+            anyhow::bail!("Anthropic API error ({status}): {msg}");
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let byte_stream = response.bytes_stream();
+
+        tokio::spawn(async move {
+            let mut buffer = String::new();
+            tokio::pin!(byte_stream);
+
+            while let Some(chunk) = byte_stream.next().await {
+                let chunk = match chunk {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx.send(Err(anyhow::anyhow!("Stream error: {e}"))).await;
+                        return;
+                    }
+                };
+
+                buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                // Process complete SSE events (delimited by \n\n)
+                while let Some(pos) = buffer.find("\n\n") {
+                    let event_block = buffer[..pos].to_string();
+                    buffer = buffer[pos + 2..].to_string();
+
+                    // Extract data line from SSE event
+                    for line in event_block.lines() {
+                        if let Some(data) = line.strip_prefix("data: ")
+                            && let Some(text) = parse_sse_text_delta(data)
+                            && tx.send(Ok(text)).await.is_err()
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
 
     fn metadata(&self) -> ProviderMetadata {
@@ -36,5 +246,35 @@ impl Provider for AnthropicProvider {
             ],
             supports_streaming: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_content_block_delta() {
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        assert_eq!(parse_sse_text_delta(data), Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn parse_non_delta_event() {
+        let data = r#"{"type":"message_start","message":{"id":"msg_1"}}"#;
+        assert_eq!(parse_sse_text_delta(data), None);
+    }
+
+    #[test]
+    fn cost_calculation() {
+        // Sonnet: $3/M in, $15/M out
+        let cost = cost_for_model("claude-sonnet-4-5-20250929", 1000, 500);
+        let expected = (1000.0 * 3.0 + 500.0 * 15.0) / 1_000_000.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+
+        // Opus: $15/M in, $75/M out
+        let cost = cost_for_model("claude-opus-4-6", 100, 200);
+        let expected = (100.0 * 15.0 + 200.0 * 75.0) / 1_000_000.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
     }
 }

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use tokio::process::Command;
-use tokio_stream::StreamExt;
 
 use super::traits::*;
 
@@ -42,18 +41,21 @@ impl Provider for CliProvider {
             .unwrap_or("");
 
         let mut cmd = self.build_command(input);
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(self.timeout_secs),
-            cmd.output(),
-        )
-        .await??;
+        let timeout = std::time::Duration::from_secs(self.timeout_secs);
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let output = match tokio::time::timeout(timeout, cmd.output()).await {
+            Ok(result) => result?,
+            Err(_) => {
+                anyhow::bail!("CLI command timed out after {}s", self.timeout_secs);
+            }
+        };
 
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("CLI command failed ({}): {stderr}", output.status);
         }
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
 
         Ok(CompletionResponse {
             content: stdout,
@@ -71,21 +73,39 @@ impl Provider for CliProvider {
             .map(|m| m.content.clone())
             .unwrap_or_default();
 
-        let mut cmd = self.build_command(&input);
-        let mut child = cmd.spawn()?;
+        let mut child = self.build_command(&input).spawn()?;
 
         let stdout = child
             .stdout
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture stdout"))?;
 
-        let reader = tokio::io::BufReader::new(stdout);
-        let lines = tokio::io::AsyncBufReadExt::lines(reader);
-        let stream = tokio_stream::wrappers::LinesStream::new(lines);
+        let timeout_secs = self.timeout_secs;
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
 
-        Ok(Box::pin(stream.map(
-            |line: Result<String, std::io::Error>| line.map_err(|e| anyhow::anyhow!(e)),
-        )))
+        tokio::spawn(async move {
+            let reader = tokio::io::BufReader::new(stdout);
+            let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
+
+            let timeout = std::time::Duration::from_secs(timeout_secs);
+            let result = tokio::time::timeout(timeout, async {
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if tx.send(Ok(line)).await.is_err() {
+                        break;
+                    }
+                }
+            })
+            .await;
+
+            if result.is_err() {
+                let _ = tx.send(Err(anyhow::anyhow!("CLI command timed out"))).await;
+                let _ = child.kill().await;
+            }
+
+            let _ = child.wait().await;
+        });
+
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
 
     fn metadata(&self) -> ProviderMetadata {
@@ -94,5 +114,72 @@ impl Provider for CliProvider {
             models: vec![self.command.clone()],
             supports_streaming: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn echo_request(text: &str) -> CompletionRequest {
+        CompletionRequest {
+            model: "echo".to_string(),
+            system_prompt: String::new(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: text.to_string(),
+            }],
+            temperature: 0.0,
+            max_tokens: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cli_complete_echo() {
+        let provider = CliProvider::new("echo".to_string(), vec![], 10);
+        let response = provider
+            .complete(echo_request("hello world"))
+            .await
+            .unwrap();
+        assert_eq!(response.content.trim(), "hello world");
+        assert_eq!(response.tokens_in, 0);
+        assert_eq!(response.cost, 0.0);
+    }
+
+    #[tokio::test]
+    async fn cli_complete_with_args() {
+        let provider = CliProvider::new("echo".to_string(), vec!["prefix".to_string()], 10);
+        let response = provider.complete(echo_request("test")).await.unwrap();
+        assert_eq!(response.content.trim(), "prefix test");
+    }
+
+    #[tokio::test]
+    async fn cli_stream_echo() {
+        use tokio_stream::StreamExt;
+
+        let provider = CliProvider::new("echo".to_string(), vec![], 10);
+        let mut stream = provider.stream(echo_request("stream test")).await.unwrap();
+
+        let mut output = Vec::new();
+        while let Some(line) = stream.next().await {
+            output.push(line.unwrap());
+        }
+        assert_eq!(output, vec!["stream test"]);
+    }
+
+    #[tokio::test]
+    async fn cli_complete_failure() {
+        let provider = CliProvider::new("false".to_string(), vec![], 10);
+        let result = provider.complete(echo_request("")).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn cli_complete_timeout() {
+        let provider = CliProvider::new("sleep".to_string(), vec![], 1);
+        let result = provider.complete(echo_request("30")).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("timed out"), "Error was: {err}");
     }
 }

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -1,0 +1,75 @@
+use crate::core::agent::Agent;
+
+use super::traits::Provider;
+
+/// Create the appropriate provider for an agent based on its metadata.
+pub fn create_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
+    match agent.metadata.provider.as_str() {
+        "cli" => create_cli_provider(agent),
+        provider => create_api_provider(provider, agent),
+    }
+}
+
+fn create_cli_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
+    let command = agent
+        .metadata
+        .command
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("CLI provider requires 'command' in Metadata"))?;
+    let args = agent.metadata.args.clone().unwrap_or_default();
+    let timeout = agent.metadata.timeout.unwrap_or(300);
+    Ok(Box::new(super::cli::CliProvider::new(
+        command, args, timeout,
+    )))
+}
+
+#[cfg(feature = "providers-api")]
+fn create_api_provider(provider: &str, _agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
+    match provider {
+        "anthropic" => {
+            let api_key = get_api_key("ANTHROPIC_API_KEY", "anthropic")?;
+            let mut p = super::api::anthropic::AnthropicProvider::new(api_key);
+            // Allow base_url override from config
+            if let Ok(url) = std::env::var("ANTHROPIC_BASE_URL") {
+                p.base_url = url;
+            }
+            Ok(Box::new(p))
+        }
+        "openai" | "google" | "proxy" => {
+            anyhow::bail!("Provider '{provider}' is not yet implemented")
+        }
+        other => anyhow::bail!("Unknown provider: '{other}'"),
+    }
+}
+
+#[cfg(not(feature = "providers-api"))]
+fn create_api_provider(provider: &str, _agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
+    anyhow::bail!(
+        "Provider '{provider}' requires the 'providers-api' feature. \
+         Build with: cargo build --features providers-api"
+    )
+}
+
+/// Resolve an API key from environment variable or secrets file.
+#[cfg(feature = "providers-api")]
+fn get_api_key(env_var: &str, provider_name: &str) -> anyhow::Result<String> {
+    // 1. Try environment variable
+    if let Ok(key) = std::env::var(env_var)
+        && !key.is_empty()
+    {
+        return Ok(key);
+    }
+
+    // 2. Try secrets file
+    let config_dir = std::path::Path::new("config");
+    if let Ok(secrets) = crate::secrets::load_secrets(config_dir)
+        && let Some(creds) = secrets.providers.get(provider_name)
+    {
+        return Ok(creds.api_key.clone());
+    }
+
+    anyhow::bail!(
+        "No API key found for '{provider_name}'. \
+         Set {env_var} or add to config/providers.secret.yaml"
+    )
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "providers-api")]
 pub mod api;
 pub mod cli;
+pub mod factory;
+#[cfg(feature = "providers-api")]
 pub mod proxy;
 pub mod traits;


### PR DESCRIPTION
## Summary
- **Anthropic API provider** (`#13`): Full implementation with `complete()` and `stream()` (SSE parsing), cost calculation per model (opus/sonnet/haiku), API key resolution from env vars or `config/providers.secret.yaml`
- **CLI provider enhancement** (`#14`): Added timeout handling with process kill, improved streaming with line-buffered output, 5 unit tests
- **Provider factory**: `create_provider()` constructs the right provider from agent metadata, with feature-gated API providers behind `providers-api`

## Changes
- `Cargo.toml`: Added `reqwest` as optional dep behind `providers-api` feature
- `src/providers/api/anthropic.rs`: Full Anthropic provider with SSE streaming, cost calculation, 3 tests
- `src/providers/cli.rs`: Enhanced with timeout/kill, streaming, 5 tests
- `src/providers/factory.rs`: New — provider construction from agent config
- `src/providers/mod.rs`: Added `factory` and `proxy` modules

## Test plan
- [x] 3 Anthropic unit tests (SSE parsing, cost calculation)
- [x] 5 CLI provider tests (echo, args, stream, failure, timeout)
- [x] `cargo clippy` clean with and without `providers-api` feature
- [x] `cargo fmt` clean
- [x] All 16 tests passing

Closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)