### PR TITLE
feat: add awesome-copilot registry integration

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ mod link;
 mod list;
 pub(crate) mod new;
 mod prompts;
+mod registry;
 mod run;
 mod skills;
 mod up;
@@ -254,6 +255,20 @@ pub enum Command {
         #[arg(long)]
         pack: Option<String>,
     },
+    /// Browse and import agents from the community registry
+    #[command(
+        subcommand,
+        long_about = "Browse and import agents from the community registry.\n\n\
+            Integrates with awesome-copilot as a discovery and distribution mechanism. \
+            Agents are converted from Copilot format to ArmadAI Markdown on import.",
+        after_help = "Examples:\n  \
+            armadai registry sync\n  \
+            armadai registry search \"security review\"\n  \
+            armadai registry list --category official\n  \
+            armadai registry add official/security\n  \
+            armadai registry info official/security"
+    )]
+    Registry(registry::RegistryAction),
     /// Manage composable prompts
     #[command(
         subcommand,
@@ -315,6 +330,7 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         #[cfg(feature = "web")]
         Command::Web { port } => crate::web::serve(port).await,
         Command::Fleet(action) => fleet::execute(action).await,
+        Command::Registry(action) => registry::execute(action).await,
         Command::Prompts(action) => prompts::execute(action).await,
         Command::Skills(action) => skills::execute(action).await,
         Command::Link {

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -1,0 +1,224 @@
+use clap::Subcommand;
+
+use crate::registry::{cache, convert, search, sync};
+
+#[derive(Subcommand)]
+pub enum RegistryAction {
+    /// Sync (clone or pull) the community registry
+    Sync,
+    /// Search agents by keyword
+    Search {
+        /// Search query (keywords, AND logic)
+        query: String,
+        /// Filter by category
+        #[arg(long)]
+        category: Option<String>,
+    },
+    /// List all agents in the registry
+    List {
+        /// Filter by category
+        #[arg(long)]
+        category: Option<String>,
+    },
+    /// Import an agent into the user library
+    Add {
+        /// Agent path in registry (e.g. "agents/official/security.agent.md")
+        agent: String,
+        /// Overwrite existing agent
+        #[arg(long)]
+        force: bool,
+    },
+    /// Show details of a registry agent
+    Info {
+        /// Agent name or path in registry
+        agent: String,
+    },
+}
+
+pub async fn execute(action: RegistryAction) -> anyhow::Result<()> {
+    match action {
+        RegistryAction::Sync => cmd_sync().await,
+        RegistryAction::Search { query, category } => cmd_search(&query, category.as_deref()).await,
+        RegistryAction::List { category } => cmd_list(category.as_deref()).await,
+        RegistryAction::Add { agent, force } => cmd_add(&agent, force).await,
+        RegistryAction::Info { agent } => cmd_info(&agent).await,
+    }
+}
+
+async fn cmd_sync() -> anyhow::Result<()> {
+    println!("Syncing community registry...");
+    sync::registry_sync(None)?;
+    println!("Building search index...");
+    let index = cache::build_index()?;
+    println!("Indexed {} agent(s).", index.entries.len());
+    Ok(())
+}
+
+async fn cmd_search(query: &str, category: Option<&str>) -> anyhow::Result<()> {
+    check_staleness();
+    let index = cache::load_or_build_index()?;
+
+    let entries = match category {
+        Some(cat) => {
+            let filtered = search::filter_by_category(&index.entries, cat);
+            filtered.into_iter().cloned().collect::<Vec<_>>()
+        }
+        None => index.entries.clone(),
+    };
+
+    let results = search::search(&entries, query);
+
+    if results.is_empty() {
+        println!("No agents matching '{query}'.");
+        return Ok(());
+    }
+
+    // Compute column widths
+    let name_w = results
+        .iter()
+        .map(|r| r.entry.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    println!("  {:<name_w$}  SCORE  DESCRIPTION", "NAME",);
+    println!("  {:<name_w$}  -----  -----------", "-".repeat(name_w),);
+
+    for r in &results {
+        let desc = r.entry.description.as_deref().unwrap_or("-");
+        println!("  {:<name_w$}  {:>5}  {}", r.entry.name, r.score, desc);
+    }
+
+    println!("\n  {} result(s).", results.len());
+    Ok(())
+}
+
+async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
+    check_staleness();
+    let index = cache::load_or_build_index()?;
+
+    let entries: Vec<&cache::IndexEntry> = match category {
+        Some(cat) => search::filter_by_category(&index.entries, cat),
+        None => index.entries.iter().collect(),
+    };
+
+    if entries.is_empty() {
+        println!("No agents in registry.");
+        if !sync::repo_dir().join(".git").is_dir() {
+            println!("Run `armadai registry sync` to fetch the registry.");
+        }
+        return Ok(());
+    }
+
+    // Compute column widths
+    let name_w = entries
+        .iter()
+        .map(|e| e.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let cat_w = entries
+        .iter()
+        .map(|e| e.category.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+
+    println!("  {:<name_w$}  {:<cat_w$}  DESCRIPTION", "NAME", "CATEGORY",);
+    println!(
+        "  {:<name_w$}  {:<cat_w$}  -----------",
+        "-".repeat(name_w),
+        "-".repeat(cat_w),
+    );
+
+    for entry in &entries {
+        let cat = entry.category.as_deref().unwrap_or("-");
+        let desc = entry.description.as_deref().unwrap_or("-");
+        // Truncate description to 60 chars
+        let desc_display = if desc.len() > 60 {
+            format!("{}...", &desc[..57])
+        } else {
+            desc.to_string()
+        };
+        println!(
+            "  {:<name_w$}  {:<cat_w$}  {}",
+            entry.name, cat, desc_display
+        );
+    }
+
+    println!("\n  {} agent(s) in registry.", entries.len());
+    Ok(())
+}
+
+async fn cmd_add(agent: &str, force: bool) -> anyhow::Result<()> {
+    check_staleness();
+    let index = cache::load_or_build_index()?;
+
+    // Find the agent in the index by name or path
+    let entry = index
+        .entries
+        .iter()
+        .find(|e| e.name == agent || e.path == agent)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Agent '{agent}' not found in registry. Try `armadai registry search {agent}`"
+            )
+        })?;
+
+    println!("Converting {} ...", entry.name);
+    let dst = convert::import_to_library(&entry.path, force)?;
+    println!("Installed: {}", dst.display());
+    println!("\nAgent '{}' added to your library.", entry.name);
+    Ok(())
+}
+
+async fn cmd_info(agent: &str) -> anyhow::Result<()> {
+    check_staleness();
+    let index = cache::load_or_build_index()?;
+
+    let entry = index
+        .entries
+        .iter()
+        .find(|e| e.name == agent || e.path == agent)
+        .ok_or_else(|| anyhow::anyhow!("Agent '{agent}' not found in registry."))?;
+
+    println!("Name:        {}", entry.name);
+    println!("Path:        {}", entry.path);
+    if let Some(ref cat) = entry.category {
+        println!("Category:    {cat}");
+    }
+    if let Some(ref desc) = entry.description {
+        println!("Description: {desc}");
+    }
+    if !entry.tags.is_empty() {
+        println!("Tags:        [{}]", entry.tags.join(", "));
+    }
+
+    // Show the raw content
+    let repo = sync::repo_dir();
+    let src = repo.join(&entry.path);
+    if src.is_file() {
+        println!("\n--- Content ---");
+        let content = std::fs::read_to_string(&src)?;
+        // Print first 40 lines max
+        for (i, line) in content.lines().enumerate() {
+            if i >= 40 {
+                println!(
+                    "  ... (truncated, {} more lines)",
+                    content.lines().count() - 40
+                );
+                break;
+            }
+            println!("  {line}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Print a hint if the registry is stale (> 7 days old).
+fn check_staleness() {
+    if sync::is_stale(7) && sync::repo_dir().join(".git").is_dir() {
+        eprintln!("hint: registry may be outdated. Run `armadai registry sync` to refresh.");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod linker;
 mod parser;
 #[allow(dead_code)]
 mod providers;
+mod registry;
 #[allow(dead_code)]
 mod secrets;
 #[cfg(feature = "storage")]

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -1,0 +1,243 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::sync::repo_dir;
+use crate::core::config::registry_cache_dir;
+
+// ---------------------------------------------------------------------------
+// Index data model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexEntry {
+    /// Relative path inside the registry repo (e.g. "agents/official/security.agent.md")
+    pub path: String,
+    /// Agent name derived from the file
+    pub name: String,
+    /// Optional description extracted from the file
+    pub description: Option<String>,
+    /// Tags extracted from the file
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Category from the directory structure (e.g. "official", "community")
+    pub category: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Index {
+    pub entries: Vec<IndexEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Index building
+// ---------------------------------------------------------------------------
+
+/// Build a search index from the registry repo.
+///
+/// Scans for `.agent.md` and `.md` files in the repo and extracts metadata.
+pub fn build_index() -> anyhow::Result<Index> {
+    let repo = repo_dir();
+    if !repo.is_dir() {
+        anyhow::bail!("Registry not synced. Run `armadai registry sync` first.");
+    }
+
+    let mut entries = Vec::new();
+    scan_dir(&repo, &repo, &mut entries)?;
+
+    let index = Index { entries };
+    save_index(&index)?;
+    Ok(index)
+}
+
+/// Load the cached index, or build it if missing.
+pub fn load_or_build_index() -> anyhow::Result<Index> {
+    let index_path = index_file_path();
+    if index_path.is_file() {
+        let content = std::fs::read_to_string(&index_path)?;
+        let index: Index = serde_json::from_str(&content)?;
+        return Ok(index);
+    }
+    build_index()
+}
+
+fn index_file_path() -> PathBuf {
+    registry_cache_dir().join("index.json")
+}
+
+fn save_index(index: &Index) -> anyhow::Result<()> {
+    let path = index_file_path();
+    let content = serde_json::to_string_pretty(index)?;
+    std::fs::write(&path, content)?;
+    Ok(())
+}
+
+/// Recursively scan a directory for agent markdown files.
+fn scan_dir(dir: &Path, repo_root: &Path, entries: &mut Vec<IndexEntry>) -> anyhow::Result<()> {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in read.flatten() {
+        let path = entry.path();
+
+        // Skip .git directory
+        if path.file_name().is_some_and(|n| n == ".git") {
+            continue;
+        }
+
+        if path.is_dir() {
+            scan_dir(&path, repo_root, entries)?;
+        } else if is_agent_file(&path)
+            && let Ok(entry) = extract_entry(&path, repo_root)
+        {
+            entries.push(entry);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_agent_file(path: &Path) -> bool {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    name.ends_with(".agent.md")
+        || (name.ends_with(".md") && !name.eq_ignore_ascii_case("README.md"))
+}
+
+/// Extract an index entry from a file by reading its first lines.
+fn extract_entry(path: &Path, repo_root: &Path) -> anyhow::Result<IndexEntry> {
+    let content = std::fs::read_to_string(path)?;
+    let rel_path = path
+        .strip_prefix(repo_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string();
+
+    // Derive name from filename
+    let file_name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    let name = file_name.trim_end_matches(".agent").to_string();
+
+    // Extract description from first non-heading, non-empty line
+    let description = content
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.trim().is_empty())
+        .map(|l| l.trim().to_string())
+        .next();
+
+    // Derive category from parent directory name
+    let category = path
+        .parent()
+        .and_then(|p| p.strip_prefix(repo_root).ok())
+        .and_then(|p| p.components().next())
+        .and_then(|c| c.as_os_str().to_str().map(String::from));
+
+    // Try to extract tags from the content
+    let tags = extract_tags(&content);
+
+    Ok(IndexEntry {
+        path: rel_path,
+        name,
+        description,
+        tags,
+        category,
+    })
+}
+
+/// Try to extract tags from agent content (looks for `tags:` in metadata).
+fn extract_tags(content: &str) -> Vec<String> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed
+            .strip_prefix("- tags:")
+            .or_else(|| trimmed.strip_prefix("tags:"))
+        {
+            let cleaned = rest.trim().trim_start_matches('[').trim_end_matches(']');
+            return cleaned
+                .split(',')
+                .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+// ---------------------------------------------------------------------------
+// Converted agent cache
+// ---------------------------------------------------------------------------
+
+/// Return the directory for cached converted agents.
+pub fn converted_dir() -> PathBuf {
+    registry_cache_dir().join("converted")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_tags() {
+        let content = "# Agent\n\n## Metadata\n- tags: [dev, review, security]\n";
+        let tags = extract_tags(content);
+        assert_eq!(tags, vec!["dev", "review", "security"]);
+    }
+
+    #[test]
+    fn test_extract_tags_empty() {
+        let content = "# Agent\n\nNo tags here.";
+        let tags = extract_tags(content);
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("agents").join("security.agent.md");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(
+            &file,
+            "# Security Reviewer\n\nAnalyze code for OWASP vulnerabilities.\n\n## Metadata\n- tags: [security, review]\n",
+        )
+        .unwrap();
+
+        let entry = extract_entry(&file, dir.path()).unwrap();
+        assert_eq!(entry.name, "security");
+        assert_eq!(
+            entry.description.as_deref(),
+            Some("Analyze code for OWASP vulnerabilities.")
+        );
+        assert_eq!(entry.category.as_deref(), Some("agents"));
+        assert_eq!(entry.tags, vec!["security", "review"]);
+    }
+
+    #[test]
+    fn test_is_agent_file() {
+        assert!(is_agent_file(Path::new("security.agent.md")));
+        assert!(is_agent_file(Path::new("code-reviewer.md")));
+        assert!(!is_agent_file(Path::new("README.md")));
+        assert!(!is_agent_file(Path::new("readme.md")));
+        assert!(!is_agent_file(Path::new("data.json")));
+    }
+
+    #[test]
+    fn test_index_roundtrip() {
+        let index = Index {
+            entries: vec![IndexEntry {
+                path: "agents/test.agent.md".to_string(),
+                name: "test".to_string(),
+                description: Some("A test agent".to_string()),
+                tags: vec!["test".to_string()],
+                category: Some("agents".to_string()),
+            }],
+        };
+
+        let json = serde_json::to_string(&index).unwrap();
+        let deserialized: Index = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.entries.len(), 1);
+        assert_eq!(deserialized.entries[0].name, "test");
+    }
+}

--- a/src/registry/convert.rs
+++ b/src/registry/convert.rs
@@ -1,0 +1,179 @@
+use std::path::{Path, PathBuf};
+
+use super::cache::converted_dir;
+use super::sync::repo_dir;
+use crate::core::config::user_agents_dir;
+
+/// Convert a Copilot `.agent.md` file to ArmadAI Markdown format.
+///
+/// Copilot format:
+/// ```markdown
+/// ---
+/// name: Agent Name
+/// description: What it does
+/// tools: [tool1, tool2]
+/// ---
+/// Instructions body
+/// ```
+///
+/// ArmadAI format:
+/// ```markdown
+/// # Agent Name
+///
+/// ## Metadata
+/// - provider: anthropic
+/// - model: claude-sonnet-4-5-20250929
+/// - tags: []
+///
+/// ## System Prompt
+///
+/// <instructions body>
+/// ```
+pub fn convert_to_armadai(content: &str, fallback_name: &str) -> String {
+    let (frontmatter, body) = crate::parser::frontmatter::extract_frontmatter(content);
+
+    let mut name = fallback_name.to_string();
+    let mut description = String::new();
+    let mut tools: Vec<String> = Vec::new();
+
+    if let Some(fm) = frontmatter {
+        for line in fm.lines() {
+            let trimmed = line.trim();
+            if let Some(val) = trimmed.strip_prefix("name:") {
+                name = val.trim().trim_matches('"').trim_matches('\'').to_string();
+            } else if let Some(val) = trimmed.strip_prefix("description:") {
+                description = val.trim().trim_matches('"').trim_matches('\'').to_string();
+            } else if let Some(val) = trimmed.strip_prefix("tools:") {
+                let cleaned = val.trim().trim_start_matches('[').trim_end_matches(']');
+                tools = cleaned
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+        }
+    }
+
+    // If body starts with H1, use it as the name instead
+    let body_trimmed = body.trim();
+    let system_prompt = if let Some(rest) = body_trimmed.strip_prefix("# ") {
+        let first_line_end = rest.find('\n').unwrap_or(rest.len());
+        name = rest[..first_line_end].trim().to_string();
+        rest[first_line_end..].trim().to_string()
+    } else {
+        body_trimmed.to_string()
+    };
+
+    let mut output = format!(
+        "# {name}\n\n## Metadata\n- provider: anthropic\n- model: claude-sonnet-4-5-20250929\n- temperature: 0.5\n- max_tokens: 4096\n"
+    );
+
+    if !tools.is_empty() {
+        output.push_str(&format!("- tags: [{}]\n", tools.join(", ")));
+    }
+
+    if !description.is_empty() {
+        output.push_str(&format!("\n## Instructions\n\n{description}\n"));
+    }
+
+    output.push_str(&format!("\n## System Prompt\n\n{system_prompt}\n"));
+
+    output
+}
+
+/// Convert a registry agent and cache the result.
+///
+/// `registry_path` is relative to the repo root (e.g. "agents/official/security.agent.md").
+pub fn convert_cached(registry_path: &str) -> anyhow::Result<PathBuf> {
+    let repo = repo_dir();
+    let src = repo.join(registry_path);
+
+    if !src.is_file() {
+        anyhow::bail!("Registry file not found: {}", src.display());
+    }
+
+    let cache_dir = converted_dir();
+    std::fs::create_dir_all(&cache_dir)?;
+
+    // Derive output filename
+    let stem = Path::new(registry_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("agent");
+    let out_name = format!("{}.md", stem.trim_end_matches(".agent"));
+    let dst = cache_dir.join(&out_name);
+
+    let content = std::fs::read_to_string(&src)?;
+    let converted = convert_to_armadai(&content, stem);
+    std::fs::write(&dst, &converted)?;
+
+    Ok(dst)
+}
+
+/// Import a registry agent into the user library (~/.config/armadai/agents/).
+pub fn import_to_library(registry_path: &str, force: bool) -> anyhow::Result<PathBuf> {
+    let cached = convert_cached(registry_path)?;
+
+    let agents_dir = user_agents_dir();
+    std::fs::create_dir_all(&agents_dir)?;
+
+    let filename = cached.file_name().unwrap();
+    let dst = agents_dir.join(filename);
+
+    if dst.exists() && !force {
+        anyhow::bail!(
+            "Agent already exists at {}. Use --force to overwrite.",
+            dst.display()
+        );
+    }
+
+    std::fs::copy(&cached, &dst)?;
+    Ok(dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_copilot_format() {
+        let content = r#"---
+name: Security Scanner
+description: Scan code for vulnerabilities
+tools: [codebase, web-search]
+---
+You are a security expert. Analyze the codebase for OWASP Top 10 vulnerabilities.
+
+Focus on:
+- SQL injection
+- XSS
+- Authentication flaws
+"#;
+
+        let result = convert_to_armadai(content, "security-scanner");
+        assert!(result.starts_with("# Security Scanner"));
+        assert!(result.contains("## Metadata"));
+        assert!(result.contains("- provider: anthropic"));
+        assert!(result.contains("- tags: [codebase, web-search]"));
+        assert!(result.contains("## System Prompt"));
+        assert!(result.contains("OWASP Top 10"));
+    }
+
+    #[test]
+    fn test_convert_plain_markdown() {
+        let content = "# My Agent\n\nYou are a helpful assistant.\n\nDo things well.";
+        let result = convert_to_armadai(content, "my-agent");
+        assert!(result.starts_with("# My Agent"));
+        assert!(result.contains("## System Prompt"));
+        assert!(result.contains("You are a helpful assistant."));
+    }
+
+    #[test]
+    fn test_convert_no_frontmatter() {
+        let content = "Just some instructions without any structure.";
+        let result = convert_to_armadai(content, "plain");
+        assert!(result.starts_with("# plain"));
+        assert!(result.contains("## System Prompt"));
+        assert!(result.contains("Just some instructions"));
+    }
+}

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,0 +1,4 @@
+pub mod cache;
+pub mod convert;
+pub mod search;
+pub mod sync;

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -1,0 +1,195 @@
+use super::cache::IndexEntry;
+
+/// Search entries by keywords (AND logic).
+///
+/// Scores entries by relevance: name match > description match > tag match.
+/// Returns results sorted by descending score.
+pub fn search(entries: &[IndexEntry], query: &str) -> Vec<SearchResult> {
+    let keywords: Vec<String> = query.split_whitespace().map(|w| w.to_lowercase()).collect();
+
+    if keywords.is_empty() {
+        return Vec::new();
+    }
+
+    let mut results: Vec<SearchResult> = entries
+        .iter()
+        .filter_map(|entry| {
+            let score = score_entry(entry, &keywords);
+            if score > 0 {
+                Some(SearchResult {
+                    entry: entry.clone(),
+                    score,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.score.cmp(&a.score));
+    results
+}
+
+/// Filter entries by category.
+pub fn filter_by_category<'a>(entries: &'a [IndexEntry], category: &str) -> Vec<&'a IndexEntry> {
+    entries
+        .iter()
+        .filter(|e| e.category.as_deref() == Some(category))
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub entry: IndexEntry,
+    pub score: u32,
+}
+
+/// Score an entry against keywords. Returns 0 if any keyword doesn't match.
+fn score_entry(entry: &IndexEntry, keywords: &[String]) -> u32 {
+    let mut total = 0;
+
+    for kw in keywords {
+        let mut kw_score = 0u32;
+
+        // Name match (highest weight)
+        if entry.name.to_lowercase().contains(kw) {
+            kw_score += 10;
+        }
+
+        // Description match
+        if let Some(ref desc) = entry.description
+            && desc.to_lowercase().contains(kw)
+        {
+            kw_score += 5;
+        }
+
+        // Tag match
+        if entry.tags.iter().any(|t| t.to_lowercase().contains(kw)) {
+            kw_score += 3;
+        }
+
+        // Category match
+        if let Some(ref cat) = entry.category
+            && cat.to_lowercase().contains(kw)
+        {
+            kw_score += 1;
+        }
+
+        // AND logic: all keywords must match somewhere
+        if kw_score == 0 {
+            return 0;
+        }
+        total += kw_score;
+    }
+
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(
+        name: &str,
+        desc: Option<&str>,
+        tags: &[&str],
+        category: Option<&str>,
+    ) -> IndexEntry {
+        IndexEntry {
+            path: format!("{name}.md"),
+            name: name.to_string(),
+            description: desc.map(String::from),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            category: category.map(String::from),
+        }
+    }
+
+    #[test]
+    fn test_search_single_keyword() {
+        let entries = vec![
+            make_entry(
+                "security-scanner",
+                Some("OWASP vulnerability scanner"),
+                &["security"],
+                None,
+            ),
+            make_entry(
+                "code-reviewer",
+                Some("General code review"),
+                &["review"],
+                None,
+            ),
+        ];
+
+        let results = search(&entries, "security");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].entry.name, "security-scanner");
+    }
+
+    #[test]
+    fn test_search_multiple_keywords_and() {
+        let entries = vec![
+            make_entry(
+                "security-scanner",
+                Some("OWASP vulnerability scanner"),
+                &["security"],
+                None,
+            ),
+            make_entry(
+                "security-reviewer",
+                Some("Code security review"),
+                &["security", "review"],
+                None,
+            ),
+        ];
+
+        let results = search(&entries, "security review");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].entry.name, "security-reviewer");
+    }
+
+    #[test]
+    fn test_search_no_match() {
+        let entries = vec![make_entry(
+            "code-reviewer",
+            Some("General code review"),
+            &["review"],
+            None,
+        )];
+
+        let results = search(&entries, "nonexistent");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_ranking() {
+        let entries = vec![
+            make_entry("test-writer", Some("Writes tests"), &["testing"], None),
+            make_entry("reviewer", Some("Reviews test coverage"), &["test"], None),
+        ];
+
+        let results = search(&entries, "test");
+        assert_eq!(results.len(), 2);
+        // "test-writer" should rank higher (name match = 10 + desc match = 5)
+        assert_eq!(results[0].entry.name, "test-writer");
+    }
+
+    #[test]
+    fn test_search_empty_query() {
+        let entries = vec![make_entry("test", None, &[], None)];
+        let results = search(&entries, "");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_filter_by_category() {
+        let entries = vec![
+            make_entry("a", None, &[], Some("official")),
+            make_entry("b", None, &[], Some("community")),
+            make_entry("c", None, &[], Some("official")),
+        ];
+
+        let filtered = filter_by_category(&entries, "official");
+        assert_eq!(filtered.len(), 2);
+    }
+}

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::core::config::registry_cache_dir;
+
+const DEFAULT_REGISTRY_URL: &str = "https://github.com/anthropics/awesome-copilot.git";
+
+/// Return the path to the cloned registry repository.
+pub fn repo_dir() -> std::path::PathBuf {
+    registry_cache_dir().join("repo")
+}
+
+/// Clone or pull the registry repository.
+///
+/// Uses system `git` — no libgit2 dependency.
+pub fn registry_sync(url: Option<&str>) -> anyhow::Result<()> {
+    let url = url.unwrap_or(DEFAULT_REGISTRY_URL);
+    let repo = repo_dir();
+
+    if repo.join(".git").is_dir() {
+        pull(&repo)?;
+    } else {
+        clone(url, &repo)?;
+    }
+
+    Ok(())
+}
+
+fn clone(url: &str, dest: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dest)?;
+
+    let output = Command::new("git")
+        .args(["clone", "--depth", "1", url])
+        .arg(dest)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git clone failed: {stderr}");
+    }
+
+    println!("Cloned registry from {url}");
+    Ok(())
+}
+
+fn pull(repo: &Path) -> anyhow::Result<()> {
+    let output = Command::new("git")
+        .args(["pull", "--ff-only"])
+        .current_dir(repo)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git pull failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.contains("Already up to date") {
+        println!("Registry already up to date.");
+    } else {
+        println!("Registry updated.");
+    }
+
+    Ok(())
+}
+
+/// Check if the registry was last synced more than `days` ago.
+/// Returns `true` if a re-sync is recommended.
+pub fn is_stale(days: u64) -> bool {
+    let repo = repo_dir();
+    let git_dir = repo.join(".git");
+    if !git_dir.is_dir() {
+        return true;
+    }
+
+    let fetch_head = git_dir.join("FETCH_HEAD");
+    let check_path = if fetch_head.exists() {
+        fetch_head
+    } else {
+        git_dir.join("HEAD")
+    };
+
+    match std::fs::metadata(&check_path).and_then(|m| m.modified()) {
+        Ok(modified) => {
+            let age = std::time::SystemTime::now()
+                .duration_since(modified)
+                .unwrap_or_default();
+            age.as_secs() > days * 86400
+        }
+        Err(_) => true,
+    }
+}


### PR DESCRIPTION
## Summary

Closes #49

- Add `src/registry/` module with 4 sub-modules:
  - `sync.rs` — Clone or pull the awesome-copilot registry via system `git` (no libgit2)
  - `cache.rs` — Build and persist a JSON search index from the registry
  - `search.rs` — Multi-keyword AND search with relevance ranking (name > desc > tags > category)
  - `convert.rs` — Copilot `.agent.md` → ArmadAI Markdown format conversion
- Add `armadai registry` CLI subcommands: `sync`, `search`, `list`, `add`, `info`
- Staleness detection: hint after 7 days without sync
- `AgentRef::Registry` resolution already supported in `project.rs`
- 14 new tests covering indexing, search ranking, conversion, and serialization

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --no-default-features --features tui -- -D warnings` passes (CI mode)
- [x] `cargo clippy --no-default-features --features tui,providers-api -- -D warnings` passes
- [x] `cargo test --no-default-features --features tui,providers-api` — 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)