### PR TITLE
feat: implement SOPS + age secret management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 
 # Secrets — NEVER commit unencrypted secrets
 config/age-key.txt
+config/age-key.txt.bak
 config/providers.secret.yaml
 
 # Storage

--- a/README.md
+++ b/README.md
@@ -45,21 +45,25 @@ The binary is at `target/release/swarm`.
 ### Configure providers
 
 ```bash
-# Initialize secret management
-swarm config secrets init
+# Option A: Encrypted secrets (recommended)
+swarm config secrets init       # Generates age key + .sops.yaml
+sops config/providers.sops.yaml # Edit encrypted API keys
 
-# Edit your API keys (encrypted)
-sops config/providers.sops.yaml
-```
+# Option B: Environment variables
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
 
-Or for quick testing, create `config/providers.secret.yaml` (unencrypted, gitignored):
-
-```yaml
+# Option C: Plain file (quick testing, gitignored)
+cat > config/providers.secret.yaml << 'EOF'
 providers:
   anthropic:
     api_key: sk-ant-...
   openai:
     api_key: sk-...
+EOF
+
+# Check provider status
+swarm config providers
 ```
 
 ### Create your first agent
@@ -89,8 +93,9 @@ swarm run my-assistant "Explain how async/await works in Rust"
 | `swarm history [--agent a]` | View execution history | Done |
 | `swarm history --replay <id>` | Replay a past execution | Planned |
 | `swarm costs [--agent a] [--from d]` | View cost tracking | Done |
-| `swarm config providers` | Manage provider configs | Planned |
-| `swarm config secrets init` | Initialize SOPS + age | Planned |
+| `swarm config providers` | Show provider configs and secrets status | Done |
+| `swarm config secrets init` | Initialize SOPS + age encryption | Done |
+| `swarm config secrets rotate` | Rotate age encryption key | Done |
 | `swarm tui` | Launch the TUI dashboard | Done |
 | `swarm completion <shell>` | Generate shell completions | Done |
 | `swarm up / down` | Start/stop infra (Docker Compose) | Done |

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use clap::Subcommand;
 
 #[derive(Subcommand)]
@@ -21,16 +23,243 @@ pub enum SecretsAction {
 
 pub async fn execute(action: ConfigAction) -> anyhow::Result<()> {
     match action {
-        ConfigAction::Providers => {
-            todo!("config providers command")
-        }
+        ConfigAction::Providers => show_providers().await,
         ConfigAction::Secrets { action } => match action {
-            SecretsAction::Init => {
-                todo!("secrets init command")
-            }
-            SecretsAction::Rotate => {
-                todo!("secrets rotate command")
-            }
+            SecretsAction::Init => secrets_init().await,
+            SecretsAction::Rotate => secrets_rotate().await,
         },
     }
+}
+
+/// Show configured providers and their status.
+async fn show_providers() -> anyhow::Result<()> {
+    let config_dir = Path::new("config");
+
+    // Show provider config
+    let config_path = config_dir.join("providers.yaml");
+    if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)?;
+        println!("Provider configuration ({}):\n", config_path.display());
+        println!("{content}");
+    } else {
+        println!(
+            "No provider configuration found at {}",
+            config_path.display()
+        );
+    }
+
+    println!("---");
+
+    // Show secrets status
+    let sops_path = config_dir.join("providers.sops.yaml");
+    let plain_path = config_dir.join("providers.secret.yaml");
+
+    if sops_path.exists() {
+        println!("Secrets: encrypted (SOPS) at {}", sops_path.display());
+        // Try to list provider names from decrypted content
+        match crate::secrets::load_secrets(config_dir) {
+            Ok(secrets) => {
+                let names: Vec<&String> = secrets.providers.keys().collect();
+                println!(
+                    "  Configured API keys: {}",
+                    names
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            Err(e) => {
+                println!("  (could not decrypt: {e})");
+            }
+        }
+    } else if plain_path.exists() {
+        println!(
+            "Secrets: unencrypted at {} (consider running: swarm config secrets init)",
+            plain_path.display()
+        );
+        match crate::secrets::load_secrets(config_dir) {
+            Ok(secrets) => {
+                let names: Vec<&String> = secrets.providers.keys().collect();
+                println!(
+                    "  Configured API keys: {}",
+                    names
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            Err(e) => {
+                println!("  (could not read: {e})");
+            }
+        }
+    } else {
+        println!("No secrets file found. Create one:");
+        println!("  Option A: swarm config secrets init  (encrypted with SOPS + age)");
+        println!("  Option B: Create config/providers.secret.yaml manually (unencrypted)");
+    }
+
+    // Check environment variables
+    println!("\n--- Environment variables ---");
+    for (name, var) in [
+        ("Anthropic", "ANTHROPIC_API_KEY"),
+        ("OpenAI", "OPENAI_API_KEY"),
+        ("Google", "GOOGLE_API_KEY"),
+    ] {
+        let status = if std::env::var(var).is_ok_and(|v| !v.is_empty()) {
+            "set"
+        } else {
+            "not set"
+        };
+        println!("  {name}: ${var} = {status}");
+    }
+
+    Ok(())
+}
+
+/// Initialize SOPS + age encryption.
+async fn secrets_init() -> anyhow::Result<()> {
+    let config_dir = Path::new("config");
+    std::fs::create_dir_all(config_dir)?;
+
+    // Run init_sops which generates age key + .sops.yaml
+    crate::secrets::sops::init_sops(config_dir)?;
+
+    // Create template providers.sops.yaml if it doesn't exist
+    let sops_path = config_dir.join("providers.sops.yaml");
+    if !sops_path.exists() {
+        let template = r#"# Provider API keys (encrypted with SOPS + age)
+# Edit with: sops config/providers.sops.yaml
+providers:
+  anthropic:
+    api_key: "sk-ant-your-key-here"
+  openai:
+    api_key: "sk-your-key-here"
+  google:
+    api_key: "AIza-your-key-here"
+"#;
+        std::fs::write(&sops_path, template)?;
+        println!("Template created at: {}", sops_path.display());
+
+        // Try to encrypt it with sops
+        let encrypt = std::process::Command::new("sops")
+            .args(["--encrypt", "--in-place", &sops_path.display().to_string()])
+            .output();
+
+        match encrypt {
+            Ok(output) if output.status.success() => {
+                println!("File encrypted successfully.");
+                println!("\nEdit your secrets with:");
+                println!("  sops config/providers.sops.yaml");
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                println!(
+                    "\nWarning: could not encrypt file: {stderr}\n\
+                     Make sure SOPS_AGE_KEY_FILE is set, then encrypt manually:\n  \
+                     sops --encrypt --in-place config/providers.sops.yaml"
+                );
+            }
+            Err(_) => {
+                println!(
+                    "\nWarning: sops not found. Install it and encrypt manually:\n  \
+                     sops --encrypt --in-place config/providers.sops.yaml"
+                );
+            }
+        }
+    } else {
+        println!("Secrets file already exists at: {}", sops_path.display());
+        println!("Edit with: sops config/providers.sops.yaml");
+    }
+
+    Ok(())
+}
+
+/// Rotate the age encryption key.
+async fn secrets_rotate() -> anyhow::Result<()> {
+    let config_dir = Path::new("config");
+    let key_path = config_dir.join("age-key.txt");
+    let sops_path = config_dir.join("providers.sops.yaml");
+
+    if !key_path.exists() {
+        anyhow::bail!(
+            "No age key found at {}. Run 'swarm config secrets init' first.",
+            key_path.display()
+        );
+    }
+
+    if !sops_path.exists() {
+        anyhow::bail!(
+            "No encrypted secrets file found at {}. Run 'swarm config secrets init' first.",
+            sops_path.display()
+        );
+    }
+
+    // 1. Decrypt current secrets
+    println!("Decrypting current secrets...");
+    let secrets = crate::secrets::sops::decrypt_file(&sops_path)?;
+
+    // 2. Backup old key
+    let backup_path = config_dir.join("age-key.txt.bak");
+    std::fs::copy(&key_path, &backup_path)?;
+    println!("Old key backed up to: {}", backup_path.display());
+
+    // 3. Generate new key
+    std::fs::remove_file(&key_path)?;
+    let output = std::process::Command::new("age-keygen")
+        .args(["-o", &key_path.display().to_string()])
+        .output()?;
+
+    if !output.status.success() {
+        // Restore backup
+        std::fs::copy(&backup_path, &key_path)?;
+        anyhow::bail!(
+            "age-keygen failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    println!("New age key generated.");
+
+    // 4. Update .sops.yaml with new public key
+    let key_content = std::fs::read_to_string(&key_path)?;
+    let public_key = key_content
+        .lines()
+        .find(|l| l.starts_with("# public key:"))
+        .and_then(|l| l.strip_prefix("# public key: "))
+        .ok_or_else(|| anyhow::anyhow!("Could not extract public key"))?;
+
+    let sops_config = format!(
+        r#"creation_rules:
+  - path_regex: \.sops\.yaml$
+    age: "{public_key}"
+"#
+    );
+    let sops_config_path = Path::new(".sops.yaml");
+    std::fs::write(sops_config_path, sops_config)?;
+    println!("Updated .sops.yaml with new public key.");
+
+    // 5. Re-encrypt secrets with new key
+    let yaml = serde_yml::to_string(&secrets)?;
+    std::fs::write(&sops_path, yaml)?;
+
+    let encrypt = std::process::Command::new("sops")
+        .args(["--encrypt", "--in-place", &sops_path.display().to_string()])
+        .output()?;
+
+    if !encrypt.status.success() {
+        anyhow::bail!(
+            "Failed to re-encrypt with new key: {}",
+            String::from_utf8_lossy(&encrypt.stderr)
+        );
+    }
+
+    println!("Secrets re-encrypted with new key.");
+    println!("\nDon't forget to update SOPS_AGE_KEY_FILE if needed.");
+    println!(
+        "You can delete the backup when confirmed: rm {}",
+        backup_path.display()
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Wire `swarm config secrets init` to generate age key, create `.sops.yaml`, and encrypt template secrets file
- Wire `swarm config secrets rotate` to decrypt, re-key, and re-encrypt
- Wire `swarm config providers` to show provider config, secrets status, and env var status
- Update documentation with full secret management workflow

## Commands

| Command | Description |
|---|---|
| `swarm config providers` | Show provider config, secrets status (encrypted/plain/missing), env var status |
| `swarm config secrets init` | Generate age key pair + `.sops.yaml` + encrypted `providers.sops.yaml` template |
| `swarm config secrets rotate` | Decrypt current secrets, generate new key, re-encrypt, backup old key |

## Secret resolution order

1. Environment variables (`ANTHROPIC_API_KEY`, etc.)
2. SOPS-encrypted file (`config/providers.sops.yaml`)
3. Plain file (`config/providers.secret.yaml`, gitignored)

Closes #23

## Test plan

- [ ] `cargo test` — 18 tests pass
- [ ] `cargo clippy` — clean in both CI and full feature modes
- [ ] `swarm config providers` — shows config and env var status
- [ ] `swarm config secrets init` — generates age key and .sops.yaml (requires age + sops installed)
- [ ] `swarm config secrets rotate` — rotates key and re-encrypts (requires existing setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)