### PR TITLE
feat: model_fallback — automatic model retry chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "armadai"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -82,6 +82,21 @@ Available models: `gpt-4o`, `gpt-4o-mini`, `o1`
 - temperature: 0.7
 ```
 
+## Model Fallback
+
+Declare fallback models for automatic retry when the primary model is unavailable (404, "model not found"). All fallbacks must use the same provider.
+
+```markdown
+## Metadata
+- provider: google
+- model: gemini-3.0-pro
+- model_fallback: [gemini-2.5-pro, gemini-2.5-flash]
+```
+
+If `gemini-3.0-pro` returns a "model not found" error, ArmadAI automatically retries with `gemini-2.5-pro`, then `gemini-2.5-flash`. Non-model errors (auth, rate limit) are not retried.
+
+The plural alias `model_fallbacks` is also accepted.
+
 ## CLI Provider
 
 Execute any command-line tool as an agent. The input is passed as the last argument to the command, and stdout is captured as the output.

--- a/src/cli/inspect.rs
+++ b/src/cli/inspect.rs
@@ -22,6 +22,12 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
     if let Some(ref command) = agent.metadata.command {
         println!("  Command:        {command}");
     }
+    if !agent.metadata.model_fallback.is_empty() {
+        println!(
+            "  Fallbacks:      [{}]",
+            agent.metadata.model_fallback.join(", ")
+        );
+    }
     if let Some(ref args) = agent.metadata.args {
         println!("  Args:           [{}]", args.join(", "));
     }

--- a/src/core/agent.rs
+++ b/src/core/agent.rs
@@ -49,6 +49,9 @@ pub struct AgentMetadata {
     /// File/directory scope patterns (e.g. ["src/**/*.rs", "tests/"])
     #[serde(default)]
     pub scope: Vec<String>,
+    /// Fallback models to try if the primary model is unavailable
+    #[serde(default)]
+    pub model_fallback: Vec<String>,
     /// Cost limit per execution (USD)
     pub cost_limit: Option<f64>,
     /// Rate limit (e.g. "10/min")

--- a/src/linker/claude.rs
+++ b/src/linker/claude.rs
@@ -162,6 +162,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         }
     }
@@ -201,6 +202,7 @@ mod tests {
             stacks: vec!["rust".to_string()],
             scope: vec![],
             model: Some("claude-sonnet-4-5-20250929".to_string()),
+            model_fallback: vec![],
             temperature: 0.5,
         }];
         let files = linker.generate(&agents, None, &[]);
@@ -308,6 +310,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         };
         let agents = vec![make_agent("Worker", "You do the work.")];

--- a/src/linker/copilot.rs
+++ b/src/linker/copilot.rs
@@ -159,6 +159,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         }
     }
@@ -197,6 +198,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         }];
         let files = linker.generate(&agents, None, &[]);
@@ -290,6 +292,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         };
         let agents = vec![make_agent("Worker", "You do the work.")];

--- a/src/linker/gemini.rs
+++ b/src/linker/gemini.rs
@@ -219,6 +219,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         }
     }
@@ -265,6 +266,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: Some("gemini-2.5-pro".to_string()),
+            model_fallback: vec![],
             temperature: 0.3,
         }];
         let files = linker.generate(&agents, None, &[]);
@@ -390,6 +392,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         };
         let agents = vec![make_agent("Worker", "You do the work.")];

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -25,6 +25,7 @@ pub struct LinkAgent {
     pub stacks: Vec<String>,
     pub scope: Vec<String>,
     pub model: Option<String>,
+    pub model_fallback: Vec<String>,
     pub temperature: f32,
 }
 
@@ -99,6 +100,7 @@ impl From<&Agent> for LinkAgent {
             stacks: agent.metadata.stacks.clone(),
             scope: agent.metadata.scope.clone(),
             model: agent.metadata.model.clone(),
+            model_fallback: agent.metadata.model_fallback.clone(),
             temperature: agent.metadata.temperature,
         }
     }

--- a/src/linker/opencode.rs
+++ b/src/linker/opencode.rs
@@ -171,6 +171,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         }
     }
@@ -217,6 +218,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: Some("anthropic/claude-sonnet-4-5".to_string()),
+            model_fallback: vec![],
             temperature: 0.3,
         }];
         let files = linker.generate(&agents, None, &[]);
@@ -249,6 +251,7 @@ mod tests {
             stacks: vec!["rust".to_string()],
             scope: vec![],
             model: Some("anthropic/claude-sonnet-4-5".to_string()),
+            model_fallback: vec![],
             temperature: 0.5,
         }];
         let files = linker.generate(&agents, None, &[]);
@@ -342,6 +345,7 @@ mod tests {
             stacks: vec![],
             scope: vec![],
             model: None,
+            model_fallback: vec![],
             temperature: 0.7,
         };
         let agents = vec![make_agent("Worker", "You do the work.")];

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -61,6 +61,16 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         ]),
     ];
 
+    if !meta.model_fallback.is_empty() {
+        meta_lines.push(Line::from(vec![
+            Span::styled("Fallback: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                meta.model_fallback.join(", "),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+
     if !meta.tags.is_empty() {
         meta_lines.push(Line::from(vec![
             Span::styled("Tags:     ", Style::default().add_modifier(Modifier::BOLD)),

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -12,6 +12,7 @@ pub struct AgentSummary {
     tags: Vec<String>,
     stacks: Vec<String>,
     scope: Vec<String>,
+    model_fallback: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -23,6 +24,7 @@ pub struct AgentDetail {
     tags: Vec<String>,
     stacks: Vec<String>,
     scope: Vec<String>,
+    model_fallback: Vec<String>,
     temperature: f32,
     max_tokens: Option<u32>,
     timeout: Option<u64>,
@@ -76,6 +78,7 @@ pub async fn list_agents() -> Json<Vec<AgentSummary>> {
                 tags: a.metadata.tags,
                 stacks: a.metadata.stacks,
                 scope: a.metadata.scope,
+                model_fallback: a.metadata.model_fallback,
             }
         })
         .collect();
@@ -98,6 +101,7 @@ pub async fn get_agent(Path(name): Path<String>) -> Json<serde_json::Value> {
                 tags: a.metadata.tags,
                 stacks: a.metadata.stacks,
                 scope: a.metadata.scope,
+                model_fallback: a.metadata.model_fallback,
                 temperature: a.metadata.temperature,
                 max_tokens: a.metadata.max_tokens,
                 timeout: a.metadata.timeout,

--- a/starters/code-analysis-rust/agents/lead-analyst.md
+++ b/starters/code-analysis-rust/agents/lead-analyst.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.4
 - max_tokens: 8192
 - tags: [coordinator, lead, analysis]

--- a/starters/code-analysis-rust/agents/rust-doc-writer.md
+++ b/starters/code-analysis-rust/agents/rust-doc-writer.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.5
 - max_tokens: 4096
 - tags: [docs, documentation, analysis]

--- a/starters/code-analysis-rust/agents/rust-reviewer.md
+++ b/starters/code-analysis-rust/agents/rust-reviewer.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [review, quality, analysis]

--- a/starters/code-analysis-rust/agents/rust-security.md
+++ b/starters/code-analysis-rust/agents/rust-security.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.2
 - max_tokens: 4096
 - tags: [security, audit, analysis]

--- a/starters/code-analysis-rust/agents/rust-test-analyzer.md
+++ b/starters/code-analysis-rust/agents/rust-test-analyzer.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [test, quality, analysis]

--- a/starters/code-analysis-web/agents/lead-analyst.md
+++ b/starters/code-analysis-web/agents/lead-analyst.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.4
 - max_tokens: 8192
 - tags: [coordinator, lead, analysis]

--- a/starters/code-analysis-web/agents/web-doc-writer.md
+++ b/starters/code-analysis-web/agents/web-doc-writer.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.5
 - max_tokens: 4096
 - tags: [docs, documentation, analysis]

--- a/starters/code-analysis-web/agents/web-reviewer.md
+++ b/starters/code-analysis-web/agents/web-reviewer.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [review, quality, analysis]

--- a/starters/code-analysis-web/agents/web-security.md
+++ b/starters/code-analysis-web/agents/web-security.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.2
 - max_tokens: 4096
 - tags: [security, audit, analysis]

--- a/starters/code-analysis-web/agents/web-test-analyzer.md
+++ b/starters/code-analysis-web/agents/web-test-analyzer.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: google
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [test, quality, analysis]

--- a/starters/pirate-crew/agents/capitaine.md
+++ b/starters/pirate-crew/agents/capitaine.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: gemini
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.4
 - max_tokens: 8192
 - tags: [coordinator, lead, pirate]

--- a/starters/pirate-crew/agents/cartographe.md
+++ b/starters/pirate-crew/agents/cartographe.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: gemini
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.4
 - max_tokens: 4096
 - tags: [docs, documentation, pirate]

--- a/starters/pirate-crew/agents/charpentier.md
+++ b/starters/pirate-crew/agents/charpentier.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: gemini
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [test, quality, pirate]

--- a/starters/pirate-crew/agents/vigie.md
+++ b/starters/pirate-crew/agents/vigie.md
@@ -3,6 +3,7 @@
 ## Metadata
 - provider: gemini
 - model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash]
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [review, security, quality, pirate]


### PR DESCRIPTION
## Summary

- Add `model_fallback` field to agent metadata for automatic model retry when the primary model is unavailable (HTTP 404 / "model not found")
- Fallback chain iterates through declared models on the same provider; non-model errors (auth 401, rate limit 429) are propagated immediately
- All 14 Google/Gemini starter agents updated with `model_fallback: [gemini-2.5-flash]`
- Documented in `docs/wiki/providers.md`, displayed in `inspect`, TUI detail view, and web API
- Version bump to **0.3.0**

### Agent syntax

```markdown
## Metadata
- provider: google
- model: gemini-3.0-pro
- model_fallback: [gemini-2.5-pro, gemini-2.5-flash]
```

## Test plan

- [x] `cargo test` — 179 tests pass (including 7 new: 3 parser + 4 is_model_not_found)
- [x] `cargo clippy` clean in both CI (`--features tui`) and full (`--features tui,providers-api`) modes
- [x] `cargo fmt -- --check` passes
- [ ] Manual: `armadai inspect lead-analyst` shows Fallbacks line
- [ ] Manual: run agent with unavailable model, verify fallback triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)