### PR TITLE
fix: correct awesome-copilot registry URL

### DIFF
--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use crate::core::config::registry_cache_dir;
 
-const DEFAULT_REGISTRY_URL: &str = "https://github.com/anthropics/awesome-copilot.git";
+const DEFAULT_REGISTRY_URL: &str = "https://github.com/github/awesome-copilot.git";
 
 /// Return the path to the cloned registry repository.
 pub fn repo_dir() -> std::path::PathBuf {


### PR DESCRIPTION
## Summary
- Fix default registry URL from `anthropics/awesome-copilot` to `github/awesome-copilot`

## Test plan
- [x] Clippy / tests pass
- [ ] Verify `armadai registry sync` clones from the correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)