### PR TITLE
feat: add skills registry for GitHub-based discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -289,6 +289,11 @@ armadai/
 │   │   ├── cache.rs           # Index JSON, scanning fichiers
 │   │   ├── search.rs          # Recherche multi-mots-clés avec scoring
 │   │   └── convert.rs         # Conversion Copilot → ArmadAI
+│   ├── skills_registry/       # Découverte de skills GitHub
+│   │   ├── mod.rs
+│   │   ├── sync.rs            # Clone/pull de repos de skills
+│   │   ├── cache.rs           # Index JSON des SKILL.md découverts
+│   │   └── search.rs          # Recherche multi-mots-clés avec scoring
 │   ├── storage/                 # Couche persistance
 │   │   ├── mod.rs
 │   │   ├── embedded.rs          # SurrealDB mode embarqué
@@ -358,6 +363,7 @@ armadai link --target <t>            # Générer configs natives (claude, copilo
 armadai registry sync/search/list/add # Registre communautaire
 armadai prompts list/show            # Fragments de prompts composables
 armadai skills list/show             # Skills (standard SKILL.md)
+armadai skills sync/search/add/info  # Registre de skills GitHub
 armadai init --pack <name>           # Installer un starter pack
 armadai update                       # Mise à jour automatique
 armadai completion <shell>           # Générer les completions shell
@@ -380,7 +386,8 @@ Toute la résolution de chemins et la configuration utilisateur passe par `core/
 ├── prompts/             # Fragments de prompts composables
 ├── skills/              # Skills des agents
 ├── fleets/              # Définitions de flottes
-└── registry/            # Cache du registre awesome-copilot
+├── registry/            # Cache du registre awesome-copilot
+└── skills-registry/     # Cache du registre de skills GitHub
 ```
 
 ### Résolution XDG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`.
 - `parser/frontmatter.rs` — Generic YAML frontmatter extraction reused by prompts and skills.
 - `linker/` — Generates native config files for target AI CLIs. Trait `Linker` with one implementation per CLI (claude, copilot, cursor, aider, codex, gemini, windsurf, cline).
 - `registry/` — awesome-copilot integration. Sync, search, convert agents from the community catalog.
+- `skills_registry/` — GitHub-based skills discovery. Sync repos, build search index, install skills (`sync.rs`, `cache.rs`, `search.rs`).
 - `storage/` — SQLite wrapper (via rusqlite). `schema.rs` defines the `runs` table, `queries.rs` has CRUD operations.
 - `tui/` — Ratatui-based terminal UI. `app.rs` holds state (incl. command palette), `views/` renders tabs (Agents/Detail/History/Costs + shortcuts bar + command palette overlay), `widgets/` provides reusable components.
 - `web/` — Axum-based web UI. Embedded single-page HTML app with JSON API endpoints (`/api/agents`, `/api/history`, `/api/costs`).

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ armadai run my-assistant "Explain how async/await works in Rust"
 | `armadai registry sync/search/list/add` | Browse and import community agents | Done |
 | `armadai prompts list/show` | Manage composable prompts | Done |
 | `armadai skills list/show` | Manage composable skills | Done |
+| `armadai skills sync/search/add/info` | Discover and install skills from GitHub | Done |
 | `armadai update` | Self-update to latest release | Done |
 | `armadai tui` | Launch the TUI dashboard | Done |
 | `armadai web [--port N]` | Launch the web UI | Done |

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -160,6 +160,24 @@ armadai registry search "security review"
 armadai registry add official/security
 ```
 
+## Discover Skills
+
+Browse and install skills from GitHub repos:
+
+```bash
+# Sync remote skill sources
+armadai skills sync
+
+# Search for skills
+armadai skills search "testing"
+
+# Install a skill
+armadai skills add anthropics/skills/webapp-testing
+
+# List installed skills
+armadai skills list
+```
+
 ## Next Steps
 
 - [Agent Format](agent-format.md) — full reference for agent Markdown files

--- a/docs/wiki/registry.md
+++ b/docs/wiki/registry.md
@@ -85,6 +85,7 @@ The registry works offline after the initial sync. Run `armadai registry sync` w
 
 ## See Also
 
+- [Skills & Prompts](skills-prompts.md) — skills discovery and installation from GitHub repos
 - [Getting Started](getting-started.md) — installation and first steps
 - [Starter Packs](starter-packs.md) — curated agent bundles
 - [Link Command](link.md) — generating config for AI CLIs

--- a/docs/wiki/skills-prompts.md
+++ b/docs/wiki/skills-prompts.md
@@ -82,6 +82,50 @@ skills:
   - path: ./scripts/deploy             # Project-local skill directory
 ```
 
+## Skills Registry
+
+Discover and install skills from GitHub repos without copying files manually.
+
+### Sync remote sources
+
+```bash
+armadai skills sync
+```
+
+Clones or updates the default skill sources (shallow clone) and builds a local search index at `~/.config/armadai/skills-registry/`.
+
+### Search skills
+
+```bash
+armadai skills search "testing"
+armadai skills search "docker compose"
+```
+
+Multi-keyword AND search with weighted scoring (name > description > tags > source repo).
+
+### Install a skill
+
+```bash
+# Install a specific skill from a repo
+armadai skills add anthropics/skills/webapp-testing
+
+# If the repo has only one skill, the skill name is optional
+armadai skills add owner/repo
+
+# Overwrite an existing skill
+armadai skills add anthropics/skills/webapp-testing --force
+```
+
+The skill directory (SKILL.md + scripts/ + references/ + assets/) is copied to `~/.config/armadai/skills/<skill-name>/`.
+
+### Show skill info
+
+```bash
+armadai skills info webapp-testing
+```
+
+Displays metadata from the registry index and the SKILL.md content.
+
 ## How Prompts are Linked
 
 When running `armadai link`, prompts are included in the generated config:
@@ -96,4 +140,5 @@ When running `armadai link`, prompts are included in the generated config:
 
 - [Agent Format](agent-format.md) — agent Markdown file reference
 - [Link Command](link.md) — generating config for AI CLIs
-- [Registry](registry.md) — community agents and prompts
+- [Registry](registry.md) — community agents
+- [Getting Started](getting-started.md) — installation and first steps

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -290,10 +290,15 @@ pub enum Command {
         long_about = "Manage composable skills.\n\n\
             Skills follow the SKILL.md open standard — structured knowledge with \
             scripts, references and assets. Each skill lives in a directory \
-            containing a SKILL.md file.",
+            containing a SKILL.md file.\n\n\
+            Discover and install skills from GitHub repos with sync/search/add.",
         after_help = "Examples:\n  \
             armadai skills list\n  \
-            armadai skills show docker-compose"
+            armadai skills show docker-compose\n  \
+            armadai skills sync\n  \
+            armadai skills search \"testing\"\n  \
+            armadai skills add anthropics/skills/webapp-testing\n  \
+            armadai skills info webapp-testing"
     )]
     Skills(skills::SkillsAction),
     /// Self-update to the latest release

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -3,6 +3,7 @@ use clap::Subcommand;
 use crate::core::config::user_skills_dir;
 use crate::core::project;
 use crate::core::skill::{Skill, load_all_skills};
+use crate::skills_registry::{cache, search, sync};
 
 #[derive(Subcommand)]
 pub enum SkillsAction {
@@ -13,12 +14,36 @@ pub enum SkillsAction {
         /// Skill name
         name: String,
     },
+    /// Sync skills from remote sources
+    Sync,
+    /// Search skills in the registry
+    Search {
+        /// Search query (keywords, AND logic)
+        query: String,
+    },
+    /// Add a skill from a GitHub repo (owner/repo or owner/repo/skill-name)
+    Add {
+        /// Skill source (e.g. "anthropics/skills/webapp-testing" or "owner/repo")
+        source: String,
+        /// Overwrite existing skill
+        #[arg(long)]
+        force: bool,
+    },
+    /// Show info about a skill from the registry
+    Info {
+        /// Skill name
+        name: String,
+    },
 }
 
 pub async fn execute(action: SkillsAction) -> anyhow::Result<()> {
     match action {
         SkillsAction::List => list().await,
         SkillsAction::Show { name } => show(&name).await,
+        SkillsAction::Sync => cmd_sync().await,
+        SkillsAction::Search { query } => cmd_search(&query).await,
+        SkillsAction::Add { source, force } => cmd_add(&source, force).await,
+        SkillsAction::Info { name } => cmd_info(&name).await,
     }
 }
 
@@ -29,6 +54,9 @@ async fn list() -> anyhow::Result<()> {
         println!("No skills found.");
         println!(
             "Add skill directories (containing SKILL.md) in skills/ or ~/.config/armadai/skills/"
+        );
+        println!(
+            "Or run `armadai skills sync` then `armadai skills search <query>` to discover remote skills."
         );
         return Ok(());
     }
@@ -130,6 +158,263 @@ async fn show(name: &str) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Registry commands
+// ---------------------------------------------------------------------------
+
+async fn cmd_sync() -> anyhow::Result<()> {
+    let sources = cache::effective_sources();
+    println!("Syncing {} skill source(s)...", sources.len());
+    sync::sync_all(&sources)?;
+    println!("Building search index...");
+    let index = cache::build_index(&sources)?;
+    println!("Indexed {} skill(s).", index.entries.len());
+    Ok(())
+}
+
+async fn cmd_search(query: &str) -> anyhow::Result<()> {
+    check_staleness();
+    let sources = cache::effective_sources();
+    let index = cache::load_or_build_index(&sources)?;
+
+    if index.entries.is_empty() {
+        println!("No skills indexed. Run `armadai skills sync` first.");
+        return Ok(());
+    }
+
+    let results = search::search(&index.entries, query);
+
+    if results.is_empty() {
+        println!("No skills matching '{query}'.");
+        return Ok(());
+    }
+
+    // Compute column widths
+    let name_w = results
+        .iter()
+        .map(|r| r.entry.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let repo_w = results
+        .iter()
+        .map(|r| r.entry.source_repo.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+
+    println!(
+        "  {:<name_w$}  {:>5}  {:<repo_w$}  DESCRIPTION",
+        "NAME", "SCORE", "SOURCE",
+    );
+    println!(
+        "  {:<name_w$}  {:>5}  {:<repo_w$}  -----------",
+        "-".repeat(name_w),
+        "-----",
+        "-".repeat(repo_w),
+    );
+
+    for r in &results {
+        let desc = r.entry.description.as_deref().unwrap_or("-");
+        let desc_display = if desc.len() > 50 {
+            format!("{}...", &desc[..47])
+        } else {
+            desc.to_string()
+        };
+        println!(
+            "  {:<name_w$}  {:>5}  {:<repo_w$}  {}",
+            r.entry.name, r.score, r.entry.source_repo, desc_display,
+        );
+    }
+
+    println!("\n  {} result(s).", results.len());
+    Ok(())
+}
+
+async fn cmd_add(source: &str, force: bool) -> anyhow::Result<()> {
+    // Parse source: owner/repo or owner/repo/skill-name
+    let parts: Vec<&str> = source.split('/').collect();
+    let (owner, repo, skill_name) = match parts.len() {
+        2 => (parts[0], parts[1], None),
+        n if n >= 3 => (parts[0], parts[1], Some(parts[2..].join("/"))),
+        _ => anyhow::bail!("Invalid source format. Use owner/repo or owner/repo/skill-name"),
+    };
+
+    // Clone/pull the repo
+    let repo_slug = format!("{owner}/{repo}");
+    println!("Syncing {repo_slug}...");
+    let repo_path = sync::sync_repo(&repo_slug)?;
+
+    // Scan for skills in the repo
+    let mut skill_dirs = Vec::new();
+    find_skill_dirs(&repo_path, &mut skill_dirs);
+
+    if skill_dirs.is_empty() {
+        anyhow::bail!("No skills (SKILL.md) found in {repo_slug}");
+    }
+
+    // Determine which skill to install
+    let skill_dir = if let Some(ref name) = skill_name {
+        // Find skill matching the name (by dir name or relative path)
+        skill_dirs
+            .iter()
+            .find(|d| {
+                let rel = d.strip_prefix(&repo_path).unwrap_or(d);
+                let dir_name = d.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                dir_name == name.as_str() || rel.to_string_lossy() == *name
+            })
+            .ok_or_else(|| {
+                let available: Vec<String> = skill_dirs
+                    .iter()
+                    .filter_map(|d| d.file_name().and_then(|s| s.to_str()).map(String::from))
+                    .collect();
+                anyhow::anyhow!(
+                    "Skill '{name}' not found in {repo_slug}. Available: {}",
+                    available.join(", ")
+                )
+            })?
+            .clone()
+    } else if skill_dirs.len() == 1 {
+        skill_dirs[0].clone()
+    } else {
+        println!("Multiple skills found in {repo_slug}:");
+        for (i, d) in skill_dirs.iter().enumerate() {
+            let name = d.file_name().and_then(|s| s.to_str()).unwrap_or("?");
+            println!("  {}. {}", i + 1, name);
+        }
+        anyhow::bail!(
+            "Specify which skill to install: armadai skills add {repo_slug}/<skill-name>"
+        );
+    };
+
+    // Load skill metadata for display
+    let skill = Skill::load(&skill_dir)?;
+    let dest = user_skills_dir().join(&skill.name);
+
+    if dest.exists() && !force {
+        anyhow::bail!(
+            "Skill '{}' already exists at {}. Use --force to overwrite.",
+            skill.name,
+            dest.display()
+        );
+    }
+
+    // Copy entire skill directory
+    copy_dir_recursive(&skill_dir, &dest)?;
+
+    println!("Installed skill '{}' to {}", skill.name, dest.display());
+    Ok(())
+}
+
+async fn cmd_info(name: &str) -> anyhow::Result<()> {
+    check_staleness();
+    let sources = cache::effective_sources();
+    let index = cache::load_or_build_index(&sources)?;
+
+    let entry = index
+        .entries
+        .iter()
+        .find(|e| e.name == name)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Skill '{name}' not found in registry. Try `armadai skills search {name}`"
+            )
+        })?;
+
+    println!("Name:        {}", entry.name);
+    println!("Source:      {}", entry.source_repo);
+    println!("Path:        {}", entry.path);
+    if let Some(ref desc) = entry.description {
+        println!("Description: {desc}");
+    }
+    if !entry.tags.is_empty() {
+        println!("Tags:        [{}]", entry.tags.join(", "));
+    }
+
+    // Try to show SKILL.md content from cloned repo
+    if let Some((owner, repo)) = sync::parse_source(&entry.source_repo) {
+        let skill_file = sync::repo_dir(&owner, &repo)
+            .join(&entry.path)
+            .join("SKILL.md");
+        if skill_file.is_file() {
+            println!("\n--- SKILL.md ---");
+            let content = std::fs::read_to_string(&skill_file)?;
+            for (i, line) in content.lines().enumerate() {
+                if i >= 40 {
+                    println!(
+                        "  ... (truncated, {} more lines)",
+                        content.lines().count() - 40
+                    );
+                    break;
+                }
+                println!("  {line}");
+            }
+        }
+    }
+
+    println!(
+        "\nInstall with: armadai skills add {}/{}",
+        entry.source_repo, entry.name
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Recursively find directories containing SKILL.md.
+fn find_skill_dirs(dir: &std::path::Path, results: &mut Vec<std::path::PathBuf>) {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    for entry in read.flatten() {
+        let path = entry.path();
+        if path
+            .file_name()
+            .is_some_and(|n| n.to_str().is_some_and(|s| s.starts_with('.')))
+        {
+            continue;
+        }
+        if path.is_dir() {
+            if path.join("SKILL.md").is_file() {
+                results.push(path.clone());
+            }
+            find_skill_dirs(&path, results);
+        }
+    }
+}
+
+/// Recursively copy a directory.
+fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Result<()> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst)?;
+    }
+    std::fs::create_dir_all(dst)?;
+
+    for entry in std::fs::read_dir(src)?.flatten() {
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Print a hint if the skills registry is stale.
+fn check_staleness() {
+    if sync::is_stale(7) && sync::repos_dir().is_dir() {
+        eprintln!("hint: skills registry may be outdated. Run `armadai skills sync` to refresh.");
+    }
 }
 
 /// Collect skills from project config and/or default directories.

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -46,6 +46,10 @@ pub fn registry_cache_dir() -> PathBuf {
     config_dir().join("registry")
 }
 
+pub fn skills_registry_dir() -> PathBuf {
+    config_dir().join("skills-registry")
+}
+
 pub fn config_file_path() -> PathBuf {
     config_dir().join("config.yaml")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod providers;
 mod registry;
 #[allow(dead_code)]
 mod secrets;
+mod skills_registry;
 #[cfg(feature = "storage")]
 mod storage;
 #[cfg(feature = "tui")]

--- a/src/skills_registry/cache.rs
+++ b/src/skills_registry/cache.rs
@@ -1,0 +1,238 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::sync::{default_sources, parse_source, repo_dir, repos_dir};
+use crate::core::config::skills_registry_dir;
+use crate::core::skill::SkillFrontmatter;
+use crate::parser::frontmatter::extract_frontmatter;
+
+// ---------------------------------------------------------------------------
+// Index data model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillIndexEntry {
+    /// Skill name from SKILL.md frontmatter (or directory name)
+    pub name: String,
+    /// Optional description from frontmatter
+    pub description: Option<String>,
+    /// Source repo slug (e.g. "anthropics/skills")
+    pub source_repo: String,
+    /// Relative path inside the repo (e.g. "skills/webapp-testing")
+    pub path: String,
+    /// Tags extracted from frontmatter tools or metadata
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SkillIndex {
+    pub entries: Vec<SkillIndexEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Index building
+// ---------------------------------------------------------------------------
+
+/// Build a search index from all synced skill repos.
+pub fn build_index(sources: &[String]) -> anyhow::Result<SkillIndex> {
+    let mut entries = Vec::new();
+
+    for source in sources {
+        if let Some((owner, repo)) = parse_source(source) {
+            let dir = repo_dir(&owner, &repo);
+            if dir.is_dir() {
+                let slug = format!("{owner}/{repo}");
+                scan_repo(&dir, &dir, &slug, &mut entries)?;
+            }
+        }
+    }
+
+    let index = SkillIndex { entries };
+    save_index(&index)?;
+    Ok(index)
+}
+
+/// Load the cached index, or build it from synced repos.
+pub fn load_or_build_index(sources: &[String]) -> anyhow::Result<SkillIndex> {
+    let index_path = index_file_path();
+    if index_path.is_file() {
+        let content = std::fs::read_to_string(&index_path)?;
+        let index: SkillIndex = serde_json::from_str(&content)?;
+        return Ok(index);
+    }
+
+    // Try to build from whatever is already cloned
+    if repos_dir().is_dir() {
+        return build_index(sources);
+    }
+
+    Ok(SkillIndex::default())
+}
+
+fn index_file_path() -> PathBuf {
+    skills_registry_dir().join("index.json")
+}
+
+fn save_index(index: &SkillIndex) -> anyhow::Result<()> {
+    let path = index_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = serde_json::to_string_pretty(index)?;
+    std::fs::write(&path, content)?;
+    Ok(())
+}
+
+/// Recursively scan a repo for directories containing SKILL.md.
+fn scan_repo(
+    dir: &Path,
+    repo_root: &Path,
+    source_slug: &str,
+    entries: &mut Vec<SkillIndexEntry>,
+) -> anyhow::Result<()> {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in read.flatten() {
+        let path = entry.path();
+
+        // Skip hidden directories
+        if path
+            .file_name()
+            .is_some_and(|n| n.to_str().is_some_and(|s| s.starts_with('.')))
+        {
+            continue;
+        }
+
+        if path.is_dir() {
+            let skill_file = path.join("SKILL.md");
+            if skill_file.is_file()
+                && let Ok(entry) = extract_skill_entry(&path, &skill_file, repo_root, source_slug)
+            {
+                entries.push(entry);
+            }
+            // Continue scanning subdirectories
+            scan_repo(&path, repo_root, source_slug, entries)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract a skill index entry from a directory with a SKILL.md.
+fn extract_skill_entry(
+    skill_dir: &Path,
+    skill_file: &Path,
+    repo_root: &Path,
+    source_slug: &str,
+) -> anyhow::Result<SkillIndexEntry> {
+    let content = std::fs::read_to_string(skill_file)?;
+    let (fm_str, _body) = extract_frontmatter(&content);
+
+    let fm: SkillFrontmatter = match fm_str {
+        Some(yaml) => serde_yaml_ng::from_str(yaml).unwrap_or_default(),
+        None => SkillFrontmatter::default(),
+    };
+
+    let name = fm.name.unwrap_or_else(|| {
+        skill_dir
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    });
+
+    let rel_path = skill_dir
+        .strip_prefix(repo_root)
+        .unwrap_or(skill_dir)
+        .to_string_lossy()
+        .to_string();
+
+    Ok(SkillIndexEntry {
+        name,
+        description: fm.description,
+        source_repo: source_slug.to_string(),
+        path: rel_path,
+        tags: fm.tools, // use tools as tags for searchability
+    })
+}
+
+/// Get the effective sources list (from defaults).
+pub fn effective_sources() -> Vec<String> {
+    default_sources()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_skill_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("webapp-testing");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: webapp-testing\ndescription: Web application testing skill\ntools:\n  - playwright\n  - jest\n---\n# WebApp Testing\n\nTest web apps.",
+        ).unwrap();
+
+        let entry = extract_skill_entry(
+            &skill_dir,
+            &skill_dir.join("SKILL.md"),
+            dir.path(),
+            "anthropics/skills",
+        )
+        .unwrap();
+
+        assert_eq!(entry.name, "webapp-testing");
+        assert_eq!(
+            entry.description.as_deref(),
+            Some("Web application testing skill")
+        );
+        assert_eq!(entry.source_repo, "anthropics/skills");
+        assert_eq!(entry.path, "webapp-testing");
+        assert_eq!(entry.tags, vec!["playwright", "jest"]);
+    }
+
+    #[test]
+    fn test_extract_skill_entry_no_frontmatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("simple");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Simple Skill\n\nJust a body.").unwrap();
+
+        let entry = extract_skill_entry(
+            &skill_dir,
+            &skill_dir.join("SKILL.md"),
+            dir.path(),
+            "owner/repo",
+        )
+        .unwrap();
+
+        assert_eq!(entry.name, "simple");
+        assert!(entry.description.is_none());
+        assert!(entry.tags.is_empty());
+    }
+
+    #[test]
+    fn test_index_roundtrip() {
+        let index = SkillIndex {
+            entries: vec![SkillIndexEntry {
+                name: "docker-compose".to_string(),
+                description: Some("Docker Compose management".to_string()),
+                source_repo: "anthropics/skills".to_string(),
+                path: "skills/docker-compose".to_string(),
+                tags: vec!["docker".to_string(), "compose".to_string()],
+            }],
+        };
+
+        let json = serde_json::to_string(&index).unwrap();
+        let deserialized: SkillIndex = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.entries.len(), 1);
+        assert_eq!(deserialized.entries[0].name, "docker-compose");
+    }
+}

--- a/src/skills_registry/mod.rs
+++ b/src/skills_registry/mod.rs
@@ -1,0 +1,3 @@
+pub mod cache;
+pub mod search;
+pub mod sync;

--- a/src/skills_registry/search.rs
+++ b/src/skills_registry/search.rs
@@ -1,0 +1,178 @@
+use super::cache::SkillIndexEntry;
+
+/// Search skill entries by keywords (AND logic).
+///
+/// Scores entries by relevance: name > description > tags > source repo.
+/// Returns results sorted by descending score.
+pub fn search(entries: &[SkillIndexEntry], query: &str) -> Vec<SearchResult> {
+    let keywords: Vec<String> = query.split_whitespace().map(|w| w.to_lowercase()).collect();
+
+    if keywords.is_empty() {
+        return Vec::new();
+    }
+
+    let mut results: Vec<SearchResult> = entries
+        .iter()
+        .filter_map(|entry| {
+            let score = score_entry(entry, &keywords);
+            if score > 0 {
+                Some(SearchResult {
+                    entry: entry.clone(),
+                    score,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.score.cmp(&a.score));
+    results
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub entry: SkillIndexEntry,
+    pub score: u32,
+}
+
+/// Score an entry against keywords. Returns 0 if any keyword doesn't match.
+fn score_entry(entry: &SkillIndexEntry, keywords: &[String]) -> u32 {
+    let mut total = 0;
+
+    for kw in keywords {
+        let mut kw_score = 0u32;
+
+        // Name match (highest weight)
+        if entry.name.to_lowercase().contains(kw) {
+            kw_score += 10;
+        }
+
+        // Description match
+        if let Some(ref desc) = entry.description
+            && desc.to_lowercase().contains(kw)
+        {
+            kw_score += 5;
+        }
+
+        // Tag match
+        if entry.tags.iter().any(|t| t.to_lowercase().contains(kw)) {
+            kw_score += 3;
+        }
+
+        // Source repo match
+        if entry.source_repo.to_lowercase().contains(kw) {
+            kw_score += 1;
+        }
+
+        // AND logic: all keywords must match somewhere
+        if kw_score == 0 {
+            return 0;
+        }
+        total += kw_score;
+    }
+
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(name: &str, desc: Option<&str>, tags: &[&str], source: &str) -> SkillIndexEntry {
+        SkillIndexEntry {
+            name: name.to_string(),
+            description: desc.map(String::from),
+            source_repo: source.to_string(),
+            path: format!("skills/{name}"),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn test_search_single_keyword() {
+        let entries = vec![
+            make_entry(
+                "webapp-testing",
+                Some("Test web applications"),
+                &["playwright"],
+                "anthropics/skills",
+            ),
+            make_entry(
+                "docker-compose",
+                Some("Manage Docker Compose"),
+                &["docker"],
+                "anthropics/skills",
+            ),
+        ];
+
+        let results = search(&entries, "testing");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].entry.name, "webapp-testing");
+    }
+
+    #[test]
+    fn test_search_multiple_keywords_and() {
+        let entries = vec![
+            make_entry(
+                "webapp-testing",
+                Some("Test web applications with Playwright"),
+                &["playwright", "testing"],
+                "anthropics/skills",
+            ),
+            make_entry(
+                "unit-testing",
+                Some("Unit test framework"),
+                &["jest"],
+                "anthropics/skills",
+            ),
+        ];
+
+        let results = search(&entries, "testing playwright");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].entry.name, "webapp-testing");
+    }
+
+    #[test]
+    fn test_search_no_match() {
+        let entries = vec![make_entry(
+            "docker-compose",
+            Some("Docker management"),
+            &["docker"],
+            "anthropics/skills",
+        )];
+
+        let results = search(&entries, "nonexistent");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_ranking() {
+        let entries = vec![
+            make_entry(
+                "test-runner",
+                Some("Run tests"),
+                &["testing"],
+                "anthropics/skills",
+            ),
+            make_entry(
+                "linter",
+                Some("Lint and test code"),
+                &["test"],
+                "anthropics/skills",
+            ),
+        ];
+
+        let results = search(&entries, "test");
+        assert_eq!(results.len(), 2);
+        // "test-runner" should rank higher (name match = 10 + desc match = 5)
+        assert_eq!(results[0].entry.name, "test-runner");
+    }
+
+    #[test]
+    fn test_search_empty_query() {
+        let entries = vec![make_entry("test", None, &[], "anthropics/skills")];
+        let results = search(&entries, "");
+        assert!(results.is_empty());
+    }
+}

--- a/src/skills_registry/sync.rs
+++ b/src/skills_registry/sync.rs
@@ -1,0 +1,171 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::config::skills_registry_dir;
+
+/// Default skill sources (well-known GitHub repos containing skills).
+pub fn default_sources() -> Vec<String> {
+    vec![
+        "https://github.com/anthropics/skills".to_string(),
+        "https://github.com/openai/skills".to_string(),
+    ]
+}
+
+/// Return the root directory for cloned skill repos.
+pub fn repos_dir() -> PathBuf {
+    skills_registry_dir().join("repos")
+}
+
+/// Return the directory for a specific owner/repo clone.
+pub fn repo_dir(owner: &str, repo: &str) -> PathBuf {
+    repos_dir().join(owner).join(repo)
+}
+
+/// Parse a GitHub URL into (owner, repo).
+///
+/// Accepts:
+///  - `https://github.com/owner/repo`
+///  - `https://github.com/owner/repo.git`
+///  - `owner/repo`
+pub fn parse_source(source: &str) -> Option<(String, String)> {
+    // Try URL format first
+    let stripped = source
+        .strip_prefix("https://github.com/")
+        .or_else(|| source.strip_prefix("http://github.com/"))
+        .unwrap_or(source);
+
+    let stripped = stripped.trim_end_matches(".git").trim_end_matches('/');
+    let parts: Vec<&str> = stripped.splitn(3, '/').collect();
+    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some((parts[0].to_string(), parts[1].to_string()))
+    } else {
+        None
+    }
+}
+
+/// Clone or pull a single skill repo by GitHub URL or owner/repo slug.
+pub fn sync_repo(source: &str) -> anyhow::Result<PathBuf> {
+    let (owner, repo) = parse_source(source).ok_or_else(|| {
+        anyhow::anyhow!("Invalid source '{source}'. Use owner/repo or a GitHub URL.")
+    })?;
+
+    let url = format!("https://github.com/{owner}/{repo}.git");
+    let dest = repo_dir(&owner, &repo);
+
+    if dest.join(".git").is_dir() {
+        pull(&dest)?;
+    } else {
+        clone(&url, &dest)?;
+    }
+
+    Ok(dest)
+}
+
+/// Sync all configured sources.
+pub fn sync_all(sources: &[String]) -> anyhow::Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+    for source in sources {
+        match sync_repo(source) {
+            Ok(dir) => dirs.push(dir),
+            Err(e) => eprintln!("  warn: failed to sync {source}: {e}"),
+        }
+    }
+    Ok(dirs)
+}
+
+fn clone(url: &str, dest: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let output = Command::new("git")
+        .args(["clone", "--depth", "1", url])
+        .arg(dest)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git clone failed for {url}: {stderr}");
+    }
+
+    println!("  Cloned {url}");
+    Ok(())
+}
+
+fn pull(repo: &Path) -> anyhow::Result<()> {
+    let output = Command::new("git")
+        .args(["pull", "--ff-only"])
+        .current_dir(repo)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git pull failed for {}: {stderr}", repo.display());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.contains("Already up to date") {
+        println!("  {} already up to date.", repo.display());
+    } else {
+        println!("  {} updated.", repo.display());
+    }
+
+    Ok(())
+}
+
+/// Check if the skills registry was last synced more than `days` ago.
+pub fn is_stale(days: u64) -> bool {
+    let dir = repos_dir();
+    if !dir.is_dir() {
+        return true;
+    }
+
+    match std::fs::metadata(&dir).and_then(|m| m.modified()) {
+        Ok(modified) => {
+            let age = std::time::SystemTime::now()
+                .duration_since(modified)
+                .unwrap_or_default();
+            age.as_secs() > days * 86400
+        }
+        Err(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_source_url() {
+        let (owner, repo) = parse_source("https://github.com/anthropics/skills").unwrap();
+        assert_eq!(owner, "anthropics");
+        assert_eq!(repo, "skills");
+    }
+
+    #[test]
+    fn test_parse_source_url_with_git() {
+        let (owner, repo) = parse_source("https://github.com/anthropics/skills.git").unwrap();
+        assert_eq!(owner, "anthropics");
+        assert_eq!(repo, "skills");
+    }
+
+    #[test]
+    fn test_parse_source_slug() {
+        let (owner, repo) = parse_source("openai/skills").unwrap();
+        assert_eq!(owner, "openai");
+        assert_eq!(repo, "skills");
+    }
+
+    #[test]
+    fn test_parse_source_invalid() {
+        assert!(parse_source("invalid").is_none());
+        assert!(parse_source("").is_none());
+        assert!(parse_source("/").is_none());
+    }
+
+    #[test]
+    fn test_repo_dir_structure() {
+        let dir = repo_dir("anthropics", "skills");
+        assert!(dir.ends_with("anthropics/skills"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `skills_registry/` module (`sync.rs`, `cache.rs`, `search.rs`) for discovering and installing skills from GitHub repos
- Add 4 new subcommands to `armadai skills`: `sync`, `search`, `add`, `info`
- Follow the same patterns as the existing `registry/` module (awesome-copilot)

## New commands

| Command | Description |
|---------|-------------|
| `armadai skills sync` | Clone/pull default skill sources, rebuild search index |
| `armadai skills search "query"` | Multi-keyword AND search with weighted scoring |
| `armadai skills add owner/repo[/skill-name]` | Clone repo and install skill to `~/.config/armadai/skills/` |
| `armadai skills info <name>` | Show metadata and SKILL.md content from registry |

## Files changed

**Created (4):**
- `src/skills_registry/mod.rs` — module exports
- `src/skills_registry/sync.rs` — git clone/pull of GitHub repos
- `src/skills_registry/cache.rs` — JSON index of discovered SKILL.md files
- `src/skills_registry/search.rs` — keyword search with scoring

**Modified (10):**
- `src/main.rs` — declare `skills_registry` module
- `src/core/config.rs` — add `skills_registry_dir()` path helper
- `src/cli/skills.rs` — add Sync/Search/Add/Info variants + handlers
- `src/cli/mod.rs` — update help text with new examples
- `README.md`, `CLAUDE.md`, `ARCHITECTURE.md` — document new module
- `docs/wiki/skills-prompts.md`, `registry.md`, `getting-started.md` — wiki updates

## Test plan

- [x] `cargo clippy --no-default-features --features tui,providers-api -- -D warnings` (0 warnings)
- [x] `cargo clippy --no-default-features --features tui -- -D warnings` (0 warnings)
- [x] `cargo test --no-default-features --features tui,providers-api` (141 passed, 8 new)
- [x] `cargo test --no-default-features --features tui` (138 passed)
- [x] `cargo fmt -- --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)