### PR TITLE
fix: match coordinator name against slugified agent name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ArmadAI is an AI agent fleet orchestrator written in Rust (edition 2024). Agents are defined as Markdown files and executed against any LLM provider (API or CLI tool). The binary is named `armadai`.
 
+## Your role
+
+You are the main coordinator of this project, you have knoledge and can help other agents to analyze, but your task is to mainly delegate to @dev-lead so that he can himself delegate to each agent.
+
 ## Build & Test Commands
 
 ```bash

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -69,9 +69,10 @@ pub async fn execute(
     let coordinator_name =
         coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
     let mut coordinator = coordinator_name.and_then(|name| {
-        let idx = link_agents
-            .iter()
-            .position(|a| a.name.eq_ignore_ascii_case(&name))?;
+        let idx = link_agents.iter().position(|a| {
+            a.name.eq_ignore_ascii_case(&name)
+                || crate::linker::slugify(&a.name).eq_ignore_ascii_case(&name)
+        })?;
         Some(link_agents.remove(idx))
     });
 


### PR DESCRIPTION
## Summary
- The coordinator extraction in `link` compared the config value (e.g. `dev-lead`) against the agent display name (e.g. `Dev Lead`), which never matched when using slug form
- Now also compares against `slugify(&a.name)` so both `dev-lead` and `Dev Lead` work as coordinator identifiers
- Adds coordinator role section to `CLAUDE.md`

## Test plan
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — 459/459 pass
- [x] `armadai link --dry-run` shows `.claude/CLAUDE.md` with coordinator, `dev-lead` absent from agents list

🤖 Generated with [Claude Code](https://claude.com/claude-code)