### PR TITLE
feat: add web UI dashboard for fleet management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Heavy optional dependencies are gated behind feature flags to keep CI fast (~1mi
 | `tui` | ratatui, crossterm | TUI dashboard |
 | `storage` | surrealdb (in-memory) | Embedded DB |
 | `storage-rocksdb` | surrealdb + RocksDB | Persistent storage (C++ build) |
+| `web` | axum, tower-http | Web UI dashboard |
 | `providers-api` | reqwest | HTTP-based LLM providers |
 
 Default features: `tui`, `storage-rocksdb`, `providers-api`. CI build uses `--no-default-features --features tui,storage` to skip RocksDB.
@@ -54,6 +55,7 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`. Sever
 - `core/` — Domain types: `Agent`, `AgentMetadata`, `Task`, `SharedContext`, `Coordinator`, `Pipeline`.
 - `storage/` — SurrealDB wrapper. `schema.rs` defines tables (`runs`, `agent_stats`), `queries.rs` has CRUD operations.
 - `tui/` — Ratatui-based terminal UI. `app.rs` holds state (incl. command palette), `views/` renders tabs (Agents/Detail/History/Costs + shortcuts bar + command palette overlay), `widgets/` provides reusable components.
+- `web/` — Axum-based web UI. Embedded single-page HTML app with JSON API endpoints (`/api/agents`, `/api/history`, `/api/costs`).
 - `secrets/` — SOPS + age encrypted secrets loader.
 
 **Provider trait** (`providers/traits.rs`):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1958,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +1983,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2544,6 +2603,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -4193,6 +4258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,6 +4763,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "clap_complete",
@@ -4702,6 +4779,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -5136,6 +5214,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5174,6 +5253,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [features]
 default = ["tui", "storage-rocksdb", "providers-api"]
 tui = ["dep:ratatui", "dep:crossterm"]
+web = ["dep:axum", "dep:tower-http"]
 storage = ["dep:surrealdb"]
 storage-rocksdb = ["storage", "surrealdb/kv-rocksdb"]
 providers-api = ["dep:reqwest"]
@@ -30,8 +31,12 @@ clap_complete = "4"
 ratatui = { version = "0.30", optional = true }
 crossterm = { version = "0.29", optional = true }
 
-# HTTP (optional — enable with `providers-api` feature)
+# HTTP client (optional — enable with `providers-api` feature)
 reqwest = { version = "0.12", features = ["json", "stream"], optional = true }
+
+# HTTP server (optional — enable with `web` feature)
+axum = { version = "0.8", optional = true }
+tower-http = { version = "0.6", features = ["cors"], optional = true }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ swarm run my-assistant "Explain how async/await works in Rust"
 | `swarm config secrets init` | Initialize SOPS + age encryption | Done |
 | `swarm config secrets rotate` | Rotate age encryption key | Done |
 | `swarm tui` | Launch the TUI dashboard | Done |
+| `swarm web [--port N]` | Launch the web UI | Done |
 | `swarm completion <shell>` | Generate shell completions | Done |
 | `swarm up / down` | Start/stop infra (Docker Compose) | Done |
 
@@ -235,6 +236,21 @@ Launch with `swarm tui`. The dashboard provides fleet management views:
 | `r` | Refresh data |
 | `q` / `Esc` | Quit |
 
+## Web UI
+
+Launch with `swarm web` (default port 3000):
+
+```bash
+swarm web              # http://localhost:3000
+swarm web --port 8080  # custom port
+```
+
+The web UI provides a read-only dashboard for your agent fleet:
+
+- **Agents** — browse all loaded agents, click to view full configuration
+- **History** — execution history with tokens, costs, and duration
+- **Costs** — aggregated cost summary per agent
+
 ## Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed technical documentation.
@@ -242,7 +258,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed technical documentation.
 ```
 HOST MACHINE
 ├── swarm (native binary)
-│   ├── CLI + TUI
+│   ├── CLI + TUI + Web UI
 │   ├── Providers (API / CLI / Proxy)
 │   ├── SurrealDB (embedded)
 │   └── SOPS + age secrets
@@ -259,6 +275,7 @@ Heavy dependencies are gated behind optional feature flags for faster compilatio
 | Feature | Default | Description |
 |---|---|---|
 | `tui` | Yes | TUI dashboard (ratatui + crossterm) |
+| `web` | No | Web UI dashboard (axum + tower-http) |
 | `storage` | Yes* | SurrealDB with in-memory backend |
 | `storage-rocksdb` | Yes | SurrealDB with persistent RocksDB backend |
 | `providers-api` | Yes | HTTP API providers (Anthropic, OpenAI, Google) |

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -97,6 +97,21 @@ swarm tui
 
 Use `Tab`/`Shift+Tab` to switch views, `j`/`k` to navigate, `Enter` to view agent details, `:` to open the command palette, and `q` to quit.
 
+## Web UI
+
+For a browser-based dashboard:
+
+```bash
+swarm web              # http://localhost:3000
+swarm web --port 8080  # custom port
+```
+
+Browse agents, view execution history, and track costs from your browser. Requires the `web` feature flag (not enabled by default):
+
+```bash
+cargo build --release --features web
+```
+
 ## Next Steps
 
 - [Agent Format](agent-format.md) — full reference for agent Markdown files

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -88,6 +88,13 @@ pub enum Command {
     /// Launch the TUI dashboard
     #[cfg(feature = "tui")]
     Tui,
+    /// Launch the web UI
+    #[cfg(feature = "web")]
+    Web {
+        /// Port to listen on
+        #[arg(long, short, default_value = "3000")]
+        port: u16,
+    },
     /// Start infrastructure services (Docker Compose)
     Up,
     /// Stop infrastructure services (Docker Compose)
@@ -117,6 +124,8 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         Command::Config { action } => config::execute(action).await,
         #[cfg(feature = "tui")]
         Command::Tui => crate::tui::run().await,
+        #[cfg(feature = "web")]
+        Command::Web { port } => crate::web::serve(port).await,
         Command::Up => up::start().await,
         Command::Down => up::stop().await,
         Command::Completion { shell } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod secrets;
 mod storage;
 #[cfg(feature = "tui")]
 mod tui;
+#[cfg(feature = "web")]
+mod web;
 
 use clap::Parser;
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1,0 +1,179 @@
+use axum::Json;
+use axum::extract::Path;
+use serde::Serialize;
+
+use crate::core::agent::Agent;
+
+#[derive(Serialize)]
+pub struct AgentSummary {
+    name: String,
+    provider: String,
+    model: String,
+    tags: Vec<String>,
+    stacks: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct AgentDetail {
+    name: String,
+    source: String,
+    provider: String,
+    model: String,
+    tags: Vec<String>,
+    stacks: Vec<String>,
+    temperature: f32,
+    max_tokens: Option<u32>,
+    timeout: Option<u64>,
+    rate_limit: Option<String>,
+    system_prompt: String,
+    instructions: Option<String>,
+    output_format: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct HistoryEntry {
+    agent: String,
+    provider: String,
+    model: String,
+    tokens_in: i64,
+    tokens_out: i64,
+    cost: f64,
+    duration_ms: i64,
+    status: String,
+}
+
+#[derive(Serialize)]
+pub struct CostSummary {
+    agent: String,
+    total_runs: i64,
+    total_cost: f64,
+    total_tokens_in: i64,
+    total_tokens_out: i64,
+}
+
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    error: String,
+}
+
+fn load_agents() -> Vec<Agent> {
+    let agents_dir = std::path::Path::new("agents");
+    Agent::load_all(agents_dir).unwrap_or_default()
+}
+
+pub async fn list_agents() -> Json<Vec<AgentSummary>> {
+    let agents = load_agents();
+    let summaries = agents
+        .into_iter()
+        .map(|a| {
+            let model = a.model_display();
+            AgentSummary {
+                name: a.name,
+                provider: a.metadata.provider,
+                model,
+                tags: a.metadata.tags,
+                stacks: a.metadata.stacks,
+            }
+        })
+        .collect();
+    Json(summaries)
+}
+
+pub async fn get_agent(Path(name): Path<String>) -> Json<serde_json::Value> {
+    let agents = load_agents();
+    match agents
+        .into_iter()
+        .find(|a| a.name.eq_ignore_ascii_case(&name))
+    {
+        Some(a) => {
+            let model = a.model_display();
+            let detail = AgentDetail {
+                name: a.name,
+                source: a.source.display().to_string(),
+                provider: a.metadata.provider,
+                model,
+                tags: a.metadata.tags,
+                stacks: a.metadata.stacks,
+                temperature: a.metadata.temperature,
+                max_tokens: a.metadata.max_tokens,
+                timeout: a.metadata.timeout,
+                rate_limit: a.metadata.rate_limit,
+                system_prompt: a.system_prompt,
+                instructions: a.instructions,
+                output_format: a.output_format,
+            };
+            Json(serde_json::to_value(detail).unwrap())
+        }
+        None => Json(
+            serde_json::to_value(ErrorResponse {
+                error: format!("Agent '{name}' not found"),
+            })
+            .unwrap(),
+        ),
+    }
+}
+
+#[cfg(feature = "storage")]
+pub async fn get_history() -> Json<Vec<HistoryEntry>> {
+    use crate::storage::{init_db, queries};
+
+    let db = match init_db().await {
+        Ok(db) => db,
+        Err(_) => return Json(vec![]),
+    };
+
+    match queries::get_history(&db, None, 100).await {
+        Ok(records) => Json(
+            records
+                .into_iter()
+                .map(|r| HistoryEntry {
+                    agent: r.agent,
+                    provider: r.provider,
+                    model: r.model,
+                    tokens_in: r.tokens_in,
+                    tokens_out: r.tokens_out,
+                    cost: r.cost,
+                    duration_ms: r.duration_ms,
+                    status: r.status,
+                })
+                .collect(),
+        ),
+        Err(_) => Json(vec![]),
+    }
+}
+
+#[cfg(not(feature = "storage"))]
+pub async fn get_history() -> Json<Vec<HistoryEntry>> {
+    Json(vec![])
+}
+
+#[cfg(feature = "storage")]
+pub async fn get_costs() -> Json<Vec<CostSummary>> {
+    use crate::storage::{init_db, queries};
+
+    let db = match init_db().await {
+        Ok(db) => db,
+        Err(_) => return Json(vec![]),
+    };
+
+    match queries::get_costs_summary(&db, None).await {
+        Ok(summaries) => Json(
+            summaries
+                .into_iter()
+                .map(|s| CostSummary {
+                    agent: s.agent,
+                    total_runs: s.total_runs,
+                    total_cost: s.total_cost,
+                    total_tokens_in: s.total_tokens_in,
+                    total_tokens_out: s.total_tokens_out,
+                })
+                .collect(),
+        ),
+        Err(_) => Json(vec![]),
+    }
+}
+
+#[cfg(not(feature = "storage"))]
+pub async fn get_costs() -> Json<Vec<CostSummary>> {
+    Json(vec![])
+}

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>swarm-festai</title>
+<style>
+  :root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --green: #3fb950; --yellow: #d29922; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
+  header { background: var(--surface); border-bottom: 1px solid var(--border); padding: 12px 24px; display: flex; align-items: center; gap: 16px; }
+  header h1 { font-size: 18px; font-weight: 600; }
+  header h1 span { color: var(--accent); }
+  nav { display: flex; gap: 4px; }
+  nav button { background: none; border: 1px solid transparent; color: var(--muted); padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 14px; }
+  nav button:hover { color: var(--text); }
+  nav button.active { background: var(--bg); border-color: var(--border); color: var(--text); }
+  main { max-width: 1200px; margin: 24px auto; padding: 0 24px; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  .card-header { padding: 12px 16px; border-bottom: 1px solid var(--border); font-weight: 600; font-size: 14px; color: var(--muted); }
+  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  th { text-align: left; padding: 8px 16px; color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid var(--border); }
+  td { padding: 10px 16px; border-bottom: 1px solid var(--border); }
+  tr:last-child td { border-bottom: none; }
+  tr:hover td { background: rgba(88,166,255,0.04); }
+  .tag { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 12px; background: rgba(88,166,255,0.15); color: var(--accent); margin-right: 4px; }
+  .tag.stack { background: rgba(63,185,80,0.15); color: var(--green); }
+  .clickable { cursor: pointer; }
+  .clickable:hover td:first-child { color: var(--accent); }
+  .detail { padding: 20px; }
+  .detail h2 { font-size: 20px; margin-bottom: 16px; }
+  .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 20px; }
+  .detail-field label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; text-transform: uppercase; }
+  .detail-field span { font-size: 14px; }
+  .prompt-box { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 16px; font-size: 14px; white-space: pre-wrap; line-height: 1.6; margin-bottom: 16px; }
+  .prompt-box-title { font-size: 12px; color: var(--muted); text-transform: uppercase; margin-bottom: 8px; }
+  .back-btn { background: none; border: 1px solid var(--border); color: var(--text); padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px; margin-bottom: 16px; }
+  .back-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .empty { padding: 40px; text-align: center; color: var(--muted); }
+  .cost { color: var(--yellow); }
+  #view { display: none; }
+</style>
+</head>
+<body>
+<header>
+  <h1><span>swarm</span>-festai</h1>
+  <nav>
+    <button class="active" onclick="showTab('agents')">Agents</button>
+    <button onclick="showTab('history')">History</button>
+    <button onclick="showTab('costs')">Costs</button>
+  </nav>
+</header>
+<main>
+  <div id="agents" class="card"></div>
+  <div id="history" class="card" style="display:none"></div>
+  <div id="costs" class="card" style="display:none"></div>
+  <div id="view" class="card"></div>
+</main>
+<script>
+let currentTab = 'agents';
+
+function showTab(tab) {
+  document.querySelectorAll('nav button').forEach(b => b.classList.remove('active'));
+  event.target.classList.add('active');
+  ['agents','history','costs','view'].forEach(id => document.getElementById(id).style.display = 'none');
+  document.getElementById(tab).style.display = 'block';
+  currentTab = tab;
+  if (tab === 'agents') loadAgents();
+  if (tab === 'history') loadHistory();
+  if (tab === 'costs') loadCosts();
+}
+
+async function loadAgents() {
+  const res = await fetch('/api/agents');
+  const agents = await res.json();
+  const el = document.getElementById('agents');
+  if (!agents.length) { el.innerHTML = '<div class="empty">No agents found. Create one with: swarm new my-agent</div>'; return; }
+  el.innerHTML = `
+    <div class="card-header">${agents.length} agents loaded</div>
+    <table>
+      <tr><th>Agent</th><th>Provider</th><th>Model</th><th>Tags</th><th>Stacks</th></tr>
+      ${agents.map(a => `
+        <tr class="clickable" onclick="viewAgent('${a.name}')">
+          <td>${a.name}</td>
+          <td>${a.provider}</td>
+          <td>${a.model}</td>
+          <td>${a.tags.map(t => `<span class="tag">${t}</span>`).join('')}</td>
+          <td>${a.stacks.map(s => `<span class="tag stack">${s}</span>`).join('')}</td>
+        </tr>`).join('')}
+    </table>`;
+}
+
+async function viewAgent(name) {
+  const res = await fetch(`/api/agents/${encodeURIComponent(name)}`);
+  const a = await res.json();
+  if (a.error) return;
+  ['agents','history','costs'].forEach(id => document.getElementById(id).style.display = 'none');
+  const el = document.getElementById('view');
+  el.style.display = 'block';
+  el.innerHTML = `
+    <div class="detail">
+      <button class="back-btn" onclick="backToList()">&larr; Back to agents</button>
+      <h2>${a.name}</h2>
+      <div class="detail-grid">
+        <div class="detail-field"><label>Provider</label><span>${a.provider}</span></div>
+        <div class="detail-field"><label>Model</label><span>${a.model}</span></div>
+        <div class="detail-field"><label>Temperature</label><span>${a.temperature}</span></div>
+        <div class="detail-field"><label>Max Tokens</label><span>${a.max_tokens || 'default'}</span></div>
+        <div class="detail-field"><label>Timeout</label><span>${a.timeout ? a.timeout + 's' : 'default'}</span></div>
+        <div class="detail-field"><label>Rate Limit</label><span>${a.rate_limit || 'none'}</span></div>
+        <div class="detail-field"><label>Tags</label><span>${a.tags.map(t => `<span class="tag">${t}</span>`).join('') || 'none'}</span></div>
+        <div class="detail-field"><label>Stacks</label><span>${a.stacks.map(s => `<span class="tag stack">${s}</span>`).join('') || 'none'}</span></div>
+      </div>
+      <div class="prompt-box-title">System Prompt</div>
+      <div class="prompt-box">${a.system_prompt || '(none)'}</div>
+      ${a.instructions ? `<div class="prompt-box-title">Instructions</div><div class="prompt-box">${a.instructions}</div>` : ''}
+      ${a.output_format ? `<div class="prompt-box-title">Output Format</div><div class="prompt-box">${a.output_format}</div>` : ''}
+      <div class="detail-field" style="margin-top:12px"><label>Source</label><span style="color:var(--muted)">${a.source}</span></div>
+    </div>`;
+}
+
+function backToList() {
+  document.getElementById('view').style.display = 'none';
+  document.getElementById('agents').style.display = 'block';
+}
+
+async function loadHistory() {
+  const res = await fetch('/api/history');
+  const history = await res.json();
+  const el = document.getElementById('history');
+  if (!history.length) { el.innerHTML = '<div class="empty">No execution history yet.</div>'; return; }
+  el.innerHTML = `
+    <div class="card-header">${history.length} runs</div>
+    <table>
+      <tr><th>Agent</th><th>Provider</th><th>Model</th><th>Tokens In</th><th>Tokens Out</th><th>Cost</th><th>Duration</th><th>Status</th></tr>
+      ${history.map(h => `
+        <tr>
+          <td>${h.agent}</td>
+          <td>${h.provider}</td>
+          <td>${h.model}</td>
+          <td>${h.tokens_in}</td>
+          <td>${h.tokens_out}</td>
+          <td class="cost">$${h.cost.toFixed(6)}</td>
+          <td>${h.duration_ms}ms</td>
+          <td>${h.status}</td>
+        </tr>`).join('')}
+    </table>`;
+}
+
+async function loadCosts() {
+  const res = await fetch('/api/costs');
+  const costs = await res.json();
+  const el = document.getElementById('costs');
+  if (!costs.length) { el.innerHTML = '<div class="empty">No cost data yet.</div>'; return; }
+  const total = costs.reduce((s, c) => s + c.total_cost, 0);
+  el.innerHTML = `
+    <div class="card-header">Cost summary &mdash; total: <span class="cost">$${total.toFixed(4)}</span></div>
+    <table>
+      <tr><th>Agent</th><th>Runs</th><th>Cost (USD)</th><th>Tokens In</th><th>Tokens Out</th></tr>
+      ${costs.map(c => `
+        <tr>
+          <td>${c.agent}</td>
+          <td>${c.total_runs}</td>
+          <td class="cost">$${c.total_cost.toFixed(6)}</td>
+          <td>${c.total_tokens_in}</td>
+          <td>${c.total_tokens_out}</td>
+        </tr>`).join('')}
+    </table>`;
+}
+
+// Initial load
+loadAgents();
+</script>
+</body>
+</html>

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,0 +1,26 @@
+mod api;
+
+use axum::{Router, response::Html, routing::get};
+use tower_http::cors::CorsLayer;
+
+/// Serve the web UI on the given port.
+pub async fn serve(port: u16) -> anyhow::Result<()> {
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/api/agents", get(api::list_agents))
+        .route("/api/agents/{name}", get(api::get_agent))
+        .route("/api/history", get(api::get_history))
+        .route("/api/costs", get(api::get_costs))
+        .layer(CorsLayer::permissive());
+
+    let addr = format!("0.0.0.0:{port}");
+    println!("Web UI available at: http://localhost:{port}");
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn index() -> Html<&'static str> {
+    Html(include_str!("index.html"))
+}


### PR DESCRIPTION
## Summary
- Add axum-based web UI behind `web` feature flag (`swarm web [--port N]`)
- Embedded single-page HTML app with dark theme, agent browser with click-to-detail, execution history, and cost tracking
- JSON API endpoints: `/api/agents`, `/api/agents/{name}`, `/api/history`, `/api/costs`
- Update README, wiki, and CLAUDE.md with web UI documentation

Closes #36

## Test plan
- [ ] `cargo clippy --no-default-features --features "tui,web"` passes
- [ ] `cargo clippy --no-default-features --features tui` passes (no web)
- [ ] `cargo test --no-default-features --features tui` — 18 tests pass
- [ ] `swarm web` starts server on port 3000
- [ ] Browse to http://localhost:3000 — agents list loads
- [ ] Click agent row — detail view opens
- [ ] History and Costs tabs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)