### PR TITLE
feat: add coordinator delegation instructions to linker output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.10.4 (2026-03-25)
+
+### Feat
+
+- add coordinator name and delegation instructions to generated CLAUDE.md/GEMINI.md
+
 ## v0.10.3 (2026-03-24)
 
 ### Feat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "armadai"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"

--- a/src/linker/claude.rs
+++ b/src/linker/claude.rs
@@ -107,6 +107,15 @@ fn generate_claude_md(coordinator: &LinkAgent, agents: &[LinkAgent]) -> OutputFi
 
     if !agents.is_empty() {
         ensure_blank_line(&mut content);
+        content.push_str("## Coordination\n\n");
+        content.push_str(&format!(
+            "You are the project coordinator (`{}`). Your role is to analyze each request \
+             and delegate to the appropriate specialized agent listed below. \
+             Use `/agents` to activate a sub-agent.\n",
+            coordinator.name
+        ));
+
+        ensure_blank_line(&mut content);
         content.push_str("## Team\n\n");
         content.push_str("| Agent | Description |\n");
         content.push_str("|-------|-------------|\n");
@@ -332,5 +341,34 @@ mod tests {
         assert!(file.content.contains("You lead the team."));
         assert!(file.content.contains("Always be kind."));
         assert!(file.content.contains("## Team"));
+    }
+
+    #[test]
+    fn test_generate_coordinator_coordination_section() {
+        let linker = ClaudeLinker;
+        let coordinator = make_agent("Capitaine", "You are the captain of the crew.");
+        let agents = vec![
+            make_agent("Vigie", "You watch from the mast."),
+            make_agent("Charpentier", "You repair the hull."),
+        ];
+        let files = linker.generate(&agents, Some(&coordinator), &[]);
+
+        let claude_md = files
+            .iter()
+            .find(|f| f.path.ends_with("CLAUDE.md"))
+            .unwrap();
+
+        // Coordination section must be present with the coordinator's name
+        assert!(claude_md.content.contains("## Coordination"));
+        assert!(claude_md.content.contains("`Capitaine`"));
+        assert!(claude_md.content.contains("/agents"));
+
+        // Coordination section must appear before the Team section
+        let coord_pos = claude_md.content.find("## Coordination").unwrap();
+        let team_pos = claude_md.content.find("## Team").unwrap();
+        assert!(
+            coord_pos < team_pos,
+            "## Coordination must appear before ## Team"
+        );
     }
 }

--- a/src/linker/gemini.rs
+++ b/src/linker/gemini.rs
@@ -117,6 +117,15 @@ fn generate_agents_md(agents: &[LinkAgent], coordinator: Option<&LinkAgent>) -> 
 
         if !agents.is_empty() {
             ensure_blank_line(&mut content);
+            content.push_str("## Coordination\n\n");
+            content.push_str(&format!(
+                "You are the project coordinator (`{}`). Analyze each request and delegate \
+                 to the most appropriate agent from the team below. For complex tasks, \
+                 combine multiple agents' perspectives.\n",
+                coord.name
+            ));
+
+            ensure_blank_line(&mut content);
             content.push_str("## Team\n\n");
             content.push_str("| Agent | File | Description |\n");
             content.push_str("|-------|------|-------------|\n");
@@ -405,5 +414,37 @@ mod tests {
         assert!(file.content.contains("Always be kind."));
         assert!(file.content.contains("## Team"));
         assert!(file.content.contains("agents/worker.md"));
+    }
+
+    #[test]
+    fn test_generate_coordinator_coordination_section() {
+        let linker = GeminiLinker;
+        let coordinator = make_agent("Capitaine", "You are the captain of the crew.");
+        let agents = vec![
+            make_agent("Vigie", "You watch from the mast."),
+            make_agent("Charpentier", "You repair the hull."),
+        ];
+        let files = linker.generate(&agents, Some(&coordinator), &[]);
+
+        let gemini_md = files
+            .iter()
+            .find(|f| f.path.ends_with("GEMINI.md"))
+            .unwrap();
+
+        // Coordination section must be present with the coordinator's name
+        assert!(gemini_md.content.contains("## Coordination"));
+        assert!(gemini_md.content.contains("`Capitaine`"));
+        assert!(gemini_md.content.contains("complex tasks"));
+
+        // Coordination section must appear before the Team section
+        let coord_pos = gemini_md.content.find("## Coordination").unwrap();
+        let team_pos = gemini_md.content.find("## Team").unwrap();
+        assert!(
+            coord_pos < team_pos,
+            "## Coordination must appear before ## Team"
+        );
+
+        // Should not contain the no-coordinator generic text
+        assert!(!gemini_md.content.contains("team coordinator"));
     }
 }


### PR DESCRIPTION
## Summary

- Add a `## Coordination` section in generated `CLAUDE.md` files (Claude linker) that includes the coordinator agent name and delegation instructions for the fleet
- Add an equivalent coordination section in generated `AGENTS.md` files (Gemini linker) with the same coordinator identity and routing guidance
- Bump version to 0.10.4

## Details

When running `armadai link`, the generated configuration files now include a dedicated coordination section. This section identifies the coordinator agent by name and provides delegation instructions so that the target AI CLI (Claude, Gemini) understands the fleet structure and knows how to route tasks to the appropriate specialist agents.

## Test plan

- [ ] Run `armadai link --target claude` and verify `CLAUDE.md` contains a `## Coordination` section with coordinator name and delegation instructions
- [ ] Run `armadai link --target gemini` and verify `AGENTS.md` contains an equivalent coordination section
- [ ] Verify CI passes (fmt, clippy in both feature modes, tests, audit)

Generated with [Claude Code](https://claude.ai/claude-code)