### PR TITLE
feat: ArmadAI interactive shell (Phases 0-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "include_dir",
  "pulldown-cmark",
  "ratatui",
+ "regex",
  "reqwest",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +30,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -110,6 +129,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tui-markdown",
  "uuid",
 ]
 
@@ -202,6 +222,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -418,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +716,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +795,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -816,6 +876,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -1259,6 +1325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1479,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1454,6 +1545,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1613,6 +1726,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1786,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1679,6 +1824,15 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -1924,6 +2078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2146,35 @@ checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2089,6 +2278,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2277,6 +2475,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2614,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -2535,12 +2766,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2548,6 +2781,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2634,6 +2877,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2749,6 +3022,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-markdown"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e766339aabad4528c3fccddf4acf03bc2b7ae6642def41e43c7af1a11f183122"
+dependencies = [
+ "ansi-to-tui",
+ "itertools",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui-core",
+ "rstest",
+ "syntect",
+ "tracing",
+]
 
 [[package]]
 name = "typenum"
@@ -2877,6 +3166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3127,6 +3426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +3656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,6 +3757,21 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ include_dir = "0.7"
 # Utils
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [features]
 default = ["tui", "web", "storage", "providers-api"]
-tui = ["dep:ratatui", "dep:crossterm"]
+tui = ["dep:ratatui", "dep:crossterm", "dep:tui-markdown"]
 web = ["dep:axum", "dep:tower-http"]
 storage = ["dep:rusqlite"]
 providers-api = ["dep:reqwest"]
@@ -49,6 +49,7 @@ rusqlite = { version = "0.39", features = ["bundled"], optional = true }
 
 # Markdown parsing
 pulldown-cmark = "0.13"
+tui-markdown = { version = "0.3", optional = true }
 
 # Logging
 tracing = "0.1"

--- a/skills/armadai-protocol/SKILL.md
+++ b/skills/armadai-protocol/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: armadai-protocol
+description: Response protocol for ArmadAI shell — standardized markers for end-of-response detection and metadata
+version: "1.0.0"
+tools: []
+---
+
+# ArmadAI Response Protocol
+
+You MUST follow this protocol for ALL your responses when running in ArmadAI shell mode.
+
+## Markers
+
+### End of Response
+
+When you have completely finished your response, end with this marker on its own line:
+
+```
+<!--ARMADAI_END-->
+```
+
+This marker signals to the shell that you have finished generating your response and that it is safe to proceed.
+
+### Delegation
+
+When delegating a task to a sub-agent, prefix the delegation with:
+
+```
+<!--ARMADAI_DELEGATE:agent-name-->
+```
+
+Where `agent-name` is the exact name (or slug) of the agent you're delegating to. This marker should appear inline where the delegation occurs.
+
+### Metadata
+
+At the very end of your response (just before the END marker), include metadata:
+
+```
+<!--ARMADAI_META:key1=value1,key2=value2-->
+```
+
+Common metadata keys:
+- `status` — `complete`, `partial`, `error`, `delegated`
+- `tokens` — Estimated token count (optional)
+- `delegated_to` — Agent name if you delegated the task
+
+## Complete Example
+
+Here's a complete response following the protocol:
+
+```markdown
+I analyzed the code and found two issues:
+
+1. Missing error handling on line 42
+2. Unused variable on line 15
+
+I recommend adding a Result return type and removing the unused variable.
+
+<!--ARMADAI_META:status=complete-->
+<!--ARMADAI_END-->
+```
+
+## Example with Delegation
+
+```markdown
+I'll delegate the code review to the QA specialist.
+
+<!--ARMADAI_DELEGATE:qa-specialist-->
+
+Please review the changes in src/core/agent.rs and verify test coverage.
+
+<!--ARMADAI_META:status=delegated,delegated_to=qa-specialist-->
+<!--ARMADAI_END-->
+```
+
+## Rules
+
+1. The `END` marker MUST be the very last line of your response (no text after it)
+2. The `META` marker MUST appear just before the `END` marker
+3. `DELEGATE` markers appear inline where delegation occurs
+4. Never omit the `END` marker, even for short responses
+5. Markers must be on their own line
+6. Markers are HTML comments and will not be visible in rendered Markdown
+
+## Why This Protocol?
+
+- **Deterministic parsing**: The shell can reliably detect when you've finished responding
+- **Streaming support**: No need to wait for timeout or guess when response is complete
+- **Metadata extraction**: Status, delegation info, and other data can be extracted without LLM parsing
+- **Clean output**: Markers are stripped for display, users see only your actual response
+- **Composability**: Multiple agents can use the same protocol for hierarchical delegation

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -162,6 +162,13 @@ pub enum Command {
         #[command(subcommand)]
         action: config::ConfigAction,
     },
+    /// Launch the interactive shell
+    #[cfg(feature = "tui")]
+    #[command(long_about = "Launch the interactive shell.\n\n\
+            Conversational interface for interacting with LLM providers. \
+            Type messages and press Enter to get responses. Use Ctrl+C or Esc to quit, \
+            Ctrl+L to clear conversation.")]
+    Shell,
     /// Launch the TUI dashboard
     #[cfg(feature = "tui")]
     #[command(long_about = "Launch the TUI dashboard.\n\n\
@@ -391,6 +398,8 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         Command::History { agent } => history::execute(agent).await,
         Command::Costs { agent, from } => costs::execute(agent, from).await,
         Command::Config { action } => config::execute(action).await,
+        #[cfg(feature = "tui")]
+        Command::Shell => crate::shell::app::run_shell().await,
         #[cfg(feature = "tui")]
         Command::Tui => crate::tui::run().await,
         #[cfg(feature = "web")]

--- a/src/linker/claude.rs
+++ b/src/linker/claude.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{LinkAgent, Linker, OutputFile, slugify};
+use super::{LinkAgent, Linker, OutputFile, armadai_protocol_block, slugify};
 
 /// Generates Claude Code sub-agent files (`.claude/agents/{slug}.md`).
 ///
@@ -138,6 +138,9 @@ fn generate_claude_md(coordinator: &LinkAgent, agents: &[LinkAgent]) -> OutputFi
             "\nTo delegate to a specialized agent, use `/agents` and select the appropriate one.\n",
         );
     }
+
+    // Inject ArmadAI response protocol
+    content.push_str(armadai_protocol_block());
 
     OutputFile {
         path: PathBuf::from(".claude/CLAUDE.md"),
@@ -369,6 +372,20 @@ mod tests {
         assert!(
             coord_pos < team_pos,
             "## Coordination must appear before ## Team"
+        );
+
+        // Protocol block must be present
+        assert!(claude_md.content.contains("## ArmadAI Response Protocol"));
+        assert!(claude_md.content.contains("<!--ARMADAI_END-->"));
+        assert!(
+            claude_md
+                .content
+                .contains("<!--ARMADAI_DELEGATE:agent-name-->")
+        );
+        assert!(
+            claude_md
+                .content
+                .contains("<!--ARMADAI_META:status=complete-->")
         );
     }
 }

--- a/src/linker/codex.rs
+++ b/src/linker/codex.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{LinkAgent, Linker, OutputFile, slugify};
+use super::{LinkAgent, Linker, OutputFile, armadai_protocol_block, slugify};
 
 /// Generates OpenAI Codex CLI config files in `.codex/`.
 ///
@@ -187,6 +187,9 @@ fn generate_agents_md(agents: &[LinkAgent], coordinator: Option<&LinkAgent>) -> 
              5. For complex tasks, combine multiple members' perspectives\n",
         );
     }
+
+    // Inject ArmadAI response protocol
+    content.push_str(armadai_protocol_block());
 
     OutputFile {
         path: PathBuf::from(".codex/AGENTS.md"),
@@ -438,5 +441,11 @@ mod tests {
         assert!(file.content.contains("Always be kind."));
         assert!(file.content.contains("## Team"));
         assert!(file.content.contains("agents/worker.toml"));
+
+        // Protocol block must be present
+        assert!(file.content.contains("## ArmadAI Response Protocol"));
+        assert!(file.content.contains("<!--ARMADAI_END-->"));
+        assert!(file.content.contains("<!--ARMADAI_DELEGATE:agent-name-->"));
+        assert!(file.content.contains("<!--ARMADAI_META:status=complete-->"));
     }
 }

--- a/src/linker/copilot.rs
+++ b/src/linker/copilot.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{LinkAgent, Linker, OutputFile, slugify};
+use super::{LinkAgent, Linker, OutputFile, armadai_protocol_block, slugify};
 
 /// Generates GitHub Copilot agent files (`.github/agents/{slug}.agent.md`).
 ///
@@ -119,6 +119,9 @@ fn generate_copilot_instructions(coordinator: &LinkAgent, agents: &[LinkAgent]) 
     if !content.ends_with('\n') {
         content.push('\n');
     }
+
+    // Inject ArmadAI response protocol
+    content.push_str(armadai_protocol_block());
 
     OutputFile {
         path: PathBuf::from(".github/copilot-instructions.md"),
@@ -304,5 +307,11 @@ mod tests {
         assert!(file.content.contains("You lead the team."));
         assert!(file.content.contains("Always be kind."));
         assert!(file.content.contains("## Team"));
+
+        // Protocol block must be present
+        assert!(file.content.contains("## ArmadAI Response Protocol"));
+        assert!(file.content.contains("<!--ARMADAI_END-->"));
+        assert!(file.content.contains("<!--ARMADAI_DELEGATE:agent-name-->"));
+        assert!(file.content.contains("<!--ARMADAI_META:status=complete-->"));
     }
 }

--- a/src/linker/gemini.rs
+++ b/src/linker/gemini.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{LinkAgent, Linker, OutputFile, slugify};
+use super::{LinkAgent, Linker, OutputFile, armadai_protocol_block, slugify};
 
 /// Generates Gemini CLI config files in `.gemini/`.
 ///
@@ -190,6 +190,9 @@ fn generate_agents_md(agents: &[LinkAgent], coordinator: Option<&LinkAgent>) -> 
              5. For complex tasks, combine multiple members' perspectives\n",
         );
     }
+
+    // Inject ArmadAI response protocol
+    content.push_str(armadai_protocol_block());
 
     OutputFile {
         path: PathBuf::from(".gemini/GEMINI.md"),
@@ -446,5 +449,19 @@ mod tests {
 
         // Should not contain the no-coordinator generic text
         assert!(!gemini_md.content.contains("team coordinator"));
+
+        // Protocol block must be present
+        assert!(gemini_md.content.contains("## ArmadAI Response Protocol"));
+        assert!(gemini_md.content.contains("<!--ARMADAI_END-->"));
+        assert!(
+            gemini_md
+                .content
+                .contains("<!--ARMADAI_DELEGATE:agent-name-->")
+        );
+        assert!(
+            gemini_md
+                .content
+                .contains("<!--ARMADAI_META:status=complete-->")
+        );
     }
 }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -141,6 +141,25 @@ impl From<&Agent> for LinkAgent {
     }
 }
 
+/// Protocol block appended to linked config files for ArmadAI shell parsing.
+pub fn armadai_protocol_block() -> &'static str {
+    r"
+
+## ArmadAI Response Protocol
+
+Follow this protocol for all responses:
+
+1. When finished responding, end with this marker on its own line:
+   <!--ARMADAI_END-->
+
+2. When delegating to a sub-agent, prefix with:
+   <!--ARMADAI_DELEGATE:agent-name-->
+
+3. Before the END marker, include metadata:
+   <!--ARMADAI_META:status=complete-->
+"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/linker/opencode.rs
+++ b/src/linker/opencode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{LinkAgent, Linker, OutputFile, slugify};
+use super::{LinkAgent, Linker, OutputFile, armadai_protocol_block, slugify};
 
 /// Generates OpenCode agent files in `.opencode/`.
 ///
@@ -133,6 +133,9 @@ fn generate_instructions_md(coordinator: &LinkAgent, agents: &[LinkAgent]) -> Ou
             ));
         }
     }
+
+    // Inject ArmadAI response protocol
+    content.push_str(armadai_protocol_block());
 
     OutputFile {
         path: PathBuf::from(".opencode/instructions.md"),
@@ -359,6 +362,12 @@ mod tests {
         assert!(file.content.contains("Always be kind."));
         assert!(file.content.contains("## Team"));
         assert!(file.content.contains("agents/worker.md"));
+
+        // Protocol block must be present
+        assert!(file.content.contains("## ArmadAI Response Protocol"));
+        assert!(file.content.contains("<!--ARMADAI_END-->"));
+        assert!(file.content.contains("<!--ARMADAI_DELEGATE:agent-name-->"));
+        assert!(file.content.contains("<!--ARMADAI_META:status=complete-->"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ mod providers;
 mod registry;
 #[allow(dead_code)]
 mod secrets;
+#[allow(dead_code)]
+mod shell;
 mod skills_registry;
 #[cfg(feature = "storage")]
 mod storage;

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -130,6 +130,44 @@ async fn event_loop(
                 CommandResult::Quit => {
                     break;
                 }
+                CommandResult::SwitchProvider(provider_name) => {
+                    if provider_name.is_empty() {
+                        app.show_popup(
+                            "Usage: /switch <provider>\nExample: /switch claude".to_string(),
+                        );
+                        continue;
+                    }
+
+                    // Find the provider in the registry
+                    let providers = super::detect::list_providers();
+                    if let Some(provider) = providers.iter().find(|p| {
+                        p.command == provider_name
+                            || p.display_name.to_lowercase() == provider_name.to_lowercase()
+                    }) {
+                        if !provider.available {
+                            app.show_popup(format!("Provider '{}' is not available. Make sure '{}' is installed and in your PATH.", provider.display_name, provider.command));
+                            continue;
+                        }
+
+                        // Switch the provider
+                        runner.switch_provider(provider.command.clone(), provider.args.clone());
+                        app.set_provider_name(provider.display_name.clone());
+                        app.set_model_name(provider.model_name.clone());
+
+                        app.show_popup(format!(
+                            "Switched to {} ({})\nModel: {}",
+                            provider.display_name, provider.command, provider.model_name
+                        ));
+                    } else {
+                        let available: Vec<String> = providers
+                            .iter()
+                            .filter(|p| p.available)
+                            .map(|p| p.command.clone())
+                            .collect();
+                        app.show_popup(format!("Unknown provider: '{}'\nAvailable providers: {}\nUse /providers to see all options.", provider_name, available.join(", ")));
+                    }
+                    continue;
+                }
             }
             continue;
         }

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -1,0 +1,99 @@
+//! Main shell entry point and event loop integration.
+//!
+//! Ties together the runner (will be created in parallel) and TUI.
+
+#![cfg(feature = "tui")]
+
+use anyhow::Result;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+use std::io;
+use std::time::Duration;
+
+use super::tui::ShellApp;
+
+/// Main shell entry point.
+pub async fn run_shell() -> Result<()> {
+    // Detect provider (for now, hardcode gemini check)
+    let provider_name = "Gemini";
+    let command = "gemini";
+
+    // Check if gemini is available
+    let which_result = std::process::Command::new("which").arg(command).output();
+
+    if which_result.is_err() || !which_result.unwrap().status.success() {
+        anyhow::bail!(
+            "No supported CLI tool found. Install gemini, claude, or aider. \
+             To start the shell: armadai shell"
+        );
+    }
+
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = ShellApp::new(provider_name.to_string());
+
+    // Event loop
+    let result = event_loop(&mut terminal, &mut app).await;
+
+    // Cleanup
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+
+    result
+}
+
+async fn event_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut ShellApp,
+) -> Result<()> {
+    loop {
+        // Render
+        terminal.draw(|f| app.render(f))?;
+
+        // Handle events
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            // Only process Press events, ignore repeats
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            if app.handle_key(key) {
+                break; // quit
+            }
+
+            // Check if user submitted input (Enter key)
+            if key.code == KeyCode::Enter
+                && !app.should_quit()
+                && let Some(input) = app.take_input()
+            {
+                app.add_user_message(&input);
+                app.set_loading(true);
+
+                // Force redraw to show "thinking..."
+                terminal.draw(|f| app.render(f))?;
+
+                // TODO: Execute turn here when runner module is ready
+                // For now, just simulate a response
+                tokio::time::sleep(Duration::from_millis(500)).await;
+
+                let response = format!("Echo: {}", input);
+                app.add_assistant_message(&response);
+                app.update_metrics(10, 20, 0.0, Duration::from_millis(500));
+                app.set_loading(false);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -12,7 +12,6 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
 use std::time::Duration;
 
-use super::detect::detect_provider;
 use super::runner::ShellRunner;
 use super::tui::ShellApp;
 
@@ -29,12 +28,16 @@ fn restore_terminal() {
 
 /// Main shell entry point.
 pub async fn run_shell() -> Result<()> {
-    let config = detect_provider().ok_or_else(|| {
-        anyhow::anyhow!(
-            "No supported CLI tool found. Install gemini, claude, or aider.\n\
-             Supported tools: gemini, claude, aider, codex"
-        )
-    })?;
+    // Run wizard to ensure project is ready
+    let wizard_result = super::wizard::ensure_project_ready()?;
+
+    // Use wizard result for provider config
+    let config = super::runner::RunnerConfig {
+        command: wizard_result.provider_command.clone(),
+        args: wizard_result.provider_args,
+        max_history_turns: 5,
+        timeout: std::time::Duration::from_secs(120),
+    };
 
     let provider_name = super::detect::provider_display_name(&config.command).to_string();
 
@@ -57,9 +60,8 @@ pub async fn run_shell() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let model_name = super::detect::detect_model_name(&config.command);
     let mut app = ShellApp::new(provider_name);
-    app.set_model_name(model_name);
+    app.set_model_name(wizard_result.model_name);
     let mut runner = ShellRunner::new(config);
 
     // Event loop
@@ -111,6 +113,27 @@ async fn event_loop(
         let Some(input) = app.take_input() else {
             continue;
         };
+
+        // Check for slash commands first
+        if let Some(result) =
+            super::commands::try_execute(&input, runner, app.provider_name(), app.model_name())
+        {
+            use super::commands::CommandResult;
+            match result {
+                CommandResult::Display(text) => {
+                    app.add_system_message(&text);
+                }
+                CommandResult::Clear => {
+                    app.clear_conversation();
+                    runner.clear();
+                    app.add_system_message("Conversation cleared.");
+                }
+                CommandResult::Quit => {
+                    break;
+                }
+            }
+            continue;
+        }
 
         app.add_user_message(&input);
         app.set_loading(true);
@@ -175,7 +198,10 @@ async fn event_loop(
                 }
                 Ok(output) => {
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                    app.add_assistant_message(&format!("Error (exit {}): {}", output.status, stderr));
+                    app.add_assistant_message(&format!(
+                        "Error (exit {}): {}",
+                        output.status, stderr
+                    ));
                 }
                 Err(e) => {
                     app.add_assistant_message(&format!("Error: {e}"));

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -121,12 +121,11 @@ async fn event_loop(
             use super::commands::CommandResult;
             match result {
                 CommandResult::Display(text) => {
-                    app.add_system_message(&text);
+                    app.show_popup(text);
                 }
                 CommandResult::Clear => {
                     app.clear_conversation();
                     runner.clear();
-                    app.add_system_message("Conversation cleared.");
                 }
                 CommandResult::Quit => {
                     break;

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -1,6 +1,4 @@
 //! Main shell entry point and event loop integration.
-//!
-//! Ties together the runner (will be created in parallel) and TUI.
 
 #![cfg(feature = "tui")]
 
@@ -14,39 +12,62 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
 use std::time::Duration;
 
+use super::detect::detect_provider;
+use super::runner::ShellRunner;
 use super::tui::ShellApp;
+
+/// Restore the terminal to normal state. Called on exit and on panic.
+fn restore_terminal() {
+    let _ = disable_raw_mode();
+    let _ = execute!(
+        io::stdout(),
+        crossterm::event::DisableMouseCapture,
+        LeaveAlternateScreen,
+        crossterm::cursor::Show
+    );
+}
 
 /// Main shell entry point.
 pub async fn run_shell() -> Result<()> {
-    // Detect provider (for now, hardcode gemini check)
-    let provider_name = "Gemini";
-    let command = "gemini";
+    let config = detect_provider().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No supported CLI tool found. Install gemini, claude, or aider.\n\
+             Supported tools: gemini, claude, aider, codex"
+        )
+    })?;
 
-    // Check if gemini is available
-    let which_result = std::process::Command::new("which").arg(command).output();
+    let provider_name = super::detect::provider_display_name(&config.command).to_string();
 
-    if which_result.is_err() || !which_result.unwrap().status.success() {
-        anyhow::bail!(
-            "No supported CLI tool found. Install gemini, claude, or aider. \
-             To start the shell: armadai shell"
-        );
-    }
+    // Install panic hook to restore terminal on crash
+    let default_panic = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        default_panic(info);
+    }));
 
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        crossterm::cursor::Hide,
+        crossterm::event::EnableMouseCapture
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = ShellApp::new(provider_name.to_string());
+    let model_name = super::detect::detect_model_name(&config.command);
+    let mut app = ShellApp::new(provider_name);
+    app.set_model_name(model_name);
+    let mut runner = ShellRunner::new(config);
 
     // Event loop
-    let result = event_loop(&mut terminal, &mut app).await;
+    let result = event_loop(&mut terminal, &mut app, &mut runner).await;
 
     // Cleanup
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    restore_terminal();
+    println!();
 
     result
 }
@@ -54,46 +75,115 @@ pub async fn run_shell() -> Result<()> {
 async fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut ShellApp,
+    runner: &mut ShellRunner,
 ) -> Result<()> {
     loop {
         // Render
         terminal.draw(|f| app.render(f))?;
 
         // Handle events
-        if event::poll(Duration::from_millis(100))?
-            && let Event::Key(key) = event::read()?
-        {
-            // Only process Press events, ignore repeats
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
+        if !event::poll(Duration::from_millis(100))? {
+            continue;
+        }
 
-            if app.handle_key(key) {
-                break; // quit
-            }
+        let evt = event::read()?;
 
-            // Check if user submitted input (Enter key)
-            if key.code == KeyCode::Enter
-                && !app.should_quit()
-                && let Some(input) = app.take_input()
+        // Handle mouse scroll
+        if let Event::Mouse(mouse) = &evt {
+            app.handle_mouse(*mouse);
+            continue;
+        }
+
+        // Handle key events
+        let key = match evt {
+            Event::Key(key) if key.kind == KeyEventKind::Press => key,
+            _ => continue,
+        };
+
+        if app.handle_key(key) {
+            break;
+        }
+
+        // Check if user submitted input
+        if key.code != KeyCode::Enter || app.should_quit() {
+            continue;
+        }
+        let Some(input) = app.take_input() else {
+            continue;
+        };
+
+        app.add_user_message(&input);
+        app.set_loading(true);
+
+        let input_clone = input.clone();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+
+        let cmd = runner.command().to_string();
+        let args: Vec<String> = runner.args().to_vec();
+        let prompt = runner.build_prompt_for(&input_clone);
+        let prompt_for_spawn = prompt.clone();
+
+        // Spawn the CLI call in background
+        let handle = tokio::spawn(async move {
+            let start = std::time::Instant::now();
+            let output = tokio::process::Command::new(&cmd)
+                .args(&args)
+                .arg(&prompt_for_spawn)
+                .output()
+                .await;
+            let _ = tx.send((output, start.elapsed()));
+        });
+
+        // Keep rendering while waiting (spinner animation)
+        loop {
+            app.tick_spinner();
+            terminal.draw(|f| app.render(f))?;
+
+            // Check for cancel during loading
+            if event::poll(Duration::from_millis(80))?
+                && let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press
+                && (key.code == KeyCode::Esc
+                    || (key.code == KeyCode::Char('c')
+                        && key.modifiers == crossterm::event::KeyModifiers::CONTROL))
             {
-                app.add_user_message(&input);
-                app.set_loading(true);
-
-                // Force redraw to show "thinking..."
-                terminal.draw(|f| app.render(f))?;
-
-                // TODO: Execute turn here when runner module is ready
-                // For now, just simulate a response
-                tokio::time::sleep(Duration::from_millis(500)).await;
-
-                let response = format!("Echo: {}", input);
-                app.add_assistant_message(&response);
-                app.update_metrics(10, 20, 0.0, Duration::from_millis(500));
+                handle.abort();
                 app.set_loading(false);
+                app.add_assistant_message("[Cancelled]");
+                break;
             }
+
+            // Check if response arrived
+            let Ok((output_result, duration)) = rx.try_recv() else {
+                continue;
+            };
+
+            match output_result {
+                Ok(output) if output.status.success() => {
+                    let raw = String::from_utf8_lossy(&output.stdout).to_string();
+                    let parsed = super::parser::parse_response(&raw);
+                    runner.record_turn(&input_clone, &parsed.content, duration);
+                    let metrics = runner.session_metrics();
+                    app.add_assistant_message(&parsed.content);
+                    app.set_session_metrics(
+                        metrics.total_tokens_in,
+                        metrics.total_tokens_out,
+                        metrics.total_cost_estimate,
+                        metrics.turn_count,
+                        duration,
+                    );
+                }
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    app.add_assistant_message(&format!("Error (exit {}): {}", output.status, stderr));
+                }
+                Err(e) => {
+                    app.add_assistant_message(&format!("Error: {e}"));
+                }
+            }
+            app.set_loading(false);
+            break;
         }
     }
-
     Ok(())
 }

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -13,7 +13,49 @@ use std::io;
 use std::time::Duration;
 
 use super::runner::ShellRunner;
+use super::session::{SessionMessage, ShellSession};
 use super::tui::ShellApp;
+
+/// Helper to save the current session state.
+fn save_current_session(
+    session_id: &str,
+    project_dir: &str,
+    provider_name: &str,
+    model_name: &str,
+    runner: &ShellRunner,
+) -> Result<()> {
+    let metrics = runner.session_metrics();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    // Convert runner history to session messages
+    let messages: Vec<SessionMessage> = runner
+        .history()
+        .iter()
+        .map(SessionMessage::from_message)
+        .collect();
+
+    // Don't save if there are no messages
+    if messages.is_empty() {
+        return Ok(());
+    }
+
+    let session = ShellSession {
+        id: session_id.to_string(),
+        name: super::session::generate_session_name(project_dir),
+        provider: provider_name.to_string(),
+        model: model_name.to_string(),
+        project_dir: project_dir.to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+        messages,
+        total_tokens_in: metrics.total_tokens_in,
+        total_tokens_out: metrics.total_tokens_out,
+        total_cost: metrics.total_cost_estimate,
+        turn_count: metrics.turn_count,
+    };
+
+    super::session::save_session(&session)
+}
 
 /// Restore the terminal to normal state. Called on exit and on panic.
 fn restore_terminal() {
@@ -41,6 +83,13 @@ pub async fn run_shell() -> Result<()> {
 
     let provider_name = super::detect::provider_display_name(&config.command).to_string();
 
+    // Generate a new session ID
+    let session_id = super::session::new_session_id();
+    let project_dir = std::env::current_dir()
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+        .to_string_lossy()
+        .to_string();
+
     // Install panic hook to restore terminal on crash
     let default_panic = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -60,12 +109,30 @@ pub async fn run_shell() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = ShellApp::new(provider_name);
-    app.set_model_name(wizard_result.model_name);
+    let mut app = ShellApp::new(provider_name.clone());
+    app.set_model_name(wizard_result.model_name.clone());
     let mut runner = ShellRunner::new(config);
 
     // Event loop
-    let result = event_loop(&mut terminal, &mut app, &mut runner).await;
+    let result = event_loop(
+        &mut terminal,
+        &mut app,
+        &mut runner,
+        &session_id,
+        &project_dir,
+        &provider_name,
+        &wizard_result.model_name,
+    )
+    .await;
+
+    // Final save on exit
+    let _ = save_current_session(
+        &session_id,
+        &project_dir,
+        &provider_name,
+        &wizard_result.model_name,
+        &runner,
+    );
 
     // Cleanup
     restore_terminal();
@@ -78,6 +145,10 @@ async fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut ShellApp,
     runner: &mut ShellRunner,
+    session_id: &str,
+    project_dir: &str,
+    provider_name: &str,
+    model_name: &str,
 ) -> Result<()> {
     loop {
         // Render
@@ -130,8 +201,8 @@ async fn event_loop(
                 CommandResult::Quit => {
                     break;
                 }
-                CommandResult::SwitchProvider(provider_name) => {
-                    if provider_name.is_empty() {
+                CommandResult::SwitchProvider(provider_name_arg) => {
+                    if provider_name_arg.is_empty() {
                         app.show_popup(
                             "Usage: /switch <provider>\nExample: /switch claude".to_string(),
                         );
@@ -141,8 +212,8 @@ async fn event_loop(
                     // Find the provider in the registry
                     let providers = super::detect::list_providers();
                     if let Some(provider) = providers.iter().find(|p| {
-                        p.command == provider_name
-                            || p.display_name.to_lowercase() == provider_name.to_lowercase()
+                        p.command == provider_name_arg
+                            || p.display_name.to_lowercase() == provider_name_arg.to_lowercase()
                     }) {
                         if !provider.available {
                             app.show_popup(format!("Provider '{}' is not available. Make sure '{}' is installed and in your PATH.", provider.display_name, provider.command));
@@ -164,7 +235,69 @@ async fn event_loop(
                             .filter(|p| p.available)
                             .map(|p| p.command.clone())
                             .collect();
-                        app.show_popup(format!("Unknown provider: '{}'\nAvailable providers: {}\nUse /providers to see all options.", provider_name, available.join(", ")));
+                        app.show_popup(format!("Unknown provider: '{}'\nAvailable providers: {}\nUse /providers to see all options.", provider_name_arg, available.join(", ")));
+                    }
+                    continue;
+                }
+                CommandResult::ResumeSession(id) => {
+                    match super::session::load_session(&id) {
+                        Ok(session) => {
+                            // Restore messages to runner
+                            let messages: Vec<super::runner::Message> =
+                                session.messages.iter().map(|m| m.to_message()).collect();
+
+                            runner.restore_from_session(messages);
+
+                            // Clear and restore UI
+                            app.clear_conversation();
+                            for msg in &session.messages {
+                                match msg.role.as_str() {
+                                    "user" => app.add_user_message(&msg.content),
+                                    "assistant" => app.add_assistant_message(&msg.content),
+                                    _ => {}
+                                }
+                            }
+
+                            // Restore metrics
+                            app.set_session_metrics(
+                                session.total_tokens_in,
+                                session.total_tokens_out,
+                                session.total_cost,
+                                session.turn_count,
+                                std::time::Duration::from_secs(0),
+                            );
+
+                            app.show_popup(format!(
+                                "Resumed session: {}\n{} turns, ${:.4}",
+                                session.name, session.turn_count, session.total_cost
+                            ));
+                        }
+                        Err(e) => {
+                            app.show_popup(format!(
+                                "Failed to resume session '{}': {}\n\nUse /sessions to see available sessions.",
+                                id, e
+                            ));
+                        }
+                    }
+                    continue;
+                }
+                CommandResult::SaveSession => {
+                    match save_current_session(
+                        session_id,
+                        project_dir,
+                        provider_name,
+                        model_name,
+                        runner,
+                    ) {
+                        Ok(_) => {
+                            app.show_popup(format!(
+                                "Session saved: {}\n\nUse /resume {} to restore this session later.",
+                                session_id, session_id
+                            ));
+                        }
+                        Err(e) => {
+                            app.show_popup(format!("Failed to save session: {}", e));
+                        }
                     }
                     continue;
                 }
@@ -231,6 +364,15 @@ async fn event_loop(
                         metrics.total_cost_estimate,
                         metrics.turn_count,
                         duration,
+                    );
+
+                    // Auto-save session after each turn
+                    let _ = save_current_session(
+                        session_id,
+                        project_dir,
+                        provider_name,
+                        model_name,
+                        runner,
                     );
                 }
                 Ok(output) => {

--- a/src/shell/commands.rs
+++ b/src/shell/commands.rs
@@ -58,6 +58,21 @@ pub const COMMANDS: &[SlashCommand] = &[
         description: "Switch provider (e.g. /switch claude)",
     },
     SlashCommand {
+        name: "sessions",
+        aliases: &["ss"],
+        description: "List saved sessions",
+    },
+    SlashCommand {
+        name: "resume",
+        aliases: &["r"],
+        description: "Resume a saved session (e.g. /resume 20260401_1430)",
+    },
+    SlashCommand {
+        name: "save",
+        aliases: &[],
+        description: "Force save current session",
+    },
+    SlashCommand {
         name: "quit",
         aliases: &["q", "exit"],
         description: "Exit the shell",
@@ -75,6 +90,10 @@ pub enum CommandResult {
     Quit,
     /// Switch to a different provider
     SwitchProvider(String),
+    /// Resume a saved session
+    ResumeSession(String),
+    /// Save current session
+    SaveSession,
 }
 
 /// Find a command by name or alias
@@ -114,6 +133,18 @@ pub fn try_execute(
             let arg = trimmed[1..].split_whitespace().nth(1).unwrap_or("");
             Some(CommandResult::SwitchProvider(arg.to_string()))
         }
+        Some(c) if c.name == "sessions" => Some(CommandResult::Display(format_sessions())),
+        Some(c) if c.name == "resume" => {
+            let arg = trimmed[1..].split_whitespace().nth(1).unwrap_or("");
+            if arg.is_empty() {
+                Some(CommandResult::Display(
+                    "Usage: /resume <session-id>\nExample: /resume 20260401_1430\n\nUse /sessions to see available sessions.".to_string()
+                ))
+            } else {
+                Some(CommandResult::ResumeSession(arg.to_string()))
+            }
+        }
+        Some(c) if c.name == "save" => Some(CommandResult::SaveSession),
         Some(c) if c.name == "quit" => Some(CommandResult::Quit),
         _ => Some(CommandResult::Display(format!(
             "Unknown command: /{cmd_part}\nType /help for available commands."
@@ -492,6 +523,38 @@ fn format_history(runner: &ShellRunner) -> String {
         }
     }
 
+    text
+}
+
+/// Format sessions list
+fn format_sessions() -> String {
+    use super::session::{format_relative_time, list_sessions};
+
+    let sessions = list_sessions();
+    let mut text = "# Saved Sessions\n\n".to_string();
+
+    if sessions.is_empty() {
+        text.push_str("*(no saved sessions)*\n\n");
+        text.push_str("Sessions are automatically saved as you chat.\n");
+        text.push_str("Use `/resume <session-id>` to restore a previous conversation.\n");
+        return text;
+    }
+
+    for session in &sessions {
+        let project = session
+            .project_dir
+            .split('/')
+            .next_back()
+            .unwrap_or(&session.project_dir);
+        let relative = format_relative_time(&session.updated_at);
+
+        text.push_str(&format!(
+            "- **{}** — {} ({} turns, ${:.4}) — {}\n",
+            session.id, project, session.turn_count, session.total_cost, relative
+        ));
+    }
+
+    text.push_str("\nUse `/resume <session-id>` to restore a session.\n");
     text
 }
 

--- a/src/shell/commands.rs
+++ b/src/shell/commands.rs
@@ -48,6 +48,16 @@ pub const COMMANDS: &[SlashCommand] = &[
         description: "Show prompt history",
     },
     SlashCommand {
+        name: "providers",
+        aliases: &["p"],
+        description: "List available providers",
+    },
+    SlashCommand {
+        name: "switch",
+        aliases: &["sw"],
+        description: "Switch provider (e.g. /switch claude)",
+    },
+    SlashCommand {
         name: "quit",
         aliases: &["q", "exit"],
         description: "Exit the shell",
@@ -63,6 +73,8 @@ pub enum CommandResult {
     Clear,
     /// Exit shell
     Quit,
+    /// Switch to a different provider
+    SwitchProvider(String),
 }
 
 /// Find a command by name or alias
@@ -97,6 +109,11 @@ pub fn try_execute(
             model_name,
         ))),
         Some(c) if c.name == "history" => Some(CommandResult::Display(format_history(runner))),
+        Some(c) if c.name == "providers" => Some(CommandResult::Display(format_providers())),
+        Some(c) if c.name == "switch" => {
+            let arg = trimmed[1..].split_whitespace().nth(1).unwrap_or("");
+            Some(CommandResult::SwitchProvider(arg.to_string()))
+        }
         Some(c) if c.name == "quit" => Some(CommandResult::Quit),
         _ => Some(CommandResult::Display(format!(
             "Unknown command: /{cmd_part}\nType /help for available commands."
@@ -212,7 +229,10 @@ fn parse_field_from_yaml(content: &str, field: &str) -> Option<String> {
     for line in content.lines() {
         let trimmed = line.trim();
         if trimmed.starts_with(&prefix) {
-            let value = trimmed[prefix.len()..].trim().trim_matches('"').trim_matches('\'');
+            let value = trimmed[prefix.len()..]
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'');
             if !value.is_empty() {
                 return Some(value.to_string());
             }
@@ -264,7 +284,11 @@ fn parse_teams_from_yaml(content: &str) -> Vec<TeamInfo> {
         }
 
         if trimmed.starts_with("- lead:") {
-            let val = trimmed.strip_prefix("- lead:").unwrap().trim().trim_matches('"');
+            let val = trimmed
+                .strip_prefix("- lead:")
+                .unwrap()
+                .trim()
+                .trim_matches('"');
             if !val.is_empty() {
                 current_lead = Some(val.to_string());
             }
@@ -378,11 +402,7 @@ fn parse_agents_from_yaml(content: &str) -> Vec<String> {
 
 /// Format model info
 fn format_model(provider: &str, model: &str) -> String {
-    let model_display = if model.is_empty() {
-        "(not set)"
-    } else {
-        model
-    };
+    let model_display = if model.is_empty() { "(not set)" } else { model };
 
     let pricing = match (
         provider.to_lowercase().as_str(),
@@ -401,6 +421,39 @@ fn format_model(provider: &str, model: &str) -> String {
     text.push_str(&format!("- **Provider:** {}\n", provider));
     text.push_str(&format!("- **Model:** {}\n", model_display));
     text.push_str(&format!("- **Pricing:** {}\n", pricing));
+    text
+}
+
+/// Format providers list
+fn format_providers() -> String {
+    use super::detect::list_providers;
+
+    let providers = list_providers();
+    let mut text = "# Available Providers\n\n".to_string();
+
+    if providers.is_empty() {
+        text.push_str("*(no providers found)*\n");
+        return text;
+    }
+
+    for provider in &providers {
+        let status = if provider.available {
+            "✓ available"
+        } else {
+            "✗ not installed"
+        };
+
+        text.push_str(&format!(
+            "- **{}** ({}) — {}\n",
+            provider.display_name, provider.command, status
+        ));
+
+        if provider.available && !provider.model_name.is_empty() {
+            text.push_str(&format!("  Model: {}\n", provider.model_name));
+        }
+    }
+
+    text.push_str("\nUse `/switch <provider>` to change provider (e.g., `/switch claude`)\n");
     text
 }
 

--- a/src/shell/commands.rs
+++ b/src/shell/commands.rs
@@ -106,16 +106,20 @@ pub fn try_execute(
 
 /// Format help text showing all available commands
 fn format_help() -> String {
-    let mut text = "Available commands:\n".to_string();
-    text.push_str("─".repeat(40).as_str());
-    text.push('\n');
+    let mut text = "# Available Commands\n\n".to_string();
 
     for cmd in COMMANDS {
-        text.push_str(&format!("  /{:<10}", cmd.name));
-        if !cmd.aliases.is_empty() {
-            text.push_str(&format!("({})", cmd.aliases.join(", ")));
-        }
-        text.push_str(&format!("  — {}\n", cmd.description));
+        let aliases = if cmd.aliases.is_empty() {
+            String::new()
+        } else {
+            format!(" *({})*", cmd.aliases.join(", "))
+        };
+        text.push_str(&format!(
+            "- **/{name}**{aliases} — {desc}\n",
+            name = cmd.name,
+            aliases = aliases,
+            desc = cmd.description,
+        ));
     }
 
     text
@@ -124,38 +128,170 @@ fn format_help() -> String {
 /// Format cost summary
 fn format_cost(runner: &ShellRunner) -> String {
     let metrics = runner.session_metrics();
-    let provider_names = ["Gemini", "Claude", "OpenAI"];
-    let provider_name = provider_names.first().copied().unwrap_or("Unknown");
 
-    format!(
-        "Session Cost Summary\n{}\nTurns:      {}\nTokens in:  {} (~estimated)\nTokens out: {} (~estimated)\nEst. cost:  ${:.6}\nProvider:   {}",
-        "─".repeat(40),
-        metrics.turn_count,
-        metrics.total_tokens_in,
-        metrics.total_tokens_out,
-        metrics.total_cost_estimate,
-        provider_name,
-    )
+    let mut text = "# Session Cost Summary\n\n".to_string();
+    text.push_str(&format!("- **Turns:** {}\n", metrics.turn_count));
+    text.push_str(&format!(
+        "- **Tokens in:** {} *(~estimated)*\n",
+        metrics.total_tokens_in
+    ));
+    text.push_str(&format!(
+        "- **Tokens out:** {} *(~estimated)*\n",
+        metrics.total_tokens_out
+    ));
+    text.push_str(&format!(
+        "- **Est. cost:** ${:.6}\n",
+        metrics.total_cost_estimate
+    ));
+    text
 }
 
-/// Format agents list from config
+/// Format agents list with orchestration organization
 fn format_agents() -> String {
-    let mut text = "Available Agents\n".to_string();
-    text.push_str("─".repeat(40).as_str());
-    text.push('\n');
+    let mut text = String::new();
 
-    // Try to find agents from project config
+    // Try to read orchestration config for team structure
+    let config_content = std::fs::read_to_string(".armadai/config.yaml")
+        .or_else(|_| std::fs::read_to_string("armadai.yaml"))
+        .unwrap_or_default();
+
+    let coordinator = parse_field_from_yaml(&config_content, "coordinator");
+    let teams = parse_teams_from_yaml(&config_content);
     let agents = list_agents_from_config();
 
     if agents.is_empty() {
         text.push_str("(no agents found in project config)\n");
-    } else {
-        for agent in agents {
-            text.push_str(&format!("  • {}\n", agent));
+        return text;
+    }
+
+    // If we have orchestration info, show the org chart
+    if let Some(ref coord) = coordinator {
+        let pattern = parse_field_from_yaml(&config_content, "pattern")
+            .unwrap_or_else(|| "hierarchical".to_string());
+        text.push_str("# Orchestration\n\n");
+        text.push_str(&format!("- **Pattern:** {}\n\n", pattern));
+        text.push_str(&format!("### 🎯 Coordinator: {}\n\n", coord));
+
+        if !teams.is_empty() {
+            for (i, team) in teams.iter().enumerate() {
+                if let Some(ref lead) = team.lead {
+                    text.push_str(&format!("### 📋 Team {} — Lead: {}\n", i + 1, lead));
+                } else {
+                    text.push_str(&format!("### 👥 Team {} — Direct reports\n", i + 1));
+                }
+                for agent in &team.agents {
+                    text.push_str(&format!("- 🔧 {}\n", agent));
+                }
+                text.push('\n');
+            }
+        } else {
+            text.push_str("### 👥 Agents\n");
+            for agent in &agents {
+                if Some(agent) != coordinator.as_ref() {
+                    text.push_str(&format!("- 🔧 {}\n", agent));
+                }
+            }
         }
+
+        text.push_str(&format!("**Total:** {} agent(s)\n", agents.len()));
+    } else {
+        // No orchestration — flat list
+        text.push_str("# Available Agents\n\n");
+        for agent in &agents {
+            text.push_str(&format!("- {}\n", agent));
+        }
+        text.push_str(&format!("\n**Total:** {} agent(s)\n", agents.len()));
     }
 
     text
+}
+
+/// Simple YAML field parser
+fn parse_field_from_yaml(content: &str, field: &str) -> Option<String> {
+    let prefix = format!("{}:", field);
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(&prefix) {
+            let value = trimmed[prefix.len()..].trim().trim_matches('"').trim_matches('\'');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Parse teams from orchestration YAML config
+fn parse_teams_from_yaml(content: &str) -> Vec<TeamInfo> {
+    let mut teams = Vec::new();
+    let mut in_teams = false;
+    let mut current_lead: Option<String> = None;
+    let mut current_agents: Vec<String> = Vec::new();
+    let mut in_agents_list = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("teams:") {
+            in_teams = true;
+            continue;
+        }
+
+        if !in_teams {
+            continue;
+        }
+
+        // Exit teams on next top-level key
+        if !trimmed.is_empty()
+            && !trimmed.starts_with('-')
+            && !trimmed.starts_with(' ')
+            && !trimmed.starts_with('\t')
+            && !trimmed.starts_with("lead:")
+            && !trimmed.starts_with("agents:")
+        {
+            break;
+        }
+
+        if trimmed.starts_with("- lead:") || trimmed.starts_with("- agents:") {
+            // Save previous team
+            if !current_agents.is_empty() || current_lead.is_some() {
+                teams.push(TeamInfo {
+                    lead: current_lead.take(),
+                    agents: std::mem::take(&mut current_agents),
+                });
+            }
+            in_agents_list = false;
+        }
+
+        if trimmed.starts_with("- lead:") {
+            let val = trimmed.strip_prefix("- lead:").unwrap().trim().trim_matches('"');
+            if !val.is_empty() {
+                current_lead = Some(val.to_string());
+            }
+        } else if trimmed.contains("agents:") {
+            in_agents_list = true;
+        } else if in_agents_list && trimmed.starts_with("- ") {
+            let agent = trimmed.strip_prefix("- ").unwrap().trim().trim_matches('"');
+            if !agent.is_empty() && !agent.contains(':') {
+                current_agents.push(agent.to_string());
+            }
+        }
+    }
+
+    // Save last team
+    if !current_agents.is_empty() || current_lead.is_some() {
+        teams.push(TeamInfo {
+            lead: current_lead,
+            agents: current_agents,
+        });
+    }
+
+    teams
+}
+
+struct TeamInfo {
+    lead: Option<String>,
+    agents: Vec<String>,
 }
 
 /// List agent names from armadai.yaml or .armadai/config.yaml
@@ -242,50 +378,40 @@ fn parse_agents_from_yaml(content: &str) -> Vec<String> {
 
 /// Format model info
 fn format_model(provider: &str, model: &str) -> String {
-    let mut text = "Current Model\n".to_string();
-    text.push_str("─".repeat(40).as_str());
-    text.push('\n');
+    let model_display = if model.is_empty() {
+        "(not set)"
+    } else {
+        model
+    };
 
-    text.push_str(&format!("Provider:  {}\n", provider));
-    text.push_str(&format!(
-        "Model:     {}\n",
-        if model.is_empty() { "(not set)" } else { model }
-    ));
-
-    // Add pricing info for common models
-    match (
+    let pricing = match (
         provider.to_lowercase().as_str(),
         model.to_lowercase().as_str(),
     ) {
-        ("gemini", "gemini-2.5-flash") | ("gemini", _) => {
-            text.push_str("Pricing:   $0.075/1M tokens in, $0.30/1M tokens out\n");
-        }
-        ("claude", _) if model.contains("3.5") => {
-            text.push_str("Pricing:   $3.00/1M tokens in, $15.00/1M tokens out\n");
-        }
-        ("claude", _) if model.contains("opus") => {
-            text.push_str("Pricing:   $15.00/1M tokens in, $75.00/1M tokens out\n");
-        }
-        ("openai", _) if model.contains("gpt-4") => {
-            text.push_str("Pricing:   $0.03/1K tokens in, $0.06/1K tokens out\n");
-        }
-        _ => {
-            text.push_str("Pricing:   (unknown)\n");
-        }
-    }
+        ("gemini", m) if m.contains("flash") => "$0.075/1M in, $0.30/1M out",
+        ("gemini", m) if m.contains("pro") => "$1.25/1M in, $10.00/1M out",
+        ("claude", m) if m.contains("sonnet") => "$3.00/1M in, $15.00/1M out",
+        ("claude", m) if m.contains("opus") => "$15.00/1M in, $75.00/1M out",
+        ("claude", m) if m.contains("haiku") => "$0.80/1M in, $4.00/1M out",
+        ("openai", m) if m.contains("gpt-4o") => "$2.50/1M in, $10.00/1M out",
+        _ => "(unknown)",
+    };
 
+    let mut text = "# Current Model\n\n".to_string();
+    text.push_str(&format!("- **Provider:** {}\n", provider));
+    text.push_str(&format!("- **Model:** {}\n", model_display));
+    text.push_str(&format!("- **Pricing:** {}\n", pricing));
     text
 }
 
 /// Format conversation history
 fn format_history(runner: &ShellRunner) -> String {
-    let mut text = "Conversation History\n".to_string();
-    text.push_str("─".repeat(40).as_str());
-    text.push('\n');
-
     let history = runner.history();
+
+    let mut text = "# Conversation History\n\n".to_string();
+
     if history.is_empty() {
-        text.push_str("(no messages in history)\n");
+        text.push_str("*(no messages yet)*\n");
         return text;
     }
 
@@ -293,21 +419,21 @@ fn format_history(runner: &ShellRunner) -> String {
     for msg in history {
         match msg.role {
             MessageRole::User => {
-                let preview = if msg.content.len() > 60 {
-                    format!("{}…", &msg.content[..60])
+                let preview = if msg.content.len() > 80 {
+                    format!("{}…", &msg.content[..80])
                 } else {
                     msg.content.clone()
                 };
-                text.push_str(&format!("Turn {}: You — {}\n", turn, preview));
+                text.push_str(&format!("**Turn {}** — {}\n", turn, preview));
                 turn += 1;
             }
             MessageRole::Assistant => {
-                let preview = if msg.content.len() > 60 {
-                    format!("{}…", &msg.content[..60])
+                let preview = if msg.content.len() > 80 {
+                    format!("{}…", &msg.content[..80])
                 } else {
                     msg.content.clone()
                 };
-                text.push_str(&format!("        → {}\n", preview));
+                text.push_str(&format!("- → {}\n", preview));
             }
             MessageRole::System => {}
         }

--- a/src/shell/commands.rs
+++ b/src/shell/commands.rs
@@ -1,0 +1,383 @@
+//! Slash commands for the ArmadAI shell TUI
+//!
+//! Provides slash command support for shell-internal operations like help, clear, costs, etc.
+
+#![cfg(feature = "tui")]
+
+use super::runner::{MessageRole, ShellRunner};
+use std::path::PathBuf;
+
+/// A slash command definition
+#[derive(Debug, Clone)]
+pub struct SlashCommand {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+}
+
+/// All available commands
+pub const COMMANDS: &[SlashCommand] = &[
+    SlashCommand {
+        name: "help",
+        aliases: &["h", "?"],
+        description: "Show available commands",
+    },
+    SlashCommand {
+        name: "clear",
+        aliases: &["c"],
+        description: "Clear the conversation",
+    },
+    SlashCommand {
+        name: "cost",
+        aliases: &["costs"],
+        description: "Show session cost summary",
+    },
+    SlashCommand {
+        name: "agents",
+        aliases: &["a"],
+        description: "List available agents",
+    },
+    SlashCommand {
+        name: "model",
+        aliases: &["m"],
+        description: "Show current model info",
+    },
+    SlashCommand {
+        name: "history",
+        aliases: &["hist"],
+        description: "Show prompt history",
+    },
+    SlashCommand {
+        name: "quit",
+        aliases: &["q", "exit"],
+        description: "Exit the shell",
+    },
+];
+
+/// Result of executing a slash command
+#[derive(Debug)]
+pub enum CommandResult {
+    /// Display text in the messages area
+    Display(String),
+    /// Clear conversation
+    Clear,
+    /// Exit shell
+    Quit,
+}
+
+/// Find a command by name or alias
+pub fn find_command(input: &str) -> Option<&'static SlashCommand> {
+    COMMANDS
+        .iter()
+        .find(|cmd| cmd.name == input || cmd.aliases.contains(&input))
+}
+
+/// Try to parse and execute a slash command.
+/// Returns Some(CommandResult) if the input was a command, None if it's a normal message.
+pub fn try_execute(
+    input: &str,
+    runner: &ShellRunner,
+    provider_name: &str,
+    model_name: &str,
+) -> Option<CommandResult> {
+    let trimmed = input.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+
+    let cmd_part = trimmed[1..].split_whitespace().next().unwrap_or("");
+
+    match find_command(cmd_part) {
+        Some(c) if c.name == "help" => Some(CommandResult::Display(format_help())),
+        Some(c) if c.name == "clear" => Some(CommandResult::Clear),
+        Some(c) if c.name == "cost" => Some(CommandResult::Display(format_cost(runner))),
+        Some(c) if c.name == "agents" => Some(CommandResult::Display(format_agents())),
+        Some(c) if c.name == "model" => Some(CommandResult::Display(format_model(
+            provider_name,
+            model_name,
+        ))),
+        Some(c) if c.name == "history" => Some(CommandResult::Display(format_history(runner))),
+        Some(c) if c.name == "quit" => Some(CommandResult::Quit),
+        _ => Some(CommandResult::Display(format!(
+            "Unknown command: /{cmd_part}\nType /help for available commands."
+        ))),
+    }
+}
+
+/// Format help text showing all available commands
+fn format_help() -> String {
+    let mut text = "Available commands:\n".to_string();
+    text.push_str("─".repeat(40).as_str());
+    text.push('\n');
+
+    for cmd in COMMANDS {
+        text.push_str(&format!("  /{:<10}", cmd.name));
+        if !cmd.aliases.is_empty() {
+            text.push_str(&format!("({})", cmd.aliases.join(", ")));
+        }
+        text.push_str(&format!("  — {}\n", cmd.description));
+    }
+
+    text
+}
+
+/// Format cost summary
+fn format_cost(runner: &ShellRunner) -> String {
+    let metrics = runner.session_metrics();
+    let provider_names = ["Gemini", "Claude", "OpenAI"];
+    let provider_name = provider_names.first().copied().unwrap_or("Unknown");
+
+    format!(
+        "Session Cost Summary\n{}\nTurns:      {}\nTokens in:  {} (~estimated)\nTokens out: {} (~estimated)\nEst. cost:  ${:.6}\nProvider:   {}",
+        "─".repeat(40),
+        metrics.turn_count,
+        metrics.total_tokens_in,
+        metrics.total_tokens_out,
+        metrics.total_cost_estimate,
+        provider_name,
+    )
+}
+
+/// Format agents list from config
+fn format_agents() -> String {
+    let mut text = "Available Agents\n".to_string();
+    text.push_str("─".repeat(40).as_str());
+    text.push('\n');
+
+    // Try to find agents from project config
+    let agents = list_agents_from_config();
+
+    if agents.is_empty() {
+        text.push_str("(no agents found in project config)\n");
+    } else {
+        for agent in agents {
+            text.push_str(&format!("  • {}\n", agent));
+        }
+    }
+
+    text
+}
+
+/// List agent names from armadai.yaml or .armadai/config.yaml
+fn list_agents_from_config() -> Vec<String> {
+    // Try .armadai/config.yaml first
+    let config_paths = [
+        PathBuf::from(".armadai/config.yaml"),
+        PathBuf::from("armadai.yaml"),
+        PathBuf::from(".gemini/agents"),
+    ];
+
+    for path in &config_paths {
+        if path.ends_with("agents") && path.is_dir() {
+            // List .md files in agents directory
+            if let Ok(entries) = std::fs::read_dir(path) {
+                let mut agents: Vec<String> = entries
+                    .filter_map(|e| {
+                        let entry = e.ok()?;
+                        let path = entry.path();
+                        if path.extension().is_some_and(|ext| ext == "md") {
+                            path.file_stem()
+                                .and_then(|stem| stem.to_str())
+                                .map(|s| s.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                agents.sort();
+                return agents;
+            }
+        } else if path.exists() && path.is_file() {
+            // Try to parse YAML config for agents list
+            if let Ok(content) = std::fs::read_to_string(path) {
+                let agents = parse_agents_from_yaml(&content);
+                if !agents.is_empty() {
+                    return agents;
+                }
+            }
+        }
+    }
+
+    Vec::new()
+}
+
+/// Parse agent names from YAML config content
+fn parse_agents_from_yaml(content: &str) -> Vec<String> {
+    let mut agents = Vec::new();
+
+    let mut in_agents_section = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Check if we're entering the agents section
+        if trimmed.starts_with("agents:") {
+            in_agents_section = true;
+            continue;
+        }
+
+        // If we hit another top-level key, exit agents section
+        if in_agents_section
+            && !trimmed.is_empty()
+            && !trimmed.starts_with('-')
+            && !trimmed.starts_with(' ')
+            && !trimmed.starts_with('\t')
+        {
+            break;
+        }
+
+        // Parse agent entries
+        if in_agents_section
+            && trimmed.starts_with("- name:")
+            && let Some(name) = trimmed.strip_prefix("- name:").map(|s| s.trim())
+        {
+            let clean_name = name.trim_matches('"').trim_matches('\'').to_string();
+            if !clean_name.is_empty() {
+                agents.push(clean_name);
+            }
+        }
+    }
+
+    agents
+}
+
+/// Format model info
+fn format_model(provider: &str, model: &str) -> String {
+    let mut text = "Current Model\n".to_string();
+    text.push_str("─".repeat(40).as_str());
+    text.push('\n');
+
+    text.push_str(&format!("Provider:  {}\n", provider));
+    text.push_str(&format!(
+        "Model:     {}\n",
+        if model.is_empty() { "(not set)" } else { model }
+    ));
+
+    // Add pricing info for common models
+    match (
+        provider.to_lowercase().as_str(),
+        model.to_lowercase().as_str(),
+    ) {
+        ("gemini", "gemini-2.5-flash") | ("gemini", _) => {
+            text.push_str("Pricing:   $0.075/1M tokens in, $0.30/1M tokens out\n");
+        }
+        ("claude", _) if model.contains("3.5") => {
+            text.push_str("Pricing:   $3.00/1M tokens in, $15.00/1M tokens out\n");
+        }
+        ("claude", _) if model.contains("opus") => {
+            text.push_str("Pricing:   $15.00/1M tokens in, $75.00/1M tokens out\n");
+        }
+        ("openai", _) if model.contains("gpt-4") => {
+            text.push_str("Pricing:   $0.03/1K tokens in, $0.06/1K tokens out\n");
+        }
+        _ => {
+            text.push_str("Pricing:   (unknown)\n");
+        }
+    }
+
+    text
+}
+
+/// Format conversation history
+fn format_history(runner: &ShellRunner) -> String {
+    let mut text = "Conversation History\n".to_string();
+    text.push_str("─".repeat(40).as_str());
+    text.push('\n');
+
+    let history = runner.history();
+    if history.is_empty() {
+        text.push_str("(no messages in history)\n");
+        return text;
+    }
+
+    let mut turn = 1;
+    for msg in history {
+        match msg.role {
+            MessageRole::User => {
+                let preview = if msg.content.len() > 60 {
+                    format!("{}…", &msg.content[..60])
+                } else {
+                    msg.content.clone()
+                };
+                text.push_str(&format!("Turn {}: You — {}\n", turn, preview));
+                turn += 1;
+            }
+            MessageRole::Assistant => {
+                let preview = if msg.content.len() > 60 {
+                    format!("{}…", &msg.content[..60])
+                } else {
+                    msg.content.clone()
+                };
+                text.push_str(&format!("        → {}\n", preview));
+            }
+            MessageRole::System => {}
+        }
+    }
+
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_command_by_name() {
+        let cmd = find_command("help");
+        assert!(cmd.is_some());
+        assert_eq!(cmd.unwrap().name, "help");
+    }
+
+    #[test]
+    fn test_find_command_by_alias() {
+        let cmd = find_command("h");
+        assert!(cmd.is_some());
+        assert_eq!(cmd.unwrap().name, "help");
+
+        let cmd = find_command("?");
+        assert!(cmd.is_some());
+        assert_eq!(cmd.unwrap().name, "help");
+    }
+
+    #[test]
+    fn test_find_command_not_found() {
+        let cmd = find_command("nonexistent");
+        assert!(cmd.is_none());
+    }
+
+    #[test]
+    fn test_parse_agents_from_yaml() {
+        let yaml = r#"
+agents:
+  - name: dev-lead
+  - name: core-specialist
+  - name: ui-specialist
+
+prompts: []
+"#;
+        let agents = parse_agents_from_yaml(yaml);
+        assert_eq!(agents.len(), 3);
+        assert!(agents.contains(&"dev-lead".to_string()));
+        assert!(agents.contains(&"core-specialist".to_string()));
+        assert!(agents.contains(&"ui-specialist".to_string()));
+    }
+
+    #[test]
+    fn test_parse_agents_from_yaml_empty() {
+        let yaml = "prompts: []";
+        let agents = parse_agents_from_yaml(yaml);
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn test_try_execute_unknown_command() {
+        let runner = ShellRunner::new(Default::default());
+        let result = try_execute("/unknown", &runner, "Gemini", "gemini-2.5-flash");
+        assert!(result.is_some());
+        match result.unwrap() {
+            CommandResult::Display(text) => {
+                assert!(text.contains("Unknown command"));
+            }
+            _ => panic!("Expected Display"),
+        }
+    }
+}

--- a/src/shell/detect.rs
+++ b/src/shell/detect.rs
@@ -78,6 +78,31 @@ pub fn provider_display_name(command: &str) -> &str {
     }
 }
 
+/// Try to detect the model name for a given provider.
+///
+/// For Gemini: reads `.gemini/settings.json` or runs `gemini --version`.
+/// For others: returns a default based on the provider.
+pub fn detect_model_name(command: &str) -> String {
+    match command {
+        "gemini" => detect_gemini_model(),
+        "claude" => "claude-sonnet-4-5".to_string(),
+        "aider" => "gpt-4o".to_string(),
+        "codex" => "codex".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn detect_gemini_model() -> String {
+    // Try to read model from .gemini/settings.json
+    if let Ok(content) = std::fs::read_to_string(".gemini/settings.json")
+        && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
+        && let Some(model) = json.get("model").and_then(|m| m.as_str())
+    {
+        return model.to_string();
+    }
+    "gemini-2.5-flash".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/shell/detect.rs
+++ b/src/shell/detect.rs
@@ -1,0 +1,128 @@
+//! Provider detection for the shell runner
+//!
+//! Auto-detects available CLI tools and returns a ready-to-use RunnerConfig.
+
+use super::runner::RunnerConfig;
+use std::time::Duration;
+
+/// Detect the best available CLI tool and return a RunnerConfig.
+///
+/// Checks in order of preference:
+/// 1. gemini (Google Gemini CLI)
+/// 2. claude (Anthropic Claude CLI)
+/// 3. aider (Aider CLI)
+/// 4. codex (OpenAI Codex CLI)
+///
+/// Returns None if no supported CLI is found.
+pub fn detect_provider() -> Option<RunnerConfig> {
+    // Try each provider in order of preference
+    let providers = vec![
+        ("gemini", vec!["-p"]),
+        ("claude", vec![]),
+        ("aider", vec!["--yes"]),
+        ("codex", vec![]),
+    ];
+
+    for (command, args) in providers {
+        if is_command_available(command) {
+            return Some(RunnerConfig {
+                command: command.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                max_history_turns: 5,
+                timeout: Duration::from_secs(120),
+            });
+        }
+    }
+
+    None
+}
+
+/// Check if a command is available in PATH.
+fn is_command_available(command: &str) -> bool {
+    #[cfg(unix)]
+    {
+        use std::process::Command;
+        Command::new("which")
+            .arg(command)
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(windows)]
+    {
+        use std::process::Command;
+        Command::new("where")
+            .arg(command)
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        // Fallback for other platforms - always return false
+        let _ = command;
+        false
+    }
+}
+
+/// Get the provider display name for the statusbar.
+pub fn provider_display_name(command: &str) -> &str {
+    match command {
+        "gemini" => "Gemini",
+        "claude" => "Claude",
+        "aider" => "Aider",
+        "codex" => "Codex",
+        _ => command,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_display_name() {
+        assert_eq!(provider_display_name("gemini"), "Gemini");
+        assert_eq!(provider_display_name("claude"), "Claude");
+        assert_eq!(provider_display_name("aider"), "Aider");
+        assert_eq!(provider_display_name("codex"), "Codex");
+        assert_eq!(provider_display_name("unknown"), "unknown");
+    }
+
+    #[test]
+    fn test_detect_provider_returns_some() {
+        // We can't guarantee which CLI is available in the test environment,
+        // but we can test that the function doesn't panic
+        let result = detect_provider();
+        // On most systems, at least one basic command should be available
+        // but we won't make assertions about which one
+        let _ = result;
+    }
+
+    #[test]
+    fn test_is_command_available_basic() {
+        // Test with a command that should always exist
+        #[cfg(unix)]
+        assert!(is_command_available("ls"));
+
+        #[cfg(windows)]
+        assert!(is_command_available("cmd"));
+
+        // Test with a command that should never exist
+        assert!(!is_command_available(
+            "this-command-definitely-does-not-exist-12345"
+        ));
+    }
+
+    #[test]
+    fn test_runner_config_has_correct_fields() {
+        // If we can detect a provider, verify it has the expected structure
+        if let Some(config) = detect_provider() {
+            assert!(!config.command.is_empty());
+            assert_eq!(config.max_history_turns, 5);
+            assert_eq!(config.timeout, Duration::from_secs(120));
+        }
+    }
+}

--- a/src/shell/detect.rs
+++ b/src/shell/detect.rs
@@ -5,6 +5,16 @@
 use super::runner::RunnerConfig;
 use std::time::Duration;
 
+/// Information about a provider's availability and configuration.
+#[derive(Debug, Clone)]
+pub struct ProviderInfo {
+    pub command: String,
+    pub args: Vec<String>,
+    pub display_name: String,
+    pub model_name: String,
+    pub available: bool,
+}
+
 /// Detect the best available CLI tool and return a RunnerConfig.
 ///
 /// Checks in order of preference:
@@ -37,8 +47,39 @@ pub fn detect_provider() -> Option<RunnerConfig> {
     None
 }
 
+/// List all known providers with their availability.
+///
+/// Returns a vector of all providers we know how to work with,
+/// including whether each one is currently available (installed in PATH).
+pub fn list_providers() -> Vec<ProviderInfo> {
+    let providers = [
+        ("gemini", vec!["-p"], "Gemini"),
+        ("claude", vec!["-p", "--output-format", "text"], "Claude"),
+        ("aider", vec!["--yes", "--message"], "Aider"),
+        ("codex", vec!["--quiet", "--full-auto"], "Codex"),
+    ];
+
+    providers
+        .iter()
+        .map(|(cmd, args, name)| {
+            let available = is_command_available(cmd);
+            ProviderInfo {
+                command: cmd.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                display_name: name.to_string(),
+                model_name: if available {
+                    detect_model_name(cmd)
+                } else {
+                    String::new()
+                },
+                available,
+            }
+        })
+        .collect()
+}
+
 /// Check if a command is available in PATH.
-fn is_command_available(command: &str) -> bool {
+pub fn is_command_available(command: &str) -> bool {
     #[cfg(unix)]
     {
         use std::process::Command;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -8,6 +8,12 @@ pub mod parser;
 pub mod runner;
 
 #[cfg(feature = "tui")]
+pub mod wizard;
+
+#[cfg(feature = "tui")]
+pub mod commands;
+
+#[cfg(feature = "tui")]
 pub mod tui;
 
 #[cfg(feature = "tui")]

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -19,6 +19,9 @@ pub mod tui;
 #[cfg(feature = "tui")]
 pub mod app;
 
+#[cfg(feature = "tui")]
+pub mod session;
+
 // Re-exported for external use when shell command is implemented
 #[allow(unused_imports)]
 pub use parser::{ParsedResponse, parse_response};

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3,8 +3,18 @@
 //! This module provides the parser and protocol support for the ArmadAI shell,
 //! including marker detection for end-of-response, delegation, and metadata extraction.
 
+pub mod detect;
 pub mod parser;
+pub mod runner;
+
+#[cfg(feature = "tui")]
+pub mod tui;
+
+#[cfg(feature = "tui")]
+pub mod app;
 
 // Re-exported for external use when shell command is implemented
 #[allow(unused_imports)]
 pub use parser::{ParsedResponse, parse_response};
+#[allow(unused_imports)]
+pub use runner::{Message, MessageRole, RunnerConfig, SessionMetrics, ShellRunner, TurnMetrics};

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,0 +1,10 @@
+//! Shell module for ArmadAI interactive mode
+//!
+//! This module provides the parser and protocol support for the ArmadAI shell,
+//! including marker detection for end-of-response, delegation, and metadata extraction.
+
+pub mod parser;
+
+// Re-exported for external use when shell command is implemented
+#[allow(unused_imports)]
+pub use parser::{ParsedResponse, parse_response};

--- a/src/shell/parser.rs
+++ b/src/shell/parser.rs
@@ -1,0 +1,307 @@
+//! Marker parser for ArmadAI response protocol
+//!
+//! Parses HTML comment markers in LLM responses to extract:
+//! - End-of-response signal (<!--ARMADAI_END-->)
+//! - Delegation instructions (<!--ARMADAI_DELEGATE:agent-name-->)
+//! - Metadata key-value pairs (<!--ARMADAI_META:key1=value1,key2=value2-->)
+
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Compiled regex patterns for marker detection
+static END_MARKER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<!--ARMADAI_END-->").expect("valid regex"));
+
+static DELEGATE_MARKER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<!--ARMADAI_DELEGATE:(.+?)-->").expect("valid regex"));
+
+static META_MARKER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<!--ARMADAI_META:(.+?)-->").expect("valid regex"));
+
+/// A parsed LLM response with markers extracted
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedResponse {
+    /// The clean content without markers
+    pub content: String,
+    /// Whether the END marker was found
+    pub complete: bool,
+    /// Delegations found (agent names)
+    pub delegations: Vec<String>,
+    /// Metadata key-value pairs
+    pub metadata: HashMap<String, String>,
+}
+
+/// Parse a raw LLM response and extract markers
+///
+/// # Example
+///
+/// ```
+/// use armadai::shell::parser::parse_response;
+///
+/// let raw = r#"
+/// Here is my response.
+///
+/// <!--ARMADAI_META:status=complete-->
+/// <!--ARMADAI_END-->
+/// "#;
+///
+/// let parsed = parse_response(raw);
+/// assert!(parsed.complete);
+/// assert_eq!(parsed.metadata.get("status"), Some(&"complete".to_string()));
+/// ```
+pub fn parse_response(raw: &str) -> ParsedResponse {
+    let mut content = raw.to_string();
+    let mut delegations = Vec::new();
+    let mut metadata = HashMap::new();
+
+    // Extract delegations
+    for cap in DELEGATE_MARKER.captures_iter(raw) {
+        if let Some(agent) = cap.get(1) {
+            delegations.push(agent.as_str().trim().to_string());
+        }
+    }
+
+    // Extract metadata
+    for cap in META_MARKER.captures_iter(raw) {
+        if let Some(meta_str) = cap.get(1) {
+            for pair in meta_str.as_str().split(',') {
+                let pair = pair.trim();
+                if let Some((key, value)) = pair.split_once('=') {
+                    metadata.insert(key.trim().to_string(), value.trim().to_string());
+                }
+            }
+        }
+    }
+
+    // Check for end marker
+    let complete = END_MARKER.is_match(raw);
+
+    // Strip all markers from content
+    content = DELEGATE_MARKER.replace_all(&content, "").to_string();
+    content = META_MARKER.replace_all(&content, "").to_string();
+    content = END_MARKER.replace_all(&content, "").to_string();
+
+    // Clean up extra whitespace
+    content = content.trim().to_string();
+
+    ParsedResponse {
+        content,
+        complete,
+        delegations,
+        metadata,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_complete_response_with_all_markers() {
+        let raw = r#"
+I analyzed the code and found two issues:
+1. Missing error handling on line 42
+2. Unused variable on line 15
+
+<!--ARMADAI_META:status=complete,tokens=150-->
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        assert!(parsed.complete);
+        assert_eq!(parsed.delegations.len(), 0);
+        assert_eq!(parsed.metadata.get("status"), Some(&"complete".to_string()));
+        assert_eq!(parsed.metadata.get("tokens"), Some(&"150".to_string()));
+        assert!(parsed.content.contains("Missing error handling"));
+        assert!(!parsed.content.contains("ARMADAI"));
+    }
+
+    #[test]
+    fn test_response_with_no_markers() {
+        let raw = "Just a plain response with no markers.";
+
+        let parsed = parse_response(raw);
+
+        assert!(!parsed.complete);
+        assert_eq!(parsed.delegations.len(), 0);
+        assert!(parsed.metadata.is_empty());
+        assert_eq!(parsed.content, "Just a plain response with no markers.");
+    }
+
+    #[test]
+    fn test_response_with_only_end_marker() {
+        let raw = r#"
+Simple response.
+
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        assert!(parsed.complete);
+        assert_eq!(parsed.delegations.len(), 0);
+        assert!(parsed.metadata.is_empty());
+        assert_eq!(parsed.content, "Simple response.");
+    }
+
+    #[test]
+    fn test_multiple_delegate_markers() {
+        let raw = r#"
+I'll delegate to two agents:
+
+<!--ARMADAI_DELEGATE:qa-specialist-->
+Please review the tests.
+
+<!--ARMADAI_DELEGATE:ui-specialist-->
+Update the dashboard.
+
+<!--ARMADAI_META:status=delegated-->
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        assert!(parsed.complete);
+        assert_eq!(parsed.delegations.len(), 2);
+        assert_eq!(parsed.delegations[0], "qa-specialist");
+        assert_eq!(parsed.delegations[1], "ui-specialist");
+        assert_eq!(
+            parsed.metadata.get("status"),
+            Some(&"delegated".to_string())
+        );
+    }
+
+    #[test]
+    fn test_meta_with_multiple_key_value_pairs() {
+        let raw = r#"
+Response with metadata.
+
+<!--ARMADAI_META:status=complete,tokens=200,model=claude-3-opus-->
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        assert!(parsed.complete);
+        assert_eq!(parsed.metadata.len(), 3);
+        assert_eq!(parsed.metadata.get("status"), Some(&"complete".to_string()));
+        assert_eq!(parsed.metadata.get("tokens"), Some(&"200".to_string()));
+        assert_eq!(
+            parsed.metadata.get("model"),
+            Some(&"claude-3-opus".to_string())
+        );
+    }
+
+    #[test]
+    fn test_markers_embedded_in_code_blocks() {
+        let raw = r#"
+Here's how to use the protocol:
+
+```markdown
+Your response here.
+
+<!--ARMADAI_META:status=complete-->
+<!--ARMADAI_END-->
+```
+
+Above is an example.
+
+<!--ARMADAI_META:status=complete-->
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        // Should detect both the marker in the code block AND the real one
+        assert!(parsed.complete);
+        // The code block marker will also be stripped, which is expected behavior
+        // since we're doing simple regex matching
+        assert!(parsed.content.contains("Here's how to use the protocol"));
+    }
+
+    #[test]
+    fn test_partial_malformed_markers() {
+        let raw = r#"
+Response with malformed markers.
+
+<!--ARMADAI_DELEGATE-->
+<!--ARMADAI_META-->
+<!--ARMADAI-->
+
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        // Only the END marker should be recognized
+        assert!(parsed.complete);
+        assert_eq!(parsed.delegations.len(), 0);
+        assert!(parsed.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_whitespace_handling() {
+        let raw = r#"
+
+
+Response with lots of whitespace.
+
+
+<!--ARMADAI_META:  status = complete  ,  tokens = 100  -->
+<!--ARMADAI_END-->
+
+
+"#;
+
+        let parsed = parse_response(raw);
+
+        assert!(parsed.complete);
+        assert_eq!(parsed.metadata.get("status"), Some(&"complete".to_string()));
+        assert_eq!(parsed.metadata.get("tokens"), Some(&"100".to_string()));
+        assert_eq!(parsed.content, "Response with lots of whitespace.");
+    }
+
+    #[test]
+    fn test_delegate_with_spaces() {
+        let raw = r#"
+<!--ARMADAI_DELEGATE:  qa-specialist  -->
+
+<!--ARMADAI_END-->
+"#;
+
+        let parsed = parse_response(raw);
+
+        assert!(parsed.complete);
+        assert_eq!(parsed.delegations.len(), 1);
+        assert_eq!(parsed.delegations[0], "qa-specialist");
+    }
+
+    #[test]
+    fn test_empty_response() {
+        let raw = "";
+
+        let parsed = parse_response(raw);
+
+        assert!(!parsed.complete);
+        assert_eq!(parsed.delegations.len(), 0);
+        assert!(parsed.metadata.is_empty());
+        assert_eq!(parsed.content, "");
+    }
+
+    #[test]
+    fn test_end_marker_not_at_end() {
+        let raw = r#"
+<!--ARMADAI_END-->
+
+Wait, I have more to say!
+"#;
+
+        let parsed = parse_response(raw);
+
+        // Marker is still detected even if not at the end
+        assert!(parsed.complete);
+        assert!(parsed.content.contains("Wait, I have more to say!"));
+    }
+}

--- a/src/shell/runner.rs
+++ b/src/shell/runner.rs
@@ -284,6 +284,37 @@ impl ShellRunner {
         self.config.args = args;
         // Keep history — it's still useful as context
     }
+
+    /// Restore session state from a saved session.
+    pub fn restore_from_session(&mut self, messages: Vec<Message>) {
+        self.clear();
+        self.history = messages;
+        // Recalculate metrics from history
+        for msg in &self.history {
+            if let MessageRole::Assistant = msg.role
+                && let Some(ref metrics) = msg.metrics
+            {
+                self.total_tokens_in += metrics.tokens_in_estimate;
+                self.total_tokens_out += metrics.tokens_out_estimate;
+                self.turn_count = metrics.turn_number;
+                // Recalculate cost
+                let turn_cost = (metrics.tokens_in_estimate as f64 / 1_000_000.0)
+                    * COST_PER_1M_INPUT
+                    + (metrics.tokens_out_estimate as f64 / 1_000_000.0) * COST_PER_1M_OUTPUT;
+                self.total_cost_estimate += turn_cost;
+            }
+        }
+    }
+
+    /// Get the current provider command
+    pub fn provider_command(&self) -> &str {
+        &self.config.command
+    }
+
+    /// Get turn count
+    pub fn turn_count(&self) -> u32 {
+        self.turn_count
+    }
 }
 
 #[cfg(test)]

--- a/src/shell/runner.rs
+++ b/src/shell/runner.rs
@@ -274,6 +274,16 @@ impl ShellRunner {
         self.total_tokens_out = 0;
         self.total_cost_estimate = 0.0;
     }
+
+    /// Switch to a different provider while keeping conversation history.
+    ///
+    /// This allows changing the CLI tool mid-session while preserving context.
+    /// The history is kept because it can still be useful for the new provider.
+    pub fn switch_provider(&mut self, command: String, args: Vec<String>) {
+        self.config.command = command;
+        self.config.args = args;
+        // Keep history — it's still useful as context
+    }
 }
 
 #[cfg(test)]

--- a/src/shell/runner.rs
+++ b/src/shell/runner.rs
@@ -1,0 +1,375 @@
+//! Shell runner - executes CLI commands and manages conversation state
+//!
+//! This module provides the core engine for the shell interactive mode:
+//! - Conversation history management
+//! - CLI execution via tokio::process::Command
+//! - Token and cost tracking
+//! - Prompt building with context
+
+use std::time::{Duration, Instant};
+use tokio::process::Command;
+
+use super::parser::{ParsedResponse, parse_response};
+
+/// Cost constants for Gemini Flash (per 1M tokens)
+const COST_PER_1M_INPUT: f64 = 0.15;
+const COST_PER_1M_OUTPUT: f64 = 0.60;
+
+/// Metrics for a single turn.
+#[derive(Debug, Clone)]
+pub struct TurnMetrics {
+    pub tokens_in_estimate: usize,
+    pub tokens_out_estimate: usize,
+    pub duration: Duration,
+    pub turn_number: u32,
+}
+
+/// A single message in the conversation.
+#[derive(Debug, Clone)]
+pub struct Message {
+    pub role: MessageRole,
+    pub content: String,
+    pub metrics: Option<TurnMetrics>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessageRole {
+    User,
+    Assistant,
+    System,
+}
+
+/// Configuration for the shell runner.
+#[derive(Debug, Clone)]
+pub struct RunnerConfig {
+    /// CLI command to run (e.g., "gemini")
+    pub command: String,
+    /// CLI args before the prompt (e.g., ["-p"])
+    pub args: Vec<String>,
+    /// Max history turns to include (for token economy)
+    pub max_history_turns: usize,
+    /// Timeout for CLI execution
+    pub timeout: Duration,
+}
+
+impl Default for RunnerConfig {
+    fn default() -> Self {
+        Self {
+            command: "gemini".to_string(),
+            args: vec!["-p".to_string()],
+            max_history_turns: 5,
+            timeout: Duration::from_secs(120),
+        }
+    }
+}
+
+/// Session-level cumulative metrics
+#[derive(Debug, Clone)]
+pub struct SessionMetrics {
+    pub turn_count: u32,
+    pub total_tokens_in: usize,
+    pub total_tokens_out: usize,
+    pub total_cost_estimate: f64,
+}
+
+/// The shell runner manages conversation state and CLI execution.
+pub struct ShellRunner {
+    config: RunnerConfig,
+    history: Vec<Message>,
+    turn_count: u32,
+    total_tokens_in: usize,
+    total_tokens_out: usize,
+    total_cost_estimate: f64,
+}
+
+impl ShellRunner {
+    pub fn new(config: RunnerConfig) -> Self {
+        Self {
+            config,
+            history: Vec::new(),
+            turn_count: 0,
+            total_tokens_in: 0,
+            total_tokens_out: 0,
+            total_cost_estimate: 0.0,
+        }
+    }
+
+    /// Execute a turn: send user message, get response.
+    /// Returns the parsed response and metrics.
+    pub async fn send(
+        &mut self,
+        user_input: &str,
+    ) -> anyhow::Result<(ParsedResponse, TurnMetrics)> {
+        // 1. Add user message to history
+        self.history.push(Message {
+            role: MessageRole::User,
+            content: user_input.to_string(),
+            metrics: None,
+        });
+
+        // 2. Build the full prompt (history + current message)
+        let prompt = self.build_prompt(user_input);
+
+        // 3. Call the CLI with tokio::process::Command
+        let start = Instant::now();
+
+        let output = tokio::time::timeout(
+            self.config.timeout,
+            Command::new(&self.config.command)
+                .args(&self.config.args)
+                .arg(&prompt)
+                .output(),
+        )
+        .await??;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("CLI command failed ({}): {stderr}", output.status);
+        }
+
+        let raw = String::from_utf8_lossy(&output.stdout).to_string();
+        let duration = start.elapsed();
+
+        // 4. Parse the response with parse_response()
+        let parsed = parse_response(&raw);
+
+        // 5. Calculate metrics
+        let tokens_in = Self::estimate_tokens(&prompt);
+        let tokens_out = Self::estimate_tokens(&parsed.content);
+
+        self.turn_count += 1;
+        self.total_tokens_in += tokens_in;
+        self.total_tokens_out += tokens_out;
+
+        // Calculate cost estimate (Gemini Flash pricing)
+        let turn_cost = (tokens_in as f64 / 1_000_000.0) * COST_PER_1M_INPUT
+            + (tokens_out as f64 / 1_000_000.0) * COST_PER_1M_OUTPUT;
+        self.total_cost_estimate += turn_cost;
+
+        let metrics = TurnMetrics {
+            tokens_in_estimate: tokens_in,
+            tokens_out_estimate: tokens_out,
+            duration,
+            turn_number: self.turn_count,
+        };
+
+        // 6. Add assistant message to history
+        self.history.push(Message {
+            role: MessageRole::Assistant,
+            content: parsed.content.clone(),
+            metrics: Some(metrics.clone()),
+        });
+
+        // 7. Return
+        Ok((parsed, metrics))
+    }
+
+    /// Build the prompt string including history context.
+    /// Note: This assumes the current user message has already been added to history.
+    fn build_prompt(&self, _current_input: &str) -> String {
+        let mut prompt = String::new();
+
+        // Calculate how many messages to include
+        // Each turn = 2 messages (user + assistant)
+        let max_messages = self.config.max_history_turns * 2;
+        let start = if self.history.len() > max_messages {
+            self.history.len() - max_messages
+        } else {
+            0
+        };
+
+        // Format all messages (including the most recent user message)
+        for msg in &self.history[start..] {
+            match msg.role {
+                MessageRole::User => {
+                    prompt.push_str(&format!("[User]: {}\n", msg.content));
+                }
+                MessageRole::Assistant => {
+                    prompt.push_str(&format!("[Assistant]: {}\n", msg.content));
+                }
+                MessageRole::System => {
+                    // System messages are not included in the prompt
+                }
+            }
+        }
+
+        prompt
+    }
+
+    /// Estimate token count from text (rough: chars / 4)
+    fn estimate_tokens(text: &str) -> usize {
+        text.len() / 4
+    }
+
+    /// Get cumulative session metrics
+    pub fn session_metrics(&self) -> SessionMetrics {
+        SessionMetrics {
+            turn_count: self.turn_count,
+            total_tokens_in: self.total_tokens_in,
+            total_tokens_out: self.total_tokens_out,
+            total_cost_estimate: self.total_cost_estimate,
+        }
+    }
+
+    /// Get conversation history
+    pub fn history(&self) -> &[Message] {
+        &self.history
+    }
+
+    /// Clear history
+    pub fn clear(&mut self) {
+        self.history.clear();
+        self.turn_count = 0;
+        self.total_tokens_in = 0;
+        self.total_tokens_out = 0;
+        self.total_cost_estimate = 0.0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_prompt_no_history() {
+        let config = RunnerConfig::default();
+        let mut runner = ShellRunner::new(config);
+
+        // Simulate adding user message (as send() does)
+        runner.history.push(Message {
+            role: MessageRole::User,
+            content: "Hello".to_string(),
+            metrics: None,
+        });
+
+        let prompt = runner.build_prompt("Hello");
+        assert_eq!(prompt, "[User]: Hello\n");
+    }
+
+    #[test]
+    fn test_build_prompt_with_history() {
+        let config = RunnerConfig::default();
+        let mut runner = ShellRunner::new(config);
+
+        // Add some history
+        runner.history.push(Message {
+            role: MessageRole::User,
+            content: "First question".to_string(),
+            metrics: None,
+        });
+        runner.history.push(Message {
+            role: MessageRole::Assistant,
+            content: "First answer".to_string(),
+            metrics: None,
+        });
+        // Add current user message (as send() does)
+        runner.history.push(Message {
+            role: MessageRole::User,
+            content: "Second question".to_string(),
+            metrics: None,
+        });
+
+        let prompt = runner.build_prompt("Second question");
+
+        assert!(prompt.contains("[User]: First question"));
+        assert!(prompt.contains("[Assistant]: First answer"));
+        assert!(prompt.contains("[User]: Second question"));
+    }
+
+    #[test]
+    fn test_build_prompt_truncates_history() {
+        let config = RunnerConfig {
+            max_history_turns: 2,
+            ..Default::default()
+        };
+        let mut runner = ShellRunner::new(config);
+
+        // Add 5 turns (10 messages)
+        for i in 1..=5 {
+            runner.history.push(Message {
+                role: MessageRole::User,
+                content: format!("Question {i}"),
+                metrics: None,
+            });
+            runner.history.push(Message {
+                role: MessageRole::Assistant,
+                content: format!("Answer {i}"),
+                metrics: None,
+            });
+        }
+
+        // Add current user message (as send() does)
+        runner.history.push(Message {
+            role: MessageRole::User,
+            content: "New question".to_string(),
+            metrics: None,
+        });
+
+        let prompt = runner.build_prompt("New question");
+
+        // Should only include last 2 turns (4 messages)
+        // Since we added a new user message, we have 11 messages total
+        // max_history_turns = 2 means 4 messages max
+        // So we should see only the last 4 messages
+        assert!(!prompt.contains("Question 1"));
+        assert!(!prompt.contains("Question 2"));
+        assert!(!prompt.contains("Question 3"));
+        assert!(!prompt.contains("Question 4"));
+        assert!(prompt.contains("Question 5"));
+        assert!(prompt.contains("New question"));
+    }
+
+    #[test]
+    fn test_estimate_tokens() {
+        // Rough estimate: 4 chars = 1 token
+        assert_eq!(ShellRunner::estimate_tokens("test"), 1);
+        assert_eq!(ShellRunner::estimate_tokens("hello world"), 2);
+        assert_eq!(ShellRunner::estimate_tokens("a".repeat(100).as_str()), 25);
+    }
+
+    #[test]
+    fn test_session_metrics_initial() {
+        let config = RunnerConfig::default();
+        let runner = ShellRunner::new(config);
+
+        let metrics = runner.session_metrics();
+        assert_eq!(metrics.turn_count, 0);
+        assert_eq!(metrics.total_tokens_in, 0);
+        assert_eq!(metrics.total_tokens_out, 0);
+        assert_eq!(metrics.total_cost_estimate, 0.0);
+    }
+
+    #[test]
+    fn test_clear_history() {
+        let config = RunnerConfig::default();
+        let mut runner = ShellRunner::new(config);
+
+        // Add some data
+        runner.history.push(Message {
+            role: MessageRole::User,
+            content: "Test".to_string(),
+            metrics: None,
+        });
+        runner.turn_count = 5;
+        runner.total_tokens_in = 100;
+        runner.total_tokens_out = 200;
+        runner.total_cost_estimate = 0.5;
+
+        // Clear
+        runner.clear();
+
+        // Verify everything is reset
+        assert_eq!(runner.history.len(), 0);
+        assert_eq!(runner.turn_count, 0);
+        assert_eq!(runner.total_tokens_in, 0);
+        assert_eq!(runner.total_tokens_out, 0);
+        assert_eq!(runner.total_cost_estimate, 0.0);
+    }
+
+    #[test]
+    fn test_message_role_equality() {
+        assert_eq!(MessageRole::User, MessageRole::User);
+        assert_eq!(MessageRole::Assistant, MessageRole::Assistant);
+        assert_ne!(MessageRole::User, MessageRole::Assistant);
+    }
+}

--- a/src/shell/runner.rs
+++ b/src/shell/runner.rs
@@ -196,8 +196,58 @@ impl ShellRunner {
         prompt
     }
 
+    /// Get the CLI command name.
+    pub fn command(&self) -> &str {
+        &self.config.command
+    }
+
+    /// Get the CLI args.
+    pub fn args(&self) -> &[String] {
+        &self.config.args
+    }
+
+    /// Build the prompt for a given input (public for app.rs integration).
+    pub fn build_prompt_for(&mut self, user_input: &str) -> String {
+        self.history.push(Message {
+            role: MessageRole::User,
+            content: user_input.to_string(),
+            metrics: None,
+        });
+        self.build_prompt(user_input)
+    }
+
+    /// Record a completed turn in history (called by app.rs after CLI returns).
+    pub fn record_turn(&mut self, _user_input: &str, assistant_content: &str, duration: Duration) {
+        let tokens_in = Self::estimate_tokens(
+            self.history
+                .last()
+                .map(|m| m.content.as_str())
+                .unwrap_or(""),
+        );
+        let tokens_out = Self::estimate_tokens(assistant_content);
+
+        self.turn_count += 1;
+        self.total_tokens_in += tokens_in;
+        self.total_tokens_out += tokens_out;
+
+        let turn_cost = (tokens_in as f64 / 1_000_000.0) * COST_PER_1M_INPUT
+            + (tokens_out as f64 / 1_000_000.0) * COST_PER_1M_OUTPUT;
+        self.total_cost_estimate += turn_cost;
+
+        self.history.push(Message {
+            role: MessageRole::Assistant,
+            content: assistant_content.to_string(),
+            metrics: Some(TurnMetrics {
+                tokens_in_estimate: tokens_in,
+                tokens_out_estimate: tokens_out,
+                duration,
+                turn_number: self.turn_count,
+            }),
+        });
+    }
+
     /// Estimate token count from text (rough: chars / 4)
-    fn estimate_tokens(text: &str) -> usize {
+    pub fn estimate_tokens(text: &str) -> usize {
         text.len() / 4
     }
 

--- a/src/shell/session.rs
+++ b/src/shell/session.rs
@@ -1,0 +1,249 @@
+//! Session persistence for the ArmadAI shell.
+//!
+//! Sessions are stored as JSON files in `~/.config/armadai/sessions/`.
+//! Each session captures the full conversation state, provider config, and metrics.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use super::runner::{Message, MessageRole};
+
+/// A saved shell session with full conversation state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellSession {
+    /// Unique session ID (timestamp-based or UUID)
+    pub id: String,
+    /// Human-readable name (auto-generated or user-set)
+    pub name: String,
+    /// Provider command used (e.g., "gemini", "claude")
+    pub provider: String,
+    /// Model name
+    pub model: String,
+    /// Project directory where session was started
+    pub project_dir: String,
+    /// Creation timestamp (ISO 8601)
+    pub created_at: String,
+    /// Last update timestamp
+    pub updated_at: String,
+    /// Conversation messages
+    pub messages: Vec<SessionMessage>,
+    /// Cumulative metrics
+    pub total_tokens_in: usize,
+    pub total_tokens_out: usize,
+    pub total_cost: f64,
+    pub turn_count: u32,
+}
+
+/// A message within a session (serializable version of runner::Message).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMessage {
+    pub role: String, // "user", "assistant", "system"
+    pub content: String,
+    pub timestamp: String,
+}
+
+impl SessionMessage {
+    /// Convert from runner::Message to SessionMessage.
+    pub fn from_message(msg: &Message) -> Self {
+        Self {
+            role: match msg.role {
+                MessageRole::User => "user".to_string(),
+                MessageRole::Assistant => "assistant".to_string(),
+                MessageRole::System => "system".to_string(),
+            },
+            content: msg.content.clone(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    /// Convert SessionMessage back to runner::Message.
+    pub fn to_message(&self) -> Message {
+        Message {
+            role: match self.role.as_str() {
+                "user" => MessageRole::User,
+                "assistant" => MessageRole::Assistant,
+                "system" => MessageRole::System,
+                _ => MessageRole::System, // Fallback for unknown roles
+            },
+            content: self.content.clone(),
+            metrics: None, // Metrics are not preserved on reload
+        }
+    }
+}
+
+/// Get the sessions directory (`~/.config/armadai/sessions/`).
+pub fn sessions_dir() -> PathBuf {
+    use crate::core::config::config_dir;
+    let dir = config_dir().join("sessions");
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+/// Generate a new session ID based on current timestamp.
+pub fn new_session_id() -> String {
+    chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string()
+}
+
+/// Generate a human-readable session name from project directory.
+pub fn generate_session_name(project_dir: &str) -> String {
+    let path = std::path::Path::new(project_dir);
+    let dir_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    format!("{} session", dir_name)
+}
+
+/// Save a session to disk.
+pub fn save_session(session: &ShellSession) -> Result<()> {
+    let path = sessions_dir().join(format!("{}.json", session.id));
+    let json = serde_json::to_string_pretty(session)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Load a session from disk.
+pub fn load_session(id: &str) -> Result<ShellSession> {
+    let path = sessions_dir().join(format!("{}.json", id));
+    let json = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+/// List all saved sessions (sorted by last update, newest first).
+pub fn list_sessions() -> Vec<ShellSession> {
+    let dir = sessions_dir();
+    let mut sessions = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if entry.path().extension().is_some_and(|e| e == "json")
+                && let Ok(json) = std::fs::read_to_string(entry.path())
+                && let Ok(session) = serde_json::from_str::<ShellSession>(&json)
+            {
+                sessions.push(session);
+            }
+        }
+    }
+
+    // Sort by updated_at, newest first
+    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    sessions
+}
+
+/// Delete a session.
+pub fn delete_session(id: &str) -> Result<()> {
+    let path = sessions_dir().join(format!("{}.json", id));
+    std::fs::remove_file(path)?;
+    Ok(())
+}
+
+/// Format a relative time string (e.g., "2 hours ago", "yesterday").
+pub fn format_relative_time(timestamp: &str) -> String {
+    use chrono::{DateTime, Utc};
+
+    let Ok(dt) = DateTime::parse_from_rfc3339(timestamp) else {
+        return "unknown".to_string();
+    };
+
+    let now = Utc::now();
+    let duration = now.signed_duration_since(dt.with_timezone(&Utc));
+
+    if duration.num_seconds() < 60 {
+        "just now".to_string()
+    } else if duration.num_minutes() < 60 {
+        let mins = duration.num_minutes();
+        format!("{} min{} ago", mins, if mins == 1 { "" } else { "s" })
+    } else if duration.num_hours() < 24 {
+        let hours = duration.num_hours();
+        format!("{} hour{} ago", hours, if hours == 1 { "" } else { "s" })
+    } else if duration.num_days() == 1 {
+        "yesterday".to_string()
+    } else if duration.num_days() < 7 {
+        format!("{} days ago", duration.num_days())
+    } else if duration.num_weeks() < 4 {
+        let weeks = duration.num_weeks();
+        format!("{} week{} ago", weeks, if weeks == 1 { "" } else { "s" })
+    } else if duration.num_days() < 365 {
+        let months = duration.num_days() / 30;
+        format!("{} month{} ago", months, if months == 1 { "" } else { "s" })
+    } else {
+        let years = duration.num_days() / 365;
+        format!("{} year{} ago", years, if years == 1 { "" } else { "s" })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_session_id() {
+        let id = new_session_id();
+        // Should be in format YYYYMMDD_HHMMSS
+        assert_eq!(id.len(), 15); // "20260401_143022" = 15 chars
+        assert!(id.contains('_'));
+    }
+
+    #[test]
+    fn test_generate_session_name() {
+        let name = generate_session_name("/home/user/projects/armadai");
+        assert_eq!(name, "armadai session");
+
+        let name = generate_session_name(".");
+        assert!(name.contains("session"));
+    }
+
+    #[test]
+    fn test_session_message_conversion() {
+        let msg = Message {
+            role: MessageRole::User,
+            content: "Hello".to_string(),
+            metrics: None,
+        };
+
+        let session_msg = SessionMessage::from_message(&msg);
+        assert_eq!(session_msg.role, "user");
+        assert_eq!(session_msg.content, "Hello");
+
+        let converted = session_msg.to_message();
+        assert_eq!(converted.role, MessageRole::User);
+        assert_eq!(converted.content, "Hello");
+    }
+
+    #[test]
+    fn test_format_relative_time() {
+        use chrono::{Duration, Utc};
+
+        // Just now
+        let now = Utc::now();
+        let time = format_relative_time(&now.to_rfc3339());
+        assert_eq!(time, "just now");
+
+        // 5 minutes ago
+        let past = (now - Duration::minutes(5)).to_rfc3339();
+        let time = format_relative_time(&past);
+        assert_eq!(time, "5 mins ago");
+
+        // 1 hour ago
+        let past = (now - Duration::hours(1)).to_rfc3339();
+        let time = format_relative_time(&past);
+        assert_eq!(time, "1 hour ago");
+
+        // Yesterday
+        let past = (now - Duration::days(1)).to_rfc3339();
+        let time = format_relative_time(&past);
+        assert_eq!(time, "yesterday");
+
+        // 5 days ago
+        let past = (now - Duration::days(5)).to_rfc3339();
+        let time = format_relative_time(&past);
+        assert_eq!(time, "5 days ago");
+    }
+
+    #[test]
+    fn test_sessions_dir() {
+        let dir = sessions_dir();
+        assert!(dir.ends_with("sessions"));
+    }
+}

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -23,7 +23,10 @@ struct ArmadaiStyleSheet;
 impl tui_markdown::StyleSheet for ArmadaiStyleSheet {
     fn heading(&self, level: u8) -> Style {
         match level {
-            1 => Style::new().fg(Color::Rgb(88, 166, 255)).bold().underlined(),
+            1 => Style::new()
+                .fg(Color::Rgb(88, 166, 255))
+                .bold()
+                .underlined(),
             2 => Style::new().fg(Color::Rgb(63, 185, 80)).bold(),
             3 => Style::new().fg(Color::Rgb(210, 153, 34)).bold(),
             _ => Style::new().fg(Color::Rgb(139, 148, 158)).italic(),
@@ -31,7 +34,9 @@ impl tui_markdown::StyleSheet for ArmadaiStyleSheet {
     }
 
     fn code(&self) -> Style {
-        Style::new().fg(Color::Rgb(230, 237, 243)).bg(Color::Rgb(55, 62, 71))
+        Style::new()
+            .fg(Color::Rgb(230, 237, 243))
+            .bg(Color::Rgb(55, 62, 71))
     }
 
     fn link(&self) -> Style {
@@ -59,6 +64,7 @@ pub struct DisplayMessage {
     pub role: String, // "You" or agent name
     pub content: String,
     pub is_user: bool,
+    pub is_system: bool, // System messages (commands, etc.)
 }
 
 /// Application state for the shell TUI
@@ -131,6 +137,7 @@ impl ShellApp {
             role: "You".to_string(),
             content: content.to_string(),
             is_user: true,
+            is_system: false,
         });
         self.scroll_to_bottom();
     }
@@ -141,10 +148,22 @@ impl ShellApp {
             role: self.provider_name.clone(),
             content: content.to_string(),
             is_user: false,
+            is_system: false,
         });
         // Reset to auto-scroll on new content
         self.manual_scroll = false;
         self.scroll = 0;
+    }
+
+    /// Add a system message (from slash commands, etc.)
+    pub fn add_system_message(&mut self, content: &str) {
+        self.messages.push(DisplayMessage {
+            role: "System".to_string(),
+            content: content.to_string(),
+            is_user: false,
+            is_system: true,
+        });
+        self.scroll_to_bottom();
     }
 
     /// Update metrics after a turn
@@ -378,6 +397,16 @@ impl ShellApp {
         self.should_quit
     }
 
+    /// Get the provider name
+    pub fn provider_name(&self) -> &str {
+        &self.provider_name
+    }
+
+    /// Get the model name
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
     /// Render the shell TUI
     pub fn render(&self, frame: &mut Frame) {
         let chunks = Layout::default()
@@ -396,10 +425,7 @@ impl ShellApp {
         } else {
             format!("{} ({})", self.provider_name, self.model_name)
         };
-        let header_text = format!(
-            "ArmadAI Shell — {} — Turn #{}",
-            model_info, self.turn_count
-        );
+        let header_text = format!("ArmadAI Shell — {} — Turn #{}", model_info, self.turn_count);
         let header = Paragraph::new(header_text).style(
             Style::default()
                 .fg(Color::Cyan)
@@ -431,7 +457,11 @@ impl ShellApp {
 
         for msg in &self.messages {
             // Add role label
-            let role_style = if msg.is_user {
+            let role_style = if msg.is_system {
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM)
+            } else if msg.is_user {
                 Style::default()
                     .fg(Color::Green)
                     .add_modifier(Modifier::BOLD)
@@ -441,12 +471,23 @@ impl ShellApp {
                     .add_modifier(Modifier::BOLD)
             };
 
+            let role_prefix = if msg.is_system { "⚙ " } else { "" };
             lines.push(Line::from(vec![Span::styled(
-                format!("{}: ", msg.role),
+                format!("{}{}: ", role_prefix, msg.role),
                 role_style,
             )]));
 
-            if msg.is_user {
+            if msg.is_system {
+                // System messages: dim text
+                for line in msg.content.lines() {
+                    lines.push(Line::from(Span::styled(
+                        line.to_string(),
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::DIM),
+                    )));
+                }
+            } else if msg.is_user {
                 // User messages: plain text
                 for line in msg.content.lines() {
                     lines.push(Line::from(line.to_string()));
@@ -483,7 +524,8 @@ impl ShellApp {
                         }
 
                         // Apply heading style from our stylesheet
-                        let heading_style = ArmadaiStyleSheet.heading(hash_count as u8)
+                        let heading_style = ArmadaiStyleSheet
+                            .heading(hash_count as u8)
                             .patch(line_style);
                         lines.push(Line::from(Span::styled(heading_text, heading_style)));
 
@@ -507,10 +549,15 @@ impl ShellApp {
         // Add loading indicator as last message
         if self.loading {
             let spinner = SPINNER_FRAMES[self.spinner_frame];
-            let elapsed = self.loading_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
+            let elapsed = self
+                .loading_start
+                .map(|s| s.elapsed().as_secs_f64())
+                .unwrap_or(0.0);
             lines.push(Line::from(vec![Span::styled(
                 format!("{spinner} Generating response… {elapsed:.0}s"),
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
             )]));
         }
 
@@ -541,15 +588,14 @@ impl ShellApp {
 
     fn render_statusbar(&self, frame: &mut Frame, area: Rect) {
         let status_text = if self.loading {
-            let elapsed = self.loading_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
+            let elapsed = self
+                .loading_start
+                .map(|s| s.elapsed().as_secs_f64())
+                .unwrap_or(0.0);
             let spinner = SPINNER_FRAMES[self.spinner_frame];
             format!(
                 "{} │ {} in │ {} out │ ${:.3} │ {spinner} thinking… {:.0}s",
-                self.provider_name,
-                self.tokens_in,
-                self.tokens_out,
-                self.cost,
-                elapsed,
+                self.provider_name, self.tokens_in, self.tokens_out, self.cost, elapsed,
             )
         } else {
             format!(
@@ -563,8 +609,11 @@ impl ShellApp {
             )
         };
 
-        let statusbar = Paragraph::new(status_text)
-            .style(Style::default().fg(Color::DarkGray).bg(Color::Rgb(22, 27, 34)));
+        let statusbar = Paragraph::new(status_text).style(
+            Style::default()
+                .fg(Color::DarkGray)
+                .bg(Color::Rgb(22, 27, 34)),
+        );
 
         frame.render_widget(statusbar, area);
     }
@@ -627,6 +676,19 @@ mod tests {
         assert_eq!(app.messages.len(), 2);
         assert!(app.messages[0].is_user);
         assert!(!app.messages[1].is_user);
+        assert!(!app.messages[0].is_system);
+        assert!(!app.messages[1].is_system);
+    }
+
+    #[test]
+    fn test_add_system_message() {
+        let mut app = ShellApp::new("Gemini".to_string());
+        app.add_system_message("Session cleared");
+
+        assert_eq!(app.messages.len(), 1);
+        assert!(!app.messages[0].is_user);
+        assert!(app.messages[0].is_system);
+        assert_eq!(app.messages[0].role, "System");
     }
 
     #[test]

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -463,6 +463,11 @@ impl ShellApp {
         &self.model_name
     }
 
+    /// Set the provider name (used when switching providers)
+    pub fn set_provider_name(&mut self, name: String) {
+        self.provider_name = name;
+    }
+
     /// Render the shell TUI
     pub fn render(&self, frame: &mut Frame) {
         let chunks = Layout::default()

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -13,7 +13,45 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tui_markdown::StyleSheet;
+
+/// Custom stylesheet for ArmadAI shell — designed for dark terminal themes.
+#[derive(Clone, Copy, Debug, Default)]
+struct ArmadaiStyleSheet;
+
+impl tui_markdown::StyleSheet for ArmadaiStyleSheet {
+    fn heading(&self, level: u8) -> Style {
+        match level {
+            1 => Style::new().fg(Color::Rgb(88, 166, 255)).bold().underlined(),
+            2 => Style::new().fg(Color::Rgb(63, 185, 80)).bold(),
+            3 => Style::new().fg(Color::Rgb(210, 153, 34)).bold(),
+            _ => Style::new().fg(Color::Rgb(139, 148, 158)).italic(),
+        }
+    }
+
+    fn code(&self) -> Style {
+        Style::new().fg(Color::Rgb(230, 237, 243)).bg(Color::Rgb(55, 62, 71))
+    }
+
+    fn link(&self) -> Style {
+        Style::new().fg(Color::Rgb(88, 166, 255)).underlined()
+    }
+
+    fn blockquote(&self) -> Style {
+        Style::new().fg(Color::Rgb(139, 148, 158)).italic()
+    }
+
+    fn heading_meta(&self) -> Style {
+        Style::new().dim()
+    }
+
+    fn metadata_block(&self) -> Style {
+        Style::new().fg(Color::Rgb(210, 153, 34))
+    }
+}
+
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 /// A single message in the conversation
 #[derive(Debug, Clone)]
@@ -35,14 +73,28 @@ pub struct ShellApp {
     scroll: u16,
     /// Whether we're waiting for a response
     loading: bool,
+    /// Spinner frame index
+    spinner_frame: usize,
+    /// When loading started
+    loading_start: Option<Instant>,
+    /// Input history (previous prompts)
+    input_history: Vec<String>,
+    /// Current position in input history (None = not browsing)
+    history_index: Option<usize>,
+    /// Saved current input when browsing history
+    saved_input: String,
     /// Provider name for statusbar
     provider_name: String,
+    /// Model name for header
+    model_name: String,
     /// Session metrics for statusbar
     turn_count: u32,
     tokens_in: usize,
     tokens_out: usize,
     cost: f64,
     last_duration: Duration,
+    /// Whether user has manually scrolled (disables auto-scroll to bottom)
+    manual_scroll: bool,
     /// Should quit
     should_quit: bool,
 }
@@ -56,7 +108,14 @@ impl ShellApp {
             cursor: 0,
             scroll: 0,
             loading: false,
+            spinner_frame: 0,
+            loading_start: None,
+            input_history: Vec::new(),
+            history_index: None,
+            saved_input: String::new(),
+            manual_scroll: false,
             provider_name,
+            model_name: String::new(),
             turn_count: 0,
             tokens_in: 0,
             tokens_out: 0,
@@ -83,7 +142,9 @@ impl ShellApp {
             content: content.to_string(),
             is_user: false,
         });
-        self.scroll_to_bottom();
+        // Reset to auto-scroll on new content
+        self.manual_scroll = false;
+        self.scroll = 0;
     }
 
     /// Update metrics after a turn
@@ -107,14 +168,52 @@ impl ShellApp {
             return None;
         }
         let result = self.input.clone();
+        // Save to history
+        self.input_history.push(result.clone());
+        self.history_index = None;
+        self.saved_input.clear();
         self.input.clear();
         self.cursor = 0;
         Some(result)
     }
 
+    /// Set model name for display
+    pub fn set_model_name(&mut self, name: String) {
+        self.model_name = name;
+    }
+
+    /// Set session metrics from the runner (replaces update_metrics for cumulative data)
+    pub fn set_session_metrics(
+        &mut self,
+        tokens_in: usize,
+        tokens_out: usize,
+        cost: f64,
+        turn_count: u32,
+        last_duration: Duration,
+    ) {
+        self.tokens_in = tokens_in;
+        self.tokens_out = tokens_out;
+        self.cost = cost;
+        self.turn_count = turn_count;
+        self.last_duration = last_duration;
+    }
+
     /// Set loading state
     pub fn set_loading(&mut self, loading: bool) {
         self.loading = loading;
+        if loading {
+            self.loading_start = Some(Instant::now());
+            self.spinner_frame = 0;
+        } else {
+            self.loading_start = None;
+        }
+    }
+
+    /// Advance the spinner animation (call on each render tick during loading)
+    pub fn tick_spinner(&mut self) {
+        if self.loading {
+            self.spinner_frame = (self.spinner_frame + 1) % SPINNER_FRAMES.len();
+        }
     }
 
     /// Clear the conversation
@@ -123,19 +222,29 @@ impl ShellApp {
         self.scroll = 0;
     }
 
+    /// Convert a char-based cursor position to a byte index in the input string.
+    fn char_to_byte(&self, char_pos: usize) -> usize {
+        self.input
+            .char_indices()
+            .nth(char_pos)
+            .map(|(i, _)| i)
+            .unwrap_or(self.input.len())
+    }
+
     /// Scroll messages area
     fn scroll_to_bottom(&mut self) {
         // Will be calculated based on content height in render
     }
 
     fn scroll_up(&mut self) {
-        if self.scroll > 0 {
-            self.scroll = self.scroll.saturating_sub(5);
-        }
+        self.scroll = self.scroll.saturating_sub(2);
+        self.manual_scroll = true;
     }
 
     fn scroll_down(&mut self) {
-        self.scroll = self.scroll.saturating_add(5);
+        self.scroll = self.scroll.saturating_add(2);
+        // Mark as manually scrolled so auto-scroll doesn't override
+        self.manual_scroll = true;
     }
 
     /// Handle a key event, returns true if should quit
@@ -159,20 +268,23 @@ impl ShellApp {
             }
             // Regular character input
             KeyCode::Char(c) => {
-                self.input.insert(self.cursor, c);
+                let byte_idx = self.char_to_byte(self.cursor);
+                self.input.insert(byte_idx, c);
                 self.cursor += 1;
                 false
             }
             KeyCode::Backspace => {
                 if self.cursor > 0 {
-                    self.input.remove(self.cursor - 1);
                     self.cursor -= 1;
+                    let byte_idx = self.char_to_byte(self.cursor);
+                    self.input.remove(byte_idx);
                 }
                 false
             }
             KeyCode::Delete => {
-                if self.cursor < self.input.len() {
-                    self.input.remove(self.cursor);
+                if self.cursor < self.input.chars().count() {
+                    let byte_idx = self.char_to_byte(self.cursor);
+                    self.input.remove(byte_idx);
                 }
                 false
             }
@@ -183,7 +295,7 @@ impl ShellApp {
                 false
             }
             KeyCode::Right => {
-                if self.cursor < self.input.len() {
+                if self.cursor < self.input.chars().count() {
                     self.cursor += 1;
                 }
                 false
@@ -193,7 +305,47 @@ impl ShellApp {
                 false
             }
             KeyCode::End => {
-                self.cursor = self.input.len();
+                self.cursor = self.input.chars().count();
+                false
+            }
+            KeyCode::Up => {
+                // Navigate input history (older)
+                if !self.input_history.is_empty() {
+                    match self.history_index {
+                        None => {
+                            // Start browsing: save current input, show last history item
+                            self.saved_input = self.input.clone();
+                            let idx = self.input_history.len() - 1;
+                            self.history_index = Some(idx);
+                            self.input = self.input_history[idx].clone();
+                            self.cursor = self.input.chars().count();
+                        }
+                        Some(idx) if idx > 0 => {
+                            let new_idx = idx - 1;
+                            self.history_index = Some(new_idx);
+                            self.input = self.input_history[new_idx].clone();
+                            self.cursor = self.input.chars().count();
+                        }
+                        _ => {} // At oldest item, do nothing
+                    }
+                }
+                false
+            }
+            KeyCode::Down => {
+                // Navigate input history (newer)
+                if let Some(idx) = self.history_index {
+                    if idx + 1 < self.input_history.len() {
+                        let new_idx = idx + 1;
+                        self.history_index = Some(new_idx);
+                        self.input = self.input_history[new_idx].clone();
+                        self.cursor = self.input.chars().count();
+                    } else {
+                        // Back to current input
+                        self.history_index = None;
+                        self.input = self.saved_input.clone();
+                        self.cursor = self.input.chars().count();
+                    }
+                }
                 false
             }
             KeyCode::PageUp => {
@@ -212,6 +364,16 @@ impl ShellApp {
         }
     }
 
+    /// Handle mouse events (scroll wheel)
+    pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
+        use crossterm::event::MouseEventKind;
+        match mouse.kind {
+            MouseEventKind::ScrollUp => self.scroll_up(),
+            MouseEventKind::ScrollDown => self.scroll_down(),
+            _ => {}
+        }
+    }
+
     pub fn should_quit(&self) -> bool {
         self.should_quit
     }
@@ -224,14 +386,19 @@ impl ShellApp {
                 Constraint::Length(1), // Header
                 Constraint::Min(0),    // Messages area
                 Constraint::Length(1), // Statusbar
-                Constraint::Length(1), // Input line
+                Constraint::Length(3), // Input line (with borders)
             ])
             .split(frame.area());
 
         // Header
+        let model_info = if self.model_name.is_empty() {
+            self.provider_name.clone()
+        } else {
+            format!("{} ({})", self.provider_name, self.model_name)
+        };
         let header_text = format!(
-            "ArmadAI Shell — provider: {} — Turn #{}",
-            self.provider_name, self.turn_count
+            "ArmadAI Shell — {} — Turn #{}",
+            model_info, self.turn_count
         );
         let header = Paragraph::new(header_text).style(
             Style::default()
@@ -279,32 +446,110 @@ impl ShellApp {
                 role_style,
             )]));
 
-            // Add content lines with wrapping
-            for line in msg.content.lines() {
-                lines.push(Line::from(line.to_string()));
+            if msg.is_user {
+                // User messages: plain text
+                for line in msg.content.lines() {
+                    lines.push(Line::from(line.to_string()));
+                }
+            } else {
+                // Assistant messages: rich markdown rendering
+                let opts = tui_markdown::Options::new(ArmadaiStyleSheet);
+                let md_text = tui_markdown::from_str_with_options(&msg.content, &opts);
+                for line in md_text.lines {
+                    // Post-process: strip leading ### markers from headings,
+                    // replace with clean styled text
+                    let first_span_str: String = line
+                        .spans
+                        .first()
+                        .map(|s| s.content.to_string())
+                        .unwrap_or_default();
+                    if first_span_str.starts_with('#') {
+                        // It's a heading line — strip the # prefix, keep the original line style
+                        let line_style = line.style;
+                        lines.push(Line::from(""));
+
+                        // Determine heading level for separator
+                        let hash_count = first_span_str.chars().take_while(|c| *c == '#').count();
+
+                        // Build the cleaned heading text
+                        let mut heading_text = String::new();
+                        for s in &line.spans {
+                            let content = s.content.to_string();
+                            if content.starts_with('#') {
+                                heading_text.push_str(content.trim_start_matches('#').trim_start());
+                            } else {
+                                heading_text.push_str(&content);
+                            }
+                        }
+
+                        // Apply heading style from our stylesheet
+                        let heading_style = ArmadaiStyleSheet.heading(hash_count as u8)
+                            .patch(line_style);
+                        lines.push(Line::from(Span::styled(heading_text, heading_style)));
+
+                        // Add separator after H1/H2/H3
+                        if hash_count <= 3 {
+                            lines.push(Line::from(Span::styled(
+                                "─".repeat(50),
+                                Style::default().fg(Color::DarkGray),
+                            )));
+                        }
+                    } else {
+                        lines.push(line);
+                    }
+                }
             }
 
             // Add blank line between messages
             lines.push(Line::from(""));
         }
 
+        // Add loading indicator as last message
+        if self.loading {
+            let spinner = SPINNER_FRAMES[self.spinner_frame];
+            let elapsed = self.loading_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
+            lines.push(Line::from(vec![Span::styled(
+                format!("{spinner} Generating response… {elapsed:.0}s"),
+                Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            )]));
+        }
+
+        // Calculate scroll position
+        let visible_height = area.height.saturating_sub(2) as usize; // minus borders
+        let total_lines = lines.len();
+        let max_scroll = if total_lines > visible_height {
+            (total_lines - visible_height) as u16
+        } else {
+            0
+        };
+        let scroll = if self.manual_scroll {
+            // User is manually scrolling — clamp to valid range
+            self.scroll.min(max_scroll)
+        } else {
+            // Auto-scroll to bottom
+            max_scroll
+        };
+
         // Create paragraph with message content
         let messages_text = Paragraph::new(lines)
             .block(Block::default().borders(Borders::ALL))
-            .wrap(Wrap { trim: true });
+            .wrap(Wrap { trim: true })
+            .scroll((scroll, 0));
 
         frame.render_widget(messages_text, area);
     }
 
     fn render_statusbar(&self, frame: &mut Frame, area: Rect) {
         let status_text = if self.loading {
+            let elapsed = self.loading_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
+            let spinner = SPINNER_FRAMES[self.spinner_frame];
             format!(
-                "{} │ {} in │ {} out │ ${:.3} │ {:.1}s │ thinking...",
+                "{} │ {} in │ {} out │ ${:.3} │ {spinner} thinking… {:.0}s",
                 self.provider_name,
                 self.tokens_in,
                 self.tokens_out,
                 self.cost,
-                self.last_duration.as_secs_f64()
+                elapsed,
             )
         } else {
             format!(
@@ -319,8 +564,7 @@ impl ShellApp {
         };
 
         let statusbar = Paragraph::new(status_text)
-            .style(Style::default().fg(Color::DarkGray))
-            .block(Block::default().borders(Borders::ALL));
+            .style(Style::default().fg(Color::DarkGray).bg(Color::Rgb(22, 27, 34)));
 
         frame.render_widget(statusbar, area);
     }
@@ -343,7 +587,7 @@ impl ShellApp {
         }
 
         // If cursor is at end, show cursor
-        if self.cursor >= self.input.len() && !self.loading {
+        if self.cursor >= self.input.chars().count() && !self.loading {
             input_spans.push(Span::styled(
                 " ",
                 Style::default().bg(Color::White).fg(Color::Black),
@@ -352,8 +596,10 @@ impl ShellApp {
 
         let input_line = Paragraph::new(Line::from(input_spans)).block(
             Block::default()
-                .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
-                .style(Style::default()),
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray))
+                .title(" Input ")
+                .title_style(Style::default().fg(Color::Cyan)),
         );
 
         frame.render_widget(input_line, area);

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -101,6 +101,10 @@ pub struct ShellApp {
     last_duration: Duration,
     /// Whether user has manually scrolled (disables auto-scroll to bottom)
     manual_scroll: bool,
+    /// Overlay popup content (shown on top of messages, dismissed with Esc)
+    popup: Option<String>,
+    /// Popup scroll offset
+    popup_scroll: u16,
     /// Should quit
     should_quit: bool,
 }
@@ -120,6 +124,8 @@ impl ShellApp {
             history_index: None,
             saved_input: String::new(),
             manual_scroll: false,
+            popup: None,
+            popup_scroll: 0,
             provider_name,
             model_name: String::new(),
             turn_count: 0,
@@ -164,6 +170,23 @@ impl ShellApp {
             is_system: true,
         });
         self.scroll_to_bottom();
+    }
+
+    /// Show a popup overlay (dismissed with Esc or any key)
+    pub fn show_popup(&mut self, content: String) {
+        self.popup = Some(content);
+        self.popup_scroll = 0;
+    }
+
+    /// Dismiss the popup
+    pub fn dismiss_popup(&mut self) {
+        self.popup = None;
+        self.popup_scroll = 0;
+    }
+
+    /// Whether a popup is currently shown
+    pub fn has_popup(&self) -> bool {
+        self.popup.is_some()
     }
 
     /// Update metrics after a turn
@@ -269,6 +292,27 @@ impl ShellApp {
     /// Handle a key event, returns true if should quit
     pub fn handle_key(&mut self, key: KeyEvent) -> bool {
         use crossterm::event::{KeyCode, KeyModifiers};
+
+        // If popup is active, handle popup keys first
+        if self.has_popup() {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => self.dismiss_popup(),
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.popup_scroll = self.popup_scroll.saturating_sub(2);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.popup_scroll = self.popup_scroll.saturating_add(2);
+                }
+                KeyCode::PageUp => {
+                    self.popup_scroll = self.popup_scroll.saturating_sub(10);
+                }
+                KeyCode::PageDown => {
+                    self.popup_scroll = self.popup_scroll.saturating_add(10);
+                }
+                _ => self.dismiss_popup(),
+            }
+            return false;
+        }
 
         match key.code {
             // Handle Ctrl+C and Esc for quit
@@ -386,10 +430,22 @@ impl ShellApp {
     /// Handle mouse events (scroll wheel)
     pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
         use crossterm::event::MouseEventKind;
-        match mouse.kind {
-            MouseEventKind::ScrollUp => self.scroll_up(),
-            MouseEventKind::ScrollDown => self.scroll_down(),
-            _ => {}
+        if self.has_popup() {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    self.popup_scroll = self.popup_scroll.saturating_sub(2);
+                }
+                MouseEventKind::ScrollDown => {
+                    self.popup_scroll = self.popup_scroll.saturating_add(2);
+                }
+                _ => {}
+            }
+        } else {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => self.scroll_up(),
+                MouseEventKind::ScrollDown => self.scroll_down(),
+                _ => {}
+            }
         }
     }
 
@@ -441,6 +497,85 @@ impl ShellApp {
 
         // Input line
         self.render_input_line(frame, chunks[3]);
+
+        // Popup overlay (rendered on top of everything)
+        if let Some(ref content) = self.popup {
+            self.render_popup(frame, content);
+        }
+    }
+
+    fn render_popup(&self, frame: &mut Frame, content: &str) {
+        let area = frame.area();
+
+        // Center the popup: 80% width, 70% height
+        let popup_width = (area.width as f32 * 0.80) as u16;
+        let popup_height = (area.height as f32 * 0.70) as u16;
+        let x = (area.width.saturating_sub(popup_width)) / 2;
+        let y = (area.height.saturating_sub(popup_height)) / 2;
+        let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+        // Semi-transparent background (clear the area)
+        frame.render_widget(ratatui::widgets::Clear, popup_area);
+
+        // Render markdown content inside the popup
+        let opts = tui_markdown::Options::new(ArmadaiStyleSheet);
+        let md_text = tui_markdown::from_str_with_options(content, &opts);
+
+        // Post-process headings (same as messages)
+        let mut lines: Vec<Line> = Vec::new();
+        for line in md_text.lines {
+            let first_span_str: String = line
+                .spans
+                .first()
+                .map(|s| s.content.to_string())
+                .unwrap_or_default();
+            if first_span_str.starts_with('#') {
+                let line_style = line.style;
+                lines.push(Line::from(""));
+                let hash_count = first_span_str.chars().take_while(|c| *c == '#').count();
+                let mut heading_text = String::new();
+                for s in &line.spans {
+                    let c = s.content.to_string();
+                    if c.starts_with('#') {
+                        heading_text.push_str(c.trim_start_matches('#').trim_start());
+                    } else {
+                        heading_text.push_str(&c);
+                    }
+                }
+                let heading_style = ArmadaiStyleSheet
+                    .heading(hash_count as u8)
+                    .patch(line_style);
+                lines.push(Line::from(Span::styled(heading_text, heading_style)));
+                if hash_count <= 3 {
+                    lines.push(Line::from(Span::styled(
+                        "─".repeat(popup_width.saturating_sub(4) as usize),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+            } else {
+                lines.push(line);
+            }
+        }
+
+        // Footer hint
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            " Esc to close │ ↑↓ scroll",
+            Style::default().fg(Color::DarkGray),
+        )));
+
+        let popup = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan))
+                    .title(" ArmadAI ")
+                    .title_style(Style::default().fg(Color::Cyan).bold()),
+            )
+            .wrap(Wrap { trim: true })
+            .scroll((self.popup_scroll, 0));
+
+        frame.render_widget(popup, popup_area);
     }
 
     fn render_messages_area(&self, frame: &mut Frame, area: Rect) {
@@ -478,14 +613,41 @@ impl ShellApp {
             )]));
 
             if msg.is_system {
-                // System messages: dim text
-                for line in msg.content.lines() {
-                    lines.push(Line::from(Span::styled(
-                        line.to_string(),
-                        Style::default()
-                            .fg(Color::DarkGray)
-                            .add_modifier(Modifier::DIM),
-                    )));
+                // System messages: render as markdown (same as assistant)
+                let opts = tui_markdown::Options::new(ArmadaiStyleSheet);
+                let md_text = tui_markdown::from_str_with_options(&msg.content, &opts);
+                for line in md_text.lines {
+                    let first_span_str: String = line
+                        .spans
+                        .first()
+                        .map(|s| s.content.to_string())
+                        .unwrap_or_default();
+                    if first_span_str.starts_with('#') {
+                        let line_style = line.style;
+                        lines.push(Line::from(""));
+                        let hash_count = first_span_str.chars().take_while(|c| *c == '#').count();
+                        let mut heading_text = String::new();
+                        for s in &line.spans {
+                            let content = s.content.to_string();
+                            if content.starts_with('#') {
+                                heading_text.push_str(content.trim_start_matches('#').trim_start());
+                            } else {
+                                heading_text.push_str(&content);
+                            }
+                        }
+                        let heading_style = ArmadaiStyleSheet
+                            .heading(hash_count as u8)
+                            .patch(line_style);
+                        lines.push(Line::from(Span::styled(heading_text, heading_style)));
+                        if hash_count <= 3 {
+                            lines.push(Line::from(Span::styled(
+                                "─".repeat(50),
+                                Style::default().fg(Color::DarkGray),
+                            )));
+                        }
+                    } else {
+                        lines.push(line);
+                    }
                 }
             } else if msg.is_user {
                 // User messages: plain text

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -1,0 +1,407 @@
+//! TUI for the ArmadAI interactive shell.
+//!
+//! Provides a conversational interface with:
+//! - Message area showing user and assistant exchanges
+//! - Input box at the bottom
+//! - Status bar with provider info and metrics
+
+#![cfg(feature = "tui")]
+
+use crossterm::event::KeyEvent;
+use ratatui::{
+    prelude::*,
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+use std::time::Duration;
+
+/// A single message in the conversation
+#[derive(Debug, Clone)]
+pub struct DisplayMessage {
+    pub role: String, // "You" or agent name
+    pub content: String,
+    pub is_user: bool,
+}
+
+/// Application state for the shell TUI
+pub struct ShellApp {
+    /// Conversation messages for display
+    messages: Vec<DisplayMessage>,
+    /// Current user input
+    input: String,
+    /// Cursor position in input
+    cursor: usize,
+    /// Scroll offset for messages area
+    scroll: u16,
+    /// Whether we're waiting for a response
+    loading: bool,
+    /// Provider name for statusbar
+    provider_name: String,
+    /// Session metrics for statusbar
+    turn_count: u32,
+    tokens_in: usize,
+    tokens_out: usize,
+    cost: f64,
+    last_duration: Duration,
+    /// Should quit
+    should_quit: bool,
+}
+
+impl ShellApp {
+    /// Create a new shell app
+    pub fn new(provider_name: String) -> Self {
+        Self {
+            messages: Vec::new(),
+            input: String::new(),
+            cursor: 0,
+            scroll: 0,
+            loading: false,
+            provider_name,
+            turn_count: 0,
+            tokens_in: 0,
+            tokens_out: 0,
+            cost: 0.0,
+            last_duration: Duration::from_secs(0),
+            should_quit: false,
+        }
+    }
+
+    /// Add a user message to the display
+    pub fn add_user_message(&mut self, content: &str) {
+        self.messages.push(DisplayMessage {
+            role: "You".to_string(),
+            content: content.to_string(),
+            is_user: true,
+        });
+        self.scroll_to_bottom();
+    }
+
+    /// Add an assistant response to the display
+    pub fn add_assistant_message(&mut self, content: &str) {
+        self.messages.push(DisplayMessage {
+            role: self.provider_name.clone(),
+            content: content.to_string(),
+            is_user: false,
+        });
+        self.scroll_to_bottom();
+    }
+
+    /// Update metrics after a turn
+    pub fn update_metrics(
+        &mut self,
+        tokens_in: usize,
+        tokens_out: usize,
+        cost: f64,
+        duration: Duration,
+    ) {
+        self.tokens_in += tokens_in;
+        self.tokens_out += tokens_out;
+        self.cost += cost;
+        self.last_duration = duration;
+        self.turn_count += 1;
+    }
+
+    /// Take the current input (returns it and clears the input box)
+    pub fn take_input(&mut self) -> Option<String> {
+        if self.input.is_empty() {
+            return None;
+        }
+        let result = self.input.clone();
+        self.input.clear();
+        self.cursor = 0;
+        Some(result)
+    }
+
+    /// Set loading state
+    pub fn set_loading(&mut self, loading: bool) {
+        self.loading = loading;
+    }
+
+    /// Clear the conversation
+    pub fn clear_conversation(&mut self) {
+        self.messages.clear();
+        self.scroll = 0;
+    }
+
+    /// Scroll messages area
+    fn scroll_to_bottom(&mut self) {
+        // Will be calculated based on content height in render
+    }
+
+    fn scroll_up(&mut self) {
+        if self.scroll > 0 {
+            self.scroll = self.scroll.saturating_sub(5);
+        }
+    }
+
+    fn scroll_down(&mut self) {
+        self.scroll = self.scroll.saturating_add(5);
+    }
+
+    /// Handle a key event, returns true if should quit
+    pub fn handle_key(&mut self, key: KeyEvent) -> bool {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        match key.code {
+            // Handle Ctrl+C and Esc for quit
+            KeyCode::Esc => {
+                self.should_quit = true;
+                true
+            }
+            KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                self.should_quit = true;
+                true
+            }
+            // Handle Ctrl+L for clear
+            KeyCode::Char('l') if key.modifiers == KeyModifiers::CONTROL => {
+                self.clear_conversation();
+                false
+            }
+            // Regular character input
+            KeyCode::Char(c) => {
+                self.input.insert(self.cursor, c);
+                self.cursor += 1;
+                false
+            }
+            KeyCode::Backspace => {
+                if self.cursor > 0 {
+                    self.input.remove(self.cursor - 1);
+                    self.cursor -= 1;
+                }
+                false
+            }
+            KeyCode::Delete => {
+                if self.cursor < self.input.len() {
+                    self.input.remove(self.cursor);
+                }
+                false
+            }
+            KeyCode::Left => {
+                if self.cursor > 0 {
+                    self.cursor -= 1;
+                }
+                false
+            }
+            KeyCode::Right => {
+                if self.cursor < self.input.len() {
+                    self.cursor += 1;
+                }
+                false
+            }
+            KeyCode::Home => {
+                self.cursor = 0;
+                false
+            }
+            KeyCode::End => {
+                self.cursor = self.input.len();
+                false
+            }
+            KeyCode::PageUp => {
+                self.scroll_up();
+                false
+            }
+            KeyCode::PageDown => {
+                self.scroll_down();
+                false
+            }
+            KeyCode::Enter => {
+                // Submit will be handled by take_input
+                false
+            }
+            _ => false,
+        }
+    }
+
+    pub fn should_quit(&self) -> bool {
+        self.should_quit
+    }
+
+    /// Render the shell TUI
+    pub fn render(&self, frame: &mut Frame) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // Header
+                Constraint::Min(0),    // Messages area
+                Constraint::Length(1), // Statusbar
+                Constraint::Length(1), // Input line
+            ])
+            .split(frame.area());
+
+        // Header
+        let header_text = format!(
+            "ArmadAI Shell — provider: {} — Turn #{}",
+            self.provider_name, self.turn_count
+        );
+        let header = Paragraph::new(header_text).style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+        frame.render_widget(header, chunks[0]);
+
+        // Messages area
+        self.render_messages_area(frame, chunks[1]);
+
+        // Status bar
+        self.render_statusbar(frame, chunks[2]);
+
+        // Input line
+        self.render_input_line(frame, chunks[3]);
+    }
+
+    fn render_messages_area(&self, frame: &mut Frame, area: Rect) {
+        if self.messages.is_empty() {
+            let placeholder = Paragraph::new("Welcome to ArmadAI Shell!\n\nType your message and press Enter to get started. Press Ctrl+L to clear conversation, Ctrl+C or Esc to quit.")
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(Wrap { trim: true });
+            frame.render_widget(placeholder, area);
+            return;
+        }
+
+        // Format messages for display
+        let mut lines: Vec<Line> = Vec::new();
+
+        for msg in &self.messages {
+            // Add role label
+            let role_style = if msg.is_user {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            };
+
+            lines.push(Line::from(vec![Span::styled(
+                format!("{}: ", msg.role),
+                role_style,
+            )]));
+
+            // Add content lines with wrapping
+            for line in msg.content.lines() {
+                lines.push(Line::from(line.to_string()));
+            }
+
+            // Add blank line between messages
+            lines.push(Line::from(""));
+        }
+
+        // Create paragraph with message content
+        let messages_text = Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL))
+            .wrap(Wrap { trim: true });
+
+        frame.render_widget(messages_text, area);
+    }
+
+    fn render_statusbar(&self, frame: &mut Frame, area: Rect) {
+        let status_text = if self.loading {
+            format!(
+                "{} │ {} in │ {} out │ ${:.3} │ {:.1}s │ thinking...",
+                self.provider_name,
+                self.tokens_in,
+                self.tokens_out,
+                self.cost,
+                self.last_duration.as_secs_f64()
+            )
+        } else {
+            format!(
+                "{} │ {} in │ {} out │ ${:.3} │ {:.1}s │ #{}",
+                self.provider_name,
+                self.tokens_in,
+                self.tokens_out,
+                self.cost,
+                self.last_duration.as_secs_f64(),
+                self.turn_count
+            )
+        };
+
+        let statusbar = Paragraph::new(status_text)
+            .style(Style::default().fg(Color::DarkGray))
+            .block(Block::default().borders(Borders::ALL));
+
+        frame.render_widget(statusbar, area);
+    }
+
+    fn render_input_line(&self, frame: &mut Frame, area: Rect) {
+        let cursor_indicator = if self.loading { "..." } else { ">" };
+
+        // Build the input display with cursor
+        let mut input_spans = vec![Span::raw(format!("{} ", cursor_indicator))];
+
+        for (i, c) in self.input.chars().enumerate() {
+            if i == self.cursor {
+                input_spans.push(Span::styled(
+                    c.to_string(),
+                    Style::default().bg(Color::White).fg(Color::Black),
+                ));
+            } else {
+                input_spans.push(Span::raw(c.to_string()));
+            }
+        }
+
+        // If cursor is at end, show cursor
+        if self.cursor >= self.input.len() && !self.loading {
+            input_spans.push(Span::styled(
+                " ",
+                Style::default().bg(Color::White).fg(Color::Black),
+            ));
+        }
+
+        let input_line = Paragraph::new(Line::from(input_spans)).block(
+            Block::default()
+                .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+                .style(Style::default()),
+        );
+
+        frame.render_widget(input_line, area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_shell_app() {
+        let app = ShellApp::new("Gemini".to_string());
+        assert_eq!(app.provider_name, "Gemini");
+        assert!(app.messages.is_empty());
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn test_add_messages() {
+        let mut app = ShellApp::new("Gemini".to_string());
+        app.add_user_message("Hello");
+        app.add_assistant_message("Hi there!");
+
+        assert_eq!(app.messages.len(), 2);
+        assert!(app.messages[0].is_user);
+        assert!(!app.messages[1].is_user);
+    }
+
+    #[test]
+    fn test_take_input() {
+        let mut app = ShellApp::new("Gemini".to_string());
+        app.input = "test".to_string();
+        app.cursor = 4;
+
+        let result = app.take_input();
+        assert_eq!(result, Some("test".to_string()));
+        assert!(app.input.is_empty());
+        assert_eq!(app.cursor, 0);
+    }
+
+    #[test]
+    fn test_update_metrics() {
+        let mut app = ShellApp::new("Gemini".to_string());
+        app.update_metrics(100, 50, 0.001, Duration::from_secs(1));
+
+        assert_eq!(app.tokens_in, 100);
+        assert_eq!(app.tokens_out, 50);
+        assert_eq!(app.turn_count, 1);
+    }
+}

--- a/src/shell/wizard.rs
+++ b/src/shell/wizard.rs
@@ -1,0 +1,419 @@
+//! Project setup wizard for the shell.
+//!
+//! Guides the user through project initialization and linking before entering the shell.
+
+use anyhow::Result;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use crate::core::project;
+use crate::core::starter::{find_pack_dir, list_available_packs};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct WizardResult {
+    pub provider_command: String,
+    pub provider_args: Vec<String>,
+    pub model_name: String,
+    pub project_name: String,
+}
+
+/// Check project readiness and run wizard if needed.
+/// Returns the provider configuration to use, or an error if setup was cancelled.
+pub fn ensure_project_ready() -> Result<WizardResult> {
+    // Step 1: Check project state
+    let project_state = detect_project();
+
+    // Step 2: Initialize project if needed
+    match project_state {
+        ProjectState::NoProject => {
+            if !prompt_init()? {
+                return Err(anyhow::anyhow!("Project setup cancelled by user"));
+            }
+        }
+        ProjectState::GitRepoNoConfig => {
+            if !prompt_init()? {
+                return Err(anyhow::anyhow!("Project setup cancelled by user"));
+            }
+        }
+        ProjectState::Configured => {
+            // Project already configured, continue
+        }
+    }
+
+    // Step 3: Check for existing link
+    if let Some(linked) = detect_link() {
+        // Link exists, use it
+        return build_wizard_result(&linked.name);
+    }
+
+    // Step 4: Prompt for link if needed
+    let provider = prompt_link()?;
+
+    // Check auth
+    if !check_auth(&provider) {
+        eprintln!("\nWarning: '{}' command not found in PATH.", provider);
+        eprintln!("Make sure it is installed and available before using the shell.");
+    }
+
+    build_wizard_result(&provider)
+}
+
+// ---------------------------------------------------------------------------
+// Project detection
+// ---------------------------------------------------------------------------
+
+enum ProjectState {
+    Configured,
+    GitRepoNoConfig,
+    NoProject,
+}
+
+fn detect_project() -> ProjectState {
+    if project::find_project_config().is_some() {
+        return ProjectState::Configured;
+    }
+
+    if Path::new(".git").exists() {
+        return ProjectState::GitRepoNoConfig;
+    }
+
+    ProjectState::NoProject
+}
+
+// ---------------------------------------------------------------------------
+// Link detection
+// ---------------------------------------------------------------------------
+
+struct LinkedProvider {
+    name: String,
+    #[allow(dead_code)]
+    path: String,
+}
+
+fn detect_link() -> Option<LinkedProvider> {
+    let checks = [
+        (".gemini", "gemini"),
+        (".claude", "claude"),
+        (".github/copilot-instructions.md", "copilot"),
+        (".codex", "codex"),
+    ];
+
+    for (path, provider) in checks {
+        if Path::new(path).exists() {
+            return Some(LinkedProvider {
+                name: provider.to_string(),
+                path: path.to_string(),
+            });
+        }
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Auth check
+// ---------------------------------------------------------------------------
+
+fn check_auth(provider: &str) -> bool {
+    is_command_available(provider)
+}
+
+fn is_command_available(command: &str) -> bool {
+    #[cfg(unix)]
+    {
+        use std::process::Command;
+        Command::new("which")
+            .arg(command)
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(windows)]
+    {
+        use std::process::Command;
+        Command::new("where")
+            .arg(command)
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = command;
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompts
+// ---------------------------------------------------------------------------
+
+fn prompt_init() -> Result<bool> {
+    println!("\nArmadAI Shell — Project Setup\n");
+    println!("No ArmadAI config found in this directory.\n");
+    println!("Would you like to initialize a project?");
+    println!("  1) Quick setup with a starter pack");
+    println!("  2) Skip (use system-wide agents only)");
+
+    let choice = read_choice(1, 2)?;
+
+    if choice == 2 {
+        return Ok(false);
+    }
+
+    // Choice 1: starter pack
+    let packs = list_available_packs();
+    if packs.is_empty() {
+        eprintln!("\nNo starter packs available.");
+        return Ok(false);
+    }
+
+    println!("\nAvailable starter packs:");
+    for (i, pack) in packs.iter().enumerate() {
+        println!("  {}) {}", i + 1, pack);
+    }
+
+    let pack_choice = read_choice(1, packs.len())?;
+    let pack_name = &packs[pack_choice - 1];
+
+    // Run init with pack
+    run_init_with_pack(pack_name)?;
+
+    Ok(true)
+}
+
+fn prompt_link() -> Result<String> {
+    println!("\nNo link found. Which AI assistant do you use?");
+    println!("  1) Gemini CLI");
+    println!("  2) Claude Code");
+    println!("  3) GitHub Copilot");
+    println!("  4) Codex");
+    println!("  5) Skip");
+
+    let choice = read_choice(1, 5)?;
+
+    if choice == 5 {
+        return Err(anyhow::anyhow!("Link setup skipped by user"));
+    }
+
+    let target = match choice {
+        1 => "gemini",
+        2 => "claude",
+        3 => "copilot",
+        4 => "codex",
+        _ => unreachable!(),
+    };
+
+    // Run link
+    run_link(target)?;
+
+    Ok(target.to_string())
+}
+
+fn read_choice(min: usize, max: usize) -> Result<usize> {
+    print!("\nChoice [1]: ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(1);
+    }
+
+    let choice: usize = input.parse().map_err(|_| {
+        anyhow::anyhow!(
+            "Invalid input: expected a number between {} and {}",
+            min,
+            max
+        )
+    })?;
+
+    if choice < min || choice > max {
+        return Err(anyhow::anyhow!(
+            "Choice out of range: expected {} to {}",
+            min,
+            max
+        ));
+    }
+
+    Ok(choice)
+}
+
+// ---------------------------------------------------------------------------
+// Init/Link execution
+// ---------------------------------------------------------------------------
+
+fn run_init_with_pack(pack_name: &str) -> Result<()> {
+    use crate::core::config;
+    use crate::core::starter::StarterPack;
+
+    // Init global config
+    config::ensure_config_dirs()?;
+
+    // Install pack
+    let pack_dir = find_pack_dir(pack_name)
+        .ok_or_else(|| anyhow::anyhow!("Starter pack '{}' not found", pack_name))?;
+
+    let pack = StarterPack::load(&pack_dir)?;
+    println!(
+        "\nInstalling starter pack: {} — {}",
+        pack.name, pack.description
+    );
+
+    let (agents, prompts, skills) = pack.install(&pack_dir, false)?;
+    println!(
+        "Pack '{}' installed: {} agent(s), {} prompt(s), {} skill(s)",
+        pack.name, agents, prompts, skills
+    );
+
+    // Create project config
+    let dotarmadai = Path::new(".armadai");
+    let dotarmadai_config = dotarmadai.join("config.yaml");
+
+    if dotarmadai_config.exists() {
+        println!("\n.armadai/config.yaml already exists, skipping project init");
+        return Ok(());
+    }
+
+    // Create directory structure
+    for subdir in &["agents", "prompts", "skills", "starters"] {
+        std::fs::create_dir_all(dotarmadai.join(subdir))?;
+    }
+
+    let content = crate::cli::init::generate_project_yaml(&pack, pack_name);
+    std::fs::write(&dotarmadai_config, &content)?;
+    println!(
+        "\nCreated .armadai/config.yaml with pack '{}' agents",
+        pack.name
+    );
+
+    Ok(())
+}
+
+fn run_link(target: &str) -> Result<()> {
+    println!("\nLinking to '{}'...", target);
+
+    // Reuse link logic from cli/link.rs
+    // We need to call it synchronously, so we'll use a minimal version here
+
+    let (root, config) = project::find_project_config()
+        .ok_or_else(|| anyhow::anyhow!("No project config found after initialization"))?;
+
+    if config.agents.is_empty() {
+        return Err(anyhow::anyhow!("No agents declared in project config"));
+    }
+
+    // Resolve agents
+    let (paths, errors) = project::resolve_all_agents(&config, &root);
+    for err in &errors {
+        eprintln!("  warn: {}", err);
+    }
+
+    let mut link_agents: Vec<crate::linker::LinkAgent> = Vec::new();
+    for path in &paths {
+        match crate::parser::parse_agent_file(path) {
+            Ok(agent) => link_agents.push(crate::linker::LinkAgent::from(&agent)),
+            Err(e) => eprintln!("  warn: failed to parse {}: {}", path.display(), e),
+        }
+    }
+
+    if link_agents.is_empty() {
+        return Err(anyhow::anyhow!("No agents could be resolved"));
+    }
+
+    // Resolve deprecated models
+    for agent in &mut link_agents {
+        crate::linker::model_aliases::resolve_model_deprecations(
+            &mut agent.model,
+            &mut agent.model_fallback,
+        );
+    }
+
+    // Create linker
+    let linker = crate::linker::create_linker(target)?;
+
+    // Generate files
+    let sources = &config.sources;
+    let files = linker.generate(&link_agents, None, sources);
+
+    if files.is_empty() {
+        return Err(anyhow::anyhow!("No files to generate"));
+    }
+
+    // Resolve output paths
+    let output_dir = PathBuf::from(linker.default_output_dir());
+    let default_dir = PathBuf::from(linker.default_output_dir());
+
+    for file in &files {
+        let relative = file.path.strip_prefix(&default_dir).unwrap_or(&file.path);
+        let final_path = root.join(&output_dir).join(relative);
+
+        if let Some(parent) = final_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&final_path, &file.content)?;
+        println!("  wrote {}", final_path.display());
+    }
+
+    println!("\nLinked {} agent(s) to '{}'", link_agents.len(), target);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Result builder
+// ---------------------------------------------------------------------------
+
+fn build_wizard_result(provider: &str) -> Result<WizardResult> {
+    let (command, args) = match provider {
+        "gemini" => ("gemini", vec!["-p".to_string()]),
+        "claude" => ("claude", vec![]),
+        "aider" => ("aider", vec!["--yes".to_string()]),
+        "codex" => ("codex", vec![]),
+        _ => (provider, vec![]),
+    };
+
+    let model_name = detect_model_name(command);
+    let project_name = detect_project_name();
+
+    Ok(WizardResult {
+        provider_command: command.to_string(),
+        provider_args: args,
+        model_name,
+        project_name,
+    })
+}
+
+fn detect_model_name(command: &str) -> String {
+    match command {
+        "gemini" => {
+            // Try to read model from .gemini/settings.json
+            if let Ok(content) = std::fs::read_to_string(".gemini/settings.json")
+                && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
+                && let Some(model) = json.get("model").and_then(|m| m.as_str())
+            {
+                return model.to_string();
+            }
+            "gemini-2.5-flash".to_string()
+        }
+        "claude" => "claude-sonnet-4-5".to_string(),
+        "aider" => "gpt-4o".to_string(),
+        "codex" => "codex".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn detect_project_name() -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .unwrap_or_else(|| "unknown".to_string())
+}

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -5,8 +5,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ArmadAI</title>
 <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <style>
   :root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --green: #3fb950; --yellow: #d29922; }
+  [data-theme="light"] {
+    --bg: #ffffff;
+    --surface: #f6f8fa;
+    --border: #d0d7de;
+    --text: #1f2328;
+    --muted: #656d76;
+    --accent: #0969da;
+    --green: #1a7f37;
+    --yellow: #9a6700;
+  }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
   header { background: var(--surface); border-bottom: 1px solid var(--border); padding: 12px 24px; display: flex; align-items: center; gap: 16px; }
@@ -56,6 +67,30 @@
   .search-count { font-size: 12px; color: var(--muted); white-space: nowrap; }
   #view { display: none; }
   .mermaid { background: var(--bg); padding: 20px; text-align: center; }
+  #theme-btn { background: none; border: 1px solid transparent; color: var(--muted); padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 16px; margin-left: auto; }
+  #theme-btn:hover { color: var(--text); border-color: var(--border); }
+  .markdown-body h1, .markdown-body h2, .markdown-body h3, .markdown-body h4, .markdown-body h5, .markdown-body h6 { margin-top: 16px; margin-bottom: 8px; font-weight: 600; }
+  .markdown-body h1 { font-size: 24px; }
+  .markdown-body h2 { font-size: 20px; }
+  .markdown-body h3 { font-size: 16px; }
+  .markdown-body h4 { font-size: 14px; }
+  .markdown-body p { margin-bottom: 12px; line-height: 1.6; }
+  .markdown-body ul, .markdown-body ol { margin-left: 20px; margin-bottom: 12px; }
+  .markdown-body li { margin-bottom: 4px; }
+  .markdown-body code { background: var(--bg); border: 1px solid var(--border); border-radius: 3px; padding: 2px 6px; font-family: 'Courier New', monospace; font-size: 13px; }
+  .markdown-body pre { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 12px; overflow-x: auto; margin-bottom: 12px; }
+  .markdown-body pre code { background: none; border: none; padding: 0; }
+  .markdown-body a { color: var(--accent); text-decoration: none; }
+  .markdown-body a:hover { text-decoration: underline; }
+  .markdown-body blockquote { border-left: 3px solid var(--border); padding-left: 12px; color: var(--muted); margin: 12px 0; }
+  .markdown-body table { width: 100%; border-collapse: collapse; margin-bottom: 12px; }
+  .markdown-body th, .markdown-body td { border: 1px solid var(--border); padding: 8px 12px; text-align: left; }
+  .markdown-body th { background: var(--bg); font-weight: 600; }
+  .download-btn { background: none; border: 1px solid var(--green); color: var(--green); padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px; margin-bottom: 16px; margin-right: 8px; }
+  .download-btn:hover { background: rgba(63,185,80,0.1); }
+  [data-theme="light"] .download-btn { border-color: #1a7f37; color: #1a7f37; }
+  [data-theme="light"] .download-btn:hover { background: rgba(26,127,55,0.1); }
+  .yaml-block { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 12px; font-family: 'Courier New', monospace; font-size: 13px; white-space: pre-wrap; line-height: 1.5; margin-bottom: 16px; overflow-x: auto; }
 </style>
 </head>
 <body>
@@ -71,6 +106,7 @@
     <button onclick="showTab('models')">Models</button>
     <button onclick="showTab('orchestration')">Orchestration</button>
   </nav>
+  <button id="theme-btn" onclick="toggleTheme()" title="Toggle dark/light mode">🌙</button>
 </header>
 <main>
   <div id="agents" class="card"></div>
@@ -86,6 +122,84 @@
 <script>
 // Initialize Mermaid
 mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+
+// Theme management
+function initTheme() {
+  const saved = localStorage.getItem('armadai-theme') || 'dark';
+  applyTheme(saved);
+}
+
+function applyTheme(theme) {
+  if (theme === 'light') {
+    document.documentElement.setAttribute('data-theme', 'light');
+    document.getElementById('theme-btn').textContent = '☀️';
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+    document.getElementById('theme-btn').textContent = '🌙';
+  }
+  localStorage.setItem('armadai-theme', theme);
+  mermaid.initialize({ startOnLoad: false, theme: theme === 'light' ? 'default' : 'dark' });
+}
+
+function toggleTheme() {
+  const current = localStorage.getItem('armadai-theme') || 'dark';
+  applyTheme(current === 'dark' ? 'light' : 'dark');
+}
+
+// Markdown and sanitization helpers
+function escapeHtmlContent(text) {
+  const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
+  return text.replace(/[&<>"']/g, m => map[m]);
+}
+
+function renderMarkdown(content) {
+  if (!content) return '';
+  marked.setOptions({ breaks: true, gfm: true });
+  return marked.parse(content);
+}
+
+function downloadText(filename, content) {
+  const blob = new Blob([content], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function reconstructAgentMarkdown(agent) {
+  let md = `# ${agent.name}\n\n## Metadata\n`;
+  md += `- provider: ${agent.provider}\n`;
+  md += `- model: ${agent.model}\n`;
+  if (agent.temperature !== undefined) md += `- temperature: ${agent.temperature}\n`;
+  if (agent.max_tokens) md += `- max_tokens: ${agent.max_tokens}\n`;
+  if (agent.timeout) md += `- timeout: ${agent.timeout}\n`;
+  if (agent.rate_limit) md += `- rate_limit: ${agent.rate_limit}\n`;
+  if (agent.tags && agent.tags.length) md += `- tags: [${agent.tags.join(', ')}]\n`;
+  if (agent.stacks && agent.stacks.length) md += `- stacks: [${agent.stacks.join(', ')}]\n`;
+  md += `\n## System Prompt\n\n${agent.system_prompt || '(none)'}\n`;
+  if (agent.instructions) md += `\n## Instructions\n\n${agent.instructions}\n`;
+  if (agent.output_format) md += `\n## Output Format\n\n${agent.output_format}\n`;
+  return md;
+}
+
+function reconstructPromptMarkdown(prompt) {
+  let md = `# ${prompt.name}\n\n## Metadata\n`;
+  if (prompt.description) md += `- description: ${prompt.description}\n`;
+  if (prompt.apply_to && prompt.apply_to.length) md += `- apply_to: [${prompt.apply_to.join(', ')}]\n`;
+  md += `\n## Content\n\n${prompt.body || '(empty)'}\n`;
+  return md;
+}
+
+function reconstructSkillMarkdown(skill) {
+  let md = `# ${skill.name}\n\n## Metadata\n`;
+  if (skill.description) md += `- description: ${skill.description}\n`;
+  if (skill.version) md += `- version: ${skill.version}\n`;
+  if (skill.tools && skill.tools.length) md += `- tools: [${skill.tools.join(', ')}]\n`;
+  md += `\n## SKILL.md\n\n${skill.body || '(empty)'}\n`;
+  return md;
+}
 
 let currentTab = 'agents';
 let viewBackTab = 'agents';
@@ -190,9 +304,13 @@ async function viewAgent(name) {
   ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
+  const agentMarkdown = reconstructAgentMarkdown(a);
   el.innerHTML = `
     <div class="detail">
-      <button class="back-btn" onclick="backToList()">&larr; Back to agents</button>
+      <div style="display:flex;gap:8px">
+        <button class="back-btn" onclick="backToList()">&larr; Back to agents</button>
+        <button class="download-btn" onclick="downloadText('${a.name}.md', reconstructAgentMarkdown(agentContent))">↓ Download .md</button>
+      </div>
       <h2>${a.name}</h2>
       <div class="detail-grid">
         <div class="detail-field"><label>Provider</label><span>${a.provider}</span></div>
@@ -230,11 +348,12 @@ async function viewAgent(name) {
         ${a.model_resolution.map(r => `<tr><td>${r.target}</td><td style="color:var(--green)">${r.resolved_model}</td></tr>`).join('')}
       </table>` : ''}
       <div class="prompt-box-title">System Prompt</div>
-      <div class="prompt-box">${a.system_prompt || '(none)'}</div>
-      ${a.instructions ? `<div class="prompt-box-title">Instructions</div><div class="prompt-box">${a.instructions}</div>` : ''}
-      ${a.output_format ? `<div class="prompt-box-title">Output Format</div><div class="prompt-box">${a.output_format}</div>` : ''}
+      <div class="prompt-box markdown-body">${renderMarkdown(a.system_prompt || '(none)')}</div>
+      ${a.instructions ? `<div class="prompt-box-title">Instructions</div><div class="prompt-box markdown-body">${renderMarkdown(a.instructions)}</div>` : ''}
+      ${a.output_format ? `<div class="prompt-box-title">Output Format</div><div class="prompt-box markdown-body">${renderMarkdown(a.output_format)}</div>` : ''}
       <div class="detail-field" style="margin-top:12px"><label>Source</label><span style="color:var(--muted)">${a.source}</span></div>
     </div>`;
+  window.agentContent = a;
 }
 
 async function loadPrompts() {
@@ -267,18 +386,23 @@ async function viewPrompt(name) {
   ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
+  const promptMarkdown = reconstructPromptMarkdown(p);
   el.innerHTML = `
     <div class="detail">
-      <button class="back-btn" onclick="backToList()">&larr; Back to prompts</button>
+      <div style="display:flex;gap:8px">
+        <button class="back-btn" onclick="backToList()">&larr; Back to prompts</button>
+        <button class="download-btn" onclick="downloadText('${p.name}.md', reconstructPromptMarkdown(promptContent))">↓ Download .md</button>
+      </div>
       <h2>${p.name}</h2>
       <div class="detail-grid">
         <div class="detail-field"><label>Description</label><span>${p.description || '(none)'}</span></div>
         <div class="detail-field"><label>Applies To</label><span>${p.apply_to.map(a => `<span class="tag">${a}</span>`).join('') || 'none'}</span></div>
       </div>
       <div class="prompt-box-title">Content</div>
-      <div class="prompt-box">${p.body || '(empty)'}</div>
+      <div class="prompt-box markdown-body">${renderMarkdown(p.body || '(empty)')}</div>
       <div class="detail-field" style="margin-top:12px"><label>Source</label><span style="color:var(--muted)">${p.source}</span></div>
     </div>`;
+  window.promptContent = p;
 }
 
 async function loadSkills() {
@@ -319,9 +443,13 @@ async function viewSkill(name) {
   if (s.scripts.length) filesHtml += `<div class="list-section"><h3>Scripts</h3>${s.scripts.map(fileBlock).join('')}</div>`;
   if (s.references.length) filesHtml += `<div class="list-section"><h3>References</h3>${s.references.map(fileBlock).join('')}</div>`;
   if (s.assets.length) filesHtml += `<div class="list-section"><h3>Assets</h3>${s.assets.map(fileBlock).join('')}</div>`;
+  const skillMarkdown = reconstructSkillMarkdown(s);
   el.innerHTML = `
     <div class="detail">
-      <button class="back-btn" onclick="backToList()">&larr; Back to skills</button>
+      <div style="display:flex;gap:8px">
+        <button class="back-btn" onclick="backToList()">&larr; Back to skills</button>
+        <button class="download-btn" onclick="downloadText('${s.name}-SKILL.md', reconstructSkillMarkdown(skillContent))">↓ Download SKILL.md</button>
+      </div>
       <h2>${s.name}</h2>
       <div class="detail-grid">
         <div class="detail-field"><label>Description</label><span>${s.description || '(none)'}</span></div>
@@ -329,10 +457,11 @@ async function viewSkill(name) {
         <div class="detail-field"><label>Tools</label><span>${s.tools.map(t => `<span class="tag stack">${t}</span>`).join('') || 'none'}</span></div>
       </div>
       <div class="prompt-box-title">SKILL.md</div>
-      <div class="prompt-box">${s.body || '(empty)'}</div>
+      <div class="prompt-box markdown-body">${renderMarkdown(s.body || '(empty)')}</div>
       ${filesHtml}
       <div class="detail-field" style="margin-top:12px"><label>Source</label><span style="color:var(--muted)">${s.source}</span></div>
     </div>`;
+  window.skillContent = s;
 }
 
 async function loadStarters() {
@@ -366,15 +495,37 @@ async function viewStarter(name) {
   ['agents','prompts','skills','starters','history','costs','models'].forEach(id => document.getElementById(id).style.display = 'none');
   const el = document.getElementById('view');
   el.style.display = 'block';
+
+  // Fetch and parse YAML config for orchestration info
+  let orchestrationHtml = '';
+  try {
+    const configRes = await fetch(`/api/starters/${encodeURIComponent(name)}/config`);
+    const configYaml = await configRes.text();
+    if (configYaml.includes('orchestration:')) {
+      const orchStart = configYaml.indexOf('orchestration:');
+      if (orchStart !== -1) {
+        let orchEnd = configYaml.indexOf('\n\n', orchStart);
+        if (orchEnd === -1) orchEnd = configYaml.length;
+        const orchSection = configYaml.substring(orchStart, orchEnd).trim();
+        orchestrationHtml = `<div class="list-section"><h3>Orchestration Configuration</h3><div class="yaml-block">${escapeHtmlContent(orchSection)}</div></div>`;
+      }
+    }
+  } catch (e) {
+    console.error('Failed to fetch config:', e);
+  }
+
   el.innerHTML = `
     <div class="detail">
-      <button class="back-btn" onclick="backToList()">&larr; Back to starters</button>
+      <div style="display:flex;gap:8px">
+        <button class="back-btn" onclick="backToList()">&larr; Back to starters</button>
+        <a href="/api/starters/${encodeURIComponent(name)}/config" download="armadai.yaml" class="download-btn" style="text-decoration:none">&#8615; Download armadai.yaml</a>
+      </div>
       <h2>${s.name}</h2>
       <p style="color:var(--muted);margin-bottom:20px">${s.description}</p>
-      <a href="/api/starters/${encodeURIComponent(name)}/config" download="armadai.yaml" class="back-btn" style="display:inline-block;text-decoration:none;margin-bottom:16px;border-color:var(--green);color:var(--green)">&#8615; Download armadai.yaml</a>
       ${s.agents.length ? `<div class="list-section"><h3>Agents (${s.agents.length})</h3><ul>${s.agents.map(a => `<li>${a}</li>`).join('')}</ul></div>` : ''}
       ${s.prompts.length ? `<div class="list-section"><h3>Prompts (${s.prompts.length})</h3><ul>${s.prompts.map(p => `<li>${p}</li>`).join('')}</ul></div>` : ''}
       ${s.skills.length ? `<div class="list-section"><h3>Skills (${s.skills.length})</h3><ul>${s.skills.map(sk => `<li>${sk}</li>`).join('')}</ul></div>` : ''}
+      ${orchestrationHtml}
     </div>`;
 }
 
@@ -597,6 +748,7 @@ function escapeHtml(text) {
 }
 
 // Initial load
+initTheme();
 loadAgents();
 </script>
 </body>

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -7,6 +7,13 @@ use axum::{
 };
 use tower_http::cors::CorsLayer;
 
+/// Wait for Ctrl+C signal.
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to listen for ctrl+c");
+}
+
 /// Serve the web UI on the given port.
 pub async fn serve(port: u16) -> anyhow::Result<()> {
     let app = Router::new()
@@ -32,9 +39,14 @@ pub async fn serve(port: u16) -> anyhow::Result<()> {
 
     let addr = format!("0.0.0.0:{port}");
     println!("Web UI available at: http://localhost:{port}");
+    println!("Press Ctrl+C to stop.");
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    println!("\nWeb UI stopped.");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Introduces the ArmadAI interactive shell — a paradigm shift from pure CLI orchestrator to an interactive TUI-driven shell. This is the foundation for v0.12.0.

## What's included (Phases 0-3)

- **Phase 0** — Response protocol skill (`skills/armadai-protocol/SKILL.md`), marker injection in 5 linkers (claude, codex, copilot, gemini, opencode), marker parser in `src/linker/mod.rs`
- **Phase 1** — Shell MVP: runner (`src/shell/runner.rs`), TUI (`src/shell/tui.rs`), app state (`src/shell/app.rs`), model detection (`src/shell/detect.rs`), `armadai shell` CLI command
- **Phase 2+3 polish** — Markdown rendering, scroll, model detection, cost tracking, UTF-8 fix, wizard setup (`src/shell/wizard.rs`), slash commands (`src/shell/commands.rs`)
- **Popup overlays** — Slash command picker and markdown formatting overlays in TUI

## What's NOT included (future PRs)

- Devbox starter pack (9 agents, 2 skills, 1 prompt) — separate PR
- Phase 4: tandem mode — future work
- Phase 5: persistence — future work

## Test plan

- [ ] `cargo clippy --no-default-features --features tui` passes (CI mode)
- [ ] `cargo clippy --no-default-features --features tui,providers-api` passes
- [ ] `cargo test --no-default-features --features tui,providers-api` passes
- [ ] `cargo fmt -- --check` passes
- [ ] `armadai shell` launches the TUI
- [ ] Slash commands (e.g. `/help`, `/model`) render popup overlays correctly
- [ ] Markdown output from agents is rendered in the shell

## Notes

- Squash merge only (gitflow convention)
- Dependabot PR #107 (uuid bump) should be merged before or alongside this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)