### PR TITLE
fix: replace unsound serde_yml with serde_yaml_ng and update docs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   audit:
     name: Audit Dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,16 @@ See ARCHITECTURE.md for full details. Key modules:
 - `src/cli/` — CLI commands (clap)
 - `src/tui/` — Terminal UI (ratatui)
 - `src/core/` — Domain: Agent, Coordinator, Task, Context
+- `src/core/project.rs` — Project config (armadai.yaml) with agent/prompt/skill resolution
+- `src/core/prompt.rs` — Composable prompt fragments with YAML frontmatter
+- `src/core/skill.rs` — Skills following the SKILL.md open standard
+- `src/core/starter.rs` — Starter packs installation
+- `src/core/fleet.rs` — Fleet definitions linking agent groups to directories
 - `src/parser/` — Markdown agent file parsing
+- `src/parser/frontmatter.rs` — Generic YAML frontmatter extraction
 - `src/providers/` — LLM provider abstraction (API, CLI, proxy)
+- `src/linker/` — Generate native config for AI CLIs (Claude Code, Copilot, etc.)
+- `src/registry/` — Community agent registry integration (awesome-copilot)
 - `src/storage/` — SurrealDB persistence layer
 - `src/secrets/` — SOPS + age secret management
 
@@ -50,7 +58,7 @@ See ARCHITECTURE.md for full details. Key modules:
 
 - Unit tests go in the same file as the code (`#[cfg(test)]` module)
 - Integration tests go in `tests/`
-- Test agent files go in `agents/examples/`
+- Test agent files go in `starters/` (organized by pack)
 
 ## Commit Messages
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,11 +208,15 @@ Exécute la tâche demandée en utilisant tes outils disponibles.
 ```
 armadai/
 ├── agents/                      # Définitions d'agents
-│   ├── _coordinator.md          # Agent hub (orchestrateur)
-│   └── examples/                # Exemples fournis
-│       ├── code-reviewer.md
-│       ├── test-writer.md
-│       └── doc-generator.md
+│   └── _coordinator.md          # Agent hub (orchestrateur)
+├── starters/                    # Packs d'agents pré-configurés
+│   ├── rust-dev/
+│   │   ├── pack.yaml
+│   │   ├── agents/
+│   │   └── prompts/
+│   └── fullstack/
+│       ├── pack.yaml
+│       └── agents/
 ├── templates/                   # Templates pour scaffolding
 │   ├── basic.md
 │   ├── dev-review.md
@@ -254,11 +258,17 @@ armadai/
 │   │   ├── coordinator.rs       # Hub & spoke : décomposition et dispatch
 │   │   ├── pipeline.rs          # Mode pipeline : chaînage séquentiel
 │   │   ├── task.rs              # Définition d'une tâche + résultat
-│   │   └── context.rs           # Gestion du contexte partagé entre agents
+│   │   ├── context.rs           # Gestion du contexte partagé entre agents
+│   │   ├── project.rs          # Config projet (armadai.yaml), résolution agents/prompts/skills
+│   │   ├── fleet.rs            # Définitions de flottes, liaison projets-agents
+│   │   ├── prompt.rs           # Fragments de prompts composables (YAML frontmatter)
+│   │   ├── skill.rs            # Skills (standard SKILL.md)
+│   │   └── starter.rs          # Starter packs (installation de bundles)
 │   ├── parser/                  # Parsing Markdown → Agent
 │   │   ├── mod.rs
 │   │   ├── markdown.rs          # Parsing headings, sections, metadata
-│   │   └── metadata.rs          # Parsing de la section Metadata (YAML-like)
+│   │   ├── metadata.rs          # Parsing de la section Metadata (YAML-like)
+│   │   └── frontmatter.rs      # Extraction YAML frontmatter générique
 │   ├── providers/               # Abstraction LLM
 │   │   ├── mod.rs
 │   │   ├── traits.rs            # Provider trait + types communs
@@ -269,6 +279,16 @@ armadai/
 │   │   │   └── google.rs
 │   │   ├── proxy.rs             # LiteLLM / OpenRouter
 │   │   └── cli.rs               # CliProvider générique (spawn process)
+│   ├── linker/                # Génération de configs natives
+│   │   ├── mod.rs             # Trait Linker + dispatch
+│   │   ├── claude.rs          # .claude/agents/*.md
+│   │   └── copilot.rs         # .github/agents/*.agent.md
+│   ├── registry/              # Intégration awesome-copilot
+│   │   ├── mod.rs
+│   │   ├── sync.rs            # Clone/pull du repo registry
+│   │   ├── cache.rs           # Index JSON, scanning fichiers
+│   │   ├── search.rs          # Recherche multi-mots-clés avec scoring
+│   │   └── convert.rs         # Conversion Copilot → ArmadAI
 │   ├── storage/                 # Couche persistance
 │   │   ├── mod.rs
 │   │   ├── embedded.rs          # SurrealDB mode embarqué
@@ -333,6 +353,15 @@ armadai init --project             # Créer armadai.yaml local
 armadai tui                        # Lancer l'interface TUI
 armadai up                         # Lancer l'infra Docker (optionnel)
 armadai down                       # Arrêter l'infra Docker
+armadai fleet create/link/list/show  # Gérer les flottes d'agents
+armadai link --target <t>            # Générer configs natives (claude, copilot...)
+armadai registry sync/search/list/add # Registre communautaire
+armadai prompts list/show            # Fragments de prompts composables
+armadai skills list/show             # Skills (standard SKILL.md)
+armadai init --pack <name>           # Installer un starter pack
+armadai update                       # Mise à jour automatique
+armadai completion <shell>           # Générer les completions shell
+armadai web [--port N]               # Lancer l'interface web
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`. Sever
 - `core/prompt.rs` — Composable prompt fragments with YAML frontmatter.
 - `core/skill.rs` — Skills following the Agent Skills open standard (SKILL.md).
 - `core/fleet.rs` — Fleet definitions linking agent groups to source directories.
+- `core/starter.rs` — Starter packs: curated agent bundles installed via `armadai init --pack`.
+- `parser/frontmatter.rs` — Generic YAML frontmatter extraction reused by prompts and skills.
 - `linker/` — Generates native config files for target AI CLIs. Trait `Linker` with one implementation per CLI (claude, copilot, cursor, aider, codex, gemini, windsurf, cline).
 - `registry/` — awesome-copilot integration. Sync, search, convert agents from the community catalog.
 - `storage/` — SurrealDB wrapper. `schema.rs` defines tables (`runs`, `agent_stats`), `queries.rs` has CRUD operations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "surrealdb",
  "tempfile",
  "thiserror 2.0.18",
@@ -2504,16 +2504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,18 +4363,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5480,6 +5468,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tower-http = { version = "0.6", features = ["cors"], optional = true }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 
 # Database (optional — enable with `storage` or `storage-rocksdb` feature)
 surrealdb = { version = "2", features = ["kv-mem"], optional = true }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ armadai run my-assistant "Explain how async/await works in Rust"
 | `armadai config providers` | Show provider configs and secrets status | Done |
 | `armadai config secrets init` | Initialize SOPS + age encryption | Done |
 | `armadai config secrets rotate` | Rotate age encryption key | Done |
+| `armadai init [--force] [--project]` | Initialize ArmadAI configuration | Done |
+| `armadai init --pack <name>` | Install a starter pack (rust-dev, fullstack) | Done |
+| `armadai fleet create/link/list/show` | Manage agent fleets | Done |
+| `armadai link --target <t> [--dry-run]` | Generate native AI assistant configs | Done |
+| `armadai registry sync/search/list/add` | Browse and import community agents | Done |
+| `armadai prompts list/show` | Manage composable prompts | Done |
+| `armadai skills list/show` | Manage composable skills | Done |
+| `armadai update` | Self-update to latest release | Done |
 | `armadai tui` | Launch the TUI dashboard | Done |
 | `armadai web [--port N]` | Launch the web UI | Done |
 | `armadai completion <shell>` | Generate shell completions | Done |
@@ -197,6 +205,22 @@ Create an agent from a template:
 armadai new my-reviewer --template dev-review --stack rust
 armadai new my-tool --template cli-generic
 ```
+
+## Starter Packs
+
+Install curated bundles of agents and prompts:
+
+```bash
+armadai init --pack rust-dev      # Code reviewer, test writer, debug agent + Rust conventions
+armadai init --pack fullstack     # Full stack of 6 agents for web development
+```
+
+Available packs:
+
+| Pack | Agents | Description |
+|---|---|---|
+| `rust-dev` | code-reviewer, test-writer, debug | Rust development essentials + conventions prompt |
+| `fullstack` | code-reviewer, test-writer, doc-generator, planning-agent, security-reviewer, tech-debt-analyzer | Full stack web development |
 
 ## Shell Completion
 
@@ -345,6 +369,8 @@ Detailed documentation is available in [`docs/wiki/`](docs/wiki/):
 - [Agent Format](docs/wiki/agent-format.md) — complete reference for agent Markdown files
 - [Providers](docs/wiki/providers.md) — configuring API, CLI, and proxy providers
 - [Templates](docs/wiki/templates.md) — using and creating agent templates
+- [Starter Packs](docs/wiki/starter-packs.md) — curated agent bundles
+- [Registry](docs/wiki/registry.md) — browsing and importing community agents
 
 ## License
 

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,14 @@
+# cargo-audit configuration
+# See: https://github.com/rustsec/rustsec/tree/main/cargo-audit
+
+[advisories]
+# Ignore advisories for transitive dependencies we cannot control.
+# These are pulled in by surrealdb and have no fix available upstream.
+ignore = [
+    # atomic-polyfill (unmaintained) — via surrealdb -> rstar -> heapless
+    "RUSTSEC-2023-0089",
+    # bincode (unmaintained) — via surrealdb
+    "RUSTSEC-2025-0141",
+    # lru (unsound IterMut) — via surrealdb -> surrealkv; patched in >=0.16.3 but surrealdb pins 0.12.5
+    "RUSTSEC-2026-0002",
+]

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -38,6 +38,20 @@ armadai new my-assistant --template basic --description "general-purpose coding 
 
 This creates `agents/my-assistant.md`. Open it and customize the system prompt to your needs.
 
+## Starter Packs
+
+Instead of creating agents one by one, install a curated pack:
+
+```bash
+# Rust development essentials (code-reviewer, test-writer, debug + conventions prompt)
+armadai init --pack rust-dev
+
+# Full stack web development (6 agents)
+armadai init --pack fullstack
+```
+
+List available packs with `armadai init --pack nonexistent` (shows available options on error).
+
 ## Verify Setup
 
 ```bash
@@ -108,8 +122,25 @@ armadai web --port 8080  # custom port
 
 Browse agents, view execution history, and track costs from your browser. The `web` feature is enabled by default.
 
+## Community Registry
+
+Browse and import agents from the community:
+
+```bash
+# Sync the registry
+armadai registry sync
+
+# Search for agents
+armadai registry search "security review"
+
+# Import an agent
+armadai registry add official/security
+```
+
 ## Next Steps
 
 - [Agent Format](agent-format.md) — full reference for agent Markdown files
 - [Providers](providers.md) — configure API, CLI, and proxy providers
 - [Templates](templates.md) — available templates and how to create your own
+- [Starter Packs](starter-packs.md) — curated agent bundles for quick setup
+- [Registry](registry.md) — browsing and importing community agents

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -245,7 +245,7 @@ async fn secrets_rotate() -> anyhow::Result<()> {
     println!("Updated .sops.yaml with new public key.");
 
     // 5. Re-encrypt secrets with new key
-    let yaml = serde_yml::to_string(&secrets)?;
+    let yaml = serde_yaml_ng::to_string(&secrets)?;
     std::fs::write(&sops_path, yaml)?;
 
     let encrypt = std::process::Command::new("sops")

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -180,7 +180,7 @@ impl Default for LoggingConfig {
 pub fn load_user_config() -> UserConfig {
     let path = config_file_path();
     match std::fs::read_to_string(&path) {
-        Ok(content) => serde_yml::from_str(&content).unwrap_or_default(),
+        Ok(content) => serde_yaml_ng::from_str(&content).unwrap_or_default(),
         Err(_) => UserConfig::default(),
     }
 }
@@ -223,14 +223,14 @@ pub fn load_providers_config() -> ProvidersConfig {
     // Try global config first
     let global_path = providers_file_path();
     if let Ok(content) = std::fs::read_to_string(&global_path)
-        && let Ok(cfg) = serde_yml::from_str(&content)
+        && let Ok(cfg) = serde_yaml_ng::from_str(&content)
     {
         return cfg;
     }
     // Fallback to project-local
     let local_path = Path::new("config/providers.yaml");
     if let Ok(content) = std::fs::read_to_string(local_path)
-        && let Ok(cfg) = serde_yml::from_str(&content)
+        && let Ok(cfg) = serde_yaml_ng::from_str(&content)
     {
         return cfg;
     }
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn test_partial_deserialize() {
         let yaml = "defaults:\n  provider: openai\n";
-        let cfg: UserConfig = serde_yml::from_str(yaml).unwrap();
+        let cfg: UserConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(cfg.defaults.provider, "openai");
         // Other fields keep defaults
         assert_eq!(cfg.defaults.max_tokens, 4096);
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn test_empty_deserialize() {
         let yaml = "";
-        let cfg: UserConfig = serde_yml::from_str(yaml).unwrap_or_default();
+        let cfg: UserConfig = serde_yaml_ng::from_str(yaml).unwrap_or_default();
         assert_eq!(cfg.defaults.provider, "anthropic");
     }
 
@@ -420,7 +420,7 @@ providers:
     models:
       - gpt-4o
 "#;
-        let cfg: ProvidersConfig = serde_yml::from_str(yaml).unwrap();
+        let cfg: ProvidersConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(cfg.providers.len(), 2);
         assert!(cfg.providers.contains_key("anthropic"));
         let anthropic = &cfg.providers["anthropic"];

--- a/src/core/fleet.rs
+++ b/src/core/fleet.rs
@@ -18,13 +18,13 @@ impl FleetDefinition {
     /// Load a fleet definition from a YAML file.
     pub fn load(path: &Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path)?;
-        let def: FleetDefinition = serde_yml::from_str(&content)?;
+        let def: FleetDefinition = serde_yaml_ng::from_str(&content)?;
         Ok(def)
     }
 
     /// Save the fleet definition to a YAML file.
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
-        let content = serde_yml::to_string(self)?;
+        let content = serde_yaml_ng::to_string(self)?;
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -55,8 +55,8 @@ mod tests {
             source: PathBuf::from("/home/user/armadai"),
         };
 
-        let yaml = serde_yml::to_string(&fleet).unwrap();
-        let parsed: FleetDefinition = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_yaml_ng::to_string(&fleet).unwrap();
+        let parsed: FleetDefinition = serde_yaml_ng::from_str(&yaml).unwrap();
 
         assert_eq!(parsed.fleet, "test-fleet");
         assert_eq!(parsed.agents.len(), 2);

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -86,13 +86,13 @@ impl ProjectConfig {
 
         // Detect format: if there's a `fleet:` key, it's the old format
         let probe: FormatProbe =
-            serde_yml::from_str(&content).unwrap_or(FormatProbe { fleet: None });
+            serde_yaml_ng::from_str(&content).unwrap_or(FormatProbe { fleet: None });
 
         if probe.fleet.is_some() {
-            let fleet: FleetDefinition = serde_yml::from_str(&content)?;
+            let fleet: FleetDefinition = serde_yaml_ng::from_str(&content)?;
             Ok(Self::from_legacy_fleet(&fleet))
         } else {
-            let config: ProjectConfig = serde_yml::from_str(&content)?;
+            let config: ProjectConfig = serde_yaml_ng::from_str(&content)?;
             Ok(config)
         }
     }
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_agent_ref_named() {
         let yaml = "- name: code-reviewer\n";
-        let refs: Vec<AgentRef> = serde_yml::from_str(yaml).unwrap();
+        let refs: Vec<AgentRef> = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(
             refs[0],
             AgentRef::Named {
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     fn test_agent_ref_registry() {
         let yaml = "- registry: official/security\n";
-        let refs: Vec<AgentRef> = serde_yml::from_str(yaml).unwrap();
+        let refs: Vec<AgentRef> = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(
             refs[0],
             AgentRef::Registry {
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn test_agent_ref_path() {
         let yaml = "- path: .armadai/agents/team.md\n";
-        let refs: Vec<AgentRef> = serde_yml::from_str(yaml).unwrap();
+        let refs: Vec<AgentRef> = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(
             refs[0],
             AgentRef::Path {
@@ -434,7 +434,7 @@ link:
     copilot:
       output: .github/agents/
 "#;
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_yaml_ng::from_str(yaml).unwrap();
 
         assert_eq!(config.agents.len(), 3);
         assert_eq!(
@@ -482,7 +482,7 @@ link:
     #[test]
     fn test_partial_config_deserialize() {
         let yaml = "agents:\n  - name: my-agent\n";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(config.agents.len(), 1);
         assert!(config.prompts.is_empty());
         assert!(config.skills.is_empty());
@@ -493,7 +493,7 @@ link:
     #[test]
     fn test_empty_config_deserialize() {
         let yaml = "";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap_or_default();
+        let config: ProjectConfig = serde_yaml_ng::from_str(yaml).unwrap_or_default();
         assert!(config.agents.is_empty());
         assert!(config.prompts.is_empty());
     }

--- a/src/core/prompt.rs
+++ b/src/core/prompt.rs
@@ -35,7 +35,7 @@ impl Prompt {
         let (fm_str, body) = extract_frontmatter(content);
 
         let fm: PromptFrontmatter = match fm_str {
-            Some(yaml) => serde_yml::from_str(yaml)?,
+            Some(yaml) => serde_yaml_ng::from_str(yaml)?,
             None => PromptFrontmatter::default(),
         };
 

--- a/src/core/skill.rs
+++ b/src/core/skill.rs
@@ -46,7 +46,7 @@ impl Skill {
         let (fm_str, body) = extract_frontmatter(&content);
 
         let fm: SkillFrontmatter = match fm_str {
-            Some(yaml) => serde_yml::from_str(yaml)?,
+            Some(yaml) => serde_yaml_ng::from_str(yaml)?,
             None => SkillFrontmatter::default(),
         };
 

--- a/src/core/starter.rs
+++ b/src/core/starter.rs
@@ -30,7 +30,7 @@ impl StarterPack {
             anyhow::bail!("No pack.yaml found in {}", dir.display());
         }
         let content = std::fs::read_to_string(&pack_file)?;
-        let pack: StarterPack = serde_yml::from_str(&content)?;
+        let pack: StarterPack = serde_yaml_ng::from_str(&content)?;
         Ok(pack)
     }
 

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -26,7 +26,7 @@ pub fn load_secrets(config_dir: &Path) -> anyhow::Result<ProviderSecrets> {
     let plain_path = config_dir.join("providers.secret.yaml");
     if plain_path.exists() {
         let content = std::fs::read_to_string(&plain_path)?;
-        let secrets: ProviderSecrets = serde_yml::from_str(&content)?;
+        let secrets: ProviderSecrets = serde_yaml_ng::from_str(&content)?;
         tracing::warn!("Loaded secrets from unencrypted file — consider using SOPS + age");
         return Ok(secrets);
     }

--- a/src/secrets/sops.rs
+++ b/src/secrets/sops.rs
@@ -15,7 +15,7 @@ pub fn decrypt_file(path: &Path) -> anyhow::Result<ProviderSecrets> {
     }
 
     let decrypted = String::from_utf8(output.stdout)?;
-    let secrets: ProviderSecrets = serde_yml::from_str(&decrypted)?;
+    let secrets: ProviderSecrets = serde_yaml_ng::from_str(&decrypted)?;
     Ok(secrets)
 }
 


### PR DESCRIPTION
## Summary

- Replace `serde_yml` (RUSTSEC-2025-0068, unsound) with maintained `serde_yaml_ng`, also fixing transitive `libyml` (RUSTSEC-2025-0067)
- Add `audit.toml` to ignore 3 transitive surrealdb warnings (atomic-polyfill, bincode, lru) that have no upstream fix
- Add `permissions: checks: write` to audit workflow to fix "Resource not accessible by integration" error
- Update documentation (README, ARCHITECTURE, AGENTS, CLAUDE.md, getting-started) with new commands and fix outdated `agents/examples/` references

## Test plan

- [ ] `cargo clippy --all-targets --no-default-features --features tui -- -D warnings` passes
- [ ] `cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings` passes
- [ ] `cargo test --no-default-features --features tui,providers-api` — 114 tests pass
- [ ] `cargo fmt -- --check` passes
- [ ] Security audit check passes with 0 warnings (3 ignored via audit.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)