### PR TITLE
feat: add composable skills and prompts system

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,9 @@ mod inspect;
 mod link;
 mod list;
 pub(crate) mod new;
+mod prompts;
 mod run;
+mod skills;
 mod up;
 mod update;
 mod validate;
@@ -247,6 +249,30 @@ pub enum Command {
         #[arg(long)]
         project: bool,
     },
+    /// Manage composable prompts
+    #[command(
+        subcommand,
+        long_about = "Manage composable prompt fragments.\n\n\
+            Prompts are reusable Markdown files with optional YAML frontmatter \
+            (name, description, apply_to). They compose with agents via the \
+            apply_to field or explicit project config references.",
+        after_help = "Examples:\n  \
+            armadai prompts list\n  \
+            armadai prompts show rust-conventions"
+    )]
+    Prompts(prompts::PromptsAction),
+    /// Manage composable skills
+    #[command(
+        subcommand,
+        long_about = "Manage composable skills.\n\n\
+            Skills follow the SKILL.md open standard — structured knowledge with \
+            scripts, references and assets. Each skill lives in a directory \
+            containing a SKILL.md file.",
+        after_help = "Examples:\n  \
+            armadai skills list\n  \
+            armadai skills show docker-compose"
+    )]
+    Skills(skills::SkillsAction),
     /// Self-update to the latest release
     #[command(long_about = "Self-update to the latest release.\n\n\
             Downloads the latest binary from GitHub Releases and replaces the current one.")]
@@ -284,6 +310,8 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         #[cfg(feature = "web")]
         Command::Web { port } => crate::web::serve(port).await,
         Command::Fleet(action) => fleet::execute(action).await,
+        Command::Prompts(action) => prompts::execute(action).await,
+        Command::Skills(action) => skills::execute(action).await,
         Command::Link {
             target,
             dry_run,

--- a/src/cli/prompts.rs
+++ b/src/cli/prompts.rs
@@ -1,0 +1,151 @@
+use clap::Subcommand;
+
+use crate::core::config::{AppPaths, user_prompts_dir};
+use crate::core::project;
+use crate::core::prompt::{Prompt, load_all_prompts};
+
+#[derive(Subcommand)]
+pub enum PromptsAction {
+    /// List available prompts
+    List,
+    /// Show a prompt's details
+    Show {
+        /// Prompt name
+        name: String,
+    },
+}
+
+pub async fn execute(action: PromptsAction) -> anyhow::Result<()> {
+    match action {
+        PromptsAction::List => list().await,
+        PromptsAction::Show { name } => show(&name).await,
+    }
+}
+
+async fn list() -> anyhow::Result<()> {
+    let prompts = collect_prompts();
+
+    if prompts.is_empty() {
+        println!("No prompts found.");
+        println!("Add .md files in prompts/ or ~/.config/armadai/prompts/");
+        return Ok(());
+    }
+
+    // Compute column widths
+    let name_w = prompts
+        .iter()
+        .map(|p| p.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let desc_w = prompts
+        .iter()
+        .map(|p| p.description.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(11)
+        .max(11);
+
+    // Header
+    println!(
+        "  {:<name_w$}  {:<desc_w$}  APPLY_TO",
+        "NAME", "DESCRIPTION",
+    );
+    println!(
+        "  {:<name_w$}  {:<desc_w$}  --------",
+        "-".repeat(name_w),
+        "-".repeat(desc_w),
+    );
+
+    // Rows
+    for prompt in &prompts {
+        let desc = prompt.description.as_deref().unwrap_or("-");
+        let apply = if prompt.apply_to.is_empty() {
+            "-".to_string()
+        } else {
+            prompt.apply_to.join(", ")
+        };
+        println!("  {:<name_w$}  {:<desc_w$}  {}", prompt.name, desc, apply);
+    }
+
+    println!("\n  {} prompt(s) found.", prompts.len());
+    Ok(())
+}
+
+async fn show(name: &str) -> anyhow::Result<()> {
+    let prompts = collect_prompts();
+    let prompt = prompts
+        .iter()
+        .find(|p| p.name == name)
+        .ok_or_else(|| anyhow::anyhow!("Prompt '{name}' not found"))?;
+
+    println!("Prompt: {}", prompt.name);
+    println!("Source: {}", prompt.source.display());
+
+    if let Some(ref desc) = prompt.description {
+        println!("Description: {desc}");
+    }
+    if !prompt.apply_to.is_empty() {
+        println!("Apply to: [{}]", prompt.apply_to.join(", "));
+    }
+
+    println!();
+    println!("## Body");
+    for line in prompt.body.lines() {
+        println!("  {line}");
+    }
+
+    Ok(())
+}
+
+/// Collect prompts from project config and/or default directories.
+fn collect_prompts() -> Vec<Prompt> {
+    let mut prompts = Vec::new();
+
+    // Project-level prompts
+    if let Some((root, config)) = project::find_project_config() {
+        let (paths, errors) = project::resolve_all_prompts(&config, &root);
+        for err in &errors {
+            eprintln!("  warn: {err}");
+        }
+        for path in &paths {
+            match Prompt::load(path) {
+                Ok(p) => prompts.push(p),
+                Err(e) => eprintln!("  warn: failed to load prompt {}: {e}", path.display()),
+            }
+        }
+
+        // Also scan project-local prompts/ directory for prompts not in config
+        let local_dir = root.join("prompts");
+        if local_dir.is_dir() {
+            for p in load_all_prompts(&local_dir) {
+                if !prompts.iter().any(|existing| existing.name == p.name) {
+                    prompts.push(p);
+                }
+            }
+        }
+    } else {
+        // No project config — scan default local prompts/ dir
+        let paths = AppPaths::resolve();
+        let local_dir = paths
+            .agents_dir
+            .parent()
+            .unwrap_or(paths.agents_dir.as_ref())
+            .join("prompts");
+        if local_dir.is_dir() {
+            prompts.extend(load_all_prompts(&local_dir));
+        }
+    }
+
+    // Always include user-global prompts
+    let global_dir = user_prompts_dir();
+    if global_dir.is_dir() {
+        for p in load_all_prompts(&global_dir) {
+            if !prompts.iter().any(|existing| existing.name == p.name) {
+                prompts.push(p);
+            }
+        }
+    }
+
+    prompts.sort_by(|a, b| a.name.cmp(&b.name));
+    prompts
+}

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,0 +1,181 @@
+use clap::Subcommand;
+
+use crate::core::config::user_skills_dir;
+use crate::core::project;
+use crate::core::skill::{Skill, load_all_skills};
+
+#[derive(Subcommand)]
+pub enum SkillsAction {
+    /// List available skills
+    List,
+    /// Show a skill's details
+    Show {
+        /// Skill name
+        name: String,
+    },
+}
+
+pub async fn execute(action: SkillsAction) -> anyhow::Result<()> {
+    match action {
+        SkillsAction::List => list().await,
+        SkillsAction::Show { name } => show(&name).await,
+    }
+}
+
+async fn list() -> anyhow::Result<()> {
+    let skills = collect_skills();
+
+    if skills.is_empty() {
+        println!("No skills found.");
+        println!(
+            "Add skill directories (containing SKILL.md) in skills/ or ~/.config/armadai/skills/"
+        );
+        return Ok(());
+    }
+
+    // Compute column widths
+    let name_w = skills
+        .iter()
+        .map(|s| s.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let desc_w = skills
+        .iter()
+        .map(|s| s.description.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(11)
+        .max(11);
+    let ver_w = skills
+        .iter()
+        .map(|s| s.version.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+
+    // Header
+    println!(
+        "  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  TOOLS",
+        "NAME", "DESCRIPTION", "VERSION",
+    );
+    println!(
+        "  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  -----",
+        "-".repeat(name_w),
+        "-".repeat(desc_w),
+        "-".repeat(ver_w),
+    );
+
+    // Rows
+    for skill in &skills {
+        let desc = skill.description.as_deref().unwrap_or("-");
+        let ver = skill.version.as_deref().unwrap_or("-");
+        let tools = if skill.tools.is_empty() {
+            "-".to_string()
+        } else {
+            skill.tools.join(", ")
+        };
+        println!(
+            "  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  {}",
+            skill.name, desc, ver, tools,
+        );
+    }
+
+    println!("\n  {} skill(s) found.", skills.len());
+    Ok(())
+}
+
+async fn show(name: &str) -> anyhow::Result<()> {
+    let skills = collect_skills();
+    let skill = skills
+        .iter()
+        .find(|s| s.name == name)
+        .ok_or_else(|| anyhow::anyhow!("Skill '{name}' not found"))?;
+
+    println!("Skill: {}", skill.name);
+    println!("Source: {}", skill.source.display());
+
+    if let Some(ref desc) = skill.description {
+        println!("Description: {desc}");
+    }
+    if let Some(ref ver) = skill.version {
+        println!("Version: {ver}");
+    }
+    if !skill.tools.is_empty() {
+        println!("Tools: [{}]", skill.tools.join(", "));
+    }
+
+    if !skill.scripts.is_empty() {
+        println!("\nScripts:");
+        for s in &skill.scripts {
+            println!("  - {}", s.display());
+        }
+    }
+    if !skill.references.is_empty() {
+        println!("\nReferences:");
+        for r in &skill.references {
+            println!("  - {}", r.display());
+        }
+    }
+    if !skill.assets.is_empty() {
+        println!("\nAssets:");
+        for a in &skill.assets {
+            println!("  - {}", a.display());
+        }
+    }
+
+    println!();
+    println!("## Body");
+    for line in skill.body.lines() {
+        println!("  {line}");
+    }
+
+    Ok(())
+}
+
+/// Collect skills from project config and/or default directories.
+fn collect_skills() -> Vec<Skill> {
+    let mut skills = Vec::new();
+
+    // Project-level skills
+    if let Some((root, config)) = project::find_project_config() {
+        let (paths, errors) = project::resolve_all_skills(&config, &root);
+        for err in &errors {
+            eprintln!("  warn: {err}");
+        }
+        for path in &paths {
+            match Skill::load(path) {
+                Ok(s) => skills.push(s),
+                Err(e) => eprintln!("  warn: failed to load skill {}: {e}", path.display()),
+            }
+        }
+
+        // Also scan project-local skills/ directory
+        let local_dir = root.join("skills");
+        if local_dir.is_dir() {
+            for s in load_all_skills(&local_dir) {
+                if !skills.iter().any(|existing| existing.name == s.name) {
+                    skills.push(s);
+                }
+            }
+        }
+    } else {
+        // No project config — scan local skills/ dir
+        let local_dir = std::path::Path::new("skills");
+        if local_dir.is_dir() {
+            skills.extend(load_all_skills(local_dir));
+        }
+    }
+
+    // Always include user-global skills
+    let global_dir = user_skills_dir();
+    if global_dir.is_dir() {
+        for s in load_all_skills(&global_dir) {
+            if !skills.iter().any(|existing| existing.name == s.name) {
+                skills.push(s);
+            }
+        }
+    }
+
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,5 +9,7 @@ pub mod fleet;
 #[allow(dead_code)]
 pub mod pipeline;
 pub mod project;
+pub mod prompt;
+pub mod skill;
 #[allow(dead_code)]
 pub mod task;

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use super::config::{registry_cache_dir, user_agents_dir};
+use super::config::{registry_cache_dir, user_agents_dir, user_prompts_dir, user_skills_dir};
 use super::fleet::FleetDefinition;
 
 // ---------------------------------------------------------------------------
@@ -228,6 +228,132 @@ pub fn resolve_all_agents(
 
     for agent_ref in &config.agents {
         match resolve_agent(agent_ref, project_root) {
+            Ok(path) => resolved.push(path),
+            Err(e) => errors.push(format!("{e}")),
+        }
+    }
+
+    (resolved, errors)
+}
+
+// ---------------------------------------------------------------------------
+// Prompt resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve a single `PromptRef` to an absolute path.
+pub fn resolve_prompt(prompt_ref: &PromptRef, project_root: &Path) -> anyhow::Result<PathBuf> {
+    match prompt_ref {
+        PromptRef::Path { path } => {
+            let resolved = if path.is_absolute() {
+                path.clone()
+            } else {
+                project_root.join(path)
+            };
+            if resolved.exists() {
+                Ok(resolved)
+            } else {
+                anyhow::bail!("Prompt file not found: {}", resolved.display());
+            }
+        }
+        PromptRef::Named { name } => {
+            let filename = if name.ends_with(".md") {
+                name.clone()
+            } else {
+                format!("{name}.md")
+            };
+
+            // 1. Project-local prompts/
+            let local = project_root.join("prompts").join(&filename);
+            if local.exists() {
+                return Ok(local);
+            }
+
+            // 2. User library ~/.config/armadai/prompts/
+            let global = user_prompts_dir().join(&filename);
+            if global.exists() {
+                return Ok(global);
+            }
+
+            anyhow::bail!(
+                "Prompt '{name}' not found in {} or {}",
+                local.display(),
+                global.display()
+            );
+        }
+    }
+}
+
+/// Resolve all prompt refs in the config, collecting paths.
+/// Returns resolved paths and skipped refs (with error messages).
+pub fn resolve_all_prompts(
+    config: &ProjectConfig,
+    project_root: &Path,
+) -> (Vec<PathBuf>, Vec<String>) {
+    let mut resolved = Vec::new();
+    let mut errors = Vec::new();
+
+    for prompt_ref in &config.prompts {
+        match resolve_prompt(prompt_ref, project_root) {
+            Ok(path) => resolved.push(path),
+            Err(e) => errors.push(format!("{e}")),
+        }
+    }
+
+    (resolved, errors)
+}
+
+// ---------------------------------------------------------------------------
+// Skill resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve a single `SkillRef` to an absolute path (directory containing SKILL.md).
+pub fn resolve_skill(skill_ref: &SkillRef, project_root: &Path) -> anyhow::Result<PathBuf> {
+    match skill_ref {
+        SkillRef::Path { path } => {
+            let resolved = if path.is_absolute() {
+                path.clone()
+            } else {
+                project_root.join(path)
+            };
+            if resolved.exists() {
+                Ok(resolved)
+            } else {
+                anyhow::bail!("Skill path not found: {}", resolved.display());
+            }
+        }
+        SkillRef::Named { name } => {
+            // 1. Project-local skills/<name>/
+            let local = project_root.join("skills").join(name);
+            if local.join("SKILL.md").exists() {
+                return Ok(local);
+            }
+
+            // 2. User library ~/.config/armadai/skills/<name>/
+            let global = user_skills_dir().join(name);
+            if global.join("SKILL.md").exists() {
+                return Ok(global);
+            }
+
+            anyhow::bail!(
+                "Skill '{name}' not found in {} or {}",
+                local.display(),
+                global.display()
+            );
+        }
+    }
+}
+
+/// Resolve all skill refs in the config, collecting paths.
+/// Returns resolved paths and skipped refs (with error messages).
+pub fn resolve_all_skills(
+    config: &ProjectConfig,
+    project_root: &Path,
+) -> (Vec<PathBuf>, Vec<String>) {
+    let mut resolved = Vec::new();
+    let mut errors = Vec::new();
+
+    for skill_ref in &config.skills {
+        match resolve_skill(skill_ref, project_root) {
             Ok(path) => resolved.push(path),
             Err(e) => errors.push(format!("{e}")),
         }
@@ -549,6 +675,116 @@ sources:
         };
 
         let (resolved, errors) = resolve_all_agents(&config, dir.path());
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("missing"));
+    }
+
+    #[test]
+    fn test_resolve_prompt_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let prompt_path = dir.path().join("custom").join("style.md");
+        std::fs::create_dir_all(prompt_path.parent().unwrap()).unwrap();
+        std::fs::write(&prompt_path, "# Style\n").unwrap();
+
+        let prompt_ref = PromptRef::Path {
+            path: PathBuf::from("custom/style.md"),
+        };
+        let resolved = resolve_prompt(&prompt_ref, dir.path()).unwrap();
+        assert_eq!(resolved, prompt_path);
+    }
+
+    #[test]
+    fn test_resolve_prompt_named_local() {
+        let dir = tempfile::tempdir().unwrap();
+        let prompts_dir = dir.path().join("prompts");
+        std::fs::create_dir_all(&prompts_dir).unwrap();
+        std::fs::write(prompts_dir.join("rust-style.md"), "# Rust\n").unwrap();
+
+        let prompt_ref = PromptRef::Named {
+            name: "rust-style".to_string(),
+        };
+        let resolved = resolve_prompt(&prompt_ref, dir.path()).unwrap();
+        assert_eq!(resolved, prompts_dir.join("rust-style.md"));
+    }
+
+    #[test]
+    fn test_resolve_prompt_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let prompt_ref = PromptRef::Named {
+            name: "nonexistent".to_string(),
+        };
+        assert!(resolve_prompt(&prompt_ref, dir.path()).is_err());
+    }
+
+    #[test]
+    fn test_resolve_all_prompts() {
+        let dir = tempfile::tempdir().unwrap();
+        let prompts_dir = dir.path().join("prompts");
+        std::fs::create_dir_all(&prompts_dir).unwrap();
+        std::fs::write(prompts_dir.join("found.md"), "# Found\n").unwrap();
+
+        let config = ProjectConfig {
+            prompts: vec![
+                PromptRef::Named {
+                    name: "found".to_string(),
+                },
+                PromptRef::Named {
+                    name: "missing".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let (resolved, errors) = resolve_all_prompts(&config, dir.path());
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("missing"));
+    }
+
+    #[test]
+    fn test_resolve_skill_named_local() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills").join("docker");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Docker\n").unwrap();
+
+        let skill_ref = SkillRef::Named {
+            name: "docker".to_string(),
+        };
+        let resolved = resolve_skill(&skill_ref, dir.path()).unwrap();
+        assert_eq!(resolved, skill_dir);
+    }
+
+    #[test]
+    fn test_resolve_skill_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_ref = SkillRef::Named {
+            name: "nonexistent".to_string(),
+        };
+        assert!(resolve_skill(&skill_ref, dir.path()).is_err());
+    }
+
+    #[test]
+    fn test_resolve_all_skills() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills").join("found");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Found\n").unwrap();
+
+        let config = ProjectConfig {
+            skills: vec![
+                SkillRef::Named {
+                    name: "found".to_string(),
+                },
+                SkillRef::Named {
+                    name: "missing".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let (resolved, errors) = resolve_all_skills(&config, dir.path());
         assert_eq!(resolved.len(), 1);
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("missing"));

--- a/src/core/prompt.rs
+++ b/src/core/prompt.rs
@@ -1,0 +1,213 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::parser::frontmatter::extract_frontmatter;
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PromptFrontmatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub apply_to: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Prompt {
+    pub name: String,
+    pub description: Option<String>,
+    pub apply_to: Vec<String>,
+    pub body: String,
+    pub source: PathBuf,
+}
+
+// ---------------------------------------------------------------------------
+// Parsing & loading
+// ---------------------------------------------------------------------------
+
+impl Prompt {
+    /// Parse a prompt from its raw content and source path.
+    pub fn parse(content: &str, source: PathBuf) -> anyhow::Result<Self> {
+        let (fm_str, body) = extract_frontmatter(content);
+
+        let fm: PromptFrontmatter = match fm_str {
+            Some(yaml) => serde_yml::from_str(yaml)?,
+            None => PromptFrontmatter::default(),
+        };
+
+        let name = fm.name.unwrap_or_else(|| name_from_path(&source));
+
+        Ok(Self {
+            name,
+            description: fm.description,
+            apply_to: fm.apply_to,
+            body: body.to_string(),
+            source,
+        })
+    }
+
+    /// Load a prompt from a file path.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Self::parse(&content, path.to_path_buf())
+    }
+}
+
+/// Derive a prompt name from its file path (stem without extension).
+fn name_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// Load all `.md` prompts from a directory (non-recursive).
+pub fn load_all_prompts(dir: &Path) -> Vec<Prompt> {
+    let mut prompts = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return prompts,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "md") {
+            match Prompt::load(&path) {
+                Ok(p) => prompts.push(p),
+                Err(e) => eprintln!("  warn: failed to load prompt {}: {e}", path.display()),
+            }
+        }
+    }
+    prompts.sort_by(|a, b| a.name.cmp(&b.name));
+    prompts
+}
+
+/// Filter prompts that match a given agent name via `apply_to`.
+#[allow(dead_code)]
+pub fn matching_prompts<'a>(prompts: &'a [Prompt], agent_name: &str) -> Vec<&'a Prompt> {
+    prompts
+        .iter()
+        .filter(|p| p.apply_to.iter().any(|a| a == agent_name || a == "*"))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_with_frontmatter() {
+        let content = "---\nname: rust-conventions\ndescription: Rust coding style\napply_to:\n  - code-reviewer\n  - test-writer\n---\nAlways use snake_case.";
+        let prompt = Prompt::parse(content, PathBuf::from("prompts/rust-conventions.md")).unwrap();
+        assert_eq!(prompt.name, "rust-conventions");
+        assert_eq!(prompt.description.as_deref(), Some("Rust coding style"));
+        assert_eq!(prompt.apply_to, vec!["code-reviewer", "test-writer"]);
+        assert_eq!(prompt.body, "Always use snake_case.");
+    }
+
+    #[test]
+    fn test_parse_without_frontmatter() {
+        let content = "# Just some instructions\n\nDo the thing.";
+        let prompt = Prompt::parse(content, PathBuf::from("prompts/simple.md")).unwrap();
+        assert_eq!(prompt.name, "simple");
+        assert!(prompt.description.is_none());
+        assert!(prompt.apply_to.is_empty());
+        assert_eq!(prompt.body, content);
+    }
+
+    #[test]
+    fn test_parse_name_fallback_to_filename() {
+        let content = "---\ndescription: no name field\n---\nBody.";
+        let prompt =
+            Prompt::parse(content, PathBuf::from("/home/user/prompts/my-style.md")).unwrap();
+        assert_eq!(prompt.name, "my-style");
+    }
+
+    #[test]
+    fn test_load_all_prompts() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("alpha.md"),
+            "---\nname: alpha\n---\nAlpha body.",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("beta.md"),
+            "---\nname: beta\n---\nBeta body.",
+        )
+        .unwrap();
+        // Non-md file should be ignored
+        std::fs::write(dir.path().join("readme.txt"), "not a prompt").unwrap();
+
+        let prompts = load_all_prompts(dir.path());
+        assert_eq!(prompts.len(), 2);
+        assert_eq!(prompts[0].name, "alpha");
+        assert_eq!(prompts[1].name, "beta");
+    }
+
+    #[test]
+    fn test_load_all_prompts_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let prompts = load_all_prompts(dir.path());
+        assert!(prompts.is_empty());
+    }
+
+    #[test]
+    fn test_load_all_prompts_nonexistent_dir() {
+        let prompts = load_all_prompts(Path::new("/nonexistent/dir"));
+        assert!(prompts.is_empty());
+    }
+
+    #[test]
+    fn test_matching_prompts() {
+        let prompts = vec![
+            Prompt {
+                name: "rust-style".to_string(),
+                description: None,
+                apply_to: vec!["code-reviewer".to_string()],
+                body: String::new(),
+                source: PathBuf::new(),
+            },
+            Prompt {
+                name: "global".to_string(),
+                description: None,
+                apply_to: vec!["*".to_string()],
+                body: String::new(),
+                source: PathBuf::new(),
+            },
+            Prompt {
+                name: "test-style".to_string(),
+                description: None,
+                apply_to: vec!["test-writer".to_string()],
+                body: String::new(),
+                source: PathBuf::new(),
+            },
+        ];
+
+        let matched = matching_prompts(&prompts, "code-reviewer");
+        assert_eq!(matched.len(), 2);
+        assert_eq!(matched[0].name, "rust-style");
+        assert_eq!(matched[1].name, "global");
+    }
+
+    #[test]
+    fn test_matching_prompts_no_match() {
+        let prompts = vec![Prompt {
+            name: "test-only".to_string(),
+            description: None,
+            apply_to: vec!["test-writer".to_string()],
+            body: String::new(),
+            source: PathBuf::new(),
+        }];
+
+        let matched = matching_prompts(&prompts, "code-reviewer");
+        assert!(matched.is_empty());
+    }
+}

--- a/src/core/skill.rs
+++ b/src/core/skill.rs
@@ -1,0 +1,216 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::parser::frontmatter::extract_frontmatter;
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SkillFrontmatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    #[serde(default)]
+    pub tools: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Skill {
+    pub name: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub tools: Vec<String>,
+    pub body: String,
+    pub source: PathBuf,
+    pub scripts: Vec<PathBuf>,
+    pub references: Vec<PathBuf>,
+    pub assets: Vec<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+impl Skill {
+    /// Load a skill from a directory containing a `SKILL.md` file.
+    pub fn load(dir: &Path) -> anyhow::Result<Self> {
+        let skill_file = dir.join("SKILL.md");
+        if !skill_file.is_file() {
+            anyhow::bail!("No SKILL.md found in {}", dir.display());
+        }
+
+        let content = std::fs::read_to_string(&skill_file)?;
+        let (fm_str, body) = extract_frontmatter(&content);
+
+        let fm: SkillFrontmatter = match fm_str {
+            Some(yaml) => serde_yml::from_str(yaml)?,
+            None => SkillFrontmatter::default(),
+        };
+
+        let name = fm.name.unwrap_or_else(|| name_from_dir(dir));
+
+        let scripts = list_dir_entries(&dir.join("scripts"));
+        let references = list_dir_entries(&dir.join("references"));
+        let assets = list_dir_entries(&dir.join("assets"));
+
+        Ok(Self {
+            name,
+            description: fm.description,
+            version: fm.version,
+            tools: fm.tools,
+            body: body.to_string(),
+            source: dir.to_path_buf(),
+            scripts,
+            references,
+            assets,
+        })
+    }
+}
+
+/// Derive a skill name from its directory name.
+fn name_from_dir(dir: &Path) -> String {
+    dir.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// List file entries in a subdirectory (non-recursive). Returns empty vec if
+/// the directory doesn't exist.
+fn list_dir_entries(dir: &Path) -> Vec<PathBuf> {
+    let mut entries = Vec::new();
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return entries,
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            entries.push(path);
+        }
+    }
+    entries.sort();
+    entries
+}
+
+/// Scan a directory for skill subdirectories (each containing a `SKILL.md`).
+pub fn load_all_skills(dir: &Path) -> Vec<Skill> {
+    let mut skills = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return skills,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.join("SKILL.md").is_file() {
+            match Skill::load(&path) {
+                Ok(s) => skills.push(s),
+                Err(e) => eprintln!("  warn: failed to load skill {}: {e}", path.display()),
+            }
+        }
+    }
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("docker-compose");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        let content = "---\nname: docker-compose\ndescription: Docker Compose management\nversion: \"1.0\"\ntools:\n  - docker\n  - compose\n---\n# Docker Compose\n\nManage multi-container apps.";
+        std::fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+
+        // Create subdirectories
+        let scripts_dir = skill_dir.join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+        std::fs::write(scripts_dir.join("deploy.sh"), "#!/bin/bash").unwrap();
+
+        let refs_dir = skill_dir.join("references");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::write(refs_dir.join("docs.md"), "# Docs").unwrap();
+
+        let skill = Skill::load(&skill_dir).unwrap();
+        assert_eq!(skill.name, "docker-compose");
+        assert_eq!(
+            skill.description.as_deref(),
+            Some("Docker Compose management")
+        );
+        assert_eq!(skill.version.as_deref(), Some("1.0"));
+        assert_eq!(skill.tools, vec!["docker", "compose"]);
+        assert!(skill.body.contains("# Docker Compose"));
+        assert_eq!(skill.scripts.len(), 1);
+        assert_eq!(skill.references.len(), 1);
+        assert!(skill.assets.is_empty());
+    }
+
+    #[test]
+    fn test_load_skill_no_frontmatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("simple-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Simple skill\n\nJust a body.").unwrap();
+
+        let skill = Skill::load(&skill_dir).unwrap();
+        assert_eq!(skill.name, "simple-skill");
+        assert!(skill.description.is_none());
+        assert!(skill.tools.is_empty());
+    }
+
+    #[test]
+    fn test_load_skill_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = Skill::load(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_all_skills() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Skill A
+        let a = dir.path().join("alpha");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::write(a.join("SKILL.md"), "---\nname: alpha\n---\nAlpha.").unwrap();
+
+        // Skill B
+        let b = dir.path().join("beta");
+        std::fs::create_dir_all(&b).unwrap();
+        std::fs::write(b.join("SKILL.md"), "---\nname: beta\n---\nBeta.").unwrap();
+
+        // Not a skill (no SKILL.md)
+        let c = dir.path().join("not-a-skill");
+        std::fs::create_dir_all(&c).unwrap();
+        std::fs::write(c.join("README.md"), "nothing").unwrap();
+
+        let skills = load_all_skills(dir.path());
+        assert_eq!(skills.len(), 2);
+        assert_eq!(skills[0].name, "alpha");
+        assert_eq!(skills[1].name, "beta");
+    }
+
+    #[test]
+    fn test_load_all_skills_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills = load_all_skills(dir.path());
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn test_load_all_skills_nonexistent_dir() {
+        let skills = load_all_skills(Path::new("/nonexistent/dir"));
+        assert!(skills.is_empty());
+    }
+}

--- a/src/parser/frontmatter.rs
+++ b/src/parser/frontmatter.rs
@@ -1,0 +1,116 @@
+/// Extract YAML frontmatter (between `---` delimiters) and the remaining body.
+///
+/// Returns `(frontmatter_yaml, body)`. If no frontmatter is found, returns
+/// `(None, full_content)`.
+pub fn extract_frontmatter(content: &str) -> (Option<&str>, &str) {
+    // Frontmatter must start at the very beginning of the file
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, content);
+    }
+
+    // Find the opening delimiter line end
+    let after_open = match trimmed[3..].find('\n') {
+        Some(pos) => 3 + pos + 1,
+        None => return (None, content), // only `---` with nothing after
+    };
+
+    // Check that the opening line is just `---` (possibly with trailing whitespace)
+    if !trimmed[3..after_open].trim().is_empty() {
+        return (None, content);
+    }
+
+    // Find the closing `---`
+    let rest = &trimmed[after_open..];
+    for (i, line) in rest.lines().enumerate() {
+        if line.trim() == "---" {
+            let fm_end = after_open + rest.lines().take(i).map(|l| l.len() + 1).sum::<usize>();
+            let frontmatter = &trimmed[after_open..fm_end];
+            let body_start = fm_end + line.len();
+            // Skip the optional newline right after closing ---
+            let body = if trimmed[body_start..].starts_with('\n') {
+                &trimmed[body_start + 1..]
+            } else {
+                &trimmed[body_start..]
+            };
+            let fm = frontmatter.trim();
+            if fm.is_empty() {
+                return (None, body);
+            }
+            return (Some(fm), body);
+        }
+    }
+
+    // No closing delimiter found — treat as no frontmatter
+    (None, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_frontmatter() {
+        let content = "---\nname: test\ndescription: hello\n---\nBody content here.";
+        let (fm, body) = extract_frontmatter(content);
+        assert_eq!(fm, Some("name: test\ndescription: hello"));
+        assert_eq!(body, "Body content here.");
+    }
+
+    #[test]
+    fn test_no_frontmatter() {
+        let content = "Just a regular markdown file.\nNo frontmatter.";
+        let (fm, body) = extract_frontmatter(content);
+        assert!(fm.is_none());
+        assert_eq!(body, content);
+    }
+
+    #[test]
+    fn test_empty_frontmatter() {
+        let content = "---\n---\nBody after empty frontmatter.";
+        let (fm, body) = extract_frontmatter(content);
+        assert!(fm.is_none());
+        assert_eq!(body, "Body after empty frontmatter.");
+    }
+
+    #[test]
+    fn test_frontmatter_with_dashes_in_body() {
+        let content = "---\nname: test\n---\nSome text.\n---\nMore text.";
+        let (fm, body) = extract_frontmatter(content);
+        assert_eq!(fm, Some("name: test"));
+        assert_eq!(body, "Some text.\n---\nMore text.");
+    }
+
+    #[test]
+    fn test_no_closing_delimiter() {
+        let content = "---\nname: test\nno closing delimiter";
+        let (fm, body) = extract_frontmatter(content);
+        assert!(fm.is_none());
+        assert_eq!(body, content);
+    }
+
+    #[test]
+    fn test_multiline_frontmatter() {
+        let content = "---\nname: my-prompt\ndescription: A useful prompt\napply_to:\n  - agent-a\n  - agent-b\n---\n# Body\n\nContent.";
+        let (fm, body) = extract_frontmatter(content);
+        assert!(fm.is_some());
+        let fm = fm.unwrap();
+        assert!(fm.contains("name: my-prompt"));
+        assert!(fm.contains("apply_to:"));
+        assert_eq!(body, "# Body\n\nContent.");
+    }
+
+    #[test]
+    fn test_empty_content() {
+        let (fm, body) = extract_frontmatter("");
+        assert!(fm.is_none());
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn test_only_dashes() {
+        let (fm, body) = extract_frontmatter("---");
+        assert!(fm.is_none());
+        assert_eq!(body, "---");
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,4 @@
+pub mod frontmatter;
 mod markdown;
 mod metadata;
 


### PR DESCRIPTION
## Summary

Closes #48

- Add generic YAML frontmatter parser (`parser/frontmatter.rs`) reused by prompts and skills
- Add `Prompt` struct with parse, load, directory discovery and `apply_to` matching
- Add `Skill` struct following the SKILL.md open standard with scripts/references/assets discovery
- Add `resolve_prompt` / `resolve_skill` in `project.rs` (Named → project-local → user global)
- Add `armadai prompts list|show` and `armadai skills list|show` CLI commands
- 27 new tests covering frontmatter parsing, prompt/skill loading, resolution and matching

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --no-default-features --features tui -- -D warnings` passes (CI mode)
- [x] `cargo clippy --no-default-features --features tui,providers-api -- -D warnings` passes
- [x] `cargo test --no-default-features --features tui,providers-api` — 96 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)