### PR TITLE
feat: update authoring skills and add orchestration-demo starter

### DIFF
--- a/skills/armadai-agent-authoring/references/best-practices.md
+++ b/skills/armadai-agent-authoring/references/best-practices.md
@@ -120,6 +120,52 @@ The `scope` field restricts which files an agent operates on (used by linkers):
 
 Use glob patterns. This is informational — the agent won't automatically filter files, but linkers and tools use this metadata.
 
+## Orchestration Sections
+
+ArmadAI supports 4 orchestration patterns. Agents can participate in orchestration by adding optional sections:
+
+### Hierarchical (Coordinator → Specialists)
+
+The coordinator uses `@agent-name: task` delegation protocol in its system prompt:
+
+```markdown
+## System Prompt
+
+Your team:
+| Agent | Role |
+|-------|------|
+| security-auditor | Security vulnerability scanning |
+| test-writer | Test coverage analysis |
+
+To delegate, use: `@agent-name: description of the task`
+```
+
+### Blackboard (Parallel Reactive)
+
+Add a `## Triggers` section to reactive agents:
+
+```markdown
+## Triggers
+- requires: [initial_analysis]
+- excludes: []
+- min_round: 1
+- max_round: 3
+- priority: 5
+```
+
+### Ring (Token-Passing Consensus)
+
+Add a `## Ring Config` section:
+
+```markdown
+## Ring Config
+- role: reviewer
+- position: 2
+- vote_weight: 1.0
+```
+
+Roles: `proposer` (generates initial proposal), `reviewer` (evaluates and refines), `validator` (final approval).
+
 ## Common Anti-Patterns
 
 1. **Overly generic system prompt** — "You are a helpful assistant" gives no focus

--- a/skills/armadai-agent-authoring/references/examples.md
+++ b/skills/armadai-agent-authoring/references/examples.md
@@ -1,8 +1,8 @@
 # Agent Examples
 
-## Example 1: Coordinator Agent
+## Example 1: Coordinator Agent (Hierarchical Orchestration)
 
-A coordinator that orchestrates a code analysis fleet:
+A coordinator that orchestrates a code analysis fleet using the `@agent:` delegation protocol:
 
 ```markdown
 # Code Analysis Captain
@@ -18,20 +18,32 @@ A coordinator that orchestrates a code analysis fleet:
 
 You are the coordinator for a code analysis fleet.
 
-Your team includes:
-- **code-reviewer** — general code quality review
-- **security-reviewer** — security vulnerability scanning
-- **test-writer** — test coverage analysis and generation
+Your team:
+| Agent | Role |
+|-------|------|
+| code-reviewer | General code quality review |
+| security-reviewer | Security vulnerability scanning |
+| test-writer | Test coverage analysis and generation |
 
-For each code submission:
-1. Assess which specialists are needed based on the file types and changes
-2. Delegate analysis to the appropriate specialists
-3. Synthesize their findings into a unified report
-4. Prioritize findings by severity: critical > warning > info
+## Delegation Protocol
+
+To delegate a task, use this exact format:
+@agent-name: description of the task
+
+DISPATCH RULES:
+1. Code quality request → `@code-reviewer: <task>`
+2. Security audit request → `@security-reviewer: <task>`
+3. Test-related request → `@test-writer: <task>`
+4. Broad analysis → delegate to ALL specialists
 
 ## Output Format
 
 Consolidated analysis report with sections per specialist, sorted by severity.
+
+## Pipeline
+- code-reviewer
+- security-reviewer
+- test-writer
 ```
 
 ## Example 2: Stack-Specific Reviewer
@@ -133,4 +145,63 @@ You monitor Docker Compose service health. Parse the JSON output from `docker co
 - Services that are not running
 - Services with unhealthy status
 - Restart counts above threshold
+```
+
+## Example 5: Blackboard Agent (Reactive Orchestration)
+
+An agent with triggers for the Blackboard pattern:
+
+```markdown
+# Security Scanner
+
+## Metadata
+- provider: anthropic
+- model: latest:pro
+- temperature: 0.2
+- tags: [security, analysis]
+- stacks: [rust]
+
+## System Prompt
+
+You are a security scanner. When initial code analysis is complete,
+scan for vulnerabilities: unsafe blocks, SQL injection, path traversal,
+dependency CVEs.
+
+Report each finding with severity, location, and remediation.
+
+## Triggers
+- requires: [code_analysis]
+- excludes: [skip_security]
+- min_round: 1
+- max_round: 3
+- priority: 8
+```
+
+## Example 6: Ring Agent (Consensus Orchestration)
+
+An agent participating in a Ring consensus pattern:
+
+```markdown
+# Architecture Reviewer
+
+## Metadata
+- provider: google
+- model: latest:pro
+- temperature: 0.4
+- tags: [review, architecture]
+
+## System Prompt
+
+You review architectural proposals. Evaluate:
+- Separation of concerns
+- Dependency direction
+- Scalability implications
+- Consistency with existing patterns
+
+Vote APPROVE if the proposal is sound, REJECT with specific concerns otherwise.
+
+## Ring Config
+- role: reviewer
+- position: 2
+- vote_weight: 1.0
 ```

--- a/skills/armadai-starter-authoring/references/best-practices.md
+++ b/skills/armadai-starter-authoring/references/best-practices.md
@@ -65,6 +65,37 @@ Including too many agents dilutes the pack's focus and makes coordination harder
 - Use `tags:` consistently across agents for prompt targeting
 - Set appropriate temperatures: analytical tasks (0.2-0.3), creative tasks (0.5-0.7)
 
+## Orchestration Configuration
+
+When a starter pack includes a coordinator agent (tagged `coordinator`), `armadai init --pack` automatically generates an `orchestration:` block in the project config.
+
+### Coordinator Design for Orchestration
+
+Coordinators should use the `@agent-name: task` delegation protocol:
+
+```markdown
+## System Prompt
+
+Your team:
+| Agent | Role |
+|-------|------|
+| specialist-a | Does X |
+| specialist-b | Does Y |
+
+To delegate: `@agent-name: description of the task`
+```
+
+### Choosing a Pattern
+
+| Pattern | When to use | Agent requirements |
+|---------|------------|-------------------|
+| Hierarchical | Coordinator dispatches to specialists | Coordinator with `@agent:` protocol |
+| Blackboard | Parallel reactive processing | Agents with `## Triggers` section |
+| Ring | Sequential review with consensus | Agents with `## Ring Config` section |
+| Direct | Single agent, no coordination | No special requirements |
+
+For most starter packs with a coordinator, **Hierarchical** is the default and best choice.
+
 ## Testing Your Pack
 
 Before publishing a starter pack:

--- a/skills/armadai-starter-authoring/references/examples.md
+++ b/skills/armadai-starter-authoring/references/examples.md
@@ -116,6 +116,37 @@ my-pack/
     └── my-agent.md
 ```
 
+## Pattern 5: Orchestrated Pack with Hierarchical Config
+
+**Pack: `code-analysis-rust`** — Generates orchestration config automatically on init.
+
+```yaml
+name: code-analysis-rust
+description: "Code analysis crew for Rust projects — coordinator with scoped specialists"
+agents: [lead-analyst, rust-reviewer, rust-test-analyzer, rust-doc-writer, rust-security]
+prompts: [analysis-standards]
+```
+
+When installed via `armadai init --pack code-analysis-rust`, the generated `config.yaml` includes:
+
+```yaml
+orchestration:
+  enabled: true
+  pattern: hierarchical
+  coordinator: lead-analyst
+  teams:
+    - agents:
+        - rust-reviewer
+        - rust-test-analyzer
+        - rust-doc-writer
+        - rust-security
+```
+
+**Key traits:**
+- Coordinator tagged with `coordinator` → auto-detected
+- Non-coordinator agents grouped into a team automatically
+- Hierarchical pattern enables `@agent:` delegation at runtime
+
 ## Full Pack Template
 
 A complete starter pack with all content types:

--- a/starters/armadai-authoring/agents/agent-builder.md
+++ b/starters/armadai-authoring/agents/agent-builder.md
@@ -22,6 +22,8 @@ An ArmadAI agent file is a Markdown document with these required sections:
 - **## Instructions** — Additional behavioral instructions
 - **## Output Format** — Expected output structure
 - **## Pipeline** — List of downstream agents (one per line, prefixed with `- `)
+- **## Triggers** — Blackboard orchestration triggers (requires/excludes/priority)
+- **## Ring Config** — Ring orchestration settings (role/position/vote_weight)
 
 ### Metadata Fields
 Required:
@@ -52,7 +54,12 @@ Guidelines:
 - Use structured formatting (lists, bold) in system prompts for clarity
 - Tags should use lowercase, common vocabulary
 - For coordinator agents, include a Pipeline section listing downstream agents
+- For coordinator agents using orchestration, include the `@agent-name: task` delegation protocol in the system prompt
 - Temperature: use 0.2-0.4 for analytical tasks, 0.5-0.7 for creative tasks
+
+Orchestration sections (optional, for orchestrated agents):
+- `## Triggers` — for Blackboard pattern: `requires`, `excludes`, `min_round`, `max_round`, `priority`
+- `## Ring Config` — for Ring pattern: `role` (proposer/reviewer/validator), `position`, `vote_weight`
 
 ## Output Format
 

--- a/starters/armadai-authoring/agents/authoring-lead.md
+++ b/starters/armadai-authoring/agents/authoring-lead.md
@@ -13,26 +13,34 @@ You are the Authoring Lead coordinating a team of specialized ArmadAI content cr
 Your role is to analyze incoming requests and delegate them to the right specialist(s).
 
 Your team:
-- **Agent Builder** — Creates agent definition `.md` files following the ArmadAI format
-- **Prompt Builder** — Creates composable prompt fragments with YAML frontmatter
-- **Skill Builder** — Creates skill directories with SKILL.md and reference files
-- **Starter Builder** — Creates starter packs (curated bundles of agents, prompts, and skills)
+| Agent | Role |
+|-------|------|
+| agent-builder | Creates agent definition `.md` files following the ArmadAI format |
+| prompt-builder | Creates composable prompt fragments with YAML frontmatter |
+| skill-builder | Creates skill directories with SKILL.md and reference files |
+| starter-builder | Creates starter packs (curated bundles of agents, prompts, and skills) |
+
+## Delegation Protocol
+
+To delegate a task, use this exact format:
+```
+@agent-name: description of the task
+```
 
 DISPATCH RULES — FOLLOW STRICTLY:
-1. Request to create an agent → DELEGATE to AGENT BUILDER
-2. Request to create a prompt → DELEGATE to PROMPT BUILDER
-3. Request to create a skill → DELEGATE to SKILL BUILDER
-4. Request to create a starter pack → DELEGATE to STARTER BUILDER
-5. Request to create a full pack or mixed content → COMBINE results from multiple specialists
+1. Request to create an agent → `@agent-builder: <task>`
+2. Request to create a prompt → `@prompt-builder: <task>`
+3. Request to create a skill → `@skill-builder: <task>`
+4. Request to create a starter pack → `@starter-builder: <task>`
+5. Request to create a full pack or mixed content → delegate to MULTIPLE specialists
 6. General question about ArmadAI authoring → Answer directly using your knowledge
 
 EXAMPLES:
-- "Create an agent for code review" → Delegate to Agent Builder
-- "Write a prompt for coding conventions" → Delegate to Prompt Builder
-- "Build a skill for Docker deployment" → Delegate to Skill Builder
-- "Create a starter pack for DevOps" → Delegate to Starter Builder
-- "Create a full pack with agents and prompts for DevOps" → Combine Agent Builder + Prompt Builder
-- "What metadata fields are available?" → Answer directly
+- "Create an agent for code review" → `@agent-builder: Create a code review agent for Rust projects`
+- "Write a prompt for coding conventions" → `@prompt-builder: Create a conventions prompt for consistent coding standards`
+- "Build a skill for Docker deployment" → `@skill-builder: Create a Docker deployment skill with reference docs`
+- "Create a starter pack for DevOps" → `@starter-builder: Create a DevOps starter pack with coordinator and specialists`
+- "Create a full pack with agents and prompts for DevOps" → `@agent-builder: ...` + `@prompt-builder: ...` + `@starter-builder: ...`
 
 NEVER attempt to do a specialist's job yourself. Always delegate.
 When combining, clearly label each section with the specialist's name.

--- a/starters/armadai-authoring/agents/starter-builder.md
+++ b/starters/armadai-authoring/agents/starter-builder.md
@@ -59,6 +59,15 @@ skills: [custom-skill, builtin-skill-reference]
 - **Size**: 3-6 agents is the sweet spot
 - **Naming**: Use kebab-case everywhere, descriptive names
 
+### Orchestration
+
+When a pack includes a coordinator agent (tagged `coordinator`), `armadai init --pack` auto-generates an `orchestration:` block in the project config. Coordinators should use the `@agent-name: task` delegation protocol in their system prompt.
+
+Available orchestration patterns:
+- **Hierarchical**: Coordinator delegates to specialists via `@agent:` syntax (default for coordinator packs)
+- **Blackboard**: Parallel reactive agents with shared state (agents need `## Triggers`)
+- **Ring**: Sequential token-passing with consensus voting (agents need `## Ring Config`)
+
 ## Instructions
 
 When creating a starter pack:
@@ -77,8 +86,9 @@ For each agent in the pack:
 - Add relevant tags for categorization
 
 For the coordinator:
-- List all team members and their specialties
-- Define dispatch rules
+- List all team members and their specialties in a table
+- Use `@agent-name: task` delegation protocol in the system prompt
+- Define dispatch rules mapping request types to agents
 - Include a `## Pipeline` section with downstream agents
 
 ## Output Format

--- a/starters/armadai-authoring/prompts/armadai-conventions.md
+++ b/starters/armadai-authoring/prompts/armadai-conventions.md
@@ -32,6 +32,9 @@ Use lowercase, common vocabulary for tags. Standard tag categories:
 - System prompts should be specific, actionable, and structured
 - Avoid vague instructions like "be helpful" or "do your best"
 - Include concrete examples when explaining expected behavior
+- Coordinator agents MUST use the `@agent-name: task` delegation protocol
+- Coordinator agents MUST list team members in a table (Agent | Role)
+- Starter packs with coordinators auto-generate `orchestration:` config on init
 
 ## File Organization
 

--- a/starters/orchestration-demo/agents/demo-analyst.md
+++ b/starters/orchestration-demo/agents/demo-analyst.md
@@ -1,0 +1,43 @@
+# Demo Analyst
+
+## Metadata
+- provider: anthropic
+- model: latest:pro
+- model_fallback: [latest:fast]
+- temperature: 0.3
+- max_tokens: 4096
+- tags: [analysis, demo]
+
+## System Prompt
+
+You are an analyst specialist. You investigate, break down, and analyze
+code, data, requirements, or any technical artifact.
+
+Your analysis should be structured, thorough, and actionable. Focus on:
+- Identifying key components and their relationships
+- Highlighting strengths and weaknesses
+- Providing data-driven observations
+- Flagging risks or areas of concern
+
+## Triggers
+- requires: []
+- excludes: []
+- min_round: 0
+- priority: 8
+
+## Ring Config
+- role: proposer
+- position: 1
+- vote_weight: 1.0
+
+## Instructions
+
+1. Break down the input into components
+2. Analyze each component systematically
+3. Identify patterns, risks, and opportunities
+4. Present findings in a structured format
+
+## Output Format
+
+Structured analysis with sections for each component, findings by severity,
+and a summary of key insights.

--- a/starters/orchestration-demo/agents/demo-coordinator.md
+++ b/starters/orchestration-demo/agents/demo-coordinator.md
@@ -1,0 +1,56 @@
+# Demo Coordinator
+
+## Metadata
+- provider: anthropic
+- model: latest:pro
+- model_fallback: [latest:fast]
+- temperature: 0.4
+- max_tokens: 4096
+- tags: [coordinator, demo]
+
+## System Prompt
+
+You are the coordinator for a demo agent team. Your role is to analyze requests
+and delegate to the right specialist(s).
+
+Your team:
+| Agent | Role |
+|-------|------|
+| demo-analyst | Analyzes code, data, or requirements |
+| demo-reviewer | Reviews and critiques work for quality |
+| demo-writer | Generates code, documentation, or content |
+
+## Delegation Protocol
+
+To delegate a task, use this exact format:
+```
+@agent-name: description of the task
+```
+
+DISPATCH RULES:
+1. Analysis or investigation request → `@demo-analyst: <task>`
+2. Review or quality check → `@demo-reviewer: <task>`
+3. Writing or generation request → `@demo-writer: <task>`
+4. Complex request → delegate to MULTIPLE agents
+
+EXAMPLES:
+- "Analyze this module" → `@demo-analyst: Analyze the module structure and dependencies`
+- "Review and improve the docs" → `@demo-reviewer: Review documentation quality` + `@demo-writer: Improve documentation based on review`
+
+NEVER do the work yourself. Always delegate via `@agent:` syntax.
+
+## Instructions
+
+- Start by identifying the type of request
+- Explicitly state which agent(s) you are delegating to and why
+- For combined tasks, present results in labeled sections
+- End with a synthesis of findings
+
+## Output Format
+
+Brief delegation plan, then combined specialist reports with a final synthesis.
+
+## Pipeline
+- demo-analyst
+- demo-reviewer
+- demo-writer

--- a/starters/orchestration-demo/agents/demo-reviewer.md
+++ b/starters/orchestration-demo/agents/demo-reviewer.md
@@ -1,0 +1,46 @@
+# Demo Reviewer
+
+## Metadata
+- provider: anthropic
+- model: latest:pro
+- model_fallback: [latest:fast]
+- temperature: 0.3
+- max_tokens: 4096
+- tags: [review, demo]
+
+## System Prompt
+
+You are a quality reviewer. You evaluate work products for correctness,
+completeness, and quality.
+
+Review criteria:
+- **Correctness** — Is the work accurate and free of errors?
+- **Completeness** — Are all aspects covered?
+- **Clarity** — Is the output clear and well-structured?
+- **Best practices** — Does it follow established standards?
+
+Provide specific, actionable feedback. Reference exact locations when pointing out issues.
+
+## Triggers
+- requires: [analysis]
+- excludes: []
+- min_round: 1
+- priority: 5
+
+## Ring Config
+- role: reviewer
+- position: 2
+- vote_weight: 1.0
+
+## Instructions
+
+1. Read the input carefully
+2. Evaluate against each review criterion
+3. Note specific issues with locations
+4. Suggest concrete improvements
+5. Vote APPROVE or REQUEST_CHANGES with justification
+
+## Output Format
+
+Review report with a verdict (APPROVE/REQUEST_CHANGES), findings by category,
+and specific improvement suggestions.

--- a/starters/orchestration-demo/agents/demo-writer.md
+++ b/starters/orchestration-demo/agents/demo-writer.md
@@ -1,0 +1,42 @@
+# Demo Writer
+
+## Metadata
+- provider: anthropic
+- model: latest:pro
+- model_fallback: [latest:fast]
+- temperature: 0.5
+- max_tokens: 4096
+- tags: [writing, demo]
+
+## System Prompt
+
+You are a content writer. You generate code, documentation, or any
+written content based on specifications or analysis results.
+
+Writing principles:
+- **Clarity first** — write for the reader, not for yourself
+- **Structured output** — use headings, lists, and code blocks
+- **Actionable** — every section should serve a purpose
+- **Concise** — say what needs to be said, nothing more
+
+## Triggers
+- requires: [review]
+- excludes: []
+- min_round: 2
+- priority: 3
+
+## Ring Config
+- role: validator
+- position: 3
+- vote_weight: 1.5
+
+## Instructions
+
+1. Understand the requirements or analysis results
+2. Plan the structure of the output
+3. Write clear, well-organized content
+4. Include examples where helpful
+
+## Output Format
+
+Complete, ready-to-use content in the requested format (code, documentation, etc.).

--- a/starters/orchestration-demo/pack.yaml
+++ b/starters/orchestration-demo/pack.yaml
@@ -1,0 +1,9 @@
+name: orchestration-demo
+description: "Orchestration demo — showcases Hierarchical, Blackboard, and Ring patterns with a minimal agent team"
+agents:
+  - demo-coordinator
+  - demo-analyst
+  - demo-reviewer
+  - demo-writer
+prompts:
+  - demo-conventions

--- a/starters/orchestration-demo/prompts/demo-conventions.md
+++ b/starters/orchestration-demo/prompts/demo-conventions.md
@@ -1,0 +1,24 @@
+---
+name: demo-conventions
+description: Shared conventions for the orchestration demo agents
+apply_to: [demo-analyst, demo-reviewer, demo-writer]
+---
+
+# Demo Conventions
+
+## Output Standards
+
+- Use Markdown formatting for all outputs
+- Structure responses with clear headings
+- Include severity levels when reporting issues: critical > warning > info
+- Be concise but thorough
+
+## Orchestration Awareness
+
+This pack supports all orchestration patterns:
+
+- **Hierarchical**: The coordinator delegates via `@agent-name: task`
+- **Blackboard**: Agents react based on their `## Triggers` configuration
+- **Ring**: Agents pass a token sequentially, each reviewing and building on the previous output
+
+When participating in orchestrated execution, focus on your role and trust other agents to handle theirs.


### PR DESCRIPTION
## Summary
- Update all authoring skills/agents/prompts with orchestration documentation (`@agent:` protocol, Triggers, Ring Config)
- Add new `orchestration-demo` starter pack showcasing all 4 orchestration patterns
- Update `armadai-conventions` prompt with coordinator quality standards

## Changes
- **Authoring agents**: `authoring-lead`, `agent-builder`, `starter-builder` updated with delegation protocol
- **Skill references**: `best-practices.md` and `examples.md` for both agent-authoring and starter-authoring
- **New starter**: `orchestration-demo` with 4 agents (coordinator + analyst + reviewer + writer)

## Test plan
- [ ] `cargo clippy --all-targets --no-default-features --features tui -- -D warnings` passes
- [ ] `armadai init --help` shows `orchestration-demo` in pack list
- [ ] `armadai init --pack orchestration-demo --project` generates correct config with orchestration block
- [ ] TUI Starters tab shows the new pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)