### PR TITLE
chore: release v0.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "armadai"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary
- Bump version to v0.10.5
- Includes fix from #102: coordinator name matching against slugified agent name

## Changelog since v0.10.4
- **fix**: match coordinator name against slugified agent name (#102)
- **feat**: add coordinator delegation instructions to linker output (#101)

## Test plan
- [x] CI passes (clippy, test, fmt, build, audit, conventional commits)
- [x] `armadai link --dry-run` generates `.claude/CLAUDE.md` with coordinator

🤖 Generated with [Claude Code](https://claude.com/claude-code)