### PR TITLE
feat: rebrand to ArmadAI with install script and self-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,16 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: swarm-linux-x86_64
+            artifact: armadai-linux-x86_64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: swarm-linux-aarch64
+            artifact: armadai-linux-aarch64
           - target: x86_64-apple-darwin
             os: macos-latest
-            artifact: swarm-macos-x86_64
+            artifact: armadai-macos-x86_64
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact: swarm-macos-aarch64
+            artifact: armadai-macos-aarch64
 
     steps:
       - uses: actions/checkout@v6
@@ -68,7 +68,7 @@ jobs:
       - name: Package
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/swarm dist/${{ matrix.artifact }}
+          cp target/${{ matrix.target }}/release/armadai dist/${{ matrix.artifact }}
           chmod +x dist/${{ matrix.artifact }}
 
       - uses: actions/upload-artifact@v6
@@ -91,4 +91,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: artifacts/*/swarm-*
+          files: artifacts/*/armadai-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# AGENTS.md - swarm-festai
+# AGENTS.md - ArmadAI
 
-This file provides instructions for AI coding agents working on the swarm-festai project.
+This file provides instructions for AI coding agents working on the ArmadAI project.
 
 ## Project Overview
 
-swarm-festai is an AI agent fleet orchestrator written in Rust. It allows defining,
+ArmadAI is an AI agent fleet orchestrator written in Rust. It allows defining,
 managing and executing specialized AI agents configured via Markdown files.
 
 ## Build & Test
@@ -17,7 +17,7 @@ cargo build
 cargo test
 
 # Run with debug logging
-RUST_LOG=swarm_festai=debug cargo run -- <command>
+RUST_LOG=armadai=debug cargo run -- <command>
 
 # Run clippy
 cargo clippy -- -D warnings

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# Architecture - swarm-festai
+# Architecture - ArmadAI
 
 ## Vision
 
-swarm-festai est un orchestrateur d'agents IA en ligne de commande. Il permet de
+ArmadAI est un orchestrateur d'agents IA en ligne de commande. Il permet de
 définir, gérer et exécuter une flotte d'agents spécialisés, chacun configuré via un
 simple fichier Markdown. L'outil est agnostique vis-à-vis des modèles (Claude, GPT,
 Gemini...) et des modes d'exécution (API HTTP, proxy, CLI tools).
@@ -30,7 +30,7 @@ Gemini...) et des modes d'exécution (API HTTP, proxy, CLI tools).
 ```
 ┌─ HOST MACHINE ─────────────────────────────────────────────┐
 │                                                             │
-│  swarm (binaire natif Rust)                                │
+│  armadai (binaire natif Rust)                              │
 │  ├── CLI (clap)            commandes : run, new, list...   │
 │  ├── TUI (ratatui)         monitoring, interaction, logs   │
 │  ├── Core                  parsing .md, orchestration      │
@@ -48,7 +48,7 @@ Gemini...) et des modes d'exécution (API HTTP, proxy, CLI tools).
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Le binaire `swarm` tourne toujours nativement sur la machine hôte**, jamais dans Docker.
+**Le binaire `armadai` tourne toujours nativement sur la machine hôte**, jamais dans Docker.
 Cela garantit :
 - L'accès direct au terminal (TUI)
 - L'accès aux CLI tools installés sur la machine (claude, aider, etc.)
@@ -206,7 +206,7 @@ Exécute la tâche demandée en utilisant tes outils disponibles.
 ## Structure du projet
 
 ```
-swarm-festai/
+armadai/
 ├── agents/                      # Définitions d'agents
 │   ├── _coordinator.md          # Agent hub (orchestrateur)
 │   └── examples/                # Exemples fournis
@@ -226,14 +226,14 @@ swarm-festai/
 │   ├── main.rs                  # Point d'entrée, setup tokio
 │   ├── cli/                     # Commandes CLI (clap)
 │   │   ├── mod.rs
-│   │   ├── run.rs               # swarm run <agent> [input]
-│   │   ├── new.rs               # swarm new --template <tpl> <name>
-│   │   ├── list.rs              # swarm list [--tags ...] [--stack ...]
-│   │   ├── inspect.rs           # swarm inspect <agent>
-│   │   ├── history.rs           # swarm history [--agent ...] [--replay id]
-│   │   ├── up.rs                # swarm up (lance docker-compose)
-│   │   ├── config.rs            # swarm config (gestion providers/settings)
-│   │   └── validate.rs          # swarm validate [agent] (dry-run)
+│   │   ├── run.rs               # armadai run <agent> [input]
+│   │   ├── new.rs               # armadai new --template <tpl> <name>
+│   │   ├── list.rs              # armadai list [--tags ...] [--stack ...]
+│   │   ├── inspect.rs           # armadai inspect <agent>
+│   │   ├── history.rs           # armadai history [--agent ...] [--replay id]
+│   │   ├── up.rs                # armadai up (lance docker-compose)
+│   │   ├── config.rs            # armadai config (gestion providers/settings)
+│   │   └── validate.rs          # armadai validate [agent] (dry-run)
 │   ├── tui/                     # Interface TUI
 │   │   ├── mod.rs
 │   │   ├── app.rs               # État global de l'app TUI
@@ -314,20 +314,20 @@ swarm-festai/
 ## Commandes CLI
 
 ```
-swarm run <agent> [input]        # Exécuter un agent avec un input
-swarm run --pipe <a> <b> [input] # Pipeline : chaîner des agents
-swarm new --template <tpl> <nom> # Créer un agent depuis un template
-swarm list [--tags t] [--stack s]# Lister les agents disponibles
-swarm inspect <agent>            # Afficher la config parsée d'un agent
-swarm validate [agent]           # Dry-run : valider sans appel API
-swarm history [--agent a]        # Historique des exécutions
-swarm history --replay <id>      # Rejouer une exécution passée
-swarm costs [--agent a] [--from] # Consulter les coûts
-swarm config providers           # Gérer les providers
-swarm config secrets init        # Initialiser SOPS + age
-swarm tui                        # Lancer l'interface TUI
-swarm up                         # Lancer l'infra Docker (optionnel)
-swarm down                       # Arrêter l'infra Docker
+armadai run <agent> [input]        # Exécuter un agent avec un input
+armadai run --pipe <a> <b> [input] # Pipeline : chaîner des agents
+armadai new --template <tpl> <nom> # Créer un agent depuis un template
+armadai list [--tags t] [--stack s]# Lister les agents disponibles
+armadai inspect <agent>            # Afficher la config parsée d'un agent
+armadai validate [agent]           # Dry-run : valider sans appel API
+armadai history [--agent a]        # Historique des exécutions
+armadai history --replay <id>      # Rejouer une exécution passée
+armadai costs [--agent a] [--from] # Consulter les coûts
+armadai config providers           # Gérer les providers
+armadai config secrets init        # Initialiser SOPS + age
+armadai tui                        # Lancer l'interface TUI
+armadai up                         # Lancer l'infra Docker (optionnel)
+armadai down                       # Arrêter l'infra Docker
 ```
 
 ---
@@ -336,7 +336,7 @@ swarm down                       # Arrêter l'infra Docker
 
 | #  | Feature                  | Description                                                          |
 | -- | ------------------------ | -------------------------------------------------------------------- |
-| 1  | Scaffolding rapide       | `swarm new --template` pour créer des agents en une commande         |
+| 1  | Scaffolding rapide       | `armadai new --template` pour créer des agents en une commande         |
 | 3  | Dry-run mode             | Validation de la config agent sans appel API                         |
 | 4  | Cost tracking            | Suivi des coûts par agent/exécution dans SurrealDB                   |
 | 5  | Streaming TUI            | Affichage temps réel des réponses dans la TUI                        |
@@ -373,9 +373,9 @@ config/
 ```
 
 Workflow :
-1. `swarm config secrets init` → génère une clé age, configure `.sops.yaml`
+1. `armadai config secrets init` → génère une clé age, configure `.sops.yaml`
 2. Les clés API sont stockées dans `providers.sops.yaml` (chiffré)
-3. Au runtime, `swarm` déchiffre en mémoire via la clé age locale
+3. Au runtime, `armadai` déchiffre en mémoire via la clé age locale
 4. Le fichier chiffré est committé dans git (safe), la clé age ne l'est pas
 
 ---
@@ -383,12 +383,12 @@ Workflow :
 ## Stockage (SurrealDB)
 
 ### Mode embarqué (défaut)
-- Base locale dans `~/.swarm/data/` ou `./data/`
+- Base locale dans `~/.config/armadai/data/` ou `./data/`
 - Zéro configuration, démarrage instantané
 - Idéal pour usage single-user
 
 ### Mode serveur (Docker)
-- `swarm up` lance SurrealDB via docker-compose
+- `armadai up` lance SurrealDB via docker-compose
 - Connexion via `ws://localhost:8000`
 - Pour usage multi-instance ou persistance réseau
 
@@ -423,7 +423,7 @@ DEFINE FIELD last_run    ON agent_stats TYPE datetime;
 ## Docker Compose (optionnel)
 
 ```yaml
-# Lancé via `swarm up`, arrêté via `swarm down`
+# Lancé via `armadai up`, arrêté via `armadai down`
 services:
   surrealdb:
     image: surrealdb/surrealdb:latest
@@ -431,7 +431,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - swarm-data:/data
+      - armadai-data:/data
 
   litellm:  # Optionnel : proxy multi-providers
     image: ghcr.io/berriai/litellm:main-latest
@@ -443,5 +443,5 @@ services:
       - proxy
 
 volumes:
-  swarm-data:
+  armadai-data:
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-swarm-festai is an AI agent fleet orchestrator written in Rust (edition 2024). Agents are defined as Markdown files and executed against any LLM provider (API or CLI tool). The binary is named `swarm`.
+ArmadAI is an AI agent fleet orchestrator written in Rust (edition 2024). Agents are defined as Markdown files and executed against any LLM provider (API or CLI tool). The binary is named `armadai`.
 
 ## Build & Test Commands
 
@@ -53,6 +53,12 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`. Sever
 - `parser/` — Converts Markdown agent files into `Agent` struct. Required sections: H1 (name), `## Metadata`, `## System Prompt`.
 - `providers/` — `Provider` trait (in `traits.rs`) with `complete()` and `stream()` methods. Factory (`factory.rs`) constructs the right provider from agent metadata. Implementations: `api/anthropic.rs` (full), `cli.rs` (full), openai/google/proxy (stubs).
 - `core/` — Domain types: `Agent`, `AgentMetadata`, `Task`, `SharedContext`, `Coordinator`, `Pipeline`.
+- `core/project.rs` — Project config (`armadai.yaml`) with agent/prompt/skill resolution.
+- `core/prompt.rs` — Composable prompt fragments with YAML frontmatter.
+- `core/skill.rs` — Skills following the Agent Skills open standard (SKILL.md).
+- `core/fleet.rs` — Fleet definitions linking agent groups to source directories.
+- `linker/` — Generates native config files for target AI CLIs. Trait `Linker` with one implementation per CLI (claude, copilot, cursor, aider, codex, gemini, windsurf, cline).
+- `registry/` — awesome-copilot integration. Sync, search, convert agents from the community catalog.
 - `storage/` — SurrealDB wrapper. `schema.rs` defines tables (`runs`, `agent_stats`), `queries.rs` has CRUD operations.
 - `tui/` — Ratatui-based terminal UI. `app.rs` holds state (incl. command palette), `views/` renders tabs (Agents/Detail/History/Costs + shortcuts bar + command palette overlay), `widgets/` provides reusable components.
 - `web/` — Axum-based web UI. Embedded single-page HTML app with JSON API endpoints (`/api/agents`, `/api/history`, `/api/costs`).
@@ -67,7 +73,9 @@ trait Provider: Send + Sync {
 }
 ```
 
-**Agent definition** lives in `agents/*.md`. Templates in `templates/*.md` use `{{name}}`, `{{stack}}`, `{{description}}` placeholders.
+**Agent definition** lives in `~/.config/armadai/agents/` (user library) or project-local paths. Templates in `templates/*.md` use `{{name}}`, `{{stack}}`, `{{description}}` placeholders.
+
+**Config** lives in `~/.config/armadai/` (user) and `armadai.yaml` (project).
 
 ## Git Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "armadai"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "chrono",
+ "clap",
+ "clap_complete",
+ "crossterm",
+ "dialoguer",
+ "pulldown-cmark",
+ "ratatui",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "surrealdb",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,35 +4822,6 @@ dependencies = [
  "quick_cache 0.6.18",
  "revision 0.10.0",
  "vart 0.9.3",
-]
-
-[[package]]
-name = "swarm-festai"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "chrono",
- "clap",
- "clap_complete",
- "crossterm",
- "dialoguer",
- "pulldown-cmark",
- "ratatui",
- "reqwest",
- "serde",
- "serde_json",
- "serde_yml",
- "surrealdb",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
-name = "swarm-festai"
+name = "armadai"
 version = "0.1.0"
 edition = "2024"
-description = "AI agent fleet orchestrator - define, manage and run specialized agents from Markdown files"
+description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "MIT"
+repository = "https://github.com/Dr0drigues/swarm-festai"
 
 [[bin]]
-name = "swarm"
+name = "armadai"
 path = "src/main.rs"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# swarm-festai
+# ArmadAI
 
 AI agent fleet orchestrator — define, manage and run specialized agents from Markdown files.
 
@@ -7,12 +7,12 @@ AI agent fleet orchestrator — define, manage and run specialized agents from M
 
 ## Overview
 
-swarm-festai lets you build a fleet of specialized AI agents, each configured with a simple Markdown file. It works with any LLM provider (Claude, GPT, Gemini) and any CLI tool (Claude Code, aider, etc.) through a unified interface.
+ArmadAI lets you build a fleet of specialized AI agents, each configured with a simple Markdown file. It works with any LLM provider (Claude, GPT, Gemini) and any CLI tool (Claude Code, aider, etc.) through a unified interface.
 
 ```
-swarm run code-reviewer "Review this PR for security issues"
-swarm run --pipe code-reviewer test-writer "src/main.rs"
-swarm tui
+armadai run code-reviewer "Review this PR for security issues"
+armadai run --pipe code-reviewer test-writer "src/main.rs"
+armadai tui
 ```
 
 ### Key Features
@@ -40,13 +40,13 @@ cd swarm-festai
 cargo build --release
 ```
 
-The binary is at `target/release/swarm`.
+The binary is at `target/release/armadai`.
 
 ### Configure providers
 
 ```bash
 # Option A: Encrypted secrets (recommended)
-swarm config secrets init       # Generates age key + .sops.yaml
+armadai config secrets init       # Generates age key + .sops.yaml
 sops config/providers.sops.yaml # Edit encrypted API keys
 
 # Option B: Environment variables
@@ -63,13 +63,13 @@ providers:
 EOF
 
 # Check provider status
-swarm config providers
+armadai config providers
 ```
 
 ### Create your first agent
 
 ```bash
-swarm new --template basic my-assistant
+armadai new --template basic my-assistant
 ```
 
 This creates `agents/my-assistant.md` — edit it to customize the system prompt, model, and behavior.
@@ -77,29 +77,29 @@ This creates `agents/my-assistant.md` — edit it to customize the system prompt
 ### Run an agent
 
 ```bash
-swarm run my-assistant "Explain how async/await works in Rust"
+armadai run my-assistant "Explain how async/await works in Rust"
 ```
 
 ## Usage
 
 | Command | Description | Status |
 |---|---|---|
-| `swarm list [--tags t] [--stack s]` | List available agents | Done |
-| `swarm new --template <tpl> <name>` | Create an agent from a template | Done |
-| `swarm inspect <agent>` | Show parsed agent config | Done |
-| `swarm validate [agent]` | Dry-run validation (no API calls) | Done |
-| `swarm run <agent> [input]` | Run an agent | Done |
-| `swarm run --pipe <a> <b> [input]` | Chain agents in a pipeline | Done |
-| `swarm history [--agent a]` | View execution history | Done |
-| `swarm history --replay <id>` | Replay a past execution | Planned |
-| `swarm costs [--agent a] [--from d]` | View cost tracking | Done |
-| `swarm config providers` | Show provider configs and secrets status | Done |
-| `swarm config secrets init` | Initialize SOPS + age encryption | Done |
-| `swarm config secrets rotate` | Rotate age encryption key | Done |
-| `swarm tui` | Launch the TUI dashboard | Done |
-| `swarm web [--port N]` | Launch the web UI | Done |
-| `swarm completion <shell>` | Generate shell completions | Done |
-| `swarm up / down` | Start/stop infra (Docker Compose) | Done |
+| `armadai list [--tags t] [--stack s]` | List available agents | Done |
+| `armadai new --template <tpl> <name>` | Create an agent from a template | Done |
+| `armadai inspect <agent>` | Show parsed agent config | Done |
+| `armadai validate [agent]` | Dry-run validation (no API calls) | Done |
+| `armadai run <agent> [input]` | Run an agent | Done |
+| `armadai run --pipe <a> <b> [input]` | Chain agents in a pipeline | Done |
+| `armadai history [--agent a]` | View execution history | Done |
+| `armadai history --replay <id>` | Replay a past execution | Planned |
+| `armadai costs [--agent a] [--from d]` | View cost tracking | Done |
+| `armadai config providers` | Show provider configs and secrets status | Done |
+| `armadai config secrets init` | Initialize SOPS + age encryption | Done |
+| `armadai config secrets rotate` | Rotate age encryption key | Done |
+| `armadai tui` | Launch the TUI dashboard | Done |
+| `armadai web [--port N]` | Launch the web UI | Done |
+| `armadai completion <shell>` | Generate shell completions | Done |
+| `armadai up / down` | Start/stop infra (Docker Compose) | Done |
 
 ## Agent Format
 
@@ -133,7 +133,7 @@ Structured review: bugs, security, performance, style.
 
 ### Provider names
 
-Use unified tool names — swarm auto-detects CLI tool vs API:
+Use unified tool names — ArmadAI auto-detects CLI tool vs API:
 
 | Provider | CLI tool detected | CLI not found |
 |---|---|---|
@@ -194,8 +194,8 @@ You are a versatile development assistant.
 Create an agent from a template:
 
 ```bash
-swarm new my-reviewer --template dev-review --stack rust
-swarm new my-tool --template cli-generic
+armadai new my-reviewer --template dev-review --stack rust
+armadai new my-tool --template cli-generic
 ```
 
 ## Shell Completion
@@ -204,18 +204,18 @@ Generate completion scripts for your shell:
 
 ```bash
 # Bash
-swarm completion bash > ~/.local/share/bash-completion/completions/swarm
+armadai completion bash > ~/.local/share/bash-completion/completions/armadai
 
 # Zsh
-swarm completion zsh > ~/.zfunc/_swarm
+armadai completion zsh > ~/.zfunc/_armadai
 
 # Fish
-swarm completion fish > ~/.config/fish/completions/swarm.fish
+armadai completion fish > ~/.config/fish/completions/armadai.fish
 ```
 
 ## TUI Dashboard
 
-Launch with `swarm tui`. The dashboard provides fleet management views:
+Launch with `armadai tui`. The dashboard provides fleet management views:
 
 | Tab | Description |
 |---|---|
@@ -238,11 +238,11 @@ Launch with `swarm tui`. The dashboard provides fleet management views:
 
 ## Web UI
 
-Launch with `swarm web` (default port 3000):
+Launch with `armadai web` (default port 3000):
 
 ```bash
-swarm web              # http://localhost:3000
-swarm web --port 8080  # custom port
+armadai web              # http://localhost:3000
+armadai web --port 8080  # custom port
 ```
 
 The web UI provides a read-only dashboard for your agent fleet:
@@ -257,7 +257,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed technical documentation.
 
 ```
 HOST MACHINE
-├── swarm (native binary)
+├── armadai (native binary)
 │   ├── CLI + TUI + Web UI
 │   ├── Providers (API / CLI / Proxy)
 │   ├── SurrealDB (embedded)

--- a/agents/_coordinator.md
+++ b/agents/_coordinator.md
@@ -9,7 +9,7 @@
 
 ## System Prompt
 
-You are the coordinator agent for swarm-festai. Your role is to:
+You are the coordinator agent for ArmadAI. Your role is to:
 1. Analyze incoming tasks from the user
 2. Decompose complex tasks into sub-tasks
 3. Select the most appropriate specialist agent for each sub-task

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -24,6 +24,6 @@ providers:
       - gemini-2.0-pro
 
   proxy:
-    # LiteLLM or OpenRouter endpoint (when using `swarm up`)
+    # LiteLLM or OpenRouter endpoint (when using `armadai up`)
     base_url: http://localhost:4000/v1
     models: []

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,4 +1,4 @@
-# swarm-festai global settings
+# ArmadAI global settings
 
 # Default agents directory (relative to project root)
 agents_dir: agents
@@ -12,7 +12,7 @@ storage:
   mode: embedded
   # Path for persistent embedded storage (RocksDB)
   # Use ":memory:" for in-memory only
-  path: "data/swarm.db"
+  path: "data/armadai.db"
 
 # Default provider when not specified in agent metadata
 defaults:
@@ -40,4 +40,4 @@ logging:
   level: info
   # "stdout", "file", or "both"
   output: stdout
-  file_path: "logs/swarm.log"
+  file_path: "logs/armadai.log"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - swarm-data:/data
+      - armadai-data:/data
     restart: unless-stopped
 
   litellm:
@@ -19,4 +19,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  swarm-data:
+  armadai-data:

--- a/docs/ai-agent-prompt.md
+++ b/docs/ai-agent-prompt.md
@@ -1,11 +1,11 @@
-# Swarm Agent Creation Guide
+# ArmadAI Agent Creation Guide
 
 > Universal prompt for any AI assistant (Claude Code, Gemini CLI, Cursor, Copilot, etc.)
-> to help users create valid swarm agent files.
+> to help users create valid ArmadAI agent files.
 
-## What is a Swarm Agent?
+## What is an ArmadAI Agent?
 
-A swarm agent is a Markdown file (`.md`) that defines an AI-powered specialist. Each agent has a role, a provider, and a system prompt. Agents live in the `agents/` directory and can be run with `swarm run <name> "<input>"`.
+An ArmadAI agent is a Markdown file (`.md`) that defines an AI-powered specialist. Each agent has a role, a provider, and a system prompt. Agents live in the `agents/` directory and can be run with `armadai run <name> "<input>"`.
 
 ## Agent File Format
 
@@ -45,7 +45,7 @@ A swarm agent is a Markdown file (`.md`) that defines an AI-powered specialist. 
 | `openai` | API only | `model` field, `OPENAI_API_KEY` env var |
 | `google` | API only | `model` field, `GOOGLE_API_KEY` env var |
 | `cli` | CLI only | `command` field (e.g. `command: claude`) |
-| `proxy` | API proxy | `model` field, proxy running via `swarm up` |
+| `proxy` | API proxy | `model` field, proxy running via `armadai up` |
 
 ## Known Models
 
@@ -65,7 +65,7 @@ Range: 0.0 (deterministic) to 2.0 (maximum randomness).
 
 ## Creation Flow
 
-When helping a user create a swarm agent, ask these questions in order:
+When helping a user create an ArmadAI agent, ask these questions in order:
 
 1. **Name**: What should the agent be called? (slug format: `my-agent-name`)
 2. **Provider**: Which LLM provider? (claude, gemini, gpt, anthropic, openai, google, cli, proxy)
@@ -82,7 +82,7 @@ When helping a user create a swarm agent, ask these questions in order:
 
 - Use kebab-case: `code-reviewer`, `test-writer`, `doc-generator`
 - Only letters, digits, and hyphens
-- The filename becomes the agent ID: `agents/code-reviewer.md` → `swarm run code-reviewer`
+- The filename becomes the agent ID: `agents/code-reviewer.md` → `armadai run code-reviewer`
 - The H1 heading is the display name: `# Code Reviewer`
 
 ## Complete Example
@@ -127,7 +127,7 @@ Each item: severity, location, description, suggested fix.
 After creating the file, validate it:
 
 ```bash
-swarm validate <agent-name>
+armadai validate <agent-name>
 ```
 
 This checks:
@@ -139,11 +139,11 @@ This checks:
 
 ```bash
 # Direct input
-swarm run code-reviewer "Review this function: fn add(a: i32, b: i32) -> i32 { a + b }"
+armadai run code-reviewer "Review this function: fn add(a: i32, b: i32) -> i32 { a + b }"
 
 # File input
-swarm run code-reviewer @src/main.rs
+armadai run code-reviewer @src/main.rs
 
 # Pipeline (chain agents)
-swarm run --pipe code-reviewer test-writer src/lib.rs
+armadai run --pipe code-reviewer test-writer src/lib.rs
 ```

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -141,10 +141,10 @@ Validate agent configurations without making API calls:
 
 ```bash
 # Validate all agents
-swarm validate
+armadai validate
 
 # Validate a specific agent
-swarm validate code-reviewer
+armadai validate code-reviewer
 ```
 
 Validation checks:

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -10,11 +10,11 @@ cd swarm-festai
 cargo build --release
 ```
 
-The binary is at `target/release/swarm`. Add it to your `PATH`:
+The binary is at `target/release/armadai`. Add it to your `PATH`:
 
 ```bash
 # Option 1: symlink
-ln -s $(pwd)/target/release/swarm ~/.local/bin/swarm
+ln -s $(pwd)/target/release/armadai ~/.local/bin/armadai
 
 # Option 2: cargo install
 cargo install --path .
@@ -33,7 +33,7 @@ cargo install --path .
 Create your first agent from a template:
 
 ```bash
-swarm new my-assistant --template basic --description "general-purpose coding assistant"
+armadai new my-assistant --template basic --description "general-purpose coding assistant"
 ```
 
 This creates `agents/my-assistant.md`. Open it and customize the system prompt to your needs.
@@ -42,13 +42,13 @@ This creates `agents/my-assistant.md`. Open it and customize the system prompt t
 
 ```bash
 # List all available agents
-swarm list
+armadai list
 
 # Validate all agent configurations
-swarm validate
+armadai validate
 
 # Inspect a specific agent
-swarm inspect my-assistant
+armadai inspect my-assistant
 ```
 
 ## Configure Providers
@@ -69,7 +69,7 @@ For production use, see the [Providers](providers.md) page for SOPS + age encryp
 ## Run an Agent
 
 ```bash
-swarm run my-assistant "Explain the builder pattern in Rust"
+armadai run my-assistant "Explain the builder pattern in Rust"
 ```
 
 ## Shell Completion
@@ -78,13 +78,13 @@ Set up auto-completion for your shell:
 
 ```bash
 # Bash
-swarm completion bash > ~/.local/share/bash-completion/completions/swarm
+armadai completion bash > ~/.local/share/bash-completion/completions/armadai
 
 # Zsh
-swarm completion zsh > ~/.zfunc/_swarm
+armadai completion zsh > ~/.zfunc/_armadai
 
 # Fish
-swarm completion fish > ~/.config/fish/completions/swarm.fish
+armadai completion fish > ~/.config/fish/completions/armadai.fish
 ```
 
 ## TUI Dashboard
@@ -92,7 +92,7 @@ swarm completion fish > ~/.config/fish/completions/swarm.fish
 Browse and manage your agent fleet visually:
 
 ```bash
-swarm tui
+armadai tui
 ```
 
 Use `Tab`/`Shift+Tab` to switch views, `j`/`k` to navigate, `Enter` to view agent details, `:` to open the command palette, and `q` to quit.
@@ -102,8 +102,8 @@ Use `Tab`/`Shift+Tab` to switch views, `j`/`k` to navigate, `Enter` to view agen
 For a browser-based dashboard:
 
 ```bash
-swarm web              # http://localhost:3000
-swarm web --port 8080  # custom port
+armadai web              # http://localhost:3000
+armadai web --port 8080  # custom port
 ```
 
 Browse agents, view execution history, and track costs from your browser. The `web` feature is enabled by default.

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -1,10 +1,10 @@
 # Providers
 
-swarm-festai supports three types of providers for executing agents, plus **unified tool names** that auto-detect the best backend.
+ArmadAI supports three types of providers for executing agents, plus **unified tool names** that auto-detect the best backend.
 
 ## Unified Tool Names (Recommended)
 
-Use a tool name directly as the provider. swarm auto-detects whether the CLI tool is installed and falls back to the API if not.
+Use a tool name directly as the provider. ArmadAI auto-detects whether the CLI tool is installed and falls back to the API if not.
 
 | Provider | CLI tool | API fallback | Default CLI args |
 |---|---|---|---|
@@ -109,7 +109,7 @@ Route requests through an OpenAI-compatible proxy like LiteLLM or OpenRouter.
 Start the proxy with Docker Compose:
 
 ```bash
-swarm up
+armadai up
 ```
 
 This starts LiteLLM on port 4000 (configured in `docker-compose.yml`).
@@ -148,7 +148,7 @@ Prerequisites: [SOPS](https://github.com/getsops/sops) and [age](https://github.
 
 ```bash
 # Initialize encryption (generates age key + .sops.yaml + template)
-swarm config secrets init
+armadai config secrets init
 
 # Set the key file in your shell profile
 export SOPS_AGE_KEY_FILE=config/age-key.txt
@@ -165,7 +165,7 @@ The `init` command:
 ### Key rotation
 
 ```bash
-swarm config secrets rotate
+armadai config secrets rotate
 ```
 
 This decrypts current secrets, generates a new age key, re-encrypts with the new key, and backs up the old key.
@@ -173,7 +173,7 @@ This decrypts current secrets, generates a new age key, re-encrypts with the new
 ### Check provider status
 
 ```bash
-swarm config providers
+armadai config providers
 ```
 
 Shows configured providers, secrets status (encrypted/unencrypted/missing), and environment variable status.

--- a/docs/wiki/templates.md
+++ b/docs/wiki/templates.md
@@ -9,7 +9,7 @@ Templates are Markdown files in the `templates/` directory that serve as startin
 General-purpose agent with Anthropic provider.
 
 ```bash
-swarm new my-agent --template basic --description "what this agent does"
+armadai new my-agent --template basic --description "what this agent does"
 ```
 
 ### dev-review
@@ -17,7 +17,7 @@ swarm new my-agent --template basic --description "what this agent does"
 Code review specialist. Produces structured reviews with severity levels.
 
 ```bash
-swarm new rust-reviewer --template dev-review --stack rust
+armadai new rust-reviewer --template dev-review --stack rust
 ```
 
 ### dev-test
@@ -25,7 +25,7 @@ swarm new rust-reviewer --template dev-review --stack rust
 Test generation specialist. Writes unit tests for given code.
 
 ```bash
-swarm new test-gen --template dev-test --stack typescript
+armadai new test-gen --template dev-test --stack typescript
 ```
 
 ### cli-generic
@@ -33,7 +33,7 @@ swarm new test-gen --template dev-test --stack typescript
 Wrapper for any CLI tool (claude, aider, custom scripts).
 
 ```bash
-swarm new my-tool --template cli-generic
+armadai new my-tool --template cli-generic
 ```
 
 Then edit `agents/my-tool.md` to set the `command` and `args` fields.
@@ -43,7 +43,7 @@ Then edit `agents/my-tool.md` to set the `command` and `args` fields.
 Sprint and project planning agent. Produces structured plans.
 
 ```bash
-swarm new sprint-planner --template planning --stack rust
+armadai new sprint-planner --template planning --stack rust
 ```
 
 ### security-review
@@ -51,7 +51,7 @@ swarm new sprint-planner --template planning --stack rust
 Security audit specialist. Identifies vulnerabilities (OWASP, CVE).
 
 ```bash
-swarm new sec-reviewer --template security-review --stack typescript
+armadai new sec-reviewer --template security-review --stack typescript
 ```
 
 ### debug
@@ -59,7 +59,7 @@ swarm new sec-reviewer --template security-review --stack typescript
 Debugging assistant with systematic root cause analysis.
 
 ```bash
-swarm new my-debugger --template debug --stack rust
+armadai new my-debugger --template debug --stack rust
 ```
 
 ### tech-debt
@@ -67,7 +67,7 @@ swarm new my-debugger --template debug --stack rust
 Technical debt analyzer. Identifies and prioritizes refactoring opportunities.
 
 ```bash
-swarm new debt-scanner --template tech-debt --stack java
+armadai new debt-scanner --template tech-debt --stack java
 ```
 
 ### tdd-red / tdd-green / tdd-refactor
@@ -75,9 +75,9 @@ swarm new debt-scanner --template tech-debt --stack java
 TDD cycle agents — use them in a pipeline:
 
 ```bash
-swarm new failing-tests --template tdd-red --stack rust
-swarm new make-pass --template tdd-green --stack rust
-swarm new clean-up --template tdd-refactor --stack rust
+armadai new failing-tests --template tdd-red --stack rust
+armadai new make-pass --template tdd-green --stack rust
+armadai new clean-up --template tdd-refactor --stack rust
 ```
 
 ### tech-writer
@@ -85,7 +85,7 @@ swarm new clean-up --template tdd-refactor --stack rust
 Documentation writer. Produces clear, structured docs.
 
 ```bash
-swarm new doc-writer --template tech-writer --stack rust
+armadai new doc-writer --template tech-writer --stack rust
 ```
 
 ## Placeholders

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,109 @@
+# Example: Rust Web Team
+
+A complete example of an ArmadAI fleet for reviewing, testing, documenting, and improving Rust code.
+
+## Fleet composition
+
+| Agent | Role | Temperature |
+|-------|------|-------------|
+| `rust-reviewer` | Code review (bugs, safety, idioms) | 0.3 |
+| `rust-test-writer` | Generate unit tests | 0.3 |
+| `security-auditor` | Security vulnerability scanning | 0.2 |
+| `doc-writer` | Generate `///` doc comments | 0.5 |
+| `refactor-advisor` | Identify code smells and propose refactoring | 0.5 |
+
+## Setup
+
+```bash
+# From the ArmadAI root directory
+cd example
+```
+
+The `armadai.yaml` file links this directory to the fleet. The `source: ..` path points back to the ArmadAI root where agents are loaded from `example/agents/`.
+
+## Usage
+
+### Single agent
+
+```bash
+# Code review
+armadai run rust-reviewer @sample-code/user_service.rs
+
+# Generate tests
+armadai run rust-test-writer @sample-code/user_service.rs
+
+# Security audit
+armadai run security-auditor @sample-code/user_service.rs
+
+# Generate documentation
+armadai run doc-writer @sample-code/user_service.rs
+
+# Refactoring suggestions
+armadai run refactor-advisor @sample-code/user_service.rs
+```
+
+### Pipeline (chained agents)
+
+```bash
+# Review then generate tests for the findings
+armadai run --pipe rust-reviewer rust-test-writer sample-code/user_service.rs
+
+# Full quality pass: review → security → refactor
+armadai run --pipe rust-reviewer security-auditor refactor-advisor @sample-code/user_service.rs
+```
+
+### Piping with stdin
+
+```bash
+# Pipe code from another command
+cat sample-code/user_service.rs | armadai run rust-reviewer
+
+# Pipe a git diff
+git diff HEAD~1 | armadai run rust-reviewer
+```
+
+## Fleet management
+
+```bash
+# List the fleet linked to this directory
+armadai fleet list
+
+# Show fleet details with agent status
+armadai fleet show rust-web-team
+
+# Validate all agents in the fleet
+armadai validate
+```
+
+## Expected output
+
+Each agent produces structured output in French (system prompts request this). For example, `rust-reviewer` will identify issues like:
+
+- `.unwrap()` calls that could panic under contention
+- `u.active == true` instead of idiomatic `u.active`
+- Missing `Default` impl for `UserService`
+- Email validation too simplistic (just checks for `@`)
+
+The `security-auditor` might flag:
+
+- No input sanitization on `bulk_import` (CSV injection potential)
+- Mutex poisoning not handled (`.unwrap()` on lock)
+- No rate limiting or access control patterns
+
+## Customizing
+
+To add a new agent to the fleet:
+
+```bash
+# Interactive creation
+armadai new -i
+
+# Then add it to armadai.yaml agents list
+```
+
+Or copy an existing agent and modify it:
+
+```bash
+cp agents/rust-reviewer.md agents/perf-analyzer.md
+# Edit the new file
+```

--- a/example/agents/doc-writer.md
+++ b/example/agents/doc-writer.md
@@ -1,0 +1,36 @@
+# Doc Writer
+
+## Metadata
+- provider: gemini
+- model: gemini-2.0-flash
+- temperature: 0.5
+- max_tokens: 4096
+- tags: [dev, documentation]
+- stacks: [rust]
+- cost_limit: 0.30
+
+## System Prompt
+
+You are a Rust documentation expert. You write clear, complete `///` doc comments
+following the Rust documentation conventions. You include module-level docs (`//!`),
+function/struct/enum docs with examples, and `# Examples`, `# Errors`, `# Panics`
+sections where appropriate. You write runnable doctests.
+
+Respond in French for explanations, English for code and doc comments.
+
+## Instructions
+
+1. Analyze the code to understand the public API surface
+2. Write module-level `//!` documentation explaining purpose and usage
+3. For each public item, write `///` docs with:
+   - One-line summary
+   - Detailed description if needed
+   - `# Examples` with runnable code
+   - `# Errors` listing possible error conditions
+   - `# Panics` if the function can panic
+4. Keep examples concise but complete
+
+## Output Format
+
+The annotated code with doc comments added. Only output the modified code,
+not the original. Wrap in a Rust code block.

--- a/example/agents/refactor-advisor.md
+++ b/example/agents/refactor-advisor.md
@@ -1,0 +1,51 @@
+# Refactor Advisor
+
+## Metadata
+- provider: gemini
+- model: gemini-2.0-flash
+- temperature: 0.5
+- max_tokens: 4096
+- tags: [dev, refactoring, quality]
+- stacks: [rust]
+- cost_limit: 0.40
+
+## System Prompt
+
+You are a Rust refactoring specialist. You identify code smells and suggest
+targeted refactoring strategies. You balance pragmatism with code quality:
+you never suggest refactoring for its own sake, only when it provides clear
+value (readability, testability, performance, safety). You reference established
+patterns: Extract Function, Replace Conditional with Polymorphism, Introduce
+Parameter Object, etc.
+
+Respond in French.
+
+## Instructions
+
+1. Identify code smells: long functions, deep nesting, duplicate logic, god structs
+2. Evaluate coupling and cohesion
+3. Check for SOLID principle violations relevant to Rust (especially SRP and ISP via traits)
+4. Propose concrete refactoring steps with before/after snippets
+5. Estimate effort: small (< 30 min), medium (1-2h), large (> 2h)
+
+## Output Format
+
+## Analyse de refactoring
+
+### Opportunites identifiees
+
+#### 1. [Smell name] — Effort: small/medium/large
+**Ou**: file:line
+**Probleme**: description
+**Solution**: refactoring strategy
+**Avant**:
+```rust
+// current code
+```
+**Apres**:
+```rust
+// proposed code
+```
+
+### Priorites recommandees
+Ordered list from highest impact to lowest.

--- a/example/agents/rust-reviewer.md
+++ b/example/agents/rust-reviewer.md
@@ -1,0 +1,43 @@
+# Rust Reviewer
+
+## Metadata
+- provider: gemini
+- model: gemini-2.0-flash
+- temperature: 0.3
+- max_tokens: 4096
+- tags: [dev, review, quality]
+- stacks: [rust]
+- cost_limit: 0.50
+
+## System Prompt
+
+You are a senior Rust code reviewer. You focus on correctness, safety, and idiomatic Rust.
+You catch common pitfalls: unwrap abuse, unnecessary clones, missing error propagation,
+unsafe misuse, and lifetime issues. You suggest concrete fixes with code snippets.
+
+Respond in French.
+
+## Instructions
+
+1. Read the code and understand its purpose
+2. Check for correctness: off-by-one errors, logic bugs, potential panics
+3. Check for safety: no unnecessary `unsafe`, proper error handling with `?` or `Result`
+4. Check for performance: unnecessary allocations, missing `&str` vs `String`, iterator misuse
+5. Check for idiomatic Rust: proper use of `Option`/`Result` combinators, pattern matching, traits
+6. Provide a severity for each finding: critical, warning, or info
+
+## Output Format
+
+## Revue de code
+
+### Critique
+- [location] description — suggestion de fix
+
+### Avertissements
+- [location] description — suggestion de fix
+
+### Informations
+- [location] description — suggestion de fix
+
+### Verdict
+Summary sentence: APPROVE, REQUEST_CHANGES, or COMMENT.

--- a/example/agents/rust-test-writer.md
+++ b/example/agents/rust-test-writer.md
@@ -1,0 +1,41 @@
+# Rust Test Writer
+
+## Metadata
+- provider: gemini
+- model: gemini-2.0-flash
+- temperature: 0.3
+- max_tokens: 8192
+- tags: [dev, testing]
+- stacks: [rust]
+- cost_limit: 0.50
+
+## System Prompt
+
+You are a Rust testing expert. You write comprehensive unit tests using `#[cfg(test)]` modules.
+You follow the Arrange-Act-Assert pattern and use descriptive test names. You cover happy paths,
+edge cases, error conditions, and boundary values. You use `assert_eq!`, `assert!`, and
+`#[should_panic]` appropriately. You prefer `proptest` or `quickcheck` for property-based
+testing when relevant.
+
+Respond in French (comments in English in code).
+
+## Instructions
+
+1. Analyze the code to understand all public functions and their contracts
+2. Identify edge cases: empty inputs, zero values, max values, None, error paths
+3. Write tests organized by function, with descriptive names like `test_function_name_condition_expected`
+4. Use `tempfile` for filesystem tests, mock dependencies when needed
+5. Ensure tests are independent and deterministic
+
+## Output Format
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ... tests grouped by function
+}
+```
+
+Include a short summary of what is covered and what was intentionally skipped.

--- a/example/agents/security-auditor.md
+++ b/example/agents/security-auditor.md
@@ -1,0 +1,53 @@
+# Security Auditor
+
+## Metadata
+- provider: gemini
+- model: gemini-2.0-flash
+- temperature: 0.2
+- max_tokens: 4096
+- tags: [security, review]
+- stacks: [rust]
+- cost_limit: 0.50
+
+## System Prompt
+
+You are a security-focused code auditor for Rust applications. You specialize in
+identifying vulnerabilities in web applications and CLI tools. You look for OWASP
+top 10 issues adapted to Rust: injection, broken authentication, sensitive data
+exposure, XXE, broken access control, security misconfiguration, XSS (in web output),
+insecure deserialization, and known vulnerabilities in dependencies.
+
+Respond in French.
+
+## Instructions
+
+1. Scan for unsafe code blocks and evaluate necessity
+2. Check for command injection (if `std::process::Command` is used)
+3. Check for path traversal in file operations
+4. Check for SQL injection (if database queries are present)
+5. Verify proper input validation and sanitization
+6. Check for secrets/credentials hardcoded in code
+7. Verify error messages don't leak internal details
+8. Check dependency versions for known CVEs
+
+## Output Format
+
+## Audit de securite
+
+### Vulnerabilites (par severite)
+
+#### Critique
+- [CVE/CWE ref if applicable] description, impact, remediation
+
+#### Elevee
+- description, impact, remediation
+
+#### Moyenne
+- description, impact, remediation
+
+#### Faible
+- description, impact, remediation
+
+### Resume
+Risk level: CRITICAL / HIGH / MEDIUM / LOW / CLEAN
+Recommendations summary.

--- a/example/armadai.yaml
+++ b/example/armadai.yaml
@@ -1,0 +1,8 @@
+fleet: rust-web-team
+agents:
+  - rust-reviewer
+  - rust-test-writer
+  - security-auditor
+  - doc-writer
+  - refactor-advisor
+source: .

--- a/example/sample-code/user_service.rs
+++ b/example/sample-code/user_service.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone)]
+pub struct User {
+    pub id: u64,
+    pub name: String,
+    pub email: String,
+    pub role: String,
+    pub active: bool,
+}
+
+pub struct UserService {
+    users: Mutex<HashMap<u64, User>>,
+    next_id: Mutex<u64>,
+}
+
+impl UserService {
+    pub fn new() -> Self {
+        Self {
+            users: Mutex::new(HashMap::new()),
+            next_id: Mutex::new(1),
+        }
+    }
+
+    pub fn create_user(&self, name: String, email: String, role: String) -> Result<User, String> {
+        // Validate inputs
+        if name.is_empty() {
+            return Err("Name cannot be empty".into());
+        }
+        if !email.contains("@") {
+            return Err("Invalid email".into());
+        }
+
+        let mut id_lock = self.next_id.lock().unwrap();
+        let id = *id_lock;
+        *id_lock += 1;
+        drop(id_lock);
+
+        let user = User {
+            id,
+            name,
+            email,
+            role,
+            active: true,
+        };
+
+        self.users.lock().unwrap().insert(id, user.clone());
+        Ok(user)
+    }
+
+    pub fn get_user(&self, id: u64) -> Option<User> {
+        self.users.lock().unwrap().get(&id).cloned()
+    }
+
+    pub fn find_by_email(&self, email: &str) -> Option<User> {
+        self.users
+            .lock()
+            .unwrap()
+            .values()
+            .find(|u| u.email == email)
+            .cloned()
+    }
+
+    pub fn update_user(&self, id: u64, name: Option<String>, email: Option<String>) -> Result<User, String> {
+        let mut users = self.users.lock().unwrap();
+        let user = users.get_mut(&id).ok_or("User not found")?;
+
+        if let Some(n) = name {
+            user.name = n;
+        }
+        if let Some(e) = email {
+            if !e.contains("@") {
+                return Err("Invalid email".into());
+            }
+            user.email = e;
+        }
+
+        Ok(user.clone())
+    }
+
+    pub fn delete_user(&self, id: u64) -> Result<(), String> {
+        let mut users = self.users.lock().unwrap();
+        users.remove(&id).ok_or("User not found".into()).map(|_| ())
+    }
+
+    pub fn list_active_users(&self) -> Vec<User> {
+        self.users
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|u| u.active == true)
+            .cloned()
+            .collect()
+    }
+
+    pub fn deactivate_user(&self, id: u64) -> Result<(), String> {
+        let mut users = self.users.lock().unwrap();
+        match users.get_mut(&id) {
+            Some(user) => {
+                user.active = false;
+                Ok(())
+            }
+            None => Err(format!("User {} not found", id)),
+        }
+    }
+
+    pub fn search_users(&self, query: &str) -> Vec<User> {
+        let query_lower = query.to_lowercase();
+        self.users
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|u| {
+                u.name.to_lowercase().contains(&query_lower)
+                    || u.email.to_lowercase().contains(&query_lower)
+                    || u.role.to_lowercase().contains(&query_lower)
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub fn count_by_role(&self) -> HashMap<String, usize> {
+        let mut counts = HashMap::new();
+        for user in self.users.lock().unwrap().values() {
+            *counts.entry(user.role.clone()).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    pub fn bulk_import(&self, data: &str) -> Result<Vec<User>, String> {
+        let mut imported = Vec::new();
+        for line in data.lines() {
+            let parts: Vec<&str> = line.split(',').collect();
+            if parts.len() != 3 {
+                return Err(format!("Invalid line: {}", line));
+            }
+            let user = self.create_user(
+                parts[0].trim().to_string(),
+                parts[1].trim().to_string(),
+                parts[2].trim().to_string(),
+            )?;
+            imported.push(user);
+        }
+        Ok(imported)
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# ArmadAI installer — downloads the latest release binary for your platform.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Dr0drigues/swarm-festai/develop/install.sh | bash
+#
+# Options (via environment variables):
+#   INSTALL_DIR   — where to install (default: ~/.local/bin)
+#   VERSION       — specific version to install (default: latest)
+
+set -euo pipefail
+
+REPO="Dr0drigues/swarm-festai"
+BINARY_NAME="armadai"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+# Detect OS and architecture
+detect_platform() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Linux)  os="linux" ;;
+        Darwin) os="macos" ;;
+        *)      echo "Error: unsupported OS: $os" >&2; exit 1 ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64)   arch="x86_64" ;;
+        aarch64|arm64)  arch="aarch64" ;;
+        *)              echo "Error: unsupported architecture: $arch" >&2; exit 1 ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+# Get the latest release tag from GitHub
+get_latest_version() {
+    local url="https://api.github.com/repos/${REPO}/releases/latest"
+    if command -v curl &>/dev/null; then
+        curl -fsSL "$url" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//'
+    elif command -v wget &>/dev/null; then
+        wget -qO- "$url" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//'
+    else
+        echo "Error: curl or wget is required" >&2
+        exit 1
+    fi
+}
+
+main() {
+    local platform version artifact_name download_url tmp_dir
+
+    platform="$(detect_platform)"
+    artifact_name="armadai-${platform}"
+
+    echo "ArmadAI Installer"
+    echo "================="
+    echo ""
+
+    # Determine version
+    if [ -n "${VERSION:-}" ]; then
+        version="$VERSION"
+        echo "Installing version: $version"
+    else
+        echo "Fetching latest version..."
+        version="$(get_latest_version)"
+        if [ -z "$version" ]; then
+            echo "Error: could not determine latest version." >&2
+            echo "You can specify a version with: VERSION=v0.1.0 $0" >&2
+            exit 1
+        fi
+        echo "Latest version: $version"
+    fi
+
+    download_url="https://github.com/${REPO}/releases/download/${version}/${artifact_name}"
+    echo "Platform: $platform"
+    echo "Download: $download_url"
+    echo ""
+
+    # Download
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+
+    echo "Downloading..."
+    if command -v curl &>/dev/null; then
+        curl -fsSL -o "${tmp_dir}/${BINARY_NAME}" "$download_url"
+    else
+        wget -qO "${tmp_dir}/${BINARY_NAME}" "$download_url"
+    fi
+
+    # Install
+    mkdir -p "$INSTALL_DIR"
+    chmod +x "${tmp_dir}/${BINARY_NAME}"
+    mv "${tmp_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+
+    echo "Installed to: ${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Check PATH
+    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+        echo ""
+        echo "Warning: $INSTALL_DIR is not in your PATH."
+        echo "Add it with:"
+        echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc"
+        echo "  # or for zsh:"
+        echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc"
+    fi
+
+    echo ""
+    echo "Done! Run 'armadai --version' to verify."
+}
+
+main "$@"

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -78,7 +78,7 @@ async fn show_providers() -> anyhow::Result<()> {
         }
     } else if plain_path.exists() {
         println!(
-            "Secrets: unencrypted at {} (consider running: swarm config secrets init)",
+            "Secrets: unencrypted at {} (consider running: armadai config secrets init)",
             plain_path.display()
         );
         match crate::secrets::load_secrets(config_dir) {
@@ -99,7 +99,7 @@ async fn show_providers() -> anyhow::Result<()> {
         }
     } else {
         println!("No secrets file found. Create one:");
-        println!("  Option A: swarm config secrets init  (encrypted with SOPS + age)");
+        println!("  Option A: armadai config secrets init  (encrypted with SOPS + age)");
         println!("  Option B: Create config/providers.secret.yaml manually (unencrypted)");
     }
 
@@ -187,14 +187,14 @@ async fn secrets_rotate() -> anyhow::Result<()> {
 
     if !key_path.exists() {
         anyhow::bail!(
-            "No age key found at {}. Run 'swarm config secrets init' first.",
+            "No age key found at {}. Run 'armadai config secrets init' first.",
             key_path.display()
         );
     }
 
     if !sops_path.exists() {
         anyhow::bail!(
-            "No encrypted secrets file found at {}. Run 'swarm config secrets init' first.",
+            "No encrypted secrets file found at {}. Run 'armadai config secrets init' first.",
             sops_path.display()
         );
     }

--- a/src/cli/fleet.rs
+++ b/src/cli/fleet.rs
@@ -6,7 +6,7 @@ use dialoguer::MultiSelect;
 use crate::core::agent::Agent;
 use crate::core::fleet::FleetDefinition;
 
-const FLEET_FILENAME: &str = "swarm.yaml";
+const FLEET_FILENAME: &str = "armadai.yaml";
 
 #[derive(Subcommand)]
 pub enum FleetAction {
@@ -28,13 +28,13 @@ pub enum FleetAction {
     },
     /// Link a fleet to a project directory
     #[command(
-        long_about = "Create a swarm.yaml in the target directory, linking it to a fleet.\n\n\
+        long_about = "Create a armadai.yaml in the target directory, linking it to a fleet.\n\n\
             By default links to the current directory (--local). Use --global to store in \
-            ~/.config/swarm/fleets/ or --path for a specific directory.",
+            ~/.config/armadai/fleets/ or --path for a specific directory.",
         after_help = "Examples:\n  \
-            swarm fleet link my-fleet\n  \
-            swarm fleet link my-fleet --global\n  \
-            swarm fleet link my-fleet --path /projects/web-app"
+            armadai fleet link my-fleet\n  \
+            armadai fleet link my-fleet --global\n  \
+            armadai fleet link my-fleet --path /projects/web-app"
     )]
     Link {
         /// Fleet name
@@ -42,7 +42,7 @@ pub enum FleetAction {
         /// Link in current directory (default)
         #[arg(long, default_value_t = true)]
         local: bool,
-        /// Link in global config (~/.config/swarm/fleets/)
+        /// Link in global config (~/.config/armadai/fleets/)
         #[arg(long)]
         global: bool,
         /// Link in a specific directory
@@ -132,7 +132,7 @@ async fn create_fleet(
         anyhow::bail!("No agents matched the criteria");
     }
 
-    // Resolve source directory (current working directory assumed to be the swarm-festai root)
+    // Resolve source directory (current working directory assumed to be the armadai-festai root)
     let source = std::env::current_dir()?;
 
     let fleet = FleetDefinition {
@@ -154,12 +154,12 @@ async fn create_fleet(
         println!("  - {a}");
     }
     println!("\nSaved to: {}", fleet_path.display());
-    println!("Link it to a project: swarm fleet link {name}");
+    println!("Link it to a project: armadai fleet link {name}");
 
     Ok(())
 }
 
-/// Link a fleet to a directory by creating swarm.yaml.
+/// Link a fleet to a directory by creating armadai.yaml.
 fn link_fleet(name: &str, global: bool, path: Option<&Path>) -> anyhow::Result<()> {
     // Load fleet definition
     let fleet_path = global_fleet_path(name);
@@ -173,7 +173,7 @@ fn link_fleet(name: &str, global: bool, path: Option<&Path>) -> anyhow::Result<(
                 return Ok(());
             }
         }
-        anyhow::bail!("Fleet '{name}' not found. Create it first: swarm fleet create {name}");
+        anyhow::bail!("Fleet '{name}' not found. Create it first: armadai fleet create {name}");
     }
 
     let fleet = FleetDefinition::load(&fleet_path)?;
@@ -237,7 +237,7 @@ fn list_fleets() -> anyhow::Result<()> {
 
     if !found {
         println!("No fleets found.");
-        println!("Create one: swarm fleet create <name>");
+        println!("Create one: armadai fleet create <name>");
     }
 
     Ok(())
@@ -304,7 +304,7 @@ fn global_fleet_dir() -> PathBuf {
             let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
             PathBuf::from(home).join(".config")
         });
-    config_base.join("swarm").join("fleets")
+    config_base.join("armadai").join("fleets")
 }
 
 /// Get the path for a specific fleet's global config file.

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -8,7 +8,7 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
 
     if agents.is_empty() {
         println!("No agents found in {}/", agents_dir.display());
-        println!("Create one with: swarm new --template basic <name>");
+        println!("Create one with: armadai new --template basic <name>");
         return Ok(());
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,25 +7,26 @@ mod list;
 pub(crate) mod new;
 mod run;
 mod up;
+mod update;
 mod validate;
 
 use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
-    name = "swarm",
+    name = "armadai",
     about = "AI agent fleet orchestrator",
     long_about = "AI agent fleet orchestrator — define, manage and run specialized agents from Markdown files.\n\n\
         Each agent is a .md file in agents/ with metadata, system prompt, and optional instructions.\n\
         Supports any LLM provider (Claude, GPT, Gemini) via CLI tools or API.",
     version,
     after_help = "Examples:\n  \
-        swarm new my-agent --template dev-review --stack rust\n  \
-        swarm run my-agent \"Review this code for bugs\"\n  \
-        swarm run --pipe reviewer writer src/main.rs\n  \
-        swarm list --tags dev --stack rust\n  \
-        swarm tui\n  \
-        swarm web --port 8080\n\n\
+        armadai new my-agent --template dev-review --stack rust\n  \
+        armadai run my-agent \"Review this code for bugs\"\n  \
+        armadai run --pipe reviewer writer src/main.rs\n  \
+        armadai list --tags dev --stack rust\n  \
+        armadai tui\n  \
+        armadai web --port 8080\n\n\
         Documentation: https://github.com/Dr0drigues/swarm-festai"
 )]
 pub struct Cli {
@@ -42,9 +43,9 @@ pub enum Command {
             configured provider, and prints the response. Use --pipe to chain multiple \
             agents sequentially (output of one becomes input of the next).",
         after_help = "Examples:\n  \
-            swarm run code-reviewer \"Review this function\"\n  \
-            swarm run summarizer @long-document.txt\n  \
-            swarm run --pipe reviewer writer src/main.rs"
+            armadai run code-reviewer \"Review this function\"\n  \
+            armadai run summarizer @long-document.txt\n  \
+            armadai run --pipe reviewer writer src/main.rs"
     )]
     Run {
         /// Agent name (filename without .md)
@@ -63,10 +64,10 @@ pub enum Command {
             The new agent is created at agents/<name>.md.\n\n\
             Use --interactive (-i) for a guided step-by-step creation wizard.",
         after_help = "Examples:\n  \
-            swarm new my-assistant\n  \
-            swarm new reviewer --template dev-review --stack rust\n  \
-            swarm new scanner --template security-review -d \"audit OWASP top 10\"\n  \
-            swarm new -i"
+            armadai new my-assistant\n  \
+            armadai new reviewer --template dev-review --stack rust\n  \
+            armadai new scanner --template security-review -d \"audit OWASP top 10\"\n  \
+            armadai new -i"
     )]
     New {
         /// Agent name (optional in interactive mode)
@@ -86,9 +87,9 @@ pub enum Command {
     },
     /// List available agents
     #[command(after_help = "Examples:\n  \
-        swarm list\n  \
-        swarm list --tags dev review\n  \
-        swarm list --stack rust")]
+        armadai list\n  \
+        armadai list --tags dev review\n  \
+        armadai list --stack rust")]
     List {
         /// Filter by tags
         #[arg(long)]
@@ -117,9 +118,9 @@ pub enum Command {
     },
     /// View execution history
     #[command(after_help = "Examples:\n  \
-        swarm history\n  \
-        swarm history --agent code-reviewer\n  \
-        swarm history --replay abc123")]
+        armadai history\n  \
+        armadai history --agent code-reviewer\n  \
+        armadai history --replay abc123")]
     History {
         /// Filter by agent name
         #[arg(long)]
@@ -130,9 +131,9 @@ pub enum Command {
     },
     /// View cost tracking
     #[command(after_help = "Examples:\n  \
-        swarm costs\n  \
-        swarm costs --agent code-reviewer\n  \
-        swarm costs --from 2025-01-01")]
+        armadai costs\n  \
+        armadai costs --agent code-reviewer\n  \
+        armadai costs --from 2025-01-01")]
     Costs {
         /// Filter by agent name
         #[arg(long)]
@@ -146,9 +147,9 @@ pub enum Command {
         long_about = "Manage providers and secrets.\n\n\
             Configure API keys, view provider status, and manage SOPS + age encryption.",
         after_help = "Examples:\n  \
-            swarm config providers\n  \
-            swarm config secrets init\n  \
-            swarm config secrets rotate"
+            armadai config providers\n  \
+            armadai config secrets init\n  \
+            armadai config secrets rotate"
     )]
     Config {
         #[command(subcommand)]
@@ -168,8 +169,8 @@ pub enum Command {
             Starts an HTTP server with a browser-based dashboard for browsing agents, \
             viewing execution history, and tracking costs.",
         after_help = "Examples:\n  \
-            swarm web\n  \
-            swarm web --port 8080"
+            armadai web\n  \
+            armadai web --port 8080"
     )]
     Web {
         /// Port to listen on
@@ -182,25 +183,29 @@ pub enum Command {
     Up,
     /// Stop infrastructure services (Docker Compose)
     #[command(long_about = "Stop infrastructure services (Docker Compose).\n\n\
-        Stops and removes the containers started by 'swarm up'.")]
+        Stops and removes the containers started by 'armadai up'.")]
     Down,
     /// Manage agent fleets
     #[command(
         subcommand,
         long_about = "Manage agent fleets.\n\n\
-            Create named groups of agents and link them to project directories via swarm.yaml.",
+            Create named groups of agents and link them to project directories via armadai.yaml.",
         after_help = "Examples:\n  \
-            swarm fleet create my-fleet --all\n  \
-            swarm fleet link my-fleet\n  \
-            swarm fleet list\n  \
-            swarm fleet show my-fleet"
+            armadai fleet create my-fleet --all\n  \
+            armadai fleet link my-fleet\n  \
+            armadai fleet list\n  \
+            armadai fleet show my-fleet"
     )]
     Fleet(fleet::FleetAction),
+    /// Self-update to the latest release
+    #[command(long_about = "Self-update to the latest release.\n\n\
+            Downloads the latest binary from GitHub Releases and replaces the current one.")]
+    Update,
     /// Generate shell completion scripts
     #[command(after_help = "Examples:\n  \
-        swarm completion bash > ~/.local/share/bash-completion/completions/swarm\n  \
-        swarm completion zsh > ~/.zfunc/_swarm\n  \
-        swarm completion fish > ~/.config/fish/completions/swarm.fish")]
+        armadai completion bash > ~/.local/share/bash-completion/completions/armadai\n  \
+        armadai completion zsh > ~/.zfunc/_armadai\n  \
+        armadai completion fish > ~/.config/fish/completions/armadai.fish")]
     Completion {
         /// Shell to generate completions for
         #[arg(value_enum)]
@@ -229,10 +234,16 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         #[cfg(feature = "web")]
         Command::Web { port } => crate::web::serve(port).await,
         Command::Fleet(action) => fleet::execute(action).await,
+        Command::Update => update::execute().await,
         Command::Up => up::start().await,
         Command::Down => up::stop().await,
         Command::Completion { shell } => {
-            clap_complete::generate(shell, &mut Cli::command(), "swarm", &mut std::io::stdout());
+            clap_complete::generate(
+                shell,
+                &mut Cli::command(),
+                "armadai",
+                &mut std::io::stdout(),
+            );
             Ok(())
         }
     }

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -100,7 +100,7 @@ async fn interactive_create() -> anyhow::Result<()> {
     let templates_dir = Path::new("templates");
     let agents_dir = Path::new("agents");
 
-    println!("🧙 Swarm Agent Creation Wizard\n");
+    println!("🧙 ArmadAI Agent Creation Wizard\n");
 
     // 1. Agent name
     let name: String = Input::new()

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -183,11 +183,11 @@ async fn resolve_input(input: Option<String>) -> anyhow::Result<String> {
                 let mut buf = String::new();
                 std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
                 if buf.is_empty() {
-                    anyhow::bail!("No input provided. Usage: swarm run <agent> <input>");
+                    anyhow::bail!("No input provided. Usage: armadai run <agent> <input>");
                 }
                 Ok(buf)
             } else {
-                anyhow::bail!("No input provided. Usage: swarm run <agent> \"<input>\"");
+                anyhow::bail!("No input provided. Usage: armadai run <agent> \"<input>\"");
             }
         }
     }
@@ -199,11 +199,11 @@ fn atty_is_pipe() -> bool {
     !std::io::stdin().is_terminal()
 }
 
-/// Resolve the agents directory: if a `swarm.yaml` fleet file exists in the
+/// Resolve the agents directory: if a `armadai.yaml` fleet file exists in the
 /// current directory, use the fleet's source/agents/ path. Otherwise default
 /// to the local `agents/` directory.
 fn resolve_agents_dir() -> (PathBuf, Option<FleetDefinition>) {
-    let fleet_path = Path::new("swarm.yaml");
+    let fleet_path = Path::new("armadai.yaml");
     if fleet_path.exists()
         && let Ok(fleet) = FleetDefinition::load(fleet_path)
     {
@@ -231,10 +231,10 @@ mod tests {
 
     #[test]
     fn test_resolve_agents_dir_no_fleet() {
-        // When no swarm.yaml exists in the current directory,
+        // When no armadai.yaml exists in the current directory,
         // resolve_agents_dir should return the default "agents" path
         let (dir, fleet) = resolve_agents_dir();
-        // We can't guarantee swarm.yaml doesn't exist in the test runner's cwd,
+        // We can't guarantee armadai.yaml doesn't exist in the test runner's cwd,
         // but the function should not panic
         assert!(fleet.is_none() || fleet.is_some());
         // dir should be a valid path

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,0 +1,101 @@
+use std::process::Command as ProcessCommand;
+
+/// Self-update armadai by downloading the latest release binary.
+pub async fn execute() -> anyhow::Result<()> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    let platform = match (os, arch) {
+        ("linux", "x86_64") => "linux-x86_64",
+        ("linux", "aarch64") => "linux-aarch64",
+        ("macos", "x86_64") => "macos-x86_64",
+        ("macos", "aarch64") => "macos-aarch64",
+        _ => anyhow::bail!("Unsupported platform: {os}/{arch}"),
+    };
+
+    let repo = "Dr0drigues/swarm-festai";
+    let current_version = env!("CARGO_PKG_VERSION");
+    println!("Current version: v{current_version}");
+    println!("Checking for updates...");
+
+    // Get latest release tag
+    let output = ProcessCommand::new("curl")
+        .args([
+            "-fsSL",
+            &format!("https://api.github.com/repos/{repo}/releases/latest"),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Failed to check for updates: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    let latest_version = body
+        .lines()
+        .find(|l| l.contains("\"tag_name\""))
+        .and_then(|l| {
+            l.split('"')
+                .nth(3)
+                .map(|v| v.strip_prefix('v').unwrap_or(v).to_string())
+        })
+        .ok_or_else(|| anyhow::anyhow!("Could not parse latest version from GitHub API"))?;
+
+    if latest_version == current_version {
+        println!("Already up to date (v{current_version}).");
+        return Ok(());
+    }
+
+    println!("New version available: v{latest_version}");
+
+    // Find where the current binary is installed
+    let current_exe = std::env::current_exe()?;
+    let install_dir = current_exe
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine install directory"))?;
+
+    let artifact = format!("armadai-{platform}");
+    let download_url =
+        format!("https://github.com/{repo}/releases/download/v{latest_version}/{artifact}");
+
+    println!("Downloading v{latest_version} for {platform}...");
+
+    // Download to temp file
+    let tmp_path = install_dir.join(".armadai-update-tmp");
+    let status = ProcessCommand::new("curl")
+        .args([
+            "-fsSL",
+            "-o",
+            &tmp_path.display().to_string(),
+            &download_url,
+        ])
+        .status()?;
+
+    if !status.success() {
+        // Clean up
+        let _ = std::fs::remove_file(&tmp_path);
+        anyhow::bail!(
+            "Download failed. Check your network connection or try: VERSION=v{latest_version} install.sh"
+        );
+    }
+
+    // Make executable
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&tmp_path, perms)?;
+    }
+
+    // Replace current binary
+    let target_path = install_dir.join("armadai");
+    std::fs::rename(&tmp_path, &target_path)?;
+
+    println!("Updated to v{latest_version}!");
+    println!("Run 'armadai --version' to verify.");
+
+    Ok(())
+}

--- a/src/core/fleet.rs
+++ b/src/core/fleet.rs
@@ -3,14 +3,14 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 /// A fleet definition linking a named group of agents to a source directory.
-/// Serialized as `swarm.yaml` in project directories.
+/// Serialized as `armadai.yaml` in project directories.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FleetDefinition {
     /// Fleet name
     pub fleet: String,
     /// Agent names (file stems without .md)
     pub agents: Vec<String>,
-    /// Absolute path to the swarm-festai source directory
+    /// Absolute path to the ArmadAI source directory
     pub source: PathBuf,
 }
 
@@ -52,7 +52,7 @@ mod tests {
         let fleet = FleetDefinition {
             fleet: "test-fleet".to_string(),
             agents: vec!["code-reviewer".to_string(), "test-writer".to_string()],
-            source: PathBuf::from("/home/user/swarm-festai"),
+            source: PathBuf::from("/home/user/armadai"),
         };
 
         let yaml = serde_yml::to_string(&fleet).unwrap();
@@ -60,7 +60,7 @@ mod tests {
 
         assert_eq!(parsed.fleet, "test-fleet");
         assert_eq!(parsed.agents.len(), 2);
-        assert_eq!(parsed.source, PathBuf::from("/home/user/swarm-festai"));
+        assert_eq!(parsed.source, PathBuf::from("/home/user/armadai"));
     }
 
     #[test]
@@ -79,12 +79,12 @@ mod tests {
     #[test]
     fn test_fleet_load_save_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("swarm.yaml");
+        let path = dir.path().join("armadai.yaml");
 
         let fleet = FleetDefinition {
             fleet: "my-fleet".to_string(),
             agents: vec!["agent-a".to_string(), "agent-b".to_string()],
-            source: PathBuf::from("/opt/swarm"),
+            source: PathBuf::from("/opt/armadai"),
         };
 
         fleet.save(&path).unwrap();
@@ -92,6 +92,6 @@ mod tests {
 
         assert_eq!(loaded.fleet, "my-fleet");
         assert_eq!(loaded.agents, vec!["agent-a", "agent-b"]);
-        assert_eq!(loaded.source, PathBuf::from("/opt/swarm"));
+        assert_eq!(loaded.source, PathBuf::from("/opt/armadai"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("swarm_festai=info".parse()?),
+                .add_directive("armadai=info".parse()?),
         )
         .init();
 

--- a/src/storage/embedded.rs
+++ b/src/storage/embedded.rs
@@ -7,7 +7,7 @@ use surrealdb::engine::local::{Db, RocksDb};
 #[cfg(feature = "storage-rocksdb")]
 pub async fn init_persistent(path: &str) -> anyhow::Result<Surreal<Db>> {
     let db = Surreal::new::<RocksDb>(path).await?;
-    db.use_ns("swarm").use_db("main").await?;
+    db.use_ns("armadai").use_db("main").await?;
     super::schema::apply(&db).await?;
     Ok(db)
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,7 +10,7 @@ pub type Database = Surreal<Db>;
 /// Initialize an embedded in-memory SurrealDB instance.
 pub async fn init_embedded() -> anyhow::Result<Database> {
     let db = Surreal::new::<Mem>(()).await?;
-    db.use_ns("swarm").use_db("main").await?;
+    db.use_ns("armadai").use_db("main").await?;
     schema::apply(&db).await?;
     Ok(db)
 }
@@ -20,7 +20,7 @@ pub async fn init_embedded() -> anyhow::Result<Database> {
 pub async fn init_db() -> anyhow::Result<Database> {
     #[cfg(feature = "storage-rocksdb")]
     {
-        let path = "data/swarm.db";
+        let path = "data/armadai.db";
         if let Some(parent) = std::path::Path::new(path).parent() {
             std::fs::create_dir_all(parent)?;
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -112,7 +112,7 @@ impl CommandPalette {
             },
             PaletteCommand {
                 name: "new".to_string(),
-                description: "Create a new agent (run swarm new)".to_string(),
+                description: "Create a new agent (run armadai new)".to_string(),
                 action: PaletteAction::NewAgent,
             },
             PaletteCommand {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -54,7 +54,7 @@ pub async fn run() -> Result<()> {
                                 PaletteAction::Quit => break,
                                 PaletteAction::NewAgent => {
                                     app.status_msg =
-                                        Some("Run 'swarm new <name>' from terminal".to_string());
+                                        Some("Run 'armadai new <name>' from terminal".to_string());
                                 }
                             }
                         }

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -25,11 +25,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         .collect();
 
     let tabs = Tabs::new(titles)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" swarm-festai "),
-        )
+        .block(Block::default().borders(Borders::ALL).title(" ArmadAI "))
         .select(app.tab_index)
         .style(Style::default().fg(Color::White))
         .highlight_style(
@@ -54,7 +50,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 fn render_agent_list(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     if app.agents.is_empty() {
         let msg = Paragraph::new(
-            "No agents found. Create one with: swarm new my-agent\n\n\
+            "No agents found. Create one with: armadai new my-agent\n\n\
              Press ':' to open command palette",
         )
         .block(Block::default().borders(Borders::ALL).title(" Agents "));

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -10,7 +10,7 @@ use crate::tui::app::App;
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.history.is_empty() {
         let msg =
-            Paragraph::new("No execution history. Run an agent first: swarm run <agent> <input>")
+            Paragraph::new("No execution history. Run an agent first: armadai run <agent> <input>")
                 .block(Block::default().borders(Borders::ALL).title(" History "));
         frame.render_widget(msg, area);
         return;

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>swarm-festai</title>
+<title>ArmadAI</title>
 <style>
   :root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --green: #3fb950; --yellow: #d29922; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -43,7 +43,7 @@
 </head>
 <body>
 <header>
-  <h1><span>swarm</span>-festai</h1>
+  <h1><span>Armad</span>AI</h1>
   <nav>
     <button class="active" onclick="showTab('agents')">Agents</button>
     <button onclick="showTab('history')">History</button>
@@ -74,7 +74,7 @@ async function loadAgents() {
   const res = await fetch('/api/agents');
   const agents = await res.json();
   const el = document.getElementById('agents');
-  if (!agents.length) { el.innerHTML = '<div class="empty">No agents found. Create one with: swarm new my-agent</div>'; return; }
+  if (!agents.length) { el.innerHTML = '<div class="empty">No agents found. Create one with: armadai new my-agent</div>'; return; }
   el.innerHTML = `
     <div class="card-header">${agents.length} agents loaded</div>
     <table>


### PR DESCRIPTION
## Summary

- **Full rebrand** from `swarm`/`swarm-festai` to `armadai`/`ArmadAI` across 41 files (code, config, CI, docs)
- **Install script** (`install.sh`): platform-detecting `curl | bash` installer for GitHub Releases
- **Self-update** (`armadai update`): checks latest version and replaces binary in-place
- **Example directory** with 5 Gemini-powered agents, fleet config, and sample Rust code

### Rebrand scope

| Area | Files |
|---|---|
| Binary & package | `Cargo.toml`, `src/main.rs` |
| CLI & commands | `src/cli/*.rs` (mod, fleet, run, new, list, config) |
| TUI & Web | `src/tui/**`, `src/web/index.html` |
| Storage | `src/storage/mod.rs`, `src/storage/embedded.rs` |
| Core | `src/core/fleet.rs` |
| Config | `config/settings.yaml`, `config/providers.yaml` |
| CI/CD | `.github/workflows/release.yml` |
| Docker | `docker-compose.yml` |
| Docs | `README.md`, `ARCHITECTURE.md`, `CLAUDE.md`, `AGENTS.md`, `docs/**` |

### New files

- `install.sh` — cross-platform installer
- `src/cli/update.rs` — `armadai update` command
- `example/` — complete fleet example (5 agents + fleet config + sample code + README)

## Test plan

- [x] `cargo clippy --no-default-features --features tui` — 0 warnings
- [x] `cargo test --no-default-features --features tui` — 25/25 tests pass
- [x] `cargo fmt -- --check` — clean
- [x] `grep -r swarm src/` — only GitHub URLs remain (correct)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)