### PR TITLE
fix: shell integration setup and link target autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.10.3 (2026-03-24)
+
+### Feat
+
+- add interactive shell setup (PATH + completions) on init and update
+
+### Fix
+
+- use ValueEnum for link/unlink --target autocompletion
+
 ## v0.10.0 (2026-03-23)
 
 ### Feat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "armadai"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -346,15 +346,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -372,13 +372,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -607,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1145,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
@@ -1164,9 +1163,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -1189,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -1205,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -1663,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags 2.11.0",
  "getopts",
@@ -2092,9 +2091,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2107,9 +2106,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
@@ -2120,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2561,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3466,18 +3465,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -24,6 +24,8 @@ pub async fn execute(force: bool, project: bool, pack: Option<String>) -> anyhow
         install_pack(&pack_name, force)?;
     }
 
+    super::setup::prompt_shell_setup();
+
     Ok(())
 }
 

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -7,7 +7,7 @@ use crate::linker::{self, LinkAgent};
 use crate::parser;
 
 pub async fn execute(
-    target: Option<String>,
+    target: Option<crate::linker::LinkTarget>,
     model_flag: Option<String>,
     coordinator_flag: Option<String>,
     dry_run: bool,
@@ -77,6 +77,7 @@ pub async fn execute(
 
     // 4. Determine target
     let target_name = target
+        .map(|t| t.to_string())
         .or_else(|| config.link.as_ref().and_then(|l| l.target.clone()))
         .ok_or_else(|| {
             anyhow::anyhow!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod new;
 mod prompts;
 mod registry;
 mod run;
+pub(crate) mod setup;
 mod skills;
 mod unlink;
 mod up;
@@ -236,9 +237,9 @@ pub enum Command {
             armadai link --target claude --output .claude/agents --force"
     )]
     Link {
-        /// Target AI assistant (claude, codex, copilot, gemini, opencode)
-        #[arg(long, short)]
-        target: Option<String>,
+        /// Target AI assistant
+        #[arg(long, short, value_enum)]
+        target: Option<crate::linker::LinkTarget>,
         /// Model to use in generated configs (for orchestrator targets like copilot/opencode)
         #[arg(long, short = 'm')]
         model: Option<String>,
@@ -270,9 +271,9 @@ pub enum Command {
             armadai unlink --target claude --agents code-reviewer test-writer"
     )]
     Unlink {
-        /// Target AI assistant (claude, copilot)
-        #[arg(long, short)]
-        target: Option<String>,
+        /// Target AI assistant
+        #[arg(long, short, value_enum)]
+        target: Option<crate::linker::LinkTarget>,
         /// Coordinator agent whose prompt becomes the main context file
         #[arg(long, short = 'C')]
         coordinator: Option<String>,

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -1,0 +1,278 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::CommandFactory;
+
+/// Prompt the user to set up shell integration (PATH symlink + completions).
+///
+/// Silently skips if stdin is not a terminal (non-interactive mode).
+pub fn prompt_shell_setup() {
+    if !is_interactive() {
+        return;
+    }
+
+    let needs_path = !binary_in_path();
+    let needs_completions = !completions_installed();
+
+    if !needs_path && !needs_completions {
+        return;
+    }
+
+    println!();
+    let confirmed = dialoguer::Confirm::new()
+        .with_prompt("Set up shell integration (PATH + completions)?")
+        .default(true)
+        .interact();
+
+    match confirmed {
+        Ok(true) => {
+            if needs_path {
+                setup_path();
+            }
+            if needs_completions {
+                setup_completions();
+            }
+        }
+        Ok(false) => {
+            println!("Shell integration skipped. Run `armadai init` again to set it up later.");
+        }
+        Err(_) => {
+            // Non-interactive or error — skip silently
+        }
+    }
+}
+
+/// Returns true if stdin is a terminal.
+fn is_interactive() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal()
+}
+
+/// Returns true if `armadai` resolves via PATH to the current executable.
+fn binary_in_path() -> bool {
+    let Ok(current_exe) = std::env::current_exe() else {
+        return false;
+    };
+    // Canonicalize to resolve symlinks
+    let Ok(current_canonical) = std::fs::canonicalize(&current_exe) else {
+        return false;
+    };
+
+    // Walk PATH entries looking for an `armadai` binary that resolves to the same file
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            let candidate = dir.join("armadai");
+            if candidate.exists()
+                && let Ok(canonical) = std::fs::canonicalize(&candidate)
+                && canonical == current_canonical
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns true if shell completions are already installed for the detected shell.
+fn completions_installed() -> bool {
+    let Some(completion_path) = completion_file_path() else {
+        return true; // Unknown shell — skip
+    };
+    completion_path.exists()
+}
+
+/// Returns the expected completion file path for the current shell, or None if unknown.
+fn completion_file_path() -> Option<PathBuf> {
+    let shell = detect_shell()?;
+    let home = home_dir()?;
+    let path = match shell.as_str() {
+        "zsh" => home.join(".zfunc").join("_armadai"),
+        "bash" => home
+            .join(".local")
+            .join("share")
+            .join("bash-completion")
+            .join("completions")
+            .join("armadai"),
+        "fish" => home
+            .join(".config")
+            .join("fish")
+            .join("completions")
+            .join("armadai.fish"),
+        _ => return None,
+    };
+    Some(path)
+}
+
+/// Detect the current shell from the `$SHELL` environment variable.
+fn detect_shell() -> Option<String> {
+    let shell_path = std::env::var("SHELL").ok()?;
+    let shell_name = std::path::Path::new(&shell_path)
+        .file_name()?
+        .to_str()?
+        .to_string();
+    Some(shell_name)
+}
+
+/// Return the user's home directory via `$HOME`.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+/// Create `~/.local/bin/armadai` symlink pointing to the current executable.
+fn setup_path() {
+    let Ok(current_exe) = std::env::current_exe() else {
+        eprintln!("  [PATH] Could not determine current executable path.");
+        return;
+    };
+    let Some(home) = home_dir() else {
+        eprintln!("  [PATH] Could not determine home directory.");
+        return;
+    };
+
+    let local_bin = home.join(".local").join("bin");
+    if let Err(e) = std::fs::create_dir_all(&local_bin) {
+        eprintln!("  [PATH] Failed to create {}: {e}", local_bin.display());
+        return;
+    }
+
+    let link_path = local_bin.join("armadai");
+
+    // Remove existing symlink if present (but not a real file)
+    if link_path.exists() || link_path.symlink_metadata().is_ok() {
+        if link_path
+            .symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            let _ = std::fs::remove_file(&link_path);
+        } else {
+            eprintln!(
+                "  [PATH] {} already exists and is not a symlink — skipping.",
+                link_path.display()
+            );
+            return;
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        match symlink(&current_exe, &link_path) {
+            Ok(()) => {
+                println!(
+                    "  [PATH] Symlink created: {} -> {}",
+                    link_path.display(),
+                    current_exe.display()
+                );
+            }
+            Err(e) => {
+                eprintln!("  [PATH] Failed to create symlink: {e}");
+                return;
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        println!("  [PATH] Symlink creation is not supported on this platform.");
+        println!("         Add the following directory to your PATH manually:");
+        println!(
+            "         {}",
+            current_exe.parent().unwrap_or(&current_exe).display()
+        );
+        return;
+    }
+
+    // Check if ~/.local/bin is in PATH
+    let local_bin_str = local_bin.to_string_lossy();
+    let in_path = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).any(|d| d.to_string_lossy() == local_bin_str))
+        .unwrap_or(false);
+
+    if !in_path {
+        let rc_hint = shell_rc_file();
+        println!("  [PATH] ~/.local/bin is not in your PATH.");
+        println!("         Add this line to {}:", rc_hint);
+        println!("           export PATH=\"$HOME/.local/bin:$PATH\"");
+    }
+}
+
+/// Generate shell completions and write them to the appropriate file.
+fn setup_completions() {
+    let Some(shell_name) = detect_shell() else {
+        eprintln!("  [Completions] Could not detect shell from $SHELL.");
+        return;
+    };
+
+    let clap_shell = match shell_name.as_str() {
+        "zsh" => clap_complete::Shell::Zsh,
+        "bash" => clap_complete::Shell::Bash,
+        "fish" => clap_complete::Shell::Fish,
+        other => {
+            println!("  [Completions] Shell '{other}' is not supported for auto-install.");
+            println!(
+                "               Run `armadai completion <shell>` to generate completions manually."
+            );
+            return;
+        }
+    };
+
+    let Some(completion_path) = completion_file_path() else {
+        return;
+    };
+
+    if let Some(parent) = completion_path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!(
+            "  [Completions] Failed to create directory {}: {e}",
+            parent.display()
+        );
+        return;
+    }
+
+    let mut buf = Vec::new();
+    clap_complete::generate(clap_shell, &mut super::Cli::command(), "armadai", &mut buf);
+
+    match std::fs::File::create(&completion_path).and_then(|mut f| f.write_all(&buf)) {
+        Ok(()) => {
+            println!("  [Completions] Written to {}", completion_path.display());
+            print_completion_hint(&shell_name, &completion_path);
+        }
+        Err(e) => {
+            eprintln!(
+                "  [Completions] Failed to write {}: {e}",
+                completion_path.display()
+            );
+        }
+    }
+}
+
+/// Print shell-specific hints for activating completions.
+fn print_completion_hint(shell: &str, path: &Path) {
+    match shell {
+        "zsh" => {
+            println!("  [Completions] To enable zsh completions, add to ~/.zshrc:");
+            println!("                  fpath=(~/.zfunc $fpath)");
+            println!("                  autoload -Uz compinit && compinit");
+        }
+        "bash" => {
+            println!("  [Completions] Completions will be auto-loaded on next bash session.");
+            println!("               If not, source {} manually.", path.display());
+        }
+        "fish" => {
+            println!("  [Completions] Fish completions are active immediately in new sessions.");
+        }
+        _ => {}
+    }
+}
+
+/// Return a human-friendly RC file name for the detected shell.
+fn shell_rc_file() -> String {
+    match detect_shell().as_deref() {
+        Some("zsh") => "~/.zshrc".to_string(),
+        Some("bash") => "~/.bashrc (or ~/.bash_profile on macOS)".to_string(),
+        Some("fish") => "~/.config/fish/config.fish".to_string(),
+        _ => "your shell RC file".to_string(),
+    }
+}

--- a/src/cli/unlink.rs
+++ b/src/cli/unlink.rs
@@ -5,7 +5,7 @@ use crate::linker::{self, LinkAgent};
 use crate::parser;
 
 pub async fn execute(
-    target: Option<String>,
+    target: Option<crate::linker::LinkTarget>,
     coordinator_flag: Option<String>,
     dry_run: bool,
     with_config: bool,
@@ -63,6 +63,7 @@ pub async fn execute(
 
     // 4. Determine target
     let target_name = target
+        .map(|t| t.to_string())
         .or_else(|| config.link.as_ref().and_then(|l| l.target.clone()))
         .ok_or_else(|| {
             anyhow::anyhow!(

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -97,5 +97,7 @@ pub async fn execute() -> anyhow::Result<()> {
     println!("Updated to v{latest_version}!");
     println!("Run 'armadai --version' to verify.");
 
+    super::setup::prompt_shell_setup();
+
     Ok(())
 }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -16,6 +16,34 @@ use std::path::PathBuf;
 
 use crate::core::agent::Agent;
 
+/// Supported link targets for autocompletion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum LinkTarget {
+    Claude,
+    Codex,
+    Copilot,
+    Gemini,
+    Opencode,
+}
+
+impl LinkTarget {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Copilot => "copilot",
+            Self::Gemini => "gemini",
+            Self::Opencode => "opencode",
+        }
+    }
+}
+
+impl std::fmt::Display for LinkTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A resolved agent ready for linking.
 #[allow(dead_code)]
 pub struct LinkAgent {


### PR DESCRIPTION
## Summary

- feat: add interactive shell setup (PATH symlink + shell completions) triggered automatically at the end of `armadai init` and `armadai update`
- fix: replace raw `String` with `LinkTarget` enum (deriving `ValueEnum`) for `--target` in `link` and `unlink` commands, enabling proper shell autocompletion

## Changes

- `src/cli/setup.rs` (new) — `prompt_shell_setup()` helper that installs a PATH symlink and generates shell completions interactively
- `src/cli/init.rs` / `src/cli/update.rs` — call `setup::prompt_shell_setup()` at end of `execute()`
- `src/linker/mod.rs` — `LinkTarget` enum with `#[derive(ValueEnum)]`
- `src/cli/link.rs` / `src/cli/unlink.rs` / `src/cli/mod.rs` — use `LinkTarget` enum instead of `String`
- `Cargo.toml` / `Cargo.lock` — version bump `0.10.2` → `0.10.3`
- `CHANGELOG.md` — added `v0.10.3` section

## Test plan

- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy --no-default-features --features tui,providers-api -- -D warnings` passes
- [ ] `cargo clippy --no-default-features --features tui -- -D warnings` passes (CI mode)
- [ ] `cargo test --no-default-features --features tui,providers-api` — 457 tests pass
- [ ] `armadai init` prompts for shell setup at the end
- [ ] `armadai update` prompts for shell setup at the end
- [ ] `armadai link --target <TAB>` shows autocompletion for valid targets
- [ ] `armadai unlink --target <TAB>` shows autocompletion for valid targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)