### PR TITLE
feat: add model registry refresh to TUI and Web UI

### DIFF
--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -92,6 +92,14 @@ fn parse_registry(body: &serde_json::Value) -> HashMap<String, Vec<ModelEntry>> 
     providers
 }
 
+/// Force-refresh the model registry from models.dev, ignoring cache TTL.
+/// Returns the number of providers fetched, or an error.
+#[cfg(feature = "providers-api")]
+pub async fn refresh_registry() -> anyhow::Result<usize> {
+    let registry = fetch_and_cache().await?;
+    Ok(registry.providers.len())
+}
+
 /// Load models for a provider from cache (sync). Always available, no feature gate.
 pub fn load_models_cached(provider: &str) -> Option<Vec<ModelEntry>> {
     let cached = load_cache_from(&cache_path())?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -123,6 +123,29 @@ pub async fn run() -> Result<()> {
                 KeyCode::BackTab => app.prev_tab(),
                 KeyCode::Char('j') | KeyCode::Down => app.select_next(),
                 KeyCode::Char('k') | KeyCode::Up => app.select_prev(),
+                KeyCode::Char('R')
+                    if matches!(
+                        app.current_tab,
+                        app::Tab::Models | app::Tab::ModelDetail
+                    ) =>
+                {
+                    app.status_msg = Some("Syncing models from models.dev…".to_string());
+                    // Force redraw to show status message
+                    terminal.draw(|frame| {
+                        views::dashboard::render(frame, &app);
+                        views::palette::render(frame, &app);
+                    })?;
+                    match sync_models_online().await {
+                        Ok(count) => {
+                            app.load_models();
+                            app.status_msg =
+                                Some(format!("Synced {count} providers from models.dev"));
+                        }
+                        Err(e) => {
+                            app.status_msg = Some(format!("Sync failed: {e}"));
+                        }
+                    }
+                }
                 KeyCode::Char('r') => {
                     app.load_agents();
                     app.load_prompts();
@@ -259,4 +282,15 @@ fn load_storage_data(app: &mut app::App) {
 #[cfg(not(feature = "storage"))]
 fn load_storage_data(_app: &mut app::App) {
     // No storage feature — data views will be empty
+}
+
+/// Force-refresh model registry from models.dev.
+#[cfg(feature = "providers-api")]
+async fn sync_models_online() -> anyhow::Result<usize> {
+    crate::model_registry::fetch::refresh_registry().await
+}
+
+#[cfg(not(feature = "providers-api"))]
+async fn sync_models_online() -> anyhow::Result<usize> {
+    anyhow::bail!("Model sync requires providers-api feature")
 }

--- a/src/tui/views/shortcuts.rs
+++ b/src/tui/views/shortcuts.rs
@@ -65,6 +65,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Tab::Models => vec![
             ("j/k", "Navigate"),
             ("Enter", "View detail"),
+            ("R", "Sync models.dev"),
             ("Tab", "Next tab"),
             (":", "Commands"),
             ("r", "Refresh"),

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -505,6 +505,41 @@ pub async fn list_models() -> Json<Vec<ProviderModels>> {
     Json(result)
 }
 
+#[derive(Serialize)]
+pub struct RefreshResult {
+    status: String,
+    providers: usize,
+}
+
+#[cfg(feature = "providers-api")]
+pub async fn refresh_models() -> Json<serde_json::Value> {
+    match crate::model_registry::fetch::refresh_registry().await {
+        Ok(count) => Json(
+            serde_json::to_value(RefreshResult {
+                status: "ok".to_string(),
+                providers: count,
+            })
+            .unwrap(),
+        ),
+        Err(e) => Json(
+            serde_json::to_value(ErrorResponse {
+                error: format!("Refresh failed: {e}"),
+            })
+            .unwrap(),
+        ),
+    }
+}
+
+#[cfg(not(feature = "providers-api"))]
+pub async fn refresh_models() -> Json<serde_json::Value> {
+    Json(
+        serde_json::to_value(ErrorResponse {
+            error: "Model sync requires providers-api feature".to_string(),
+        })
+        .unwrap(),
+    )
+}
+
 pub async fn get_starter_config(Path(name): Path<String>) -> impl IntoResponse {
     use crate::core::starter::{StarterPack, find_pack_dir};
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -357,7 +357,10 @@ async function loadModels() {
   if (!providers.length) { el.innerHTML = '<div class="empty">No model data cached. Run `armadai new -i` to populate.</div>'; return; }
   const totalModels = providers.reduce((s, p) => s + p.models.length, 0);
   el.innerHTML = `
-    <div class="card-header">${totalModels} models, ${providers.length} providers</div>
+    <div class="card-header" style="display:flex;justify-content:space-between;align-items:center">
+      <span>${totalModels} models, ${providers.length} providers</span>
+      <button onclick="refreshModels()" style="padding:4px 12px;border:1px solid var(--border);border-radius:4px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:12px">⟳ Sync models.dev</button>
+    </div>
     ${providers.map(p => `
       <div style="padding:8px 16px;color:var(--muted);font-weight:600;font-size:12px;text-transform:uppercase;border-bottom:1px solid var(--border);background:rgba(88,166,255,0.04)">${p.provider}</div>
       <table>
@@ -372,6 +375,18 @@ async function loadModels() {
             <td>${m.cost_output != null ? '$'+m.cost_output.toFixed(2) : '-'}</td>
           </tr>`).join('')}
       </table>`).join('')}`;
+}
+
+async function refreshModels() {
+  const btn = document.querySelector('#models button');
+  if (btn) { btn.disabled = true; btn.textContent = 'Syncing…'; }
+  try {
+    const res = await fetch('/api/models/refresh', { method: 'POST' });
+    const data = await res.json();
+    if (data.error) { alert('Sync failed: ' + data.error); }
+    else { await loadModels(); }
+  } catch (e) { alert('Sync failed: ' + e.message); }
+  finally { if (btn) { btn.disabled = false; btn.textContent = '⟳ Sync models.dev'; } }
 }
 
 // Initial load

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,6 +1,6 @@
 mod api;
 
-use axum::{Router, response::Html, routing::get};
+use axum::{Router, response::Html, routing::{get, post}};
 use tower_http::cors::CorsLayer;
 
 /// Serve the web UI on the given port.
@@ -19,6 +19,7 @@ pub async fn serve(port: u16) -> anyhow::Result<()> {
         .route("/api/starters/{name}", get(api::get_starter))
         .route("/api/starters/{name}/config", get(api::get_starter_config))
         .route("/api/models", get(api::list_models))
+        .route("/api/models/refresh", post(api::refresh_models))
         .layer(CorsLayer::permissive());
 
     let addr = format!("0.0.0.0:{port}");


### PR DESCRIPTION
## Summary
- Add `Shift+R` keybinding on Models tab in TUI to force-sync from models.dev
- Add `POST /api/models/refresh` endpoint in Web UI
- Add "Sync models.dev" button in Web UI Models tab header
- Feature-gated: works with `providers-api`, graceful error without

## Test plan
- [ ] TUI: go to Models tab (key `7`), press `R` → status shows sync result
- [ ] Web: Models tab shows refresh button, clicking it reloads models
- [ ] Clippy passes in both CI and full modes
- [ ] 457 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)