### PR TITLE
feat: add link command to generate native AI assistant configs

### DIFF
--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+
+use crate::core::project;
+use crate::linker::{self, LinkAgent};
+use crate::parser;
+
+pub async fn execute(
+    target: Option<String>,
+    dry_run: bool,
+    force: bool,
+    output: Option<PathBuf>,
+    agents_filter: Option<Vec<String>>,
+) -> anyhow::Result<()> {
+    // 1. Find project config
+    let (root, config) = project::find_project_config().ok_or_else(|| {
+        anyhow::anyhow!("No armadai.yaml found. Run `armadai init --project` to create one.")
+    })?;
+
+    if config.agents.is_empty() {
+        anyhow::bail!("No agents declared in armadai.yaml.");
+    }
+
+    // 2. Resolve and parse agents
+    let (paths, errors) = project::resolve_all_agents(&config, &root);
+    for err in &errors {
+        eprintln!("  warn: {err}");
+    }
+
+    let mut link_agents: Vec<LinkAgent> = Vec::new();
+    for path in &paths {
+        match parser::parse_agent_file(path) {
+            Ok(agent) => link_agents.push(LinkAgent::from(&agent)),
+            Err(e) => eprintln!("  warn: failed to parse {}: {e}", path.display()),
+        }
+    }
+
+    if link_agents.is_empty() {
+        anyhow::bail!("No agents could be resolved. Check your armadai.yaml.");
+    }
+
+    // 3. Filter by --agents if provided
+    if let Some(ref filter) = agents_filter {
+        let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
+        link_agents.retain(|a| filter_lower.contains(&a.name.to_lowercase()));
+        if link_agents.is_empty() {
+            anyhow::bail!("No agents match the given filter: {}", filter.join(", "));
+        }
+    }
+
+    // 4. Determine target
+    let target_name = target
+        .or_else(|| config.link.as_ref().and_then(|l| l.target.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No link target specified. Use --target or set link.target in armadai.yaml.\n\
+                 Supported targets: claude, copilot"
+            )
+        })?;
+
+    // 5. Create linker
+    let linker = linker::create_linker(&target_name)?;
+
+    // 6. Determine output directory
+    let output_dir = output
+        .or_else(|| {
+            config
+                .link
+                .as_ref()
+                .and_then(|l| l.overrides.get(&target_name))
+                .and_then(|o| o.output.as_ref())
+                .map(PathBuf::from)
+        })
+        .unwrap_or_else(|| PathBuf::from(linker.default_output_dir()));
+
+    // 7. Generate files
+    let sources = &config.sources;
+    let files = linker.generate(&link_agents, sources);
+
+    if files.is_empty() {
+        println!("No files to generate.");
+        return Ok(());
+    }
+
+    // 8. Resolve output paths relative to project root
+    let output_files: Vec<_> = files
+        .into_iter()
+        .map(|f| {
+            // Replace the default output dir prefix with the custom output dir
+            let default_dir = PathBuf::from(linker.default_output_dir());
+            let relative = f.path.strip_prefix(&default_dir).unwrap_or(&f.path);
+            let final_path = root.join(&output_dir).join(relative);
+            (final_path, f.content)
+        })
+        .collect();
+
+    // 9. Dry run or write
+    if dry_run {
+        println!(
+            "Dry run — files that would be generated for '{}':\n",
+            target_name
+        );
+        for (path, _) in &output_files {
+            println!("  {}", path.display());
+        }
+        println!("\n  {} file(s) total.", output_files.len());
+        return Ok(());
+    }
+
+    let mut written = 0;
+    let mut skipped = 0;
+
+    for (path, content) in &output_files {
+        if path.exists() && !force {
+            eprintln!(
+                "  skip: {} already exists (use --force to overwrite)",
+                path.display()
+            );
+            skipped += 1;
+            continue;
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, content)?;
+        println!("  wrote {}", path.display());
+        written += 1;
+    }
+
+    println!(
+        "\nLinked {} agent(s) to '{}': {} written, {} skipped.",
+        link_agents.len(),
+        target_name,
+        written,
+        skipped
+    );
+
+    Ok(())
+}

--- a/src/linker/claude.rs
+++ b/src/linker/claude.rs
@@ -1,0 +1,152 @@
+use std::path::PathBuf;
+
+use super::{LinkAgent, Linker, OutputFile, slugify};
+
+/// Generates Claude Code sub-agent files (`.claude/agents/{slug}.md`).
+pub struct ClaudeLinker;
+
+impl Linker for ClaudeLinker {
+    fn name(&self) -> &str {
+        "claude"
+    }
+
+    fn default_output_dir(&self) -> &str {
+        ".claude/agents"
+    }
+
+    fn generate(&self, agents: &[LinkAgent], _sources: &[String]) -> Vec<OutputFile> {
+        agents.iter().map(generate_file).collect()
+    }
+}
+
+fn generate_file(agent: &LinkAgent) -> OutputFile {
+    let slug = slugify(&agent.name);
+    let path = PathBuf::from(".claude/agents").join(format!("{slug}.md"));
+
+    let mut content = String::new();
+
+    // System prompt (main content)
+    content.push_str(&agent.system_prompt);
+
+    // Instructions section
+    if let Some(ref instructions) = agent.instructions {
+        ensure_blank_line(&mut content);
+        content.push_str("## Instructions\n\n");
+        content.push_str(instructions);
+    }
+
+    // Output format section
+    if let Some(ref output_format) = agent.output_format {
+        ensure_blank_line(&mut content);
+        content.push_str("## Output Format\n\n");
+        content.push_str(output_format);
+    }
+
+    // Context section
+    if let Some(ref context) = agent.context {
+        ensure_blank_line(&mut content);
+        content.push_str("## Context\n\n");
+        content.push_str(context);
+    }
+
+    // Ensure trailing newline
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    OutputFile { path, content }
+}
+
+/// Ensure there are two newlines (blank line) before a new section.
+fn ensure_blank_line(content: &mut String) {
+    if !content.ends_with("\n\n") {
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(name: &str, system_prompt: &str) -> LinkAgent {
+        LinkAgent {
+            name: name.to_string(),
+            system_prompt: system_prompt.to_string(),
+            instructions: None,
+            output_format: None,
+            context: None,
+            description: Some(system_prompt.lines().next().unwrap_or("").to_string()),
+            tags: vec![],
+            stacks: vec![],
+        }
+    }
+
+    #[test]
+    fn test_generate_simple_agent() {
+        let linker = ClaudeLinker;
+        let agents = vec![make_agent("Code Reviewer", "You are a code reviewer.")];
+        let files = linker.generate(&agents, &[]);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].path,
+            PathBuf::from(".claude/agents/code-reviewer.md")
+        );
+        assert_eq!(files[0].content, "You are a code reviewer.\n");
+    }
+
+    #[test]
+    fn test_generate_with_all_sections() {
+        let linker = ClaudeLinker;
+        let agents = vec![LinkAgent {
+            name: "Test Agent".to_string(),
+            system_prompt: "You are a test agent.".to_string(),
+            instructions: Some("Follow TDD practices.".to_string()),
+            output_format: Some("JSON output.".to_string()),
+            context: Some("Rust project.".to_string()),
+            description: Some("You are a test agent.".to_string()),
+            tags: vec!["test".to_string()],
+            stacks: vec!["rust".to_string()],
+        }];
+        let files = linker.generate(&agents, &[]);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from(".claude/agents/test-agent.md"));
+        assert!(files[0].content.contains("You are a test agent."));
+        assert!(
+            files[0]
+                .content
+                .contains("## Instructions\n\nFollow TDD practices.")
+        );
+        assert!(
+            files[0]
+                .content
+                .contains("## Output Format\n\nJSON output.")
+        );
+        assert!(files[0].content.contains("## Context\n\nRust project."));
+        assert!(files[0].content.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_generate_multiple_agents() {
+        let linker = ClaudeLinker;
+        let agents = vec![
+            make_agent("Agent One", "First agent."),
+            make_agent("Agent Two", "Second agent."),
+        ];
+        let files = linker.generate(&agents, &[]);
+
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].path, PathBuf::from(".claude/agents/agent-one.md"));
+        assert_eq!(files[1].path, PathBuf::from(".claude/agents/agent-two.md"));
+    }
+
+    #[test]
+    fn test_default_output_dir() {
+        let linker = ClaudeLinker;
+        assert_eq!(linker.default_output_dir(), ".claude/agents");
+    }
+}

--- a/src/linker/copilot.rs
+++ b/src/linker/copilot.rs
@@ -1,0 +1,171 @@
+use std::path::PathBuf;
+
+use super::{LinkAgent, Linker, OutputFile, slugify};
+
+/// Generates GitHub Copilot agent files (`.github/agents/{slug}.agent.md`).
+pub struct CopilotLinker;
+
+impl Linker for CopilotLinker {
+    fn name(&self) -> &str {
+        "copilot"
+    }
+
+    fn default_output_dir(&self) -> &str {
+        ".github/agents"
+    }
+
+    fn generate(&self, agents: &[LinkAgent], _sources: &[String]) -> Vec<OutputFile> {
+        agents.iter().map(generate_file).collect()
+    }
+}
+
+fn generate_file(agent: &LinkAgent) -> OutputFile {
+    let slug = slugify(&agent.name);
+    let path = PathBuf::from(".github/agents").join(format!("{slug}.agent.md"));
+
+    let mut content = String::new();
+
+    // Description intro (first line of system prompt or explicit description)
+    if let Some(ref desc) = agent.description {
+        content.push_str(desc);
+        content.push_str("\n\n");
+    }
+
+    // System prompt
+    content.push_str(&agent.system_prompt);
+
+    // Instructions section
+    if let Some(ref instructions) = agent.instructions {
+        ensure_blank_line(&mut content);
+        content.push_str("## Instructions\n\n");
+        content.push_str(instructions);
+    }
+
+    // Output format section
+    if let Some(ref output_format) = agent.output_format {
+        ensure_blank_line(&mut content);
+        content.push_str("## Output Format\n\n");
+        content.push_str(output_format);
+    }
+
+    // Context section
+    if let Some(ref context) = agent.context {
+        ensure_blank_line(&mut content);
+        content.push_str("## Context\n\n");
+        content.push_str(context);
+    }
+
+    // Ensure trailing newline
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    OutputFile { path, content }
+}
+
+/// Ensure there are two newlines (blank line) before a new section.
+fn ensure_blank_line(content: &mut String) {
+    if !content.ends_with("\n\n") {
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(name: &str, system_prompt: &str) -> LinkAgent {
+        LinkAgent {
+            name: name.to_string(),
+            system_prompt: system_prompt.to_string(),
+            instructions: None,
+            output_format: None,
+            context: None,
+            description: Some(
+                system_prompt
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string(),
+            ),
+            tags: vec![],
+            stacks: vec![],
+        }
+    }
+
+    #[test]
+    fn test_generate_simple_agent() {
+        let linker = CopilotLinker;
+        let agents = vec![make_agent("Code Reviewer", "You review code for bugs.")];
+        let files = linker.generate(&agents, &[]);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].path,
+            PathBuf::from(".github/agents/code-reviewer.agent.md")
+        );
+        // Description intro + blank line + system prompt
+        assert!(
+            files[0]
+                .content
+                .starts_with("You review code for bugs.\n\n")
+        );
+        assert!(files[0].content.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_generate_with_all_sections() {
+        let linker = CopilotLinker;
+        let agents = vec![LinkAgent {
+            name: "Test Agent".to_string(),
+            system_prompt: "You are a test agent.".to_string(),
+            instructions: Some("Write unit tests.".to_string()),
+            output_format: Some("Markdown report.".to_string()),
+            context: Some("Python project.".to_string()),
+            description: Some("You are a test agent.".to_string()),
+            tags: vec![],
+            stacks: vec![],
+        }];
+        let files = linker.generate(&agents, &[]);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].path,
+            PathBuf::from(".github/agents/test-agent.agent.md")
+        );
+        assert!(
+            files[0]
+                .content
+                .contains("## Instructions\n\nWrite unit tests.")
+        );
+        assert!(
+            files[0]
+                .content
+                .contains("## Output Format\n\nMarkdown report.")
+        );
+        assert!(files[0].content.contains("## Context\n\nPython project."));
+    }
+
+    #[test]
+    fn test_agent_md_extension() {
+        let linker = CopilotLinker;
+        let agents = vec![make_agent("my-agent", "A simple agent.")];
+        let files = linker.generate(&agents, &[]);
+
+        // Must use .agent.md extension for Copilot
+        assert_eq!(
+            files[0].path,
+            PathBuf::from(".github/agents/my-agent.agent.md")
+        );
+    }
+
+    #[test]
+    fn test_default_output_dir() {
+        let linker = CopilotLinker;
+        assert_eq!(linker.default_output_dir(), ".github/agents");
+    }
+}

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -1,0 +1,131 @@
+mod claude;
+mod copilot;
+
+pub use claude::ClaudeLinker;
+pub use copilot::CopilotLinker;
+
+use std::path::PathBuf;
+
+use crate::core::agent::Agent;
+
+/// A resolved agent ready for linking.
+#[allow(dead_code)]
+pub struct LinkAgent {
+    pub name: String,
+    pub system_prompt: String,
+    pub instructions: Option<String>,
+    pub output_format: Option<String>,
+    pub context: Option<String>,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub stacks: Vec<String>,
+}
+
+/// A file to be written by a linker.
+pub struct OutputFile {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+/// Trait for generating target-specific config files.
+#[allow(dead_code)]
+pub trait Linker: Send + Sync {
+    fn name(&self) -> &str;
+    fn default_output_dir(&self) -> &str;
+    fn generate(&self, agents: &[LinkAgent], sources: &[String]) -> Vec<OutputFile>;
+}
+
+/// Create a linker for the given target name.
+pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
+    match target {
+        "claude" => Ok(Box::new(ClaudeLinker)),
+        "copilot" => Ok(Box::new(CopilotLinker)),
+        _ => anyhow::bail!("Unknown link target: '{target}'. Supported targets: claude, copilot"),
+    }
+}
+
+/// Convert an agent name to a kebab-case slug suitable for filenames.
+pub fn slugify(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else if c == ' ' || c == '_' {
+                '-'
+            } else {
+                '\0'
+            }
+        })
+        .filter(|c| *c != '\0')
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+impl From<&Agent> for LinkAgent {
+    fn from(agent: &Agent) -> Self {
+        let description = agent
+            .system_prompt
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .map(|l| l.trim().to_string());
+
+        Self {
+            name: agent.name.clone(),
+            system_prompt: agent.system_prompt.clone(),
+            instructions: agent.instructions.clone(),
+            output_format: agent.output_format.clone(),
+            context: agent.context.clone(),
+            description,
+            tags: agent.metadata.tags.clone(),
+            stacks: agent.metadata.stacks.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slugify_simple() {
+        assert_eq!(slugify("Code Reviewer"), "code-reviewer");
+    }
+
+    #[test]
+    fn test_slugify_already_kebab() {
+        assert_eq!(slugify("code-reviewer"), "code-reviewer");
+    }
+
+    #[test]
+    fn test_slugify_underscores() {
+        assert_eq!(slugify("my_test_agent"), "my-test-agent");
+    }
+
+    #[test]
+    fn test_slugify_special_chars() {
+        assert_eq!(slugify("Agent (v2.0)"), "agent-v20");
+    }
+
+    #[test]
+    fn test_slugify_multiple_separators() {
+        assert_eq!(slugify("a--b__c  d"), "a-b-c-d");
+    }
+
+    #[test]
+    fn test_create_linker_claude() {
+        assert!(create_linker("claude").is_ok());
+    }
+
+    #[test]
+    fn test_create_linker_copilot() {
+        assert!(create_linker("copilot").is_ok());
+    }
+
+    #[test]
+    fn test_create_linker_unknown() {
+        assert!(create_linker("unknown").is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod core;
+mod linker;
 mod parser;
 #[allow(dead_code)]
 mod providers;


### PR DESCRIPTION
## Summary

- Add `armadai link` command that reads `armadai.yaml` and generates native config files for AI assistants
- Implement `ClaudeLinker` generating `.claude/agents/{slug}.md` files for Claude Code sub-agents
- Implement `CopilotLinker` generating `.github/agents/{slug}.agent.md` files for GitHub Copilot
- Support `--target`, `--dry-run`, `--force`, `--output`, and `--agents` CLI flags

Closes #47

## Test plan

- [x] `cargo clippy --no-default-features --features tui` passes
- [x] `cargo clippy --no-default-features --features tui,providers-api` passes
- [x] `cargo test --no-default-features --features tui,providers-api` — 67/67 tests pass (12 new)
- [x] `cargo fmt -- --check` passes
- [ ] Manual test: `armadai link --target claude --dry-run` on a project with `armadai.yaml`
- [ ] Manual test: `armadai link --target copilot --dry-run` on a project with `armadai.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)