### PR TITLE
chore: release v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "armadai"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary
- **fix**: use native TLS roots (`rustls-tls-native-roots`) for corporate proxy support

Fixes `UnknownIssuer` TLS errors when syncing models behind Fortigate/Zscaler proxies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)