### PR TITLE
feat: Models catalog (TUI + Web) + model resolution + dynamic templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.8.0 (2026-02-24)
+
+### Feat
+
+- add Models catalog tab in TUI (key `7`) and Web UI (`/api/models`)
+- add model resolution preview in agent detail views (TUI + Web)
+- add `preview_model_resolution()` for link target model preview
+- add sync cache-only helpers `load_models_cached` and `load_all_providers_cached`
+- dynamic `{{model}}` placeholder in templates and starter-packs
+
 ## v0.7.0 (2026-02-19)
 
 ### Feat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,13 +59,13 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`.
 - `core/starter.rs` — Starter packs: curated agent bundles installed via `armadai init --pack`.
 - `core/embedded.rs` — Version-based extraction for embedded resources (`.armadai-version` marker).
 - `parser/frontmatter.rs` — Generic YAML frontmatter extraction reused by prompts and skills.
-- `linker/` — Generates native config files for target AI CLIs. Trait `Linker` with one implementation per CLI (claude, copilot, cursor, aider, codex, gemini, windsurf, cline).
+- `linker/` — Generates native config files for target AI CLIs. Trait `Linker` with one implementation per CLI (claude, copilot, cursor, aider, codex, gemini, windsurf, cline). `model_resolution.rs` handles model remapping per target and exposes `preview_model_resolution()` for UI previews.
 - `registry/` — awesome-copilot integration. Sync, search, convert agents from the community catalog.
 - `skills_registry/` — GitHub-based skills discovery. Sync repos, build search index, install skills (`sync.rs`, `cache.rs`, `search.rs`).
-- `model_registry/` — Dynamic model catalog from models.dev. Fetches and caches model metadata (cost, context window) for enriched selection in `armadai new -i`. Gated behind `providers-api` for HTTP fetch, cache-only fallback otherwise.
+- `model_registry/` — Dynamic model catalog from models.dev. Fetches and caches model metadata (cost, context window) for enriched selection in `armadai new -i`. Gated behind `providers-api` for HTTP fetch, cache-only fallback otherwise. Sync cache-only helpers (`load_models_cached`, `load_all_providers_cached`) always available for TUI/Web.
 - `storage/` — SQLite wrapper (via rusqlite). `schema.rs` defines the `runs` table, `queries.rs` has CRUD operations.
-- `tui/` — Ratatui-based terminal UI. `app.rs` holds state (incl. command palette), `views/` renders tabs (Agents/Prompts/Skills/Starters/History/Costs + detail views + shortcuts bar + command palette overlay), `widgets/` provides reusable components. Supports `i` key to init project from starters.
-- `web/` — Axum-based web UI. Embedded single-page HTML app with JSON API endpoints (`/api/agents`, `/api/prompts`, `/api/skills`, `/api/starters`, `/api/starters/{name}/config`, `/api/history`, `/api/costs`). Skill detail views show collapsible reference file contents. Starter detail pages include YAML config download.
+- `tui/` — Ratatui-based terminal UI. `app.rs` holds state (incl. command palette), `views/` renders tabs (Agents/Prompts/Skills/Starters/History/Costs/Models + detail views + shortcuts bar + command palette overlay), `widgets/` provides reusable components. Supports `i` key to init project from starters. Models tab (key `7`) shows cached model catalog from models.dev. Agent detail view includes model resolution preview for all link targets.
+- `web/` — Axum-based web UI. Embedded single-page HTML app with JSON API endpoints (`/api/agents`, `/api/prompts`, `/api/skills`, `/api/starters`, `/api/starters/{name}/config`, `/api/history`, `/api/costs`, `/api/models`). Skill detail views show collapsible reference file contents. Starter detail pages include YAML config download. Models tab shows grouped catalog by provider. Agent detail includes model resolution table.
 - `secrets/` — SOPS + age encrypted secrets loader.
 
 **Provider trait** (`providers/traits.rs`):
@@ -77,7 +77,7 @@ trait Provider: Send + Sync {
 }
 ```
 
-**Agent definition** lives in `~/.config/armadai/agents/` (user library) or project-local paths. Templates in `templates/*.md` use `{{name}}`, `{{stack}}`, `{{description}}` placeholders.
+**Agent definition** lives in `~/.config/armadai/agents/` (user library) or project-local paths. Templates in `templates/*.md` use `{{name}}`, `{{stack}}`, `{{description}}`, `{{model}}` placeholders.
 
 **Config** lives in `~/.config/armadai/` (user) and `armadai.yaml` (project).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "armadai"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -1,11 +1,14 @@
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use crate::core::project;
+use crate::linker::model_resolution::{self, TargetKind};
 use crate::linker::{self, LinkAgent};
 use crate::parser;
 
 pub async fn execute(
     target: Option<String>,
+    model_flag: Option<String>,
     coordinator_flag: Option<String>,
     dry_run: bool,
     force: bool,
@@ -54,7 +57,7 @@ pub async fn execute(
     // 3b. Extract coordinator if configured (CLI flag takes priority over config)
     let coordinator_name =
         coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
-    let coordinator = coordinator_name.and_then(|name| {
+    let mut coordinator = coordinator_name.and_then(|name| {
         let idx = link_agents
             .iter()
             .position(|a| a.name.eq_ignore_ascii_case(&name))?;
@@ -67,9 +70,61 @@ pub async fn execute(
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "No link target specified. Use --target or set link.target in armadai.yaml.\n\
-                 Supported targets: claude, copilot, gemini"
+                 Supported targets: claude, codex, copilot, gemini, opencode"
             )
         })?;
+
+    // 4b. Model resolution: remap agent models based on target kind
+    let target_kind = model_resolution::classify_target(&target_name);
+    match target_kind {
+        TargetKind::LlmEditor { provider } => {
+            #[cfg(feature = "providers-api")]
+            {
+                model_resolution::remap_models_for_llm_editor(&mut link_agents, provider).await;
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_llm_editor(
+                        std::slice::from_mut(coord),
+                        provider,
+                    )
+                    .await;
+                }
+            }
+            #[cfg(not(feature = "providers-api"))]
+            {
+                model_resolution::remap_models_for_llm_editor(&mut link_agents, provider);
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_llm_editor(
+                        std::slice::from_mut(coord),
+                        provider,
+                    );
+                }
+            }
+        }
+        TargetKind::Orchestrator => {
+            if let Some(ref model) = model_flag {
+                model_resolution::remap_models_for_orchestrator(&mut link_agents, model);
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_orchestrator(
+                        std::slice::from_mut(coord),
+                        model,
+                    );
+                }
+            } else if std::io::stdin().is_terminal() {
+                #[cfg(feature = "providers-api")]
+                let model = model_resolution::prompt_model_interactive().await?;
+                #[cfg(not(feature = "providers-api"))]
+                let model = model_resolution::prompt_model_interactive()?;
+                model_resolution::remap_models_for_orchestrator(&mut link_agents, &model);
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_orchestrator(
+                        std::slice::from_mut(coord),
+                        &model,
+                    );
+                }
+            }
+            // else: non-interactive without --model → keep original models
+        }
+    }
 
     // 5. Create linker
     let linker = linker::create_linker(&target_name)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -218,9 +218,12 @@ pub enum Command {
             armadai link --target claude --output .claude/agents --force"
     )]
     Link {
-        /// Target AI assistant (claude, copilot)
+        /// Target AI assistant (claude, codex, copilot, gemini, opencode)
         #[arg(long, short)]
         target: Option<String>,
+        /// Model to use in generated configs (for orchestrator targets like copilot/opencode)
+        #[arg(long, short = 'm')]
+        model: Option<String>,
         /// Coordinator agent whose prompt becomes the main context file
         #[arg(long, short = 'C')]
         coordinator: Option<String>,
@@ -378,12 +381,13 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         Command::Skills(action) => skills::execute(action).await,
         Command::Link {
             target,
+            model,
             coordinator,
             dry_run,
             force,
             output,
             agents,
-        } => link::execute(target, coordinator, dry_run, force, output, agents).await,
+        } => link::execute(target, model, coordinator, dry_run, force, output, agents).await,
         Command::Unlink {
             target,
             coordinator,

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -63,6 +63,9 @@ fn template_create(
         content = content.replace("{{stack}}", s);
     }
 
+    // Replace model placeholder with default
+    content = content.replace("{{model}}", "claude-sonnet-4-5-20250929");
+
     // Check for remaining placeholders
     let remaining: Vec<&str> = content
         .match_indices("{{")

--- a/src/linker/claude.rs
+++ b/src/linker/claude.rs
@@ -55,6 +55,11 @@ fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
         .unwrap_or(&agent.name);
     // Escape YAML string
     content.push_str(&format!("description: \"{}\"\n", yaml_escape(description)));
+
+    if let Some(ref model) = agent.model {
+        content.push_str(&format!("model: {model}\n"));
+    }
+
     content.push_str("---\n\n");
 
     // System prompt (main content)
@@ -210,6 +215,11 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from(".claude/agents/test-agent.md"));
         assert!(files[0].content.contains("name: test-agent\n"));
+        assert!(
+            files[0]
+                .content
+                .contains("model: claude-sonnet-4-5-20250929\n")
+        );
         assert!(files[0].content.contains("You are a test agent."));
         assert!(
             files[0]

--- a/src/linker/codex.rs
+++ b/src/linker/codex.rs
@@ -1,0 +1,439 @@
+use std::path::PathBuf;
+
+use super::{LinkAgent, Linker, OutputFile, slugify};
+
+/// Generates OpenAI Codex CLI config files in `.codex/`.
+///
+/// Produces:
+/// - `agents/{slug}.toml` — one TOML config per agent (model + developer_instructions)
+/// - `config.toml` — main config referencing all agents
+/// - `AGENTS.md` — coordinator context document (same pattern as Gemini linker)
+pub struct CodexLinker;
+
+impl Linker for CodexLinker {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn default_output_dir(&self) -> &str {
+        ".codex"
+    }
+
+    fn generate(
+        &self,
+        agents: &[LinkAgent],
+        coordinator: Option<&LinkAgent>,
+        _sources: &[String],
+    ) -> Vec<OutputFile> {
+        if agents.is_empty() && coordinator.is_none() {
+            return Vec::new();
+        }
+
+        let mut files = Vec::new();
+
+        // Individual agent TOML files
+        for agent in agents {
+            files.push(generate_agent_file(agent));
+        }
+
+        // config.toml — main config referencing all agents
+        files.push(generate_config_toml(agents));
+
+        // AGENTS.md — coordinator context document
+        files.push(generate_agents_md(agents, coordinator));
+
+        files
+    }
+}
+
+/// Generate an individual agent TOML file at `.codex/agents/{slug}.toml`.
+fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
+    let slug = slugify(&agent.name);
+    let path = PathBuf::from(".codex/agents").join(format!("{slug}.toml"));
+
+    let model = agent.model.as_deref().unwrap_or("o3-mini");
+
+    // Build developer_instructions from all sections
+    let mut instructions = String::new();
+    instructions.push_str(&agent.system_prompt);
+
+    if let Some(ref inst) = agent.instructions {
+        ensure_blank_line(&mut instructions);
+        instructions.push_str("## Instructions\n\n");
+        instructions.push_str(inst);
+    }
+
+    if let Some(ref output_format) = agent.output_format {
+        ensure_blank_line(&mut instructions);
+        instructions.push_str("## Output Format\n\n");
+        instructions.push_str(output_format);
+    }
+
+    if let Some(ref context) = agent.context {
+        ensure_blank_line(&mut instructions);
+        instructions.push_str("## Context\n\n");
+        instructions.push_str(context);
+    }
+
+    let mut content = String::new();
+    content.push_str(&format!("model = \"{model}\"\n"));
+    content.push_str(&format!(
+        "developer_instructions = \"\"\"\n{instructions}\n\"\"\"\n"
+    ));
+
+    OutputFile { path, content }
+}
+
+/// Generate `.codex/config.toml` with references to all agent configs.
+fn generate_config_toml(agents: &[LinkAgent]) -> OutputFile {
+    let mut content = String::new();
+
+    for agent in agents {
+        let slug = slugify(&agent.name);
+        let desc = agent
+            .description
+            .as_deref()
+            .or_else(|| agent.system_prompt.lines().find(|l| !l.trim().is_empty()))
+            .unwrap_or(&agent.name);
+        let desc_escaped = toml_escape(desc);
+
+        content.push_str(&format!("[agents.{slug}]\n"));
+        content.push_str(&format!("description = \"{desc_escaped}\"\n"));
+        content.push_str(&format!("config_file = \"agents/{slug}.toml\"\n"));
+        content.push('\n');
+    }
+
+    OutputFile {
+        path: PathBuf::from(".codex/config.toml"),
+        content,
+    }
+}
+
+/// Generate the `AGENTS.md` coordinator context document.
+fn generate_agents_md(agents: &[LinkAgent], coordinator: Option<&LinkAgent>) -> OutputFile {
+    let mut content = String::new();
+
+    if let Some(coord) = coordinator {
+        content.push_str(&coord.system_prompt);
+
+        if let Some(ref instructions) = coord.instructions {
+            ensure_blank_line(&mut content);
+            content.push_str(instructions);
+        }
+
+        if !agents.is_empty() {
+            ensure_blank_line(&mut content);
+            content.push_str("## Team\n\n");
+            content.push_str("| Agent | Config | Description |\n");
+            content.push_str("|-------|--------|-------------|\n");
+
+            for agent in agents {
+                let slug = slugify(&agent.name);
+                let desc = agent
+                    .description
+                    .as_deref()
+                    .or_else(|| agent.system_prompt.lines().find(|l| !l.trim().is_empty()))
+                    .unwrap_or("");
+                let desc_truncated = if desc.len() > 80 {
+                    format!("{}...", &desc[..77])
+                } else {
+                    desc.to_string()
+                };
+                content.push_str(&format!(
+                    "| {} | [agents/{slug}.toml](agents/{slug}.toml) | {} |\n",
+                    agent.name, desc_truncated
+                ));
+            }
+        }
+    } else if agents.len() == 1 {
+        let slug = slugify(&agents[0].name);
+        content.push_str(&format!("# {}\n\n", agents[0].name));
+        content.push_str(&format!(
+            "See [agents/{slug}.toml](agents/{slug}.toml) for the full agent config.\n"
+        ));
+    } else {
+        content.push_str(
+            "You are a team coordinator managing specialized agents for this project.\n\
+             Analyze each request and adopt the most appropriate role.\n\n\
+             ## Team\n\n\
+             | Agent | Config | Description |\n\
+             |-------|--------|-------------|\n",
+        );
+
+        for agent in agents {
+            let slug = slugify(&agent.name);
+            let desc = agent
+                .description
+                .as_deref()
+                .or_else(|| agent.system_prompt.lines().find(|l| !l.trim().is_empty()))
+                .unwrap_or("");
+            let desc_truncated = if desc.len() > 80 {
+                format!("{}...", &desc[..77])
+            } else {
+                desc.to_string()
+            };
+            content.push_str(&format!(
+                "| {} | [agents/{slug}.toml](agents/{slug}.toml) | {} |\n",
+                agent.name, desc_truncated
+            ));
+        }
+
+        content.push_str(
+            "\n## How to operate\n\n\
+             1. Analyze the user's request\n\
+             2. Identify which team member is best suited\n\
+             3. Read the corresponding agent config for their full instructions\n\
+             4. Adopt their expertise to respond\n\
+             5. For complex tasks, combine multiple members' perspectives\n",
+        );
+    }
+
+    OutputFile {
+        path: PathBuf::from(".codex/AGENTS.md"),
+        content,
+    }
+}
+
+/// Escape a string for use in a TOML double-quoted value.
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Ensure there are two newlines (blank line) before a new section.
+fn ensure_blank_line(content: &mut String) {
+    if !content.ends_with("\n\n") {
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(name: &str, system_prompt: &str) -> LinkAgent {
+        LinkAgent {
+            name: name.to_string(),
+            system_prompt: system_prompt.to_string(),
+            instructions: None,
+            output_format: None,
+            context: None,
+            description: Some(system_prompt.lines().next().unwrap_or("").to_string()),
+            tags: vec![],
+            stacks: vec![],
+            scope: vec![],
+            model: None,
+            model_fallback: vec![],
+            temperature: 0.7,
+        }
+    }
+
+    #[test]
+    fn test_generate_simple_agent() {
+        let linker = CodexLinker;
+        let agents = vec![make_agent("Code Reviewer", "You review code for bugs.")];
+        let files = linker.generate(&agents, None, &[]);
+
+        // agent file + config.toml + AGENTS.md
+        assert_eq!(files.len(), 3);
+
+        let agent_file = files
+            .iter()
+            .find(|f| f.path.ends_with("code-reviewer.toml"))
+            .unwrap();
+        assert_eq!(
+            agent_file.path,
+            PathBuf::from(".codex/agents/code-reviewer.toml")
+        );
+        assert!(agent_file.content.contains("model = \"o3-mini\""));
+        assert!(
+            agent_file
+                .content
+                .contains("developer_instructions = \"\"\"")
+        );
+        assert!(agent_file.content.contains("You review code for bugs."));
+    }
+
+    #[test]
+    fn test_generate_agent_with_model() {
+        let linker = CodexLinker;
+        let agents = vec![LinkAgent {
+            name: "Test Agent".to_string(),
+            system_prompt: "You are a test agent.".to_string(),
+            instructions: Some("Follow TDD.".to_string()),
+            output_format: Some("JSON output.".to_string()),
+            context: Some("Rust project.".to_string()),
+            description: Some("You are a test agent.".to_string()),
+            tags: vec![],
+            stacks: vec![],
+            scope: vec![],
+            model: Some("gpt-4o".to_string()),
+            model_fallback: vec![],
+            temperature: 0.3,
+        }];
+        let files = linker.generate(&agents, None, &[]);
+
+        let agent_file = files
+            .iter()
+            .find(|f| f.path.ends_with("test-agent.toml"))
+            .unwrap();
+        assert!(agent_file.content.contains("model = \"gpt-4o\""));
+        assert!(agent_file.content.contains("You are a test agent."));
+        assert!(
+            agent_file
+                .content
+                .contains("## Instructions\n\nFollow TDD.")
+        );
+        assert!(
+            agent_file
+                .content
+                .contains("## Output Format\n\nJSON output.")
+        );
+        assert!(agent_file.content.contains("## Context\n\nRust project."));
+    }
+
+    #[test]
+    fn test_generate_multiple_agents() {
+        let linker = CodexLinker;
+        let agents = vec![
+            make_agent("Code Reviewer", "You review code."),
+            make_agent("Test Writer", "You write tests."),
+        ];
+        let files = linker.generate(&agents, None, &[]);
+
+        // 2 agent files + config.toml + AGENTS.md
+        assert_eq!(files.len(), 4);
+
+        assert!(
+            files
+                .iter()
+                .any(|f| f.path.as_os_str() == ".codex/agents/code-reviewer.toml")
+        );
+        assert!(
+            files
+                .iter()
+                .any(|f| f.path.as_os_str() == ".codex/agents/test-writer.toml")
+        );
+        assert!(
+            files
+                .iter()
+                .any(|f| f.path.as_os_str() == ".codex/config.toml")
+        );
+        assert!(
+            files
+                .iter()
+                .any(|f| f.path.as_os_str() == ".codex/AGENTS.md")
+        );
+
+        let agents_md = files
+            .iter()
+            .find(|f| f.path.ends_with("AGENTS.md"))
+            .unwrap();
+        assert!(agents_md.content.contains("team coordinator"));
+        assert!(agents_md.content.contains("agents/code-reviewer.toml"));
+        assert!(agents_md.content.contains("agents/test-writer.toml"));
+        assert!(agents_md.content.contains("## How to operate"));
+    }
+
+    #[test]
+    fn test_generate_empty_agents() {
+        let linker = CodexLinker;
+        let files = linker.generate(&[], None, &[]);
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_default_output_dir() {
+        let linker = CodexLinker;
+        assert_eq!(linker.default_output_dir(), ".codex");
+    }
+
+    #[test]
+    fn test_generate_with_coordinator() {
+        let linker = CodexLinker;
+        let coordinator = make_agent("Capitaine", "You are the captain of the crew.");
+        let agents = vec![
+            make_agent("Vigie", "You watch from the mast."),
+            make_agent("Charpentier", "You repair the hull."),
+        ];
+        let files = linker.generate(&agents, Some(&coordinator), &[]);
+
+        // 2 agent files + config.toml + AGENTS.md
+        assert_eq!(files.len(), 4);
+
+        let agents_md = files
+            .iter()
+            .find(|f| f.path.ends_with("AGENTS.md"))
+            .unwrap();
+        assert!(
+            agents_md
+                .content
+                .contains("You are the captain of the crew.")
+        );
+        assert!(!agents_md.content.contains("team coordinator"));
+        assert!(agents_md.content.contains("## Team"));
+        assert!(agents_md.content.contains("agents/vigie.toml"));
+        assert!(agents_md.content.contains("agents/charpentier.toml"));
+
+        // No agent file for the coordinator
+        assert!(
+            !files
+                .iter()
+                .any(|f| f.path.to_string_lossy().contains("capitaine"))
+        );
+    }
+
+    #[test]
+    fn test_config_toml_structure() {
+        let linker = CodexLinker;
+        let agents = vec![
+            make_agent("Code Reviewer", "You review code."),
+            make_agent("Test Writer", "You write tests."),
+        ];
+        let files = linker.generate(&agents, None, &[]);
+
+        let config = files
+            .iter()
+            .find(|f| f.path.ends_with("config.toml"))
+            .unwrap();
+        assert!(config.content.contains("[agents.code-reviewer]"));
+        assert!(
+            config
+                .content
+                .contains("config_file = \"agents/code-reviewer.toml\"")
+        );
+        assert!(config.content.contains("[agents.test-writer]"));
+        assert!(
+            config
+                .content
+                .contains("config_file = \"agents/test-writer.toml\"")
+        );
+    }
+
+    #[test]
+    fn test_generate_coordinator_with_instructions() {
+        let coordinator = LinkAgent {
+            name: "Leader".to_string(),
+            system_prompt: "You lead the team.".to_string(),
+            instructions: Some("Always be kind.".to_string()),
+            output_format: None,
+            context: None,
+            description: Some("You lead the team.".to_string()),
+            tags: vec![],
+            stacks: vec![],
+            scope: vec![],
+            model: None,
+            model_fallback: vec![],
+            temperature: 0.7,
+        };
+        let agents = vec![make_agent("Worker", "You do the work.")];
+
+        let file = generate_agents_md(&agents, Some(&coordinator));
+        assert!(file.content.contains("You lead the team."));
+        assert!(file.content.contains("Always be kind."));
+        assert!(file.content.contains("## Team"));
+        assert!(file.content.contains("agents/worker.toml"));
+    }
+}

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -1,9 +1,12 @@
 mod claude;
+mod codex;
 mod copilot;
 mod gemini;
+pub mod model_resolution;
 mod opencode;
 
 pub use claude::ClaudeLinker;
+pub use codex::CodexLinker;
 pub use copilot::CopilotLinker;
 pub use gemini::GeminiLinker;
 pub use opencode::OpencodeLinker;
@@ -52,11 +55,12 @@ pub trait Linker: Send + Sync {
 pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
     match target {
         "claude" => Ok(Box::new(ClaudeLinker)),
+        "codex" => Ok(Box::new(CodexLinker)),
         "copilot" => Ok(Box::new(CopilotLinker)),
         "gemini" => Ok(Box::new(GeminiLinker)),
         "opencode" => Ok(Box::new(OpencodeLinker)),
         _ => anyhow::bail!(
-            "Unknown link target: '{target}'. Supported targets: claude, copilot, gemini, opencode"
+            "Unknown link target: '{target}'. Supported targets: claude, codex, copilot, gemini, opencode"
         ),
     }
 }
@@ -148,6 +152,11 @@ mod tests {
     #[test]
     fn test_create_linker_gemini() {
         assert!(create_linker("gemini").is_ok());
+    }
+
+    #[test]
+    fn test_create_linker_codex() {
+        assert!(create_linker("codex").is_ok());
     }
 
     #[test]

--- a/src/linker/model_resolution.rs
+++ b/src/linker/model_resolution.rs
@@ -1,0 +1,321 @@
+use super::LinkAgent;
+
+/// Classification of link targets.
+pub enum TargetKind {
+    /// Target is a standalone LLM editor that speaks a specific provider's API.
+    LlmEditor { provider: &'static str },
+    /// Target is an orchestrator that can use any model (needs explicit --model).
+    Orchestrator,
+}
+
+/// Classify a link target name into its kind.
+pub fn classify_target(target: &str) -> TargetKind {
+    match target {
+        "claude" => TargetKind::LlmEditor {
+            provider: "anthropic",
+        },
+        "gemini" => TargetKind::LlmEditor { provider: "google" },
+        "codex" => TargetKind::LlmEditor { provider: "openai" },
+        // copilot, opencode, etc.
+        _ => TargetKind::Orchestrator,
+    }
+}
+
+/// Hardcoded fallback model for a given provider.
+pub fn fallback_model(provider: &str) -> &'static str {
+    match provider {
+        "anthropic" => "claude-sonnet-4-5-20250929",
+        "google" => "gemini-2.5-pro",
+        "openai" => "o3-mini",
+        _ => "claude-sonnet-4-5-20250929",
+    }
+}
+
+/// Resolve the best model for a provider from the model registry.
+/// Falls back to a hardcoded default if the registry is unavailable.
+#[cfg(feature = "providers-api")]
+pub async fn resolve_best_model(provider: &str) -> String {
+    if let Some(entries) = crate::model_registry::fetch::load_models_online(provider).await
+        && !entries.is_empty()
+    {
+        // First model in registry is typically the best/newest
+        return entries[0].id.clone();
+    }
+    fallback_model(provider).to_string()
+}
+
+/// Resolve the best model for a provider from cache only (sync).
+#[cfg(not(feature = "providers-api"))]
+pub fn resolve_best_model(provider: &str) -> String {
+    if let Some(entries) = crate::model_registry::fetch::load_models(provider)
+        && !entries.is_empty()
+    {
+        return entries[0].id.clone();
+    }
+    fallback_model(provider).to_string()
+}
+
+/// Remap all agents' models to the best model for the given LLM provider.
+#[cfg(feature = "providers-api")]
+pub async fn remap_models_for_llm_editor(agents: &mut [LinkAgent], provider: &str) {
+    let best = resolve_best_model(provider).await;
+    for agent in agents.iter_mut() {
+        agent.model = Some(best.clone());
+    }
+}
+
+/// Remap all agents' models to the best model for the given LLM provider (sync/cache-only).
+#[cfg(not(feature = "providers-api"))]
+pub fn remap_models_for_llm_editor(agents: &mut [LinkAgent], provider: &str) {
+    let best = resolve_best_model(provider);
+    for agent in agents.iter_mut() {
+        agent.model = Some(best.clone());
+    }
+}
+
+/// Remap all agents' models to a specific model (for orchestrator targets).
+pub fn remap_models_for_orchestrator(agents: &mut [LinkAgent], model: &str) {
+    for agent in agents.iter_mut() {
+        agent.model = Some(model.to_string());
+    }
+}
+
+/// Preview model resolution for all known link targets (sync, always available).
+///
+/// Returns a list of (target_name, resolved_model) tuples showing what model
+/// would be used when linking to each target.
+pub fn preview_model_resolution(agent_model: Option<&str>) -> Vec<(&'static str, String)> {
+    let targets = ["claude", "codex", "gemini", "copilot", "opencode"];
+    targets
+        .iter()
+        .map(|&target| {
+            let resolved = match classify_target(target) {
+                TargetKind::LlmEditor { provider } => {
+                    crate::model_registry::fetch::load_models_cached(provider)
+                        .and_then(|e| e.first().map(|m| m.id.clone()))
+                        .unwrap_or_else(|| fallback_model(provider).to_string())
+                }
+                TargetKind::Orchestrator => agent_model.unwrap_or("(requires --model)").to_string(),
+            };
+            (target, resolved)
+        })
+        .collect()
+}
+
+/// Prompt the user interactively to pick a provider and model.
+///
+/// Used for orchestrator targets (copilot, opencode) when no `--model` flag is given.
+#[cfg(feature = "providers-api")]
+pub async fn prompt_model_interactive() -> anyhow::Result<String> {
+    use dialoguer::Select;
+
+    let providers = &["anthropic", "google", "openai"];
+    let idx = Select::new()
+        .with_prompt("Provider for model selection")
+        .items(providers)
+        .default(0)
+        .interact()?;
+    let provider = providers[idx];
+
+    if let Some(entries) = crate::model_registry::fetch::load_models_online(provider).await
+        && !entries.is_empty()
+    {
+        let labels: Vec<String> = entries.iter().map(|e| e.display_label()).collect();
+        let mut items = labels;
+        items.push("(custom)".to_string());
+
+        let model_idx = Select::new()
+            .with_prompt("Model")
+            .items(&items)
+            .default(0)
+            .interact()?;
+
+        if model_idx == items.len() - 1 {
+            let model: String = dialoguer::Input::new()
+                .with_prompt("Custom model name")
+                .interact_text()?;
+            return Ok(model);
+        }
+        return Ok(entries[model_idx].id.clone());
+    }
+
+    let model: String = dialoguer::Input::new()
+        .with_prompt("Model name")
+        .interact_text()?;
+    Ok(model)
+}
+
+/// Prompt the user interactively to pick a provider and model (cache-only, sync).
+#[cfg(not(feature = "providers-api"))]
+pub fn prompt_model_interactive() -> anyhow::Result<String> {
+    use dialoguer::Select;
+
+    let providers = &["anthropic", "google", "openai"];
+    let idx = Select::new()
+        .with_prompt("Provider for model selection")
+        .items(providers)
+        .default(0)
+        .interact()?;
+    let provider = providers[idx];
+
+    if let Some(entries) = crate::model_registry::fetch::load_models(provider)
+        && !entries.is_empty()
+    {
+        let labels: Vec<String> = entries.iter().map(|e| e.display_label()).collect();
+        let mut items = labels;
+        items.push("(custom)".to_string());
+
+        let model_idx = Select::new()
+            .with_prompt("Model")
+            .items(&items)
+            .default(0)
+            .interact()?;
+
+        if model_idx == items.len() - 1 {
+            let model: String = dialoguer::Input::new()
+                .with_prompt("Custom model name")
+                .interact_text()?;
+            return Ok(model);
+        }
+        return Ok(entries[model_idx].id.clone());
+    }
+
+    let model: String = dialoguer::Input::new()
+        .with_prompt("Model name")
+        .interact_text()?;
+    Ok(model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(name: &str, model: Option<&str>) -> LinkAgent {
+        LinkAgent {
+            name: name.to_string(),
+            system_prompt: "You are a test agent.".to_string(),
+            instructions: None,
+            output_format: None,
+            context: None,
+            description: Some("A test agent.".to_string()),
+            tags: vec![],
+            stacks: vec![],
+            scope: vec![],
+            model: model.map(String::from),
+            model_fallback: vec![],
+            temperature: 0.7,
+        }
+    }
+
+    #[test]
+    fn test_classify_claude() {
+        assert!(matches!(
+            classify_target("claude"),
+            TargetKind::LlmEditor {
+                provider: "anthropic"
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_gemini() {
+        assert!(matches!(
+            classify_target("gemini"),
+            TargetKind::LlmEditor { provider: "google" }
+        ));
+    }
+
+    #[test]
+    fn test_classify_codex() {
+        assert!(matches!(
+            classify_target("codex"),
+            TargetKind::LlmEditor { provider: "openai" }
+        ));
+    }
+
+    #[test]
+    fn test_classify_copilot_is_orchestrator() {
+        assert!(matches!(
+            classify_target("copilot"),
+            TargetKind::Orchestrator
+        ));
+    }
+
+    #[test]
+    fn test_classify_opencode_is_orchestrator() {
+        assert!(matches!(
+            classify_target("opencode"),
+            TargetKind::Orchestrator
+        ));
+    }
+
+    #[test]
+    fn test_classify_unknown_is_orchestrator() {
+        assert!(matches!(
+            classify_target("some-tool"),
+            TargetKind::Orchestrator
+        ));
+    }
+
+    #[test]
+    fn test_fallback_models() {
+        assert_eq!(fallback_model("anthropic"), "claude-sonnet-4-5-20250929");
+        assert_eq!(fallback_model("google"), "gemini-2.5-pro");
+        assert_eq!(fallback_model("openai"), "o3-mini");
+        // Unknown provider falls back to anthropic default
+        assert_eq!(fallback_model("unknown"), "claude-sonnet-4-5-20250929");
+    }
+
+    #[test]
+    fn test_remap_orchestrator() {
+        let mut agents = vec![
+            make_agent("Agent A", Some("claude-sonnet-4-5-20250929")),
+            make_agent("Agent B", None),
+            make_agent("Agent C", Some("gpt-4o")),
+        ];
+
+        remap_models_for_orchestrator(&mut agents, "gemini-2.5-pro");
+
+        for agent in &agents {
+            assert_eq!(agent.model.as_deref(), Some("gemini-2.5-pro"));
+        }
+    }
+
+    #[test]
+    fn test_remap_orchestrator_empty() {
+        let mut agents: Vec<LinkAgent> = vec![];
+        remap_models_for_orchestrator(&mut agents, "some-model");
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn test_preview_resolution_fallbacks() {
+        // Without cache, preview should return fallback models for LLM editors
+        // and the agent model (or placeholder) for orchestrators.
+        let result = preview_model_resolution(Some("my-model"));
+        assert_eq!(result.len(), 5);
+
+        // Check targets exist
+        let targets: Vec<&str> = result.iter().map(|(t, _)| *t).collect();
+        assert!(targets.contains(&"claude"));
+        assert!(targets.contains(&"codex"));
+        assert!(targets.contains(&"gemini"));
+        assert!(targets.contains(&"copilot"));
+        assert!(targets.contains(&"opencode"));
+
+        // Orchestrator targets use agent model
+        for (target, model) in &result {
+            if matches!(classify_target(target), TargetKind::Orchestrator) {
+                assert_eq!(model, "my-model");
+            }
+        }
+
+        // Without agent model, orchestrators show placeholder
+        let result_no_model = preview_model_resolution(None);
+        for (target, model) in &result_no_model {
+            if matches!(classify_target(target), TargetKind::Orchestrator) {
+                assert_eq!(model, "(requires --model)");
+            }
+        }
+    }
+}

--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -92,6 +92,18 @@ fn parse_registry(body: &serde_json::Value) -> HashMap<String, Vec<ModelEntry>> 
     providers
 }
 
+/// Load models for a provider from cache (sync). Always available, no feature gate.
+pub fn load_models_cached(provider: &str) -> Option<Vec<ModelEntry>> {
+    let cached = load_cache_from(&cache_path())?;
+    cached.providers.get(provider).cloned()
+}
+
+/// Load all providers from cache (sync). Always available, no feature gate.
+pub fn load_all_providers_cached() -> Option<HashMap<String, Vec<ModelEntry>>> {
+    let cached = load_cache_from(&cache_path())?;
+    Some(cached.providers)
+}
+
 fn load_cache_from(path: &Path) -> Option<CachedRegistry> {
     let content = std::fs::read_to_string(path).ok()?;
     let cached: CachedRegistry = serde_json::from_str(&content).ok()?;
@@ -238,5 +250,70 @@ mod tests {
         let json = serde_json::json!({});
         let providers = parse_registry(&json);
         assert!(providers.is_empty());
+    }
+
+    #[test]
+    fn test_load_all_providers_cached_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CACHE_FILE);
+
+        let registry = CachedRegistry {
+            fetched_at: now_secs(),
+            providers: HashMap::from([
+                (
+                    "anthropic".to_string(),
+                    vec![ModelEntry {
+                        id: "claude-sonnet-4-5".to_string(),
+                        name: Some("Claude Sonnet 4.5".to_string()),
+                        cost: None,
+                        limit: None,
+                    }],
+                ),
+                (
+                    "openai".to_string(),
+                    vec![ModelEntry {
+                        id: "gpt-4o".to_string(),
+                        name: Some("GPT-4o".to_string()),
+                        cost: None,
+                        limit: None,
+                    }],
+                ),
+            ]),
+        };
+
+        save_cache_to(&path, &registry);
+
+        // Temporarily override cache path by loading directly
+        let loaded = load_cache_from(&path).expect("cache should load");
+        assert_eq!(loaded.providers.len(), 2);
+        assert!(loaded.providers.contains_key("anthropic"));
+        assert!(loaded.providers.contains_key("openai"));
+    }
+
+    #[test]
+    fn test_load_models_cached_specific_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CACHE_FILE);
+
+        let registry = CachedRegistry {
+            fetched_at: now_secs(),
+            providers: HashMap::from([(
+                "google".to_string(),
+                vec![ModelEntry {
+                    id: "gemini-2.5-pro".to_string(),
+                    name: Some("Gemini 2.5 Pro".to_string()),
+                    cost: None,
+                    limit: None,
+                }],
+            )]),
+        };
+
+        save_cache_to(&path, &registry);
+        let loaded = load_cache_from(&path).expect("cache should load");
+        let google = loaded.providers.get("google").unwrap();
+        assert_eq!(google.len(), 1);
+        assert_eq!(google[0].id, "gemini-2.5-pro");
+        // Non-existent provider
+        assert!(!loaded.providers.contains_key("unknown"));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,6 +2,7 @@ use crate::core::agent::Agent;
 use crate::core::prompt::Prompt;
 use crate::core::skill::Skill;
 use crate::core::starter::StarterPack;
+use crate::model_registry::ModelEntry;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
@@ -15,17 +16,20 @@ pub enum Tab {
     StarterDetail,
     History,
     Costs,
+    Models,
+    ModelDetail,
 }
 
 impl Tab {
     /// Tabs visible in the tab bar (detail tabs are accessed via Enter).
-    pub const ALL: [Tab; 6] = [
+    pub const ALL: [Tab; 7] = [
         Tab::Dashboard,
         Tab::Prompts,
         Tab::Skills,
         Tab::Starters,
         Tab::History,
         Tab::Costs,
+        Tab::Models,
     ];
 
     pub fn title(self) -> &'static str {
@@ -40,6 +44,8 @@ impl Tab {
             Tab::StarterDetail => "Starter",
             Tab::History => "History",
             Tab::Costs => "Costs",
+            Tab::Models => "Models",
+            Tab::ModelDetail => "Model",
         }
     }
 
@@ -139,6 +145,11 @@ impl CommandPalette {
                 action: PaletteAction::SwitchTab(Tab::Costs),
             },
             PaletteCommand {
+                name: "models".to_string(),
+                description: "View model catalog".to_string(),
+                action: PaletteAction::SwitchTab(Tab::Models),
+            },
+            PaletteCommand {
                 name: "refresh".to_string(),
                 description: "Reload agents and data".to_string(),
                 action: PaletteAction::Refresh,
@@ -222,6 +233,9 @@ pub struct App {
     pub selected_history: usize,
     // Costs
     pub costs: Vec<CostEntry>,
+    // Models (from model registry cache)
+    pub models_flat: Vec<(String, ModelEntry)>,
+    pub selected_model: usize,
     // Command palette
     pub palette: CommandPalette,
     // Status message (bottom bar)
@@ -244,6 +258,8 @@ impl App {
             history: Vec::new(),
             selected_history: 0,
             costs: Vec::new(),
+            models_flat: Vec::new(),
+            selected_model: 0,
             palette: CommandPalette::new(),
             status_msg: None,
         }
@@ -319,6 +335,27 @@ impl App {
         self.starters.get(self.selected_starter)
     }
 
+    pub fn selected_model_entry(&self) -> Option<&(String, ModelEntry)> {
+        self.models_flat.get(self.selected_model)
+    }
+
+    pub fn load_models(&mut self) {
+        use crate::model_registry::fetch::load_all_providers_cached;
+        if let Some(providers) = load_all_providers_cached() {
+            let mut flat: Vec<(String, ModelEntry)> = Vec::new();
+            let mut keys: Vec<String> = providers.keys().cloned().collect();
+            keys.sort();
+            for provider in keys {
+                if let Some(models) = providers.get(&provider) {
+                    for entry in models {
+                        flat.push((provider.clone(), entry.clone()));
+                    }
+                }
+            }
+            self.models_flat = flat;
+        }
+    }
+
     pub fn select_next(&mut self) {
         match self.current_tab {
             Tab::Dashboard => {
@@ -344,6 +381,11 @@ impl App {
             Tab::History => {
                 if !self.history.is_empty() {
                     self.selected_history = (self.selected_history + 1) % self.history.len();
+                }
+            }
+            Tab::Models => {
+                if !self.models_flat.is_empty() {
+                    self.selected_model = (self.selected_model + 1) % self.models_flat.len();
                 }
             }
             _ => {}
@@ -394,6 +436,15 @@ impl App {
                         self.history.len() - 1
                     } else {
                         self.selected_history - 1
+                    };
+                }
+            }
+            Tab::Models => {
+                if !self.models_flat.is_empty() {
+                    self.selected_model = if self.selected_model == 0 {
+                        self.models_flat.len() - 1
+                    } else {
+                        self.selected_model - 1
                     };
                 }
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -25,6 +25,7 @@ pub async fn run() -> Result<()> {
     app.load_prompts();
     app.load_skills();
     app.load_starters();
+    app.load_models();
     load_storage_data(&mut app);
 
     loop {
@@ -55,6 +56,7 @@ pub async fn run() -> Result<()> {
                                     app.load_prompts();
                                     app.load_skills();
                                     app.load_starters();
+                                    app.load_models();
                                     load_storage_data(&mut app);
                                 }
                                 PaletteAction::Quit => break,
@@ -81,8 +83,36 @@ pub async fn run() -> Result<()> {
             }
 
             // Normal mode
+
+            // Detail view: Esc goes back to parent list
+            if key.code == KeyCode::Esc {
+                match app.current_tab {
+                    app::Tab::AgentDetail => {
+                        app.switch_tab(app::Tab::Dashboard);
+                        continue;
+                    }
+                    app::Tab::PromptDetail => {
+                        app.switch_tab(app::Tab::Prompts);
+                        continue;
+                    }
+                    app::Tab::SkillDetail => {
+                        app.switch_tab(app::Tab::Skills);
+                        continue;
+                    }
+                    app::Tab::StarterDetail => {
+                        app.switch_tab(app::Tab::Starters);
+                        continue;
+                    }
+                    app::Tab::ModelDetail => {
+                        app.switch_tab(app::Tab::Models);
+                        continue;
+                    }
+                    _ => break, // Quit on Esc from top-level tabs
+                }
+            }
+
             match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Char('q') => break,
                 KeyCode::Char(':') | KeyCode::Char('p')
                     if key.modifiers.contains(KeyModifiers::CONTROL) =>
                 {
@@ -98,6 +128,7 @@ pub async fn run() -> Result<()> {
                     app.load_prompts();
                     app.load_skills();
                     app.load_starters();
+                    app.load_models();
                     load_storage_data(&mut app);
                     app.status_msg = Some("Refreshed".to_string());
                 }
@@ -113,6 +144,9 @@ pub async fn run() -> Result<()> {
                     }
                     app::Tab::Starters if app.selected_starter().is_some() => {
                         app.switch_tab(app::Tab::StarterDetail);
+                    }
+                    app::Tab::Models if app.selected_model_entry().is_some() => {
+                        app.switch_tab(app::Tab::ModelDetail);
                     }
                     _ => {}
                 },
@@ -166,6 +200,7 @@ pub async fn run() -> Result<()> {
                 KeyCode::Char('4') => app.switch_tab(app::Tab::Starters),
                 KeyCode::Char('5') => app.switch_tab(app::Tab::History),
                 KeyCode::Char('6') => app.switch_tab(app::Tab::Costs),
+                KeyCode::Char('7') => app.switch_tab(app::Tab::Models),
                 _ => {}
             }
         }

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -27,6 +27,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         .constraints([
             Constraint::Length(3), // Title
             Constraint::Length(8), // Metadata
+            Constraint::Length(8), // Model Resolution
             Constraint::Min(6),    // System Prompt
             Constraint::Length(6), // Instructions (if any)
         ])
@@ -116,6 +117,32 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         .wrap(Wrap { trim: false });
     frame.render_widget(meta_widget, chunks[1]);
 
+    // Model Resolution section
+    let resolution =
+        crate::linker::model_resolution::preview_model_resolution(agent.metadata.model.as_deref());
+    let res_lines: Vec<Line> = resolution
+        .iter()
+        .map(|(target, resolved)| {
+            Line::from(vec![
+                Span::styled(
+                    format!("{:<10}", target),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" → ", Style::default().fg(Color::DarkGray)),
+                Span::styled(resolved.as_str(), Style::default().fg(Color::Green)),
+            ])
+        })
+        .collect();
+    let res_widget = Paragraph::new(res_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Model Resolution (link targets) ")
+                .title_style(Style::default().add_modifier(Modifier::BOLD)),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(res_widget, chunks[2]);
+
     // System Prompt section
     let prompt_text = if agent.system_prompt.is_empty() {
         "(no system prompt)".to_string()
@@ -131,7 +158,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         )
         .style(Style::default().fg(Color::White))
         .wrap(Wrap { trim: false });
-    frame.render_widget(prompt_widget, chunks[2]);
+    frame.render_widget(prompt_widget, chunks[3]);
 
     // Instructions section
     let instr_text = agent.instructions.as_deref().unwrap_or("(no instructions)");
@@ -144,5 +171,5 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         )
         .style(Style::default().fg(Color::Gray))
         .wrap(Wrap { trim: false });
-    frame.render_widget(instr_widget, chunks[3]);
+    frame.render_widget(instr_widget, chunks[4]);
 }

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -47,6 +47,8 @@ pub fn render(frame: &mut Frame, app: &App) {
         Tab::StarterDetail => super::starter_detail::render(frame, app, chunks[1]),
         Tab::History => super::history::render(frame, app, chunks[1]),
         Tab::Costs => super::costs::render(frame, app, chunks[1]),
+        Tab::Models => super::models_list::render(frame, app, chunks[1]),
+        Tab::ModelDetail => super::model_detail::render(frame, app, chunks[1]),
     };
 
     // Shortcuts bar

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -2,6 +2,8 @@ pub mod agent_detail;
 pub mod costs;
 pub mod dashboard;
 pub mod history;
+pub mod model_detail;
+pub mod models_list;
 pub mod palette;
 pub mod prompt_detail;
 pub mod prompts_list;

--- a/src/tui/views/model_detail.rs
+++ b/src/tui/views/model_detail.rs
@@ -1,0 +1,131 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use crate::tui::app::App;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let (provider, entry) = match app.selected_model_entry() {
+        Some(e) => e,
+        None => {
+            let msg = Paragraph::new("No model selected. Go to Models tab and select one.").block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Model Detail "),
+            );
+            frame.render_widget(msg, area);
+            return;
+        }
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Title
+            Constraint::Length(9), // Details
+            Constraint::Min(3),    // Display label
+        ])
+        .split(area);
+
+    // Title bar
+    let title = Paragraph::new(Line::from(vec![
+        Span::styled(
+            format!(" {} ", entry.id),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  ({})", provider),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(title, chunks[0]);
+
+    // Details section
+    let name = entry.name.as_deref().unwrap_or("(unnamed)");
+    let context = entry
+        .limit
+        .as_ref()
+        .and_then(|l| l.context)
+        .map(|c| format!("{}", c))
+        .unwrap_or_else(|| "(unknown)".to_string());
+    let max_output = entry
+        .limit
+        .as_ref()
+        .and_then(|l| l.output)
+        .map(|o| format!("{}", o))
+        .unwrap_or_else(|| "(unknown)".to_string());
+    let cost_in = entry
+        .cost
+        .as_ref()
+        .and_then(|c| c.input)
+        .map(|v| format!("${:.2}", v))
+        .unwrap_or_else(|| "(unknown)".to_string());
+    let cost_out = entry
+        .cost
+        .as_ref()
+        .and_then(|c| c.output)
+        .map(|v| format!("${:.2}", v))
+        .unwrap_or_else(|| "(unknown)".to_string());
+
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+    let detail_lines = vec![
+        Line::from(vec![
+            Span::styled("Provider:       ", bold),
+            Span::raw(provider),
+        ]),
+        Line::from(vec![
+            Span::styled("Name:           ", bold),
+            Span::raw(name),
+        ]),
+        Line::from(vec![
+            Span::styled("ID:             ", bold),
+            Span::raw(&entry.id),
+        ]),
+        Line::from(vec![
+            Span::styled("Context Window: ", bold),
+            Span::raw(&context),
+        ]),
+        Line::from(vec![
+            Span::styled("Max Output:     ", bold),
+            Span::raw(&max_output),
+        ]),
+        Line::from(vec![
+            Span::styled("Cost (input):   ", bold),
+            Span::styled(&cost_in, Style::default().fg(Color::Yellow)),
+        ]),
+        Line::from(vec![
+            Span::styled("Cost (output):  ", bold),
+            Span::styled(&cost_out, Style::default().fg(Color::Yellow)),
+        ]),
+    ];
+
+    let detail_widget = Paragraph::new(detail_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Details ")
+                .title_style(bold),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(detail_widget, chunks[1]);
+
+    // Display label section
+    let label = entry.display_label();
+    let label_widget = Paragraph::new(label)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Display Label ")
+                .title_style(bold),
+        )
+        .style(Style::default().fg(Color::Green))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(label_widget, chunks[2]);
+}

--- a/src/tui/views/models_list.rs
+++ b/src/tui/views/models_list.rs
@@ -1,0 +1,94 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Paragraph, Row, Table},
+};
+
+use crate::tui::app::App;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    if app.models_flat.is_empty() {
+        let msg = Paragraph::new("No model data cached. Run `armadai new -i` to populate.")
+            .block(Block::default().borders(Borders::ALL).title(" Models "));
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        "", "PROVIDER", "MODEL ID", "NAME", "CONTEXT", "COST IN", "COST OUT",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD))
+    .bottom_margin(1);
+
+    let rows: Vec<Row> = app
+        .models_flat
+        .iter()
+        .enumerate()
+        .map(|(i, (provider, entry))| {
+            let marker = if i == app.selected_model { ">" } else { " " };
+            let name = entry.name.as_deref().unwrap_or("-").to_string();
+            let context = entry
+                .limit
+                .as_ref()
+                .and_then(|l| l.context)
+                .map(|c| format!("{}K", c / 1000))
+                .unwrap_or_else(|| "-".to_string());
+            let cost_in = entry
+                .cost
+                .as_ref()
+                .and_then(|c| c.input)
+                .map(|v| format!("${:.2}", v))
+                .unwrap_or_else(|| "-".to_string());
+            let cost_out = entry
+                .cost
+                .as_ref()
+                .and_then(|c| c.output)
+                .map(|v| format!("${:.2}", v))
+                .unwrap_or_else(|| "-".to_string());
+            let style = if i == app.selected_model {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![
+                marker.to_string(),
+                provider.clone(),
+                entry.id.clone(),
+                name,
+                context,
+                cost_in,
+                cost_out,
+            ])
+            .style(style)
+        })
+        .collect();
+
+    // Count unique providers
+    let mut providers: Vec<&str> = app.models_flat.iter().map(|(p, _)| p.as_str()).collect();
+    providers.dedup();
+    let provider_count = providers.len();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(2),
+            Constraint::Length(12),
+            Constraint::Min(20),
+            Constraint::Min(15),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(format!(
+        " Models — {} models, {} providers ",
+        app.models_flat.len(),
+        provider_count
+    )));
+
+    frame.render_widget(table, area);
+}

--- a/src/tui/views/shortcuts.rs
+++ b/src/tui/views/shortcuts.rs
@@ -19,7 +19,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("r", "Refresh"),
             ("q", "Quit"),
         ],
-        Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail => vec![
+        Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail | Tab::ModelDetail => vec![
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
             (":", "Commands"),
@@ -57,6 +57,14 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("q", "Quit"),
         ],
         Tab::Costs => vec![
+            ("Tab", "Next tab"),
+            (":", "Commands"),
+            ("r", "Refresh"),
+            ("q", "Quit"),
+        ],
+        Tab::Models => vec![
+            ("j/k", "Navigate"),
+            ("Enter", "View detail"),
             ("Tab", "Next tab"),
             (":", "Commands"),
             ("r", "Refresh"),

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -34,6 +34,7 @@ pub struct AgentDetail {
     system_prompt: String,
     instructions: Option<String>,
     output_format: Option<String>,
+    model_resolution: Vec<ModelResolutionEntry>,
 }
 
 #[derive(Serialize)]
@@ -121,6 +122,28 @@ pub struct StarterDetail {
 }
 
 #[derive(Serialize)]
+pub struct ProviderModels {
+    provider: String,
+    models: Vec<ModelSummary>,
+}
+
+#[derive(Serialize)]
+pub struct ModelSummary {
+    id: String,
+    name: Option<String>,
+    context: Option<u64>,
+    max_output: Option<u64>,
+    cost_input: Option<f64>,
+    cost_output: Option<f64>,
+}
+
+#[derive(Serialize)]
+pub struct ModelResolutionEntry {
+    target: String,
+    resolved_model: String,
+}
+
+#[derive(Serialize)]
 pub struct ErrorResponse {
     error: String,
 }
@@ -158,6 +181,16 @@ pub async fn get_agent(Path(name): Path<String>) -> Json<serde_json::Value> {
     {
         Some(a) => {
             let model = a.model_display();
+            let resolution = crate::linker::model_resolution::preview_model_resolution(
+                a.metadata.model.as_deref(),
+            );
+            let model_resolution = resolution
+                .into_iter()
+                .map(|(target, resolved)| ModelResolutionEntry {
+                    target: target.to_string(),
+                    resolved_model: resolved,
+                })
+                .collect();
             let detail = AgentDetail {
                 name: a.name,
                 source: a.source.display().to_string(),
@@ -174,6 +207,7 @@ pub async fn get_agent(Path(name): Path<String>) -> Json<serde_json::Value> {
                 system_prompt: a.system_prompt,
                 instructions: a.instructions,
                 output_format: a.output_format,
+                model_resolution,
             };
             Json(serde_json::to_value(detail).unwrap())
         }
@@ -405,6 +439,35 @@ pub async fn get_starter(Path(name): Path<String>) -> Json<serde_json::Value> {
             .unwrap(),
         ),
     }
+}
+
+pub async fn list_models() -> Json<Vec<ProviderModels>> {
+    use crate::model_registry::fetch::load_all_providers_cached;
+
+    let providers = load_all_providers_cached().unwrap_or_default();
+    let mut keys: Vec<String> = providers.keys().cloned().collect();
+    keys.sort();
+
+    let result: Vec<ProviderModels> = keys
+        .into_iter()
+        .filter_map(|provider| {
+            let entries = providers.get(&provider)?;
+            let models = entries
+                .iter()
+                .map(|e| ModelSummary {
+                    id: e.id.clone(),
+                    name: e.name.clone(),
+                    context: e.limit.as_ref().and_then(|l| l.context),
+                    max_output: e.limit.as_ref().and_then(|l| l.output),
+                    cost_input: e.cost.as_ref().and_then(|c| c.input),
+                    cost_output: e.cost.as_ref().and_then(|c| c.output),
+                })
+                .collect();
+            Some(ProviderModels { provider, models })
+        })
+        .collect();
+
+    Json(result)
 }
 
 pub async fn get_starter_config(Path(name): Path<String>) -> impl IntoResponse {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -60,6 +60,7 @@
     <button onclick="showTab('starters')">Starters</button>
     <button onclick="showTab('history')">History</button>
     <button onclick="showTab('costs')">Costs</button>
+    <button onclick="showTab('models')">Models</button>
   </nav>
 </header>
 <main>
@@ -69,6 +70,7 @@
   <div id="starters" class="card" style="display:none"></div>
   <div id="history" class="card" style="display:none"></div>
   <div id="costs" class="card" style="display:none"></div>
+  <div id="models" class="card" style="display:none"></div>
   <div id="view" class="card"></div>
 </main>
 <script>
@@ -77,10 +79,10 @@ let viewBackTab = 'agents';
 
 function showTab(tab) {
   document.querySelectorAll('nav button').forEach((b, i) => {
-    const tabs = ['agents','prompts','skills','starters','history','costs'];
+    const tabs = ['agents','prompts','skills','starters','history','costs','models'];
     b.classList.toggle('active', tabs[i] === tab);
   });
-  ['agents','prompts','skills','starters','history','costs','view'].forEach(id => document.getElementById(id).style.display = 'none');
+  ['agents','prompts','skills','starters','history','costs','models','view'].forEach(id => document.getElementById(id).style.display = 'none');
   document.getElementById(tab).style.display = 'block';
   currentTab = tab;
   if (tab === 'agents') loadAgents();
@@ -89,6 +91,7 @@ function showTab(tab) {
   if (tab === 'starters') loadStarters();
   if (tab === 'history') loadHistory();
   if (tab === 'costs') loadCosts();
+  if (tab === 'models') loadModels();
 }
 
 async function loadAgents() {
@@ -116,7 +119,7 @@ async function viewAgent(name) {
   const a = await res.json();
   if (a.error) return;
   viewBackTab = 'agents';
-  ['agents','prompts','skills','starters','history','costs'].forEach(id => document.getElementById(id).style.display = 'none');
+  ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
   el.innerHTML = `
@@ -133,6 +136,12 @@ async function viewAgent(name) {
         <div class="detail-field"><label>Tags</label><span>${a.tags.map(t => `<span class="tag">${t}</span>`).join('') || 'none'}</span></div>
         <div class="detail-field"><label>Stacks</label><span>${a.stacks.map(s => `<span class="tag stack">${s}</span>`).join('') || 'none'}</span></div>
       </div>
+      ${a.model_resolution && a.model_resolution.length ? `
+      <div class="prompt-box-title">Model Resolution (link targets)</div>
+      <table style="margin-bottom:16px">
+        <tr><th>Target</th><th>Resolved Model</th></tr>
+        ${a.model_resolution.map(r => `<tr><td>${r.target}</td><td style="color:var(--green)">${r.resolved_model}</td></tr>`).join('')}
+      </table>` : ''}
       <div class="prompt-box-title">System Prompt</div>
       <div class="prompt-box">${a.system_prompt || '(none)'}</div>
       ${a.instructions ? `<div class="prompt-box-title">Instructions</div><div class="prompt-box">${a.instructions}</div>` : ''}
@@ -165,7 +174,7 @@ async function viewPrompt(name) {
   const p = await res.json();
   if (p.error) return;
   viewBackTab = 'prompts';
-  ['agents','prompts','skills','starters','history','costs'].forEach(id => document.getElementById(id).style.display = 'none');
+  ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
   el.innerHTML = `
@@ -207,7 +216,7 @@ async function viewSkill(name) {
   const s = await res.json();
   if (s.error) return;
   viewBackTab = 'skills';
-  ['agents','prompts','skills','starters','history','costs'].forEach(id => document.getElementById(id).style.display = 'none');
+  ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
   const fileBlock = (f) => f.content
@@ -258,7 +267,7 @@ async function viewStarter(name) {
   const s = await res.json();
   if (s.error) return;
   viewBackTab = 'starters';
-  ['agents','prompts','skills','starters','history','costs'].forEach(id => document.getElementById(id).style.display = 'none');
+  ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
   el.innerHTML = `
@@ -320,6 +329,30 @@ async function loadCosts() {
           <td>${c.total_tokens_out}</td>
         </tr>`).join('')}
     </table>`;
+}
+
+async function loadModels() {
+  const res = await fetch('/api/models');
+  const providers = await res.json();
+  const el = document.getElementById('models');
+  if (!providers.length) { el.innerHTML = '<div class="empty">No model data cached. Run `armadai new -i` to populate.</div>'; return; }
+  const totalModels = providers.reduce((s, p) => s + p.models.length, 0);
+  el.innerHTML = `
+    <div class="card-header">${totalModels} models, ${providers.length} providers</div>
+    ${providers.map(p => `
+      <div style="padding:8px 16px;color:var(--muted);font-weight:600;font-size:12px;text-transform:uppercase;border-bottom:1px solid var(--border);background:rgba(88,166,255,0.04)">${p.provider}</div>
+      <table>
+        <tr><th>Model ID</th><th>Name</th><th>Context</th><th>Max Output</th><th>Cost In</th><th>Cost Out</th></tr>
+        ${p.models.map(m => `
+          <tr>
+            <td>${m.id}</td>
+            <td>${m.name || '-'}</td>
+            <td>${m.context ? (m.context/1000)+'K' : '-'}</td>
+            <td>${m.max_output || '-'}</td>
+            <td>${m.cost_input != null ? '$'+m.cost_input.toFixed(2) : '-'}</td>
+            <td>${m.cost_output != null ? '$'+m.cost_output.toFixed(2) : '-'}</td>
+          </tr>`).join('')}
+      </table>`).join('')}`;
 }
 
 // Initial load

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -18,6 +18,7 @@ pub async fn serve(port: u16) -> anyhow::Result<()> {
         .route("/api/starters", get(api::list_starters))
         .route("/api/starters/{name}", get(api::get_starter))
         .route("/api/starters/{name}/config", get(api::get_starter_config))
+        .route("/api/models", get(api::list_models))
         .layer(CorsLayer::permissive());
 
     let addr = format!("0.0.0.0:{port}");

--- a/starters/fullstack/agents/code-reviewer.md
+++ b/starters/fullstack/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [dev, review, quality]

--- a/starters/fullstack/agents/doc-generator.md
+++ b/starters/fullstack/agents/doc-generator.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.5
 - max_tokens: 4096
 - tags: [dev, documentation]

--- a/starters/fullstack/agents/test-writer.md
+++ b/starters/fullstack/agents/test-writer.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, testing]

--- a/starters/rust-dev/agents/code-reviewer.md
+++ b/starters/rust-dev/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [dev, review, quality]

--- a/starters/rust-dev/agents/debug.md
+++ b/starters/rust-dev/agents/debug.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, debug]

--- a/starters/rust-dev/agents/test-writer.md
+++ b/starters/rust-dev/agents/test-writer.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, testing]

--- a/templates/basic.md
+++ b/templates/basic.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.7
 - max_tokens: 4096
 - tags: [general]

--- a/templates/debug.md
+++ b/templates/debug.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, debug]

--- a/templates/dev-review.md
+++ b/templates/dev-review.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 4096
 - tags: [dev, review, quality]

--- a/templates/dev-test.md
+++ b/templates/dev-test.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, testing]

--- a/templates/planning.md
+++ b/templates/planning.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.5
 - max_tokens: 8192
 - tags: [planning, architecture]

--- a/templates/security-review.md
+++ b/templates/security-review.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.2
 - max_tokens: 8192
 - tags: [security, review]

--- a/templates/tdd-green.md
+++ b/templates/tdd-green.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, testing, tdd]

--- a/templates/tdd-red.md
+++ b/templates/tdd-red.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.3
 - max_tokens: 8192
 - tags: [dev, testing, tdd]

--- a/templates/tdd-refactor.md
+++ b/templates/tdd-refactor.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.4
 - max_tokens: 8192
 - tags: [dev, testing, tdd]

--- a/templates/tech-debt.md
+++ b/templates/tech-debt.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.4
 - max_tokens: 8192
 - tags: [dev, tech-debt, quality]

--- a/templates/tech-writer.md
+++ b/templates/tech-writer.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - provider: anthropic
-- model: claude-sonnet-4-5-20250929
+- model: {{model}}
 - temperature: 0.5
 - max_tokens: 8192
 - tags: [docs, writing]


### PR DESCRIPTION
## Summary

- **Models tab** in TUI (key `7`) and Web UI showing the full models.dev catalog grouped by provider (ID, name, context window, cost in/out)
- **Model resolution preview** in agent detail views (TUI + Web) showing which model will be used for each `link` target (claude, codex, gemini, copilot, opencode)
- **Dynamic `{{model}}` placeholder** in all 11 templates and 6 starter-pack agents, replaced at creation time with the default model
- **Codex linker** implementation
- Sync cache-only helpers (`load_models_cached`, `load_all_providers_cached`) always available regardless of feature flags
- Version bump to **0.8.0**

### Files changed (40 files, +1415/-40)

| Area | Changes |
|------|---------|
| `model_registry/fetch.rs` | `load_models_cached()`, `load_all_providers_cached()` + 2 tests |
| `linker/model_resolution.rs` | `preview_model_resolution()` + 1 test |
| `tui/` | `Tab::Models`, `Tab::ModelDetail`, `models_list.rs`, `model_detail.rs`, keybindings, shortcuts |
| `tui/views/agent_detail.rs` | Model resolution section |
| `web/api.rs` + `mod.rs` | `/api/models` endpoint, `ModelResolutionEntry` in agent detail |
| `web/index.html` | Models tab, model resolution table in agent detail |
| `templates/*.md` (11) | `{{model}}` placeholder |
| `starters/` (6 agents) | `{{model}}` placeholder |
| `cli/new.rs` | `{{model}}` replacement in template pipeline |
| `linker/codex.rs` | New Codex linker |

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --no-default-features --features tui` (CI mode)
- [x] `cargo clippy --no-default-features --features tui,providers-api`
- [x] `cargo test --no-default-features --features tui` — 210 tests OK
- [x] `cargo test --no-default-features --features tui,providers-api` — 220 tests OK
- [ ] `cargo run -- tui` → tab 7 (Models) displays catalog if cache exists
- [ ] `cargo run -- web` → `/api/models` returns JSON, Models tab in browser
- [ ] Agent detail view: "Model Resolution" section visible in TUI and Web
- [ ] `armadai new test --template basic` → `{{model}}` replaced in generated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)