### PR TITLE
chore: enable web feature by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Heavy optional dependencies are gated behind feature flags to keep CI fast (~1mi
 | `web` | axum, tower-http | Web UI dashboard |
 | `providers-api` | reqwest | HTTP-based LLM providers |
 
-Default features: `tui`, `storage-rocksdb`, `providers-api`. CI build uses `--no-default-features --features tui,storage` to skip RocksDB.
+Default features: `tui`, `web`, `storage-rocksdb`, `providers-api`. CI build uses `--no-default-features --features tui,storage` to skip RocksDB.
 
 Code that depends on optional features must use `#[cfg(feature = "...")]`. Several modules in `main.rs` use `#[allow(dead_code)]` because they are scaffolded but not fully wired yet.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "swarm"
 path = "src/main.rs"
 
 [features]
-default = ["tui", "storage-rocksdb", "providers-api"]
+default = ["tui", "web", "storage-rocksdb", "providers-api"]
 tui = ["dep:ratatui", "dep:crossterm"]
 web = ["dep:axum", "dep:tower-http"]
 storage = ["dep:surrealdb"]

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Heavy dependencies are gated behind optional feature flags for faster compilatio
 | Feature | Default | Description |
 |---|---|---|
 | `tui` | Yes | TUI dashboard (ratatui + crossterm) |
-| `web` | No | Web UI dashboard (axum + tower-http) |
+| `web` | Yes | Web UI dashboard (axum + tower-http) |
 | `storage` | Yes* | SurrealDB with in-memory backend |
 | `storage-rocksdb` | Yes | SurrealDB with persistent RocksDB backend |
 | `providers-api` | Yes | HTTP API providers (Anthropic, OpenAI, Google) |

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -106,11 +106,7 @@ swarm web              # http://localhost:3000
 swarm web --port 8080  # custom port
 ```
 
-Browse agents, view execution history, and track costs from your browser. Requires the `web` feature flag (not enabled by default):
-
-```bash
-cargo build --release --features web
-```
+Browse agents, view execution history, and track costs from your browser. The `web` feature is enabled by default.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Add `web` to default features in Cargo.toml so `cargo build --release` includes `swarm web`
- Update README, CLAUDE.md, and wiki to reflect the change

## Test plan
- [ ] `cargo build --release` includes `swarm web` subcommand
- [ ] `cargo build --release --no-default-features --features tui` still works without web

🤖 Generated with [Claude Code](https://claude.com/claude-code)