### PR TITLE
chore: release v0.10.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "armadai"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 description = "ArmadAI — AI agent fleet orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary

- Bump version to `0.10.6` in `Cargo.toml` and `Cargo.lock`
- Hotfix release incorporating PR #104 (`hotfix/coordination-only-all-linkers`)

## Changes included

- `--coordination-only` flag propagated to all linkers (claude, copilot, cursor, aider, codex, gemini, windsurf, cline, opencode)

## Test plan

- [ ] CI passes (fmt, clippy, test, build, conventional commits, audit)
- [ ] Version is `0.10.6` in `Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)