### PR TITLE
docs: enrich CLI help text with long descriptions and examples

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -4,9 +4,14 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum ConfigAction {
-    /// Manage provider configurations
+    /// Show provider status, API keys, and environment variables
     Providers,
     /// Initialize or manage secrets (SOPS + age)
+    #[command(
+        long_about = "Initialize or manage secrets (SOPS + age).\n\n\
+            Uses age for key generation and SOPS for encrypting provider API keys. \
+            Secrets are stored in config/providers.sops.yaml."
+    )]
     Secrets {
         #[command(subcommand)]
         action: SecretsAction,
@@ -15,9 +20,9 @@ pub enum ConfigAction {
 
 #[derive(Subcommand)]
 pub enum SecretsAction {
-    /// Initialize SOPS + age encryption for this project
+    /// Generate an age key and .sops.yaml, create encrypted secrets template
     Init,
-    /// Rotate the age encryption key
+    /// Decrypt secrets, generate a new age key, and re-encrypt
     Rotate,
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -7,11 +7,9 @@ pub enum ConfigAction {
     /// Show provider status, API keys, and environment variables
     Providers,
     /// Initialize or manage secrets (SOPS + age)
-    #[command(
-        long_about = "Initialize or manage secrets (SOPS + age).\n\n\
+    #[command(long_about = "Initialize or manage secrets (SOPS + age).\n\n\
             Uses age for key generation and SOPS for encrypting provider API keys. \
-            Secrets are stored in config/providers.sops.yaml."
-    )]
+            Secrets are stored in config/providers.sops.yaml.")]
     Secrets {
         #[command(subcommand)]
         action: SecretsAction,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,22 @@ mod validate;
 use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "swarm", about = "AI agent fleet orchestrator", version)]
+#[command(
+    name = "swarm",
+    about = "AI agent fleet orchestrator",
+    long_about = "AI agent fleet orchestrator — define, manage and run specialized agents from Markdown files.\n\n\
+        Each agent is a .md file in agents/ with metadata, system prompt, and optional instructions.\n\
+        Supports any LLM provider (Claude, GPT, Gemini) via CLI tools or API.",
+    version,
+    after_help = "Examples:\n  \
+        swarm new my-agent --template dev-review --stack rust\n  \
+        swarm run my-agent \"Review this code for bugs\"\n  \
+        swarm run --pipe reviewer writer src/main.rs\n  \
+        swarm list --tags dev --stack rust\n  \
+        swarm tui\n  \
+        swarm web --port 8080\n\n\
+        Documentation: https://github.com/Dr0drigues/swarm-festai"
+)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
@@ -20,6 +35,16 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Command {
     /// Run an agent with the given input
+    #[command(
+        long_about = "Run an agent with the given input.\n\n\
+            Loads the agent definition from agents/<name>.md, sends the input to the \
+            configured provider, and prints the response. Use --pipe to chain multiple \
+            agents sequentially (output of one becomes input of the next).",
+        after_help = "Examples:\n  \
+            swarm run code-reviewer \"Review this function\"\n  \
+            swarm run summarizer @long-document.txt\n  \
+            swarm run --pipe reviewer writer src/main.rs"
+    )]
     Run {
         /// Agent name (filename without .md)
         agent: String,
@@ -30,6 +55,16 @@ pub enum Command {
         pipe: Option<Vec<String>>,
     },
     /// Create a new agent from a template
+    #[command(
+        long_about = "Create a new agent from a template.\n\n\
+            Available templates: basic, dev-review, dev-test, cli-generic, planning, \
+            security-review, debug, tech-debt, tdd-red, tdd-green, tdd-refactor, tech-writer.\n\
+            The new agent is created at agents/<name>.md.",
+        after_help = "Examples:\n  \
+            swarm new my-assistant\n  \
+            swarm new reviewer --template dev-review --stack rust\n  \
+            swarm new scanner --template security-review -d \"audit OWASP top 10\""
+    )]
     New {
         /// Agent name
         name: String,
@@ -44,6 +79,10 @@ pub enum Command {
         description: Option<String>,
     },
     /// List available agents
+    #[command(after_help = "Examples:\n  \
+        swarm list\n  \
+        swarm list --tags dev review\n  \
+        swarm list --stack rust")]
     List {
         /// Filter by tags
         #[arg(long)]
@@ -53,16 +92,30 @@ pub enum Command {
         stack: Option<String>,
     },
     /// Inspect an agent's parsed configuration
+    #[command(
+        long_about = "Inspect an agent's parsed configuration.\n\n\
+            Displays the fully parsed agent definition: metadata, system prompt, \
+            instructions, output format, and pipeline configuration."
+    )]
     Inspect {
         /// Agent name
         agent: String,
     },
     /// Validate agent config without making API calls (dry-run)
+    #[command(
+        long_about = "Validate agent config without making API calls (dry-run).\n\n\
+            Checks that the Markdown file parses correctly and all required fields are present. \
+            If no agent name is given, validates all agents in the agents/ directory."
+    )]
     Validate {
         /// Agent name (validates all if omitted)
         agent: Option<String>,
     },
     /// View execution history
+    #[command(after_help = "Examples:\n  \
+        swarm history\n  \
+        swarm history --agent code-reviewer\n  \
+        swarm history --replay abc123")]
     History {
         /// Filter by agent name
         #[arg(long)]
@@ -72,6 +125,10 @@ pub enum Command {
         replay: Option<String>,
     },
     /// View cost tracking
+    #[command(after_help = "Examples:\n  \
+        swarm costs\n  \
+        swarm costs --agent code-reviewer\n  \
+        swarm costs --from 2025-01-01")]
     Costs {
         /// Filter by agent name
         #[arg(long)]
@@ -81,25 +138,55 @@ pub enum Command {
         from: Option<String>,
     },
     /// Manage providers and secrets
+    #[command(
+        long_about = "Manage providers and secrets.\n\n\
+            Configure API keys, view provider status, and manage SOPS + age encryption.",
+        after_help = "Examples:\n  \
+            swarm config providers\n  \
+            swarm config secrets init\n  \
+            swarm config secrets rotate"
+    )]
     Config {
         #[command(subcommand)]
         action: config::ConfigAction,
     },
     /// Launch the TUI dashboard
     #[cfg(feature = "tui")]
+    #[command(
+        long_about = "Launch the TUI dashboard.\n\n\
+            Interactive terminal interface for browsing agents, viewing history and costs. \
+            Use Tab/Shift+Tab or 1-4 to switch views, j/k to navigate, Enter for details, \
+            : or Ctrl+P for command palette, q to quit."
+    )]
     Tui,
     /// Launch the web UI
     #[cfg(feature = "web")]
+    #[command(
+        long_about = "Launch the web UI.\n\n\
+            Starts an HTTP server with a browser-based dashboard for browsing agents, \
+            viewing execution history, and tracking costs.",
+        after_help = "Examples:\n  \
+            swarm web\n  \
+            swarm web --port 8080"
+    )]
     Web {
         /// Port to listen on
         #[arg(long, short, default_value = "3000")]
         port: u16,
     },
     /// Start infrastructure services (Docker Compose)
+    #[command(long_about = "Start infrastructure services (Docker Compose).\n\n\
+        Starts SurrealDB and LiteLLM proxy containers defined in docker-compose.yml.")]
     Up,
     /// Stop infrastructure services (Docker Compose)
+    #[command(long_about = "Stop infrastructure services (Docker Compose).\n\n\
+        Stops and removes the containers started by 'swarm up'.")]
     Down,
     /// Generate shell completion scripts
+    #[command(after_help = "Examples:\n  \
+        swarm completion bash > ~/.local/share/bash-completion/completions/swarm\n  \
+        swarm completion zsh > ~/.zfunc/_swarm\n  \
+        swarm completion fish > ~/.config/fish/completions/swarm.fish")]
     Completion {
         /// Shell to generate completions for
         #[arg(value_enum)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -92,11 +92,9 @@ pub enum Command {
         stack: Option<String>,
     },
     /// Inspect an agent's parsed configuration
-    #[command(
-        long_about = "Inspect an agent's parsed configuration.\n\n\
+    #[command(long_about = "Inspect an agent's parsed configuration.\n\n\
             Displays the fully parsed agent definition: metadata, system prompt, \
-            instructions, output format, and pipeline configuration."
-    )]
+            instructions, output format, and pipeline configuration.")]
     Inspect {
         /// Agent name
         agent: String,
@@ -152,12 +150,10 @@ pub enum Command {
     },
     /// Launch the TUI dashboard
     #[cfg(feature = "tui")]
-    #[command(
-        long_about = "Launch the TUI dashboard.\n\n\
+    #[command(long_about = "Launch the TUI dashboard.\n\n\
             Interactive terminal interface for browsing agents, viewing history and costs. \
             Use Tab/Shift+Tab or 1-4 to switch views, j/k to navigate, Enter for details, \
-            : or Ctrl+P for command palette, q to quit."
-    )]
+            : or Ctrl+P for command palette, q to quit.")]
     Tui,
     /// Launch the web UI
     #[cfg(feature = "web")]


### PR DESCRIPTION
## Summary
- Add `long_about` and `after_help` to main CLI and all subcommands
- `swarm help` now shows project description, agent file format overview, and usage examples
- Each subcommand help (`swarm help run`, `swarm help new`, etc.) shows detailed descriptions and examples
- `swarm config` subcommands (`providers`, `secrets init`, `secrets rotate`) get clearer descriptions

## Test plan
- [ ] `cargo clippy --no-default-features --features tui` passes
- [ ] `cargo test --no-default-features --features tui` — 18 tests pass
- [ ] `swarm help` shows long description and examples section
- [ ] `swarm help run` shows examples
- [ ] `swarm help new` lists available templates
- [ ] `swarm help config` shows examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)