### PR TITLE
feat: add interactive agent creation and fleet management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1221,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1346,12 @@ checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -4358,6 +4390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4768,6 +4806,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "dialoguer",
  "pulldown-cmark",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = "0.1"
 # CLI
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+dialoguer = "0.11"
 
 # TUI (optional — enable with `tui` feature)
 ratatui = { version = "0.30", optional = true }

--- a/docs/ai-agent-prompt.md
+++ b/docs/ai-agent-prompt.md
@@ -1,0 +1,149 @@
+# Swarm Agent Creation Guide
+
+> Universal prompt for any AI assistant (Claude Code, Gemini CLI, Cursor, Copilot, etc.)
+> to help users create valid swarm agent files.
+
+## What is a Swarm Agent?
+
+A swarm agent is a Markdown file (`.md`) that defines an AI-powered specialist. Each agent has a role, a provider, and a system prompt. Agents live in the `agents/` directory and can be run with `swarm run <name> "<input>"`.
+
+## Agent File Format
+
+```markdown
+# Agent Display Name
+
+## Metadata
+- provider: <provider>
+- model: <model>
+- temperature: <0.0 - 2.0>
+- max_tokens: <integer>
+- tags: [tag1, tag2]
+- stacks: [rust, python]
+
+## System Prompt
+
+<The system prompt defining the agent's role and behavior.>
+
+## Instructions
+
+<Optional step-by-step execution instructions.>
+
+## Output Format
+
+<Optional description of expected output structure.>
+```
+
+## Valid Providers
+
+| Provider | Type | Requires |
+|----------|------|----------|
+| `claude` | Unified (CLI or API) | Auto-detects Claude CLI or falls back to Anthropic API |
+| `gemini` | Unified (CLI or API) | Auto-detects Gemini CLI or falls back to Google API |
+| `gpt` | Unified (CLI or API) | Auto-detects GPT CLI or falls back to OpenAI API |
+| `aider` | Unified (CLI or API) | Auto-detects aider CLI or falls back to OpenAI API |
+| `anthropic` | API only | `model` field, `ANTHROPIC_API_KEY` env var |
+| `openai` | API only | `model` field, `OPENAI_API_KEY` env var |
+| `google` | API only | `model` field, `GOOGLE_API_KEY` env var |
+| `cli` | CLI only | `command` field (e.g. `command: claude`) |
+| `proxy` | API proxy | `model` field, proxy running via `swarm up` |
+
+## Known Models
+
+**Anthropic**: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`
+**OpenAI**: `gpt-4o`, `gpt-4o-mini`, `o1`, `o3-mini`
+**Google**: `gemini-2.0-flash`, `gemini-2.0-pro`
+
+## Temperature Guide
+
+| Preset | Value | Best for |
+|--------|-------|----------|
+| Focused | 0.2 | Code review, analysis, factual tasks |
+| Balanced | 0.5 | General-purpose, moderate creativity |
+| Creative | 0.7 | Writing, brainstorming, ideation |
+
+Range: 0.0 (deterministic) to 2.0 (maximum randomness).
+
+## Creation Flow
+
+When helping a user create a swarm agent, ask these questions in order:
+
+1. **Name**: What should the agent be called? (slug format: `my-agent-name`)
+2. **Provider**: Which LLM provider? (claude, gemini, gpt, anthropic, openai, google, cli, proxy)
+3. **Model**: Which model? (suggest based on provider — see Known Models above)
+4. **Temperature**: What creativity level? (Focused 0.2 / Balanced 0.5 / Creative 0.7)
+5. **Max tokens**: Set a limit? (optional, e.g. 4096)
+6. **Tags**: Categories for filtering? (comma-separated, e.g. `dev, review`)
+7. **Stacks**: Tech stacks? (comma-separated, e.g. `rust, typescript`)
+8. **System prompt**: What is the agent's role and expertise?
+9. **Instructions**: Step-by-step process? (optional)
+10. **Output format**: Expected output structure? (optional)
+
+## Naming Convention
+
+- Use kebab-case: `code-reviewer`, `test-writer`, `doc-generator`
+- Only letters, digits, and hyphens
+- The filename becomes the agent ID: `agents/code-reviewer.md` → `swarm run code-reviewer`
+- The H1 heading is the display name: `# Code Reviewer`
+
+## Complete Example
+
+```markdown
+# Rust Code Reviewer
+
+## Metadata
+- provider: claude
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.3
+- max_tokens: 4096
+- tags: [dev, review, quality]
+- stacks: [rust]
+
+## System Prompt
+
+You are an expert Rust code reviewer. You analyze code for bugs, unsafe patterns,
+performance issues, and idiomatic Rust violations. You provide constructive feedback
+with specific line references and concrete fix suggestions.
+
+## Instructions
+
+1. Read the code carefully, understanding the overall structure
+2. Check for common Rust pitfalls (unwrap abuse, unnecessary clones, lifetime issues)
+3. Identify potential panics and error handling gaps
+4. Evaluate performance (unnecessary allocations, missing iterators)
+5. Verify adherence to Rust idioms and conventions
+
+## Output Format
+
+Structured review with sections:
+- **Critical**: Must-fix issues (bugs, panics, UB)
+- **Warning**: Should-fix issues (performance, bad patterns)
+- **Info**: Style and readability suggestions
+
+Each item: severity, location, description, suggested fix.
+```
+
+## Validation
+
+After creating the file, validate it:
+
+```bash
+swarm validate <agent-name>
+```
+
+This checks:
+- Required sections are present (H1 title, Metadata, System Prompt)
+- Provider/model consistency
+- Temperature is within range (0.0 - 2.0)
+
+## Running the Agent
+
+```bash
+# Direct input
+swarm run code-reviewer "Review this function: fn add(a: i32, b: i32) -> i32 { a + b }"
+
+# File input
+swarm run code-reviewer @src/main.rs
+
+# Pipeline (chain agents)
+swarm run --pipe code-reviewer test-writer src/lib.rs
+```

--- a/src/cli/fleet.rs
+++ b/src/cli/fleet.rs
@@ -1,0 +1,320 @@
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+use dialoguer::MultiSelect;
+
+use crate::core::agent::Agent;
+use crate::core::fleet::FleetDefinition;
+
+const FLEET_FILENAME: &str = "swarm.yaml";
+
+#[derive(Subcommand)]
+pub enum FleetAction {
+    /// Create a new fleet from available agents
+    #[command(long_about = "Create a new fleet by selecting agents.\n\n\
+            Agents are picked interactively or via --agents/--tags/--all flags.")]
+    Create {
+        /// Fleet name
+        name: String,
+        /// Agents to include (comma-separated)
+        #[arg(long)]
+        agents: Option<String>,
+        /// Include agents matching these tags
+        #[arg(long)]
+        tags: Option<Vec<String>>,
+        /// Include all agents
+        #[arg(long)]
+        all: bool,
+    },
+    /// Link a fleet to a project directory
+    #[command(
+        long_about = "Create a swarm.yaml in the target directory, linking it to a fleet.\n\n\
+            By default links to the current directory (--local). Use --global to store in \
+            ~/.config/swarm/fleets/ or --path for a specific directory.",
+        after_help = "Examples:\n  \
+            swarm fleet link my-fleet\n  \
+            swarm fleet link my-fleet --global\n  \
+            swarm fleet link my-fleet --path /projects/web-app"
+    )]
+    Link {
+        /// Fleet name
+        name: String,
+        /// Link in current directory (default)
+        #[arg(long, default_value_t = true)]
+        local: bool,
+        /// Link in global config (~/.config/swarm/fleets/)
+        #[arg(long)]
+        global: bool,
+        /// Link in a specific directory
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// List all known fleets (local + global)
+    List,
+    /// Show details of a specific fleet
+    Show {
+        /// Fleet name
+        name: String,
+    },
+}
+
+pub async fn execute(action: FleetAction) -> anyhow::Result<()> {
+    match action {
+        FleetAction::Create {
+            name,
+            agents,
+            tags,
+            all,
+        } => create_fleet(&name, agents.as_deref(), tags.as_deref(), all).await,
+        FleetAction::Link {
+            name, global, path, ..
+        } => link_fleet(&name, global, path.as_deref()),
+        FleetAction::List => list_fleets(),
+        FleetAction::Show { name } => show_fleet(&name),
+    }
+}
+
+/// Create a fleet definition file in the global config directory.
+async fn create_fleet(
+    name: &str,
+    agents_csv: Option<&str>,
+    tags: Option<&[String]>,
+    all: bool,
+) -> anyhow::Result<()> {
+    let agents_dir = Path::new("agents");
+    let available = Agent::load_all(agents_dir)?;
+
+    if available.is_empty() {
+        anyhow::bail!("No agents found in {}", agents_dir.display());
+    }
+
+    let selected_names: Vec<String> = if all {
+        available.iter().map(|a| agent_stem(&a.source)).collect()
+    } else if let Some(csv) = agents_csv {
+        crate::cli::new::parse_comma_list(csv)
+    } else if let Some(tag_filter) = tags {
+        available
+            .iter()
+            .filter(|a| a.matches_tags(tag_filter))
+            .map(|a| agent_stem(&a.source))
+            .collect()
+    } else {
+        // Interactive selection
+        let labels: Vec<String> = available
+            .iter()
+            .map(|a| {
+                let stem = agent_stem(&a.source);
+                let tags_str = if a.metadata.tags.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", a.metadata.tags.join(", "))
+                };
+                format!("{stem}{tags_str}")
+            })
+            .collect();
+
+        let selected = MultiSelect::new()
+            .with_prompt("Select agents for the fleet")
+            .items(&labels)
+            .interact()?;
+
+        if selected.is_empty() {
+            anyhow::bail!("No agents selected");
+        }
+
+        selected
+            .iter()
+            .map(|&i| agent_stem(&available[i].source))
+            .collect()
+    };
+
+    if selected_names.is_empty() {
+        anyhow::bail!("No agents matched the criteria");
+    }
+
+    // Resolve source directory (current working directory assumed to be the swarm-festai root)
+    let source = std::env::current_dir()?;
+
+    let fleet = FleetDefinition {
+        fleet: name.to_string(),
+        agents: selected_names.clone(),
+        source,
+    };
+
+    // Save to global config
+    let fleet_path = global_fleet_path(name);
+    fleet.save(&fleet_path)?;
+
+    println!(
+        "Fleet '{}' created with {} agents:",
+        name,
+        selected_names.len()
+    );
+    for a in &selected_names {
+        println!("  - {a}");
+    }
+    println!("\nSaved to: {}", fleet_path.display());
+    println!("Link it to a project: swarm fleet link {name}");
+
+    Ok(())
+}
+
+/// Link a fleet to a directory by creating swarm.yaml.
+fn link_fleet(name: &str, global: bool, path: Option<&Path>) -> anyhow::Result<()> {
+    // Load fleet definition
+    let fleet_path = global_fleet_path(name);
+    if !fleet_path.exists() {
+        // Maybe it's in the current directory?
+        let local_check = Path::new(FLEET_FILENAME);
+        if local_check.exists() {
+            let def = FleetDefinition::load(local_check)?;
+            if def.fleet == name {
+                println!("Fleet '{name}' is already linked in current directory.");
+                return Ok(());
+            }
+        }
+        anyhow::bail!("Fleet '{name}' not found. Create it first: swarm fleet create {name}");
+    }
+
+    let fleet = FleetDefinition::load(&fleet_path)?;
+
+    let target = if global {
+        global_fleet_dir().join(format!("{name}.yaml"))
+    } else if let Some(p) = path {
+        p.join(FLEET_FILENAME)
+    } else {
+        PathBuf::from(FLEET_FILENAME)
+    };
+
+    fleet.save(&target)?;
+
+    println!("Fleet '{name}' linked: {}", target.display());
+    println!("  Agents: {}", fleet.agents.join(", "));
+    println!("  Source: {}", fleet.source.display());
+
+    Ok(())
+}
+
+/// List all known fleets (local + global).
+fn list_fleets() -> anyhow::Result<()> {
+    let mut found = false;
+
+    // Check local
+    let local_path = Path::new(FLEET_FILENAME);
+    if local_path.exists()
+        && let Ok(fleet) = FleetDefinition::load(local_path)
+    {
+        println!("Local fleet:");
+        print_fleet_summary(&fleet, "  ");
+        found = true;
+    }
+
+    // Check global
+    let global_dir = global_fleet_dir();
+    if global_dir.exists() {
+        let mut global_fleets = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&global_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "yaml")
+                    && let Ok(fleet) = FleetDefinition::load(&path)
+                {
+                    global_fleets.push(fleet);
+                }
+            }
+        }
+        if !global_fleets.is_empty() {
+            if found {
+                println!();
+            }
+            println!("Global fleets:");
+            for fleet in &global_fleets {
+                print_fleet_summary(fleet, "  ");
+            }
+            found = true;
+        }
+    }
+
+    if !found {
+        println!("No fleets found.");
+        println!("Create one: swarm fleet create <name>");
+    }
+
+    Ok(())
+}
+
+/// Show details of a specific fleet.
+fn show_fleet(name: &str) -> anyhow::Result<()> {
+    // Try local first
+    let local_path = Path::new(FLEET_FILENAME);
+    if local_path.exists()
+        && let Ok(fleet) = FleetDefinition::load(local_path)
+        && fleet.fleet == name
+    {
+        print_fleet_detail(&fleet)?;
+        return Ok(());
+    }
+
+    // Try global
+    let fleet_path = global_fleet_path(name);
+    if fleet_path.exists() {
+        let fleet = FleetDefinition::load(&fleet_path)?;
+        print_fleet_detail(&fleet)?;
+        return Ok(());
+    }
+
+    anyhow::bail!("Fleet '{name}' not found");
+}
+
+fn print_fleet_summary(fleet: &FleetDefinition, indent: &str) {
+    println!("{indent}{} ({} agents)", fleet.fleet, fleet.agents.len());
+    println!("{indent}  source: {}", fleet.source.display());
+}
+
+fn print_fleet_detail(fleet: &FleetDefinition) -> anyhow::Result<()> {
+    println!("Fleet: {}", fleet.fleet);
+    println!("Source: {}", fleet.source.display());
+    println!("Agents ({}):", fleet.agents.len());
+
+    let agents_dir = fleet.agents_dir();
+    for name in &fleet.agents {
+        let status = match Agent::find_file(&agents_dir, name)
+            .and_then(|p| crate::parser::parse_agent_file(&p).ok())
+        {
+            Some(agent) => {
+                format!(
+                    "{} [{}]",
+                    agent.model_display(),
+                    agent.metadata.tags.join(", ")
+                )
+            }
+            None => "MISSING".to_string(),
+        };
+        println!("  - {name}: {status}");
+    }
+
+    Ok(())
+}
+
+/// Get the global fleet config directory.
+fn global_fleet_dir() -> PathBuf {
+    let config_base = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".config")
+        });
+    config_base.join("swarm").join("fleets")
+}
+
+/// Get the path for a specific fleet's global config file.
+fn global_fleet_path(name: &str) -> PathBuf {
+    global_fleet_dir().join(format!("{name}.yaml"))
+}
+
+/// Extract the agent stem (filename without .md) from a path.
+fn agent_stem(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default()
+}

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -1,10 +1,31 @@
 use std::path::Path;
 
+use dialoguer::{Confirm, Input, Select};
+
+use crate::providers::factory::api_backend_for_tool;
+
 pub async fn execute(
-    name: String,
+    name: Option<String>,
     template: String,
     stack: Option<String>,
     description: Option<String>,
+    interactive: bool,
+) -> anyhow::Result<()> {
+    if interactive {
+        return interactive_create().await;
+    }
+
+    let name =
+        name.ok_or_else(|| anyhow::anyhow!("Agent name is required (or use --interactive)"))?;
+    template_create(&name, &template, stack.as_deref(), description.as_deref())
+}
+
+/// Classic template-based creation (non-interactive)
+fn template_create(
+    name: &str,
+    template: &str,
+    stack: Option<&str>,
+    description: Option<&str>,
 ) -> anyhow::Result<()> {
     let templates_dir = Path::new("templates");
     let agents_dir = Path::new("agents");
@@ -30,25 +51,13 @@ pub async fn execute(
     // Read and replace placeholders
     let mut content = std::fs::read_to_string(&template_path)?;
 
-    // Convert name to title case for the H1 heading
-    let title = name
-        .split('-')
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                Some(c) => format!("{}{}", c.to_uppercase(), chars.as_str()),
-                None => String::new(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
-
+    let title = slug_to_title(name);
     content = content.replace("{{name}}", &title);
 
-    if let Some(ref desc) = description {
+    if let Some(desc) = description {
         content = content.replace("{{description}}", desc);
     }
-    if let Some(ref s) = stack {
+    if let Some(s) = stack {
         content = content.replace("{{stack}}", s);
     }
 
@@ -86,6 +95,422 @@ pub async fn execute(
     Ok(())
 }
 
+/// Interactive agent creation wizard
+async fn interactive_create() -> anyhow::Result<()> {
+    let templates_dir = Path::new("templates");
+    let agents_dir = Path::new("agents");
+
+    println!("🧙 Swarm Agent Creation Wizard\n");
+
+    // 1. Agent name
+    let name: String = Input::new()
+        .with_prompt("Agent name (slug, e.g. my-reviewer)")
+        .validate_with(|input: &String| -> Result<(), String> {
+            if input.is_empty() {
+                return Err("Name cannot be empty".into());
+            }
+            if !input
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            {
+                return Err("Use only letters, digits, hyphens, underscores".into());
+            }
+            Ok(())
+        })
+        .interact_text()?;
+
+    // Check for duplicate
+    let output_path = agents_dir.join(format!("{name}.md"));
+    if output_path.exists() {
+        anyhow::bail!("Agent '{name}' already exists at {}", output_path.display());
+    }
+
+    // 2. Template selection
+    let mut template_names = collect_template_names(templates_dir);
+    template_names.insert(0, "from scratch".to_string());
+
+    let template_idx = Select::new()
+        .with_prompt("Template")
+        .items(&template_names)
+        .default(0)
+        .interact()?;
+
+    let from_scratch = template_idx == 0;
+    let chosen_template = if from_scratch {
+        None
+    } else {
+        Some(&template_names[template_idx])
+    };
+
+    // 3. Provider
+    let providers = [
+        "claude",
+        "gemini",
+        "gpt",
+        "aider",
+        "anthropic",
+        "openai",
+        "google",
+        "cli",
+        "proxy",
+    ];
+    let provider_idx = Select::new()
+        .with_prompt("Provider")
+        .items(&providers)
+        .default(0)
+        .interact()?;
+    let provider = providers[provider_idx];
+
+    // 4. Model (filtered by provider)
+    let model = prompt_model(provider)?;
+
+    // 5. Temperature
+    let temp_presets = [
+        "Focused (0.2)",
+        "Balanced (0.5)",
+        "Creative (0.7)",
+        "Custom",
+    ];
+    let temp_idx = Select::new()
+        .with_prompt("Temperature")
+        .items(&temp_presets)
+        .default(1)
+        .interact()?;
+    let temperature: f32 = match temp_idx {
+        0 => 0.2,
+        1 => 0.5,
+        2 => 0.7,
+        _ => Input::new()
+            .with_prompt("Temperature (0.0 - 2.0)")
+            .default(0.5)
+            .validate_with(|input: &f32| {
+                if (0.0..=2.0).contains(input) {
+                    Ok(())
+                } else {
+                    Err("Must be between 0.0 and 2.0")
+                }
+            })
+            .interact_text()?,
+    };
+
+    // 6. Max tokens
+    let set_max_tokens = Confirm::new()
+        .with_prompt("Set max tokens?")
+        .default(false)
+        .interact()?;
+    let max_tokens: Option<u32> = if set_max_tokens {
+        Some(
+            Input::new()
+                .with_prompt("Max tokens")
+                .default(4096u32)
+                .interact_text()?,
+        )
+    } else {
+        None
+    };
+
+    // 7. Tags
+    let tags_input: String = Input::new()
+        .with_prompt("Tags (comma-separated, e.g. dev,review)")
+        .default("general".to_string())
+        .interact_text()?;
+    let tags = parse_comma_list(&tags_input);
+
+    // 8. Stacks
+    let stacks_input: String = Input::new()
+        .with_prompt("Stacks (comma-separated, e.g. rust,python)")
+        .allow_empty(true)
+        .interact_text()?;
+    let stacks = parse_comma_list(&stacks_input);
+
+    // 9. System prompt
+    let system_prompt: String = Input::new()
+        .with_prompt("System prompt")
+        .default("You are a helpful assistant.".to_string())
+        .interact_text()?;
+
+    // 10. Instructions (optional)
+    let add_instructions = Confirm::new()
+        .with_prompt("Add instructions?")
+        .default(false)
+        .interact()?;
+    let instructions = if add_instructions {
+        let text: String = Input::new().with_prompt("Instructions").interact_text()?;
+        Some(text)
+    } else {
+        None
+    };
+
+    // 11. Output format (optional)
+    let add_output_format = Confirm::new()
+        .with_prompt("Add output format?")
+        .default(false)
+        .interact()?;
+    let output_format = if add_output_format {
+        let text: String = Input::new().with_prompt("Output format").interact_text()?;
+        Some(text)
+    } else {
+        None
+    };
+
+    // Generate content
+    let content = if let Some(tpl_name) = chosen_template {
+        let template_path = templates_dir.join(format!("{tpl_name}.md"));
+        let mut content = std::fs::read_to_string(&template_path)?;
+        let title = slug_to_title(&name);
+        content = content.replace("{{name}}", &title);
+        content = content.replace("{{description}}", &system_prompt);
+        // Replace stacks placeholder
+        if !stacks.is_empty() {
+            content = content.replace("{{stack}}", &stacks[0]);
+        }
+        // Overwrite metadata section with user choices
+        overwrite_metadata(
+            &content,
+            provider,
+            model.as_deref(),
+            temperature,
+            max_tokens,
+            &tags,
+            &stacks,
+        )
+    } else {
+        generate_from_scratch(&AgentParams {
+            name: &name,
+            provider,
+            model: model.as_deref(),
+            temperature,
+            max_tokens,
+            tags: &tags,
+            stacks: &stacks,
+            system_prompt: &system_prompt,
+            instructions: instructions.as_deref(),
+            output_format: output_format.as_deref(),
+        })
+    };
+
+    // Write
+    std::fs::create_dir_all(agents_dir)?;
+    std::fs::write(&output_path, &content)?;
+
+    println!("\nAgent created: {}", output_path.display());
+    println!("  Name: {}", slug_to_title(&name));
+    println!("  Provider: {provider}");
+    if let Some(ref m) = model {
+        println!("  Model: {m}");
+    }
+
+    Ok(())
+}
+
+/// Prompt for model based on provider. Tries to load from config/providers.yaml.
+fn prompt_model(provider: &str) -> anyhow::Result<Option<String>> {
+    // CLI provider doesn't need a model
+    if provider == "cli" {
+        return Ok(None);
+    }
+
+    let backend = api_backend_for_tool(provider).unwrap_or(provider);
+    let models = load_provider_models(backend);
+
+    if models.is_empty() {
+        let model: String = Input::new()
+            .with_prompt("Model name")
+            .allow_empty(true)
+            .interact_text()?;
+        return Ok(if model.is_empty() { None } else { Some(model) });
+    }
+
+    let mut items: Vec<String> = models;
+    items.push("(custom)".to_string());
+
+    let idx = Select::new()
+        .with_prompt("Model")
+        .items(&items)
+        .default(0)
+        .interact()?;
+
+    if idx == items.len() - 1 {
+        let model: String = Input::new()
+            .with_prompt("Custom model name")
+            .interact_text()?;
+        Ok(Some(model))
+    } else {
+        Ok(Some(items[idx].clone()))
+    }
+}
+
+/// Load model list from config/providers.yaml for a given API backend.
+fn load_provider_models(backend: &str) -> Vec<String> {
+    let path = Path::new("config/providers.yaml");
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_yml::from_str::<serde_yml::Value>(&content) else {
+        return Vec::new();
+    };
+    let Some(providers) = value.get("providers") else {
+        return Vec::new();
+    };
+    let Some(provider) = providers.get(backend) else {
+        return Vec::new();
+    };
+    let Some(models) = provider.get("models").and_then(|m| m.as_sequence()) else {
+        return Vec::new();
+    };
+    models
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect()
+}
+
+/// Overwrite the ## Metadata section in a template with user choices.
+fn overwrite_metadata(
+    content: &str,
+    provider: &str,
+    model: Option<&str>,
+    temperature: f32,
+    max_tokens: Option<u32>,
+    tags: &[String],
+    stacks: &[String],
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut in_metadata = false;
+    let mut metadata_written = false;
+
+    for line in content.lines() {
+        if line.starts_with("## Metadata") {
+            in_metadata = true;
+            lines.push(line.to_string());
+            // Write new metadata
+            lines.push(format!("- provider: {provider}"));
+            if let Some(m) = model {
+                lines.push(format!("- model: {m}"));
+            }
+            lines.push(format!("- temperature: {temperature}"));
+            if let Some(mt) = max_tokens {
+                lines.push(format!("- max_tokens: {mt}"));
+            }
+            if !tags.is_empty() {
+                lines.push(format!("- tags: [{}]", tags.join(", ")));
+            }
+            if !stacks.is_empty() {
+                lines.push(format!("- stacks: [{}]", stacks.join(", ")));
+            }
+            metadata_written = true;
+            continue;
+        }
+
+        if in_metadata {
+            // Skip old metadata lines until next section or blank line before section
+            if line.starts_with("## ") {
+                in_metadata = false;
+                lines.push(String::new());
+                lines.push(line.to_string());
+            }
+            // Skip metadata lines (starting with -)
+            continue;
+        }
+
+        lines.push(line.to_string());
+    }
+
+    if !metadata_written {
+        // Fallback: just return original
+        return content.to_string();
+    }
+
+    lines.join("\n") + "\n"
+}
+
+/// Parameters for generating an agent from scratch.
+pub struct AgentParams<'a> {
+    pub name: &'a str,
+    pub provider: &'a str,
+    pub model: Option<&'a str>,
+    pub temperature: f32,
+    pub max_tokens: Option<u32>,
+    pub tags: &'a [String],
+    pub stacks: &'a [String],
+    pub system_prompt: &'a str,
+    pub instructions: Option<&'a str>,
+    pub output_format: Option<&'a str>,
+}
+
+/// Generate a complete agent markdown file from scratch.
+pub fn generate_from_scratch(params: &AgentParams<'_>) -> String {
+    let title = slug_to_title(params.name);
+    let mut md = format!("# {title}\n\n## Metadata\n");
+
+    md.push_str(&format!("- provider: {}\n", params.provider));
+    if let Some(m) = params.model {
+        md.push_str(&format!("- model: {m}\n"));
+    }
+    md.push_str(&format!("- temperature: {}\n", params.temperature));
+    if let Some(mt) = params.max_tokens {
+        md.push_str(&format!("- max_tokens: {mt}\n"));
+    }
+    if !params.tags.is_empty() {
+        md.push_str(&format!("- tags: [{}]\n", params.tags.join(", ")));
+    }
+    if !params.stacks.is_empty() {
+        md.push_str(&format!("- stacks: [{}]\n", params.stacks.join(", ")));
+    }
+
+    md.push_str(&format!("\n## System Prompt\n\n{}\n", params.system_prompt));
+
+    if let Some(inst) = params.instructions {
+        md.push_str(&format!("\n## Instructions\n\n{inst}\n"));
+    }
+
+    if let Some(fmt) = params.output_format {
+        md.push_str(&format!("\n## Output Format\n\n{fmt}\n"));
+    }
+
+    md
+}
+
+/// Convert a slug like "my-agent" to title case "My Agent".
+pub fn slug_to_title(slug: &str) -> String {
+    slug.split('-')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(c) => format!("{}{}", c.to_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Parse a comma-separated string into a list of trimmed, non-empty strings.
+pub fn parse_comma_list(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Collect template names (stems) from the templates directory.
+fn collect_template_names(templates_dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(templates_dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .filter_map(|e| {
+            e.path()
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+        })
+        .collect();
+    names.sort();
+    names
+}
+
 fn list_templates(templates_dir: &Path) -> anyhow::Result<()> {
     println!("Available templates:");
     if !templates_dir.exists() {
@@ -114,6 +539,7 @@ fn list_templates(templates_dir: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::fs;
 
     #[tokio::test]
@@ -142,5 +568,58 @@ mod tests {
         assert!(result.contains("# My Agent"));
         assert!(result.contains("A test agent"));
         assert!(!result.contains("{{name}}"));
+    }
+
+    #[test]
+    fn test_generate_from_scratch() {
+        let tags = vec!["dev".to_string(), "test".to_string()];
+        let stacks = vec!["rust".to_string()];
+        let md = generate_from_scratch(&AgentParams {
+            name: "test-agent",
+            provider: "claude",
+            model: Some("claude-sonnet-4-5-20250929"),
+            temperature: 0.5,
+            max_tokens: Some(4096),
+            tags: &tags,
+            stacks: &stacks,
+            system_prompt: "You are a test assistant.",
+            instructions: Some("1. Read code\n2. Write tests"),
+            output_format: Some("Markdown with code blocks"),
+        });
+
+        assert!(md.contains("# Test Agent"));
+        assert!(md.contains("- provider: claude"));
+        assert!(md.contains("- model: claude-sonnet-4-5-20250929"));
+        assert!(md.contains("- temperature: 0.5"));
+        assert!(md.contains("- max_tokens: 4096"));
+        assert!(md.contains("- tags: [dev, test]"));
+        assert!(md.contains("- stacks: [rust]"));
+        assert!(md.contains("## System Prompt"));
+        assert!(md.contains("You are a test assistant."));
+        assert!(md.contains("## Instructions"));
+        assert!(md.contains("## Output Format"));
+
+        // Verify parseable by the parser
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-agent.md");
+        std::fs::write(&path, &md).unwrap();
+        let agent = crate::parser::parse_agent_file(&path).unwrap();
+        assert_eq!(agent.name, "Test Agent");
+        assert_eq!(agent.metadata.provider, "claude");
+    }
+
+    #[test]
+    fn test_parse_comma_list() {
+        assert_eq!(parse_comma_list("a, b, c"), vec!["a", "b", "c"]);
+        assert_eq!(parse_comma_list("single"), vec!["single"]);
+        assert_eq!(parse_comma_list(""), Vec::<String>::new());
+        assert_eq!(parse_comma_list(" a , , b "), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_slug_to_title() {
+        assert_eq!(slug_to_title("my-agent"), "My Agent");
+        assert_eq!(slug_to_title("code-reviewer"), "Code Reviewer");
+        assert_eq!(slug_to_title("simple"), "Simple");
     }
 }

--- a/src/core/fleet.rs
+++ b/src/core/fleet.rs
@@ -1,0 +1,97 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// A fleet definition linking a named group of agents to a source directory.
+/// Serialized as `swarm.yaml` in project directories.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetDefinition {
+    /// Fleet name
+    pub fleet: String,
+    /// Agent names (file stems without .md)
+    pub agents: Vec<String>,
+    /// Absolute path to the swarm-festai source directory
+    pub source: PathBuf,
+}
+
+impl FleetDefinition {
+    /// Load a fleet definition from a YAML file.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let def: FleetDefinition = serde_yml::from_str(&content)?;
+        Ok(def)
+    }
+
+    /// Save the fleet definition to a YAML file.
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        let content = serde_yml::to_string(self)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+
+    /// Check if the fleet contains a given agent name.
+    pub fn contains_agent(&self, name: &str) -> bool {
+        self.agents.iter().any(|a| a == name)
+    }
+
+    /// Return the agents directory for this fleet's source.
+    pub fn agents_dir(&self) -> PathBuf {
+        self.source.join("agents")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fleet_serialize_deserialize() {
+        let fleet = FleetDefinition {
+            fleet: "test-fleet".to_string(),
+            agents: vec!["code-reviewer".to_string(), "test-writer".to_string()],
+            source: PathBuf::from("/home/user/swarm-festai"),
+        };
+
+        let yaml = serde_yml::to_string(&fleet).unwrap();
+        let parsed: FleetDefinition = serde_yml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed.fleet, "test-fleet");
+        assert_eq!(parsed.agents.len(), 2);
+        assert_eq!(parsed.source, PathBuf::from("/home/user/swarm-festai"));
+    }
+
+    #[test]
+    fn test_fleet_contains_agent() {
+        let fleet = FleetDefinition {
+            fleet: "test".to_string(),
+            agents: vec!["a".to_string(), "b".to_string()],
+            source: PathBuf::from("/tmp"),
+        };
+
+        assert!(fleet.contains_agent("a"));
+        assert!(fleet.contains_agent("b"));
+        assert!(!fleet.contains_agent("c"));
+    }
+
+    #[test]
+    fn test_fleet_load_save_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("swarm.yaml");
+
+        let fleet = FleetDefinition {
+            fleet: "my-fleet".to_string(),
+            agents: vec!["agent-a".to_string(), "agent-b".to_string()],
+            source: PathBuf::from("/opt/swarm"),
+        };
+
+        fleet.save(&path).unwrap();
+        let loaded = FleetDefinition::load(&path).unwrap();
+
+        assert_eq!(loaded.fleet, "my-fleet");
+        assert_eq!(loaded.agents, vec!["agent-a", "agent-b"]);
+        assert_eq!(loaded.source, PathBuf::from("/opt/swarm"));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@ pub mod agent;
 pub mod context;
 #[allow(dead_code)]
 pub mod coordinator;
+pub mod fleet;
 #[allow(dead_code)]
 pub mod pipeline;
 #[allow(dead_code)]

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -61,6 +61,19 @@ fn find_tool(name: &str) -> Option<&'static ToolDef> {
         .map(|(_, def)| def)
 }
 
+/// Map a unified tool name to its API backend name.
+/// Returns the backend directly for explicit API providers.
+/// e.g. "claude" → "anthropic", "gemini" → "google", "anthropic" → "anthropic"
+pub fn api_backend_for_tool(name: &str) -> Option<&'static str> {
+    match name {
+        "anthropic" => Some("anthropic"),
+        "openai" => Some("openai"),
+        "google" => Some("google"),
+        "proxy" => Some("proxy"),
+        _ => find_tool(name).map(|t| t.api_backend),
+    }
+}
+
 /// Check if a CLI command is available on the system.
 fn cli_available(command: &str) -> bool {
     std::process::Command::new("which")


### PR DESCRIPTION
## Summary

- Add `swarm new --interactive` (`-i`) wizard for guided step-by-step agent creation using `dialoguer`, with provider/model auto-discovery from `config/providers.yaml`
- Add `swarm fleet create|link|list|show` commands for grouping agents into named fleets and linking them to projects via `swarm.yaml`
- Integrate fleet resolution in `swarm run`: when a `swarm.yaml` is present, agents are loaded from the fleet source directory and validated against the fleet membership
- Add `docs/ai-agent-prompt.md` universal guide for any AI assistant to create valid swarm agents
- Add `api_backend_for_tool()` public helper to map unified provider names to API backends

## Changes

### Interactive agent creation (`swarm new -i`)
- 11-step wizard: name, template, provider, model, temperature, max_tokens, tags, stacks, system prompt, instructions, output format
- Model list filtered by provider from `config/providers.yaml`
- Supports both template-based and from-scratch creation
- `name` is now optional (required only in non-interactive mode)

### Fleet management (`swarm fleet`)
- `fleet create <name>` — interactive (MultiSelect) or CLI (`--agents`, `--tags`, `--all`)
- `fleet link <name>` — creates `swarm.yaml` (local by default, `--global`, or `--path`)
- `fleet list` — shows local + global fleets
- `fleet show <name>` — fleet details with agent status
- Fleet definitions stored in `~/.config/swarm/fleets/` (respects `XDG_CONFIG_HOME`)

### New files
- `src/cli/fleet.rs` — fleet CLI commands
- `src/core/fleet.rs` — `FleetDefinition` struct with load/save/contains
- `docs/ai-agent-prompt.md` — universal AI prompt guide

## Test plan

- [x] `cargo clippy --no-default-features --features tui` (CI mode) — 0 warnings
- [x] `cargo clippy --no-default-features --features tui,providers-api` — 0 warnings
- [x] `cargo test --no-default-features --features tui,providers-api` — 28/28 pass
- [x] `cargo fmt -- --check` — clean
- [ ] Manual: `swarm new -i` → create agent interactively → `swarm validate`
- [ ] Manual: `swarm fleet create test --all` → `swarm fleet link test` → verify `swarm.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)