### PR TITLE
feat: embedded versioning, skill references content, init from UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "armadai"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -96,14 +96,9 @@ fn install_pack(name: &str, force: bool) -> anyhow::Result<StarterPack> {
     Ok(pack)
 }
 
-/// Create an armadai.yaml in the current directory using the new project format.
-fn init_project() -> anyhow::Result<()> {
-    let path = std::path::Path::new("armadai.yaml");
-    if path.exists() {
-        anyhow::bail!("armadai.yaml already exists in current directory");
-    }
-
-    let content = "\
+/// Generate the YAML content for an empty armadai project configuration.
+pub fn generate_empty_project_yaml() -> String {
+    "\
 # ArmadAI project configuration
 # See: https://github.com/Dr0drigues/swarm-festai
 
@@ -136,8 +131,18 @@ sources: []
 #       output: .claude/
 #     copilot:
 #       output: .github/agents/
-";
+"
+    .to_string()
+}
 
+/// Create an armadai.yaml in the current directory using the new project format.
+fn init_project() -> anyhow::Result<()> {
+    let path = std::path::Path::new("armadai.yaml");
+    if path.exists() {
+        anyhow::bail!("armadai.yaml already exists in current directory");
+    }
+
+    let content = generate_empty_project_yaml();
     std::fs::write(path, content)?;
     println!("Created armadai.yaml in current directory");
     println!("  Edit it to declare agents, prompts, skills and link targets.");
@@ -145,13 +150,8 @@ sources: []
     Ok(())
 }
 
-/// Create an armadai.yaml pre-configured with the agents from a starter pack.
-fn init_project_with_pack(pack: &StarterPack, pack_name: &str) -> anyhow::Result<()> {
-    let path = std::path::Path::new("armadai.yaml");
-    if path.exists() {
-        anyhow::bail!("armadai.yaml already exists in current directory");
-    }
-
+/// Generate YAML content for an armadai project pre-configured with a starter pack.
+pub fn generate_project_yaml(pack: &StarterPack, pack_name: &str) -> String {
     // Detect provider and coordinator from the pack's agent files
     let link_target = detect_pack_provider(pack_name);
     let coordinator_name = detect_pack_coordinator(pack, pack_name);
@@ -203,6 +203,17 @@ fn init_project_with_pack(pack: &StarterPack, pack_name: &str) -> anyhow::Result
         ));
     }
 
+    content
+}
+
+/// Create an armadai.yaml pre-configured with the agents from a starter pack.
+fn init_project_with_pack(pack: &StarterPack, pack_name: &str) -> anyhow::Result<()> {
+    let path = std::path::Path::new("armadai.yaml");
+    if path.exists() {
+        anyhow::bail!("armadai.yaml already exists in current directory");
+    }
+
+    let content = generate_project_yaml(pack, pack_name);
     std::fs::write(path, &content)?;
     println!("\nCreated armadai.yaml with pack '{}' agents", pack.name);
     println!("  Run `armadai link` to generate target config files.");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod costs;
 mod fleet;
 mod history;
-mod init;
+pub mod init;
 mod inspect;
 mod link;
 mod list;

--- a/src/core/embedded.rs
+++ b/src/core/embedded.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+/// Check whether an extracted embedded directory needs updating.
+///
+/// Returns `true` if the directory doesn't contain `.armadai-version`
+/// or if the stored version differs from the current binary version.
+pub(crate) fn needs_update(dest: &Path) -> bool {
+    let version_file = dest.join(".armadai-version");
+    match std::fs::read_to_string(&version_file) {
+        Ok(v) => v.trim() != env!("CARGO_PKG_VERSION"),
+        Err(_) => true,
+    }
+}
+
+/// Write the current binary version into `.armadai-version` inside `dest`.
+pub(crate) fn write_version_marker(dest: &Path) {
+    let _ = std::fs::write(dest.join(".armadai-version"), env!("CARGO_PKG_VERSION"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_needs_update_no_dir() {
+        assert!(needs_update(Path::new("/nonexistent/path")));
+    }
+
+    #[test]
+    fn test_needs_update_no_version_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(needs_update(dir.path()));
+    }
+
+    #[test]
+    fn test_needs_update_current_version() {
+        let dir = tempfile::tempdir().unwrap();
+        write_version_marker(dir.path());
+        assert!(!needs_update(dir.path()));
+    }
+
+    #[test]
+    fn test_needs_update_old_version() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".armadai-version"), "0.0.1").unwrap();
+        assert!(needs_update(dir.path()));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod context;
 #[allow(dead_code)]
 pub mod coordinator;
+pub(crate) mod embedded;
 pub mod fleet;
 #[allow(dead_code)]
 pub mod pipeline;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -116,6 +116,32 @@ pub async fn run() -> Result<()> {
                     }
                     _ => {}
                 },
+                KeyCode::Char('i')
+                    if matches!(
+                        app.current_tab,
+                        app::Tab::Starters | app::Tab::StarterDetail
+                    ) =>
+                {
+                    if let Some(pack) = app.selected_starter().cloned() {
+                        let pack_name = pack.name.clone();
+                        let yaml = crate::cli::init::generate_project_yaml(&pack, &pack_name);
+                        let path = std::path::Path::new("armadai.yaml");
+                        if path.exists() {
+                            app.status_msg = Some("armadai.yaml already exists".to_string());
+                        } else {
+                            match std::fs::write(path, yaml) {
+                                Ok(()) => {
+                                    app.status_msg =
+                                        Some(format!("Created armadai.yaml (pack: {pack_name})"));
+                                }
+                                Err(e) => {
+                                    app.status_msg =
+                                        Some(format!("Failed to write armadai.yaml: {e}"));
+                                }
+                            }
+                        }
+                    }
+                }
                 KeyCode::Char('1') => app.switch_tab(app::Tab::Dashboard),
                 KeyCode::Char('2') => app.switch_tab(app::Tab::Prompts),
                 KeyCode::Char('3') => app.switch_tab(app::Tab::Skills),

--- a/src/tui/views/shortcuts.rs
+++ b/src/tui/views/shortcuts.rs
@@ -19,15 +19,31 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("r", "Refresh"),
             ("q", "Quit"),
         ],
-        Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail | Tab::StarterDetail => vec![
+        Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail => vec![
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
             (":", "Commands"),
             ("q", "Quit"),
         ],
-        Tab::Prompts | Tab::Skills | Tab::Starters => vec![
+        Tab::StarterDetail => vec![
+            ("Esc", "Back to list"),
+            ("i", "Init project"),
+            ("Tab", "Next tab"),
+            (":", "Commands"),
+            ("q", "Quit"),
+        ],
+        Tab::Prompts | Tab::Skills => vec![
             ("j/k", "Navigate"),
             ("Enter", "View detail"),
+            ("Tab", "Next tab"),
+            (":", "Commands"),
+            ("r", "Refresh"),
+            ("q", "Quit"),
+        ],
+        Tab::Starters => vec![
+            ("j/k", "Navigate"),
+            ("Enter", "View detail"),
+            ("i", "Init project"),
             ("Tab", "Next tab"),
             (":", "Commands"),
             ("r", "Refresh"),
@@ -48,7 +64,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         ],
     };
 
-    let spans: Vec<Span> = shortcuts
+    let mut spans: Vec<Span> = shortcuts
         .into_iter()
         .flat_map(|(key, desc)| {
             vec![
@@ -63,6 +79,16 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ]
         })
         .collect();
+
+    // Append status message if present
+    if let Some(ref msg) = app.status_msg {
+        spans.push(Span::styled(
+            format!("  {msg}"),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::ITALIC),
+        ));
+    }
 
     let bar = Paragraph::new(Line::from(spans));
     frame.render_widget(bar, area);

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -43,6 +43,10 @@
   .list-section ul { list-style: none; padding: 0; }
   .list-section li { padding: 4px 0; font-size: 14px; }
   .list-section li::before { content: "• "; color: var(--accent); }
+  .file-details { margin-bottom: 8px; }
+  .file-details summary { cursor: pointer; font-size: 14px; padding: 4px 0; color: var(--accent); }
+  .file-details summary:hover { text-decoration: underline; }
+  .file-content { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 12px; font-size: 13px; white-space: pre-wrap; line-height: 1.5; margin: 4px 0 8px 0; max-height: 400px; overflow-y: auto; }
   #view { display: none; }
 </style>
 </head>
@@ -206,10 +210,13 @@ async function viewSkill(name) {
   ['agents','prompts','skills','starters','history','costs'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
+  const fileBlock = (f) => f.content
+    ? `<details class="file-details"><summary>${f.name}</summary><pre class="file-content">${f.content.replace(/</g,'&lt;')}</pre></details>`
+    : `<div style="font-size:14px;padding:2px 0;color:var(--muted)">${f.name} (binary)</div>`;
   let filesHtml = '';
-  if (s.scripts.length) filesHtml += `<div class="list-section"><h3>Scripts</h3><ul>${s.scripts.map(f => `<li>${f}</li>`).join('')}</ul></div>`;
-  if (s.references.length) filesHtml += `<div class="list-section"><h3>References</h3><ul>${s.references.map(f => `<li>${f}</li>`).join('')}</ul></div>`;
-  if (s.assets.length) filesHtml += `<div class="list-section"><h3>Assets</h3><ul>${s.assets.map(f => `<li>${f}</li>`).join('')}</ul></div>`;
+  if (s.scripts.length) filesHtml += `<div class="list-section"><h3>Scripts</h3>${s.scripts.map(fileBlock).join('')}</div>`;
+  if (s.references.length) filesHtml += `<div class="list-section"><h3>References</h3>${s.references.map(fileBlock).join('')}</div>`;
+  if (s.assets.length) filesHtml += `<div class="list-section"><h3>Assets</h3>${s.assets.map(fileBlock).join('')}</div>`;
   el.innerHTML = `
     <div class="detail">
       <button class="back-btn" onclick="backToList()">&larr; Back to skills</button>
@@ -259,6 +266,7 @@ async function viewStarter(name) {
       <button class="back-btn" onclick="backToList()">&larr; Back to starters</button>
       <h2>${s.name}</h2>
       <p style="color:var(--muted);margin-bottom:20px">${s.description}</p>
+      <a href="/api/starters/${encodeURIComponent(name)}/config" download="armadai.yaml" class="back-btn" style="display:inline-block;text-decoration:none;margin-bottom:16px;border-color:var(--green);color:var(--green)">&#8615; Download armadai.yaml</a>
       ${s.agents.length ? `<div class="list-section"><h3>Agents (${s.agents.length})</h3><ul>${s.agents.map(a => `<li>${a}</li>`).join('')}</ul></div>` : ''}
       ${s.prompts.length ? `<div class="list-section"><h3>Prompts (${s.prompts.length})</h3><ul>${s.prompts.map(p => `<li>${p}</li>`).join('')}</ul></div>` : ''}
       ${s.skills.length ? `<div class="list-section"><h3>Skills (${s.skills.length})</h3><ul>${s.skills.map(sk => `<li>${sk}</li>`).join('')}</ul></div>` : ''}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -17,6 +17,7 @@ pub async fn serve(port: u16) -> anyhow::Result<()> {
         .route("/api/skills/{name}", get(api::get_skill))
         .route("/api/starters", get(api::list_starters))
         .route("/api/starters/{name}", get(api::get_starter))
+        .route("/api/starters/{name}/config", get(api::get_starter_config))
         .layer(CorsLayer::permissive());
 
     let addr = format!("0.0.0.0:{port}");


### PR DESCRIPTION
## Summary
- **Embedded versioning**: `.armadai-version` marker files ensure starters and built-in skills are re-extracted when the binary is updated — fixes `armadai init --pack armadai-authoring` failing on existing incomplete directories
- **Skill references content**: reference file contents now displayed in skill detail views (TUI: scrollable blocks per file, Web: collapsible `<details>` elements)
- **Init from UI**: generate `armadai.yaml` from Starters tab — TUI `i` key writes to CWD, Web download button via `GET /api/starters/{name}/config`
- **Version bump**: 0.5.2 → 0.6.0

## Files changed

| File | Change |
|------|--------|
| `src/core/embedded.rs` | New — `needs_update()`, `write_version_marker()` |
| `src/core/mod.rs` | Add `pub(crate) mod embedded` |
| `src/core/starter.rs` | Per-pack extraction with versioning in `starters_dir()` |
| `src/core/skill.rs` | Versioning in `install_embedded_skills()`, `pub(crate) extract_embedded_dir`, `read_text_file()` |
| `src/cli/init.rs` | Extract `generate_empty_project_yaml()` and `generate_project_yaml()` as `pub` |
| `src/cli/mod.rs` | `pub mod init` |
| `src/tui/mod.rs` | `i` key handler for init on Starters/StarterDetail tabs |
| `src/tui/views/shortcuts.rs` | `i` shortcut + `status_msg` display |
| `src/tui/views/skill_detail.rs` | Dynamic layout with reference file content blocks |
| `src/web/api.rs` | `SkillFile` struct, updated `SkillDetail`, `get_starter_config()` endpoint |
| `src/web/mod.rs` | Route `/api/starters/{name}/config` |
| `src/web/index.html` | Collapsible file details, starter download button |
| `Cargo.toml` | Version 0.6.0 |

## Test plan
- [x] `cargo clippy` passes in both `tui` and `tui,providers-api` modes
- [x] `cargo test` — 190 tests pass
- [x] `cargo fmt -- --check` clean
- [ ] Manual: `armadai init --pack armadai-authoring` from clean CWD
- [ ] Manual: TUI skill detail shows reference file contents
- [ ] Manual: Web skill detail shows collapsible file contents
- [ ] Manual: TUI `i` key creates armadai.yaml
- [ ] Manual: Web starter download button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)