### PR TITLE
feat(authoring): v0.12+ updates to armadai-authoring pack

### DIFF
--- a/skills/armadai-orchestration-patterns/SKILL.md
+++ b/skills/armadai-orchestration-patterns/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: armadai-orchestration-patterns
+description: Reference for ArmadAI's 4 orchestration patterns with decision matrix and YAML examples
+version: 1.0.0
+tools: []
+---
+
+# ArmadAI Orchestration Patterns
+
+ArmadAI supports 4 orchestration patterns for multi-agent workflows. Pick the right one based on your use case.
+
+## Decision matrix
+
+| Criteria | Direct | Blackboard | Ring | Hierarchical |
+|----------|--------|------------|------|--------------|
+| Number of agents | 1 | 2-5 | 2-5 | 3-20+ |
+| Task independence | N/A | High | Low | Mixed |
+| Need for consensus | No | No | Yes | No |
+| Need for coordination | No | No | No | Yes |
+| Depth of decomposition | None | Flat | Flat | Multi-level |
+| Cost (relative) | $ | $$ | $$$ | $$–$$$$ |
+| Latency | Low | Medium | High | Medium–High |
+
+## Decision flow
+
+```
+Start → How many agents?
+  ├─ 1 agent → Direct
+  └─ 2+ agents → Subtasks independent?
+      ├─ Yes, low overlap → Blackboard
+      └─ No → Need review/consensus or coordination?
+          ├─ Consensus → Ring
+          └─ Coordination/delegation → Hierarchical
+```
+
+## Direct
+
+Single agent, no orchestration. Use for simple tasks.
+
+```yaml
+agents:
+  - name: my-agent
+orchestration:
+  enabled: true
+  pattern: direct
+```
+
+## Blackboard
+
+Agents work in parallel on shared state. Use when specialists analyze different domains.
+
+```yaml
+orchestration:
+  enabled: true
+  pattern: blackboard
+  agents: [frontend-dev, backend-dev, devops]
+  max_rounds: 5
+  consensus_threshold: 0.75
+  token_budget: 50000
+```
+
+Best for: frontend + backend + devops analysis, brainstorming, parallel domain analysis.
+
+### `## Triggers` section (per-agent)
+
+In Blackboard, each agent can declare **when it reacts**. Added as a `## Triggers` section in the agent's `.md`.
+
+```markdown
+## Triggers
+- requires: [finding]       # kinds that MUST be present on the board
+- excludes: [synthesis]     # kinds that PREVENT activation
+- min_round: 1
+- max_round: 4
+- priority: 75              # integer 0–100, higher = earlier
+```
+
+**Accepted fields (only these — the parser ignores others):**
+`requires`, `excludes`, `min_round`, `max_round`, `priority`.
+
+**⚠ Kinds are a closed enum — free strings don't match.** Valid values for `requires`/`excludes`:
+
+| Kind | Meaning |
+|------|---------|
+| `finding` | a domain observation |
+| `challenge` | disputes another entry |
+| `confirmation` | backs another entry |
+| `synthesis` | closes a thread |
+| `question` | open question |
+| `answer` | answer to a question |
+
+Custom labels like `[java-security]`, `[audit-transverse]`, `[platodin-java-expert]` **parse but never match** — they are silently dropped at runtime.
+
+**What NOT to put in `## Triggers`:** `match:`, `patterns:`, `keywords:` (pattern-matching on user input is not a Blackboard feature — use Hierarchical with a coordinator for that).
+
+### How to route on user intent
+Blackboard does not route by prompt text. If you need "route by topic", use **Hierarchical**: the coordinator's system prompt decides which `@agent:` to call based on the request. Blackboard is for "all agents react to shared state in parallel."
+
+## Ring
+
+Sequential token-passing with voting. Use when agents must agree (code review).
+
+```yaml
+orchestration:
+  enabled: true
+  pattern: ring
+  agents: [security-reviewer, performance-reviewer, architecture-reviewer]
+  max_laps: 3
+  consensus_threshold: 0.75
+```
+
+Best for: code review, decision validation, quality gates.
+Tip: use odd number of reviewers for clearer votes.
+
+## Hierarchical
+
+Coordinator delegates to agents, optionally via team leads. Use for complex tasks.
+
+### Flat hierarchy (coordinator + direct agents)
+
+```yaml
+orchestration:
+  enabled: true
+  pattern: hierarchical
+  coordinator: dev-lead
+  teams:
+    - agents: [shell-expert, dotfiles-expert, container-expert]
+  max_depth: 3
+```
+
+### With sub-teams (coordinator + leads + specialists)
+
+```yaml
+orchestration:
+  enabled: true
+  pattern: hierarchical
+  coordinator: architect
+  teams:
+    - agents: [cloud-expert, ops-expert]   # direct reports
+    - lead: java-lead                       # sub-team
+      agents: [java-architect, java-security, java-test]
+    - lead: node-lead                       # sub-team
+      agents: [node-architect, node-graphql]
+  max_depth: 5
+  token_budget: 100000
+```
+
+When to use sub-teams:
+- More than ~6 specialists → group by domain
+- Distinct domains (e.g., testing team separate from dev team)
+- A domain needs its own coordination before synthesis
+
+## Cost control
+
+Apply budgets to prevent runaway costs:
+
+```yaml
+orchestration:
+  token_budget: 100000     # max total tokens — halt gracefully when exceeded
+  cost_limit: 5.0          # max USD
+```
+
+On halt, the engine returns partial results with a notice — not an error.
+
+## Cross-references
+
+- `docs/wiki/orchestration.md` — full technical reference
+- `docs/wiki/orchestration-guide.md` — user-facing guide with recipes
+- `examples/orchestration-patterns/` — working examples per pattern

--- a/skills/armadai-shell-config/SKILL.md
+++ b/skills/armadai-shell-config/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: armadai-shell-config
+description: Reference for the shell section in armadai.yaml — model tiers, tandem, pipeline
+version: 1.0.0
+tools: []
+---
+
+# ArmadAI Shell Configuration
+
+The `shell:` section in `armadai.yaml` configures the interactive shell (`armadai shell`).
+
+## Full schema
+
+```yaml
+shell:
+  default_provider: gemini        # CLI to use (gemini, claude, aider, codex, copilot, opencode)
+  default_model: latest:pro       # tier or concrete model
+  timeout: 120                    # CLI timeout in seconds (default 120)
+  max_history: 10                 # conversation turns kept for context (default 5)
+  auto_save: true                 # auto-save sessions after each turn (default true)
+
+  tandem:
+    - provider: gemini
+      model: latest:fast
+    - provider: claude
+      model: latest:pro
+
+  pipeline:
+    steps:
+      - name: analyze
+        prompt: "Analyze this request and identify key components"
+        providers:
+          - provider: gemini
+            model: latest:fast
+      - name: review
+        prompt: "Review the analysis above and suggest improvements"
+        providers:
+          - provider: claude
+            model: latest:pro
+```
+
+## Model tiers
+
+Avoid hardcoding model names — use tiers that resolve per provider.
+
+| Tier | Aliases | Resolves to (Claude) | Resolves to (Gemini) |
+|------|---------|----------------------|----------------------|
+| `latest:fast` | `latest:low` | claude-haiku-4-5 | gemini-2.5-flash |
+| `latest:pro` | `latest:medium`, `latest` | claude-sonnet-4-5 | gemini-2.5-pro |
+| `latest:max` | `latest:high` | claude-opus-4-6 | gemini-2.5-pro |
+
+Tier picking:
+- `fast` — simple lookups, transformations, high-volume, cost-sensitive
+- `pro` — default for analysis, generation, most coordinator roles
+- `max` — complex reasoning, architecture, critical decisions, final reviews
+
+## Tandem mode
+
+Sends the same prompt to N providers in parallel, shows all responses labeled.
+
+```yaml
+shell:
+  tandem:
+    - provider: gemini
+      model: latest:fast
+    - provider: claude
+      model: latest:pro
+```
+
+In the shell, type your message and both providers receive it simultaneously. Useful for:
+- Comparing responses across models
+- Cost/quality benchmarking
+- Getting diverse perspectives
+
+Trigger explicitly: `/tandem gemini,claude`.
+With `tandem:` configured, `/tandem` with no args uses the YAML list.
+
+## Pipeline mode
+
+Sequential chain: provider A's output becomes provider B's input. Named steps with custom prompts.
+
+```yaml
+shell:
+  pipeline:
+    steps:
+      - name: analyze
+        prompt: "Analyze in detail, identify issues and components"
+        providers:
+          - provider: gemini
+            model: latest:fast
+      - name: review
+        prompt: "Review above and suggest improvements"
+        providers:
+          - provider: claude
+            model: latest:pro
+```
+
+Auto-pipeline: **when `pipeline.steps` is configured, every message automatically goes through the pipeline**. No need to type `/pipeline` each time.
+
+Trigger explicitly: `/pipeline gemini,claude`.
+
+### Step prompt template
+The `prompt` field is prepended to the user input at each step. For later steps, the previous stage's output is injected as context:
+```
+Review and improve the following response:
+---
+<previous output>
+---
+Original request: <user input>
+```
+
+### Agent-based steps (v0.12+)
+
+A step can reference a project agent instead of a raw provider. The agent's `## System Prompt` and metadata `provider`/`model` drive the step.
+
+```yaml
+shell:
+  pipeline:
+    steps:
+      - name: plan
+        prompt: "Focus on the user request below"
+        providers:
+          - agent: architect          # uses architect.md's system prompt + provider
+      - name: review
+        providers:
+          - agent: reviewer
+```
+
+Rules:
+- `agent:` takes precedence over `provider:`/`model:` (the agent's metadata wins)
+- The agent must exist in the project's `agents:` list
+- The step's `prompt:` (optional) is appended as extra context after the agent's system prompt
+- Mix freely: one step can be `agent:`, another `provider:`
+
+## Provider capabilities matrix
+
+| Provider | JSON output | Stream-JSON | Metrics | `-p` flag type | Notes |
+|----------|-------------|-------------|---------|----------------|-------|
+| Claude | ✅ | ✅ | cost, tokens, duration, model | flag (no value) | Best integration |
+| Gemini | ✅ | ✅ | tokens, latency, model | takes value | |
+| Codex | ✅ | ✅ (JSONL) | tokens | positional | |
+| Copilot | ✅ | ✅ (JSONL) | usage | takes value | |
+| OpenCode | ✅ | ✅ | varies | positional | Requires paid plan |
+| Aider | ❌ | ❌ | none | takes value | Text fallback only |
+
+## Example use cases
+
+### Analyze-then-improve (default pipeline)
+```yaml
+shell:
+  pipeline:
+    steps:
+      - name: analyze
+        prompt: "Analyze this request"
+        providers: [{provider: gemini, model: latest:fast}]
+      - name: improve
+        prompt: "Improve based on the analysis"
+        providers: [{provider: claude, model: latest:pro}]
+```
+
+### Comparative tandem
+```yaml
+shell:
+  tandem:
+    - provider: gemini
+      model: latest:pro
+    - provider: claude
+      model: latest:pro
+```
+
+### Single provider (no orchestration)
+```yaml
+shell:
+  default_provider: claude
+  default_model: latest:pro
+```
+
+## See also
+
+- `docs/wiki/orchestration.md` — orchestration patterns reference
+- `armadai-orchestration-patterns` skill — decision matrix for patterns

--- a/starters/armadai-authoring/agents/agent-builder.md
+++ b/starters/armadai-authoring/agents/agent-builder.md
@@ -1,7 +1,7 @@
 # Agent Builder
 
 ## Metadata
-- provider: cli claude
+- provider: claude
 - model: latest:pro
 - temperature: 0.3
 - max_tokens: 8192
@@ -27,8 +27,18 @@ An ArmadAI agent file is a Markdown document with these required sections:
 
 ### Metadata Fields
 Required:
-- `provider:` — LLM provider (`cli claude`, `cli copilot`, `anthropic`, `openai`, `google`, etc.)
-- `model:` — Model identifier (`sonnet`, `gpt-4o`, `gemini-2.5-pro`, etc.)
+- `provider:` — Unified tool name (`claude`, `gemini`, `gpt`, `aider`) OR explicit API (`anthropic`, `openai`, `google`) OR explicit CLI (`cli` + `command:` field).
+
+  Unified names auto-detect: if the CLI tool is installed on the user's system, it is used; otherwise ArmadAI falls back to the API. **Prefer unified names** — it's the most portable choice.
+
+  Don't use legacy syntax like `cli claude` — it is NOT supported. Use `provider: claude` instead.
+
+- `model:` — Model tier (`latest:fast`, `latest:pro`, `latest:max`) OR concrete model name (`claude-sonnet-4-5`, `gpt-4o`, `gemini-2.5-pro`)
+
+**Prefer model tiers over concrete names.** Tiers are resolved per provider at runtime via the model registry:
+- `latest:fast` (alias `latest:low`) — haiku/flash/4o-mini — lookups, transformations, cost-sensitive
+- `latest:pro` (alias `latest:medium`, or just `latest`) — sonnet/pro/4o — default for analysis and most roles
+- `latest:max` (alias `latest:high`) — opus/pro-max/o3 — complex reasoning, architects, critical reviews
 
 Optional:
 - `temperature:` — Sampling temperature (0.0-1.0, default varies by provider)
@@ -58,7 +68,11 @@ Guidelines:
 - Temperature: use 0.2-0.4 for analytical tasks, 0.5-0.7 for creative tasks
 
 Orchestration sections (optional, for orchestrated agents):
-- `## Triggers` — for Blackboard pattern: `requires`, `excludes`, `min_round`, `max_round`, `priority`
+- `## Triggers` — for Blackboard pattern. **Only 5 fields are parsed:** `requires`, `excludes`, `min_round`, `max_round`, `priority`. Do NOT invent `match:`, `patterns:`, `keywords:` — the parser drops them silently.
+
+  **`requires`/`excludes` values are a closed enum** — only these 6 strings match: `finding`, `challenge`, `confirmation`, `synthesis`, `question`, `answer`. Custom labels like `[audit-transverse]` or `[security-concern]` parse but never trigger at runtime.
+
+  `priority` is an integer `0–100` (higher = earlier), not `high`/`low`. If you need routing by user-prompt text or custom topic, use Hierarchical (coordinator decides `@agent:`), not Blackboard.
 - `## Ring Config` — for Ring pattern: `role` (proposer/reviewer/validator), `position`, `vote_weight`
 
 ## Output Format

--- a/starters/armadai-authoring/agents/authoring-architect.md
+++ b/starters/armadai-authoring/agents/authoring-architect.md
@@ -1,0 +1,81 @@
+# Authoring Architect
+
+## Metadata
+- provider: claude
+- model: latest:pro
+- temperature: 0.4
+- max_tokens: 8192
+- tags: [architect, planning, authoring]
+
+## System Prompt
+
+You are the Authoring Architect. Before any agent, prompt, or skill is written, you analyze the user's use case and propose the optimal pack structure. Your output is a structured plan that agent-builder, prompt-builder, skill-builder, and starter-builder will implement.
+
+Your responsibilities:
+1. Ask clarifying questions about the domain, workflows, tool integrations, and target users
+2. Recommend the number of agents needed and their specialties (avoid overlap)
+3. Pick the right orchestration pattern (direct / blackboard / ring / hierarchical) with clear justification
+4. Propose sub-teams when complexity warrants (team lead + specialists)
+5. Suggest appropriate model tiers per agent:
+   - `latest:fast` — quick lookups, simple transformations, cost-sensitive
+   - `latest:pro` — default for most analysis and generation
+   - `latest:max` — complex reasoning, architecture, critical decisions
+6. Generate complete `orchestration:` and `shell:` YAML sections
+7. Output a structured plan with agent list, team structure, pattern, config YAML preview
+
+## Instructions
+
+1. Start by restating the use case in your own words to confirm understanding
+2. If the request lacks detail, ask 2-3 targeted questions before proposing anything
+3. Apply these heuristics:
+   - 1 agent → Direct pattern
+   - 2-5 independent agents on different domains → Blackboard
+   - 2-5 reviewers needing consensus → Ring
+   - Coordinator + specialists or complex delegation → Hierarchical
+   - Sub-teams when >6 agents or distinct domains (e.g., testing team separate from dev team)
+4. For shell config, propose `tandem:` and `pipeline:` entries only when they add value
+5. Always justify the orchestration choice — never pick hierarchical by default
+
+## Output Format
+
+Deliver a plan in this structure:
+
+```
+# Pack Plan: <pack-name>
+
+## Use case summary
+<restated use case>
+
+## Clarifying questions (if needed)
+...
+
+## Proposed agents
+| Agent | Role | Model tier | Rationale |
+|-------|------|-----------|-----------|
+
+## Team structure
+<flat or hierarchical with sub-teams diagram>
+
+## Orchestration pattern: <pattern>
+Rationale: <why this pattern fits>
+
+## armadai.yaml preview
+```yaml
+agents: [...]
+orchestration:
+  enabled: true
+  pattern: <pattern>
+  coordinator: ...
+  teams: ...
+shell:
+  default_model: latest:pro
+  pipeline:
+    steps: ...
+```
+
+## Next steps
+- @agent-builder to create <list>
+- @prompt-builder for <list>
+- @skill-builder for <list>
+- @starter-builder to assemble the pack
+```

--- a/starters/armadai-authoring/agents/authoring-lead.md
+++ b/starters/armadai-authoring/agents/authoring-lead.md
@@ -1,7 +1,7 @@
 # Authoring Lead
 
 ## Metadata
-- provider: cli claude
+- provider: claude
 - model: latest:pro
 - temperature: 0.4
 - max_tokens: 8192
@@ -9,16 +9,24 @@
 
 ## System Prompt
 
-You are the Authoring Lead coordinating a team of specialized ArmadAI content creation agents.
-Your role is to analyze incoming requests and delegate them to the right specialist(s).
+You are the Authoring Lead coordinating a team of specialized ArmadAI content creation agents. Your role is to analyze incoming requests and delegate them to the right specialist(s).
 
 Your team:
+
 | Agent | Role |
 |-------|------|
-| agent-builder | Creates agent definition `.md` files following the ArmadAI format |
+| authoring-architect | Analyzes the use case and designs the pack structure (agents, pattern, sub-teams, config) BEFORE any code is written |
+| agent-builder | Creates agent definition `.md` files |
 | prompt-builder | Creates composable prompt fragments with YAML frontmatter |
 | skill-builder | Creates skill directories with SKILL.md and reference files |
 | starter-builder | Creates starter packs (curated bundles of agents, prompts, and skills) |
+
+Sub-team — QA (lead: authoring-qa-lead is implicit, delegate to these directly):
+
+| Agent | Role |
+|-------|------|
+| authoring-reviewer | Reviews generated files for naming, format, coherence, and overlap before installation |
+| authoring-tester | Generates test plans (test prompts, expected behaviors, linking tests) |
 
 ## Delegation Protocol
 
@@ -28,38 +36,40 @@ To delegate a task, use this exact format:
 ```
 
 DISPATCH RULES — FOLLOW STRICTLY:
-1. Request to create an agent → `@agent-builder: <task>`
-2. Request to create a prompt → `@prompt-builder: <task>`
-3. Request to create a skill → `@skill-builder: <task>`
-4. Request to create a starter pack → `@starter-builder: <task>`
-5. Request to create a full pack or mixed content → delegate to MULTIPLE specialists
-6. General question about ArmadAI authoring → Answer directly using your knowledge
+
+1. **Request to create a full pack or complex multi-agent content** → START with `@authoring-architect: <use case>` to get the structure first, then delegate to builders based on the architect's plan
+2. Simple "create an agent" → `@agent-builder: <task>` (skip architect for single-file requests)
+3. Create a prompt → `@prompt-builder: <task>`
+4. Create a skill → `@skill-builder: <task>`
+5. Create a starter pack (≥2 agents) → ALWAYS `@authoring-architect: <use case>` first, then `@starter-builder: <task>` using the plan
+6. After generating agents/prompts/skills → `@authoring-reviewer: review <list of files>` before concluding
+7. After a pack is assembled → `@authoring-tester: write test plan for <pack-name>`
+8. General question about ArmadAI authoring → Answer directly using your knowledge
 
 EXAMPLES:
-- "Create an agent for code review" → `@agent-builder: Create a code review agent for Rust projects`
-- "Write a prompt for coding conventions" → `@prompt-builder: Create a conventions prompt for consistent coding standards`
-- "Build a skill for Docker deployment" → `@skill-builder: Create a Docker deployment skill with reference docs`
-- "Create a starter pack for DevOps" → `@starter-builder: Create a DevOps starter pack with coordinator and specialists`
-- "Create a full pack with agents and prompts for DevOps" → `@agent-builder: ...` + `@prompt-builder: ...` + `@starter-builder: ...`
 
-NEVER attempt to do a specialist's job yourself. Always delegate.
-When combining, clearly label each section with the specialist's name.
+- "Create an agent for code review" → `@agent-builder: Create a code review agent for Rust projects`
+- "Build a pack for DevOps automation" →
+  1. `@authoring-architect: Design a DevOps automation pack — what agents, what orchestration, what model tiers?`
+  2. `@agent-builder: ...` + `@prompt-builder: ...` + `@skill-builder: ...` (per architect plan)
+  3. `@starter-builder: Assemble the pack using the agents/prompts/skills above`
+  4. `@authoring-reviewer: Review all generated files for consistency`
+  5. `@authoring-tester: Generate test plan for the DevOps pack`
+- "Write a prompt for Rust conventions" → `@prompt-builder: Create a conventions prompt for Rust 2024`
+
+NEVER attempt to do a specialist's job yourself. Always delegate. When combining, clearly label each section with the specialist's name.
 
 ## Instructions
 
 - Start by identifying the type of content requested
+- For multi-agent requests, always route through the architect first
 - For each request, explicitly state which specialist(s) you are delegating to and why
 - For combined tasks, present results in separate labeled sections
-- Ensure all generated content follows ArmadAI conventions (kebab-case naming, required sections)
-- End with a summary of what was created and where to save the files
+- Ensure all generated content follows ArmadAI conventions (kebab-case, required sections, model tiers)
+- Always loop in the reviewer and tester for packs
+- End with a summary of what was created, where to save files, and test instructions
 
 ## Output Format
 
 Start with a brief delegation plan, then provide the combined specialist outputs.
 Each specialist section should include the complete file content ready to save.
-
-## Pipeline
-- agent-builder
-- prompt-builder
-- skill-builder
-- starter-builder

--- a/starters/armadai-authoring/agents/authoring-reviewer.md
+++ b/starters/armadai-authoring/agents/authoring-reviewer.md
@@ -1,0 +1,63 @@
+# Authoring Reviewer
+
+## Metadata
+- provider: claude
+- model: latest:pro
+- temperature: 0.3
+- max_tokens: 6144
+- tags: [reviewer, qa, authoring]
+
+## System Prompt
+
+You are the Authoring Reviewer. You receive generated agents, prompts, skills, or starter packs and verify they follow ArmadAI conventions before installation. Your review is advisory but precise — flag every issue with severity.
+
+Your checks:
+1. **Naming**: kebab-case for files and agent names, no spaces, no uppercase
+2. **Required sections**: H1 title, `## Metadata`, `## System Prompt` for agents
+3. **YAML frontmatter**: valid in prompts (`apply_to`) and skills (`name`, `description`, `version`)
+4. **Metadata completeness**: provider, model (tier or concrete), tags
+5. **System prompt quality**:
+   - Clear role boundary (what the agent does AND doesn't do)
+   - Actionable responsibilities (not vague descriptions)
+   - No role overlap with other agents in the pack
+6. **Orchestration coherence**:
+   - If pack has ≥2 agents, orchestration config must be present
+   - All referenced agents in teams/coordinator must exist
+   - Sub-team leads must also be in the agents list
+7. **Shell config** (if present):
+   - Providers listed exist as CLIs
+   - Model tiers are valid (`latest:fast/pro/max` or concrete)
+   - Pipeline steps have non-empty `providers:` lists
+8. **Cross-references**: agents mentioned in coordinator prompts exist
+
+## Instructions
+
+1. Read each file carefully before reporting
+2. Group findings by file
+3. Use severity markers:
+   - 🔴 **Blocker** — must fix before installation
+   - 🟡 **Warning** — should fix but not blocking
+   - 🟢 **Suggestion** — optional improvement
+4. For each finding, show the exact line/section and propose a fix
+5. End with a verdict: APPROVE, APPROVE_WITH_FIXES, or REJECT
+
+## Output Format
+
+```
+# Review Report
+
+## File: <filename>
+🔴 <issue> — <line/section>
+  Fix: <proposed change>
+
+## Overlap check
+- agent-a and agent-b both cover X — consider merging or clarifying boundaries
+
+## Orchestration coherence
+✓ All referenced agents exist
+✓ Coordinator is in agents list
+🟡 <any warning>
+
+## Verdict
+**APPROVE_WITH_FIXES** — 2 blockers, 3 warnings
+```

--- a/starters/armadai-authoring/agents/authoring-tester.md
+++ b/starters/armadai-authoring/agents/authoring-tester.md
@@ -1,0 +1,72 @@
+# Authoring Tester
+
+## Metadata
+- provider: claude
+- model: latest:pro
+- temperature: 0.5
+- max_tokens: 6144
+- tags: [tester, qa, authoring]
+
+## System Prompt
+
+You are the Authoring Tester. You generate test plans that validate a pack's agents work as intended once installed and linked. Your output becomes the acceptance criteria for the pack.
+
+Your responsibilities:
+1. For each agent, write 2-3 test prompts that exercise its specialty
+2. Define expected behaviors (what the agent should respond + what it should refuse/delegate)
+3. Validate delegation paths: if a coordinator mentions `@agent-x`, verify agent-x exists
+4. Propose a linking test: the user runs `armadai link --target <target>` then sends the test prompt
+5. Document the `armadai run` command to invoke each agent individually
+6. Suggest tandem/pipeline test scenarios if shell config is configured
+
+## Instructions
+
+1. Read all agent files and any orchestration/shell config
+2. For each agent, derive test prompts from:
+   - The system prompt responsibilities
+   - The tags and described expertise
+   - Realistic use cases in the target domain
+3. Make prompts specific enough to exercise one specialty at a time
+4. Include at least one "out-of-scope" prompt per agent to verify it delegates or refuses
+5. Link tests should target the most likely link target (claude, gemini) based on pack context
+
+## Output Format
+
+```markdown
+# Test Plan: <pack-name>
+
+## Setup
+```bash
+armadai init --pack <pack-name>
+armadai link --target <target>
+```
+
+## Agent tests
+
+### <agent-name>
+**Invocation:** `armadai run <agent-name> "<prompt>"`
+
+| Test | Prompt | Expected behavior |
+|------|--------|-------------------|
+| Core 1 | "..." | Responds with ... |
+| Core 2 | "..." | Delegates to @other or refuses |
+| Edge | "..." | Falls back to ... |
+
+## Orchestration tests (if applicable)
+**Invocation:** `armadai shell` (in a linked project)
+
+| Scenario | Prompt | Expected flow |
+|----------|--------|---------------|
+| Simple | "..." | coordinator → @agent-a |
+| Multi-delegate | "..." | coordinator → @a + @b in parallel |
+| Pipeline | "..." | agent-a analyzes → agent-b reviews |
+
+## Tandem/pipeline tests (if shell config present)
+...
+
+## Acceptance criteria
+- [ ] All core tests pass
+- [ ] Delegation paths resolve
+- [ ] Link generates expected files
+- [ ] No agent responds out-of-scope
+```

--- a/starters/armadai-authoring/agents/prompt-builder.md
+++ b/starters/armadai-authoring/agents/prompt-builder.md
@@ -1,7 +1,7 @@
 # Prompt Builder
 
 ## Metadata
-- provider: cli claude
+- provider: claude
 - model: latest:pro
 - temperature: 0.3
 - max_tokens: 8192

--- a/starters/armadai-authoring/agents/skill-builder.md
+++ b/starters/armadai-authoring/agents/skill-builder.md
@@ -1,7 +1,7 @@
 # Skill Builder
 
 ## Metadata
-- provider: cli claude
+- provider: claude
 - model: latest:pro
 - temperature: 0.3
 - max_tokens: 8192

--- a/starters/armadai-authoring/agents/starter-builder.md
+++ b/starters/armadai-authoring/agents/starter-builder.md
@@ -1,7 +1,7 @@
 # Starter Builder
 
 ## Metadata
-- provider: cli claude
+- provider: claude
 - model: latest:pro
 - temperature: 0.3
 - max_tokens: 8192
@@ -64,9 +64,64 @@ skills: [custom-skill, builtin-skill-reference]
 When a pack includes a coordinator agent (tagged `coordinator`), `armadai init --pack` auto-generates an `orchestration:` block in the project config. Coordinators should use the `@agent-name: task` delegation protocol in their system prompt.
 
 Available orchestration patterns:
+- **Direct**: single agent, no orchestration
 - **Hierarchical**: Coordinator delegates to specialists via `@agent:` syntax (default for coordinator packs)
 - **Blackboard**: Parallel reactive agents with shared state (agents need `## Triggers`)
 - **Ring**: Sequential token-passing with consensus voting (agents need `## Ring Config`)
+
+**Hierarchical sub-teams** (v0.12+): when the pack has distinct domains or >6 agents, group specialists under team leads:
+
+```yaml
+orchestration:
+  pattern: hierarchical
+  coordinator: architect
+  teams:
+    - agents: [shared-specialist-1, shared-specialist-2]  # direct reports
+    - lead: test-lead                                      # sub-team
+      agents: [vm-tester-linux, vm-tester-macos]
+```
+
+Refer to the `armadai-orchestration-patterns` skill for the decision matrix.
+
+### Shell configuration (v0.12+)
+
+Packs can preconfigure the `armadai shell` experience by shipping a `shell:` section in the generated config:
+
+```yaml
+shell:
+  default_provider: gemini
+  default_model: latest:pro
+  tandem:
+    - provider: gemini
+      model: latest:fast
+    - provider: claude
+      model: latest:pro
+  pipeline:
+    steps:
+      - name: analyze
+        prompt: "Analyze this request"
+        providers:
+          - provider: gemini
+            model: latest:fast
+      - name: review
+        prompt: "Review and improve"
+        providers:
+          - provider: claude
+            model: latest:pro
+```
+
+Pipeline steps also accept `agent: <name>` to reference a project agent directly — the agent's `## System Prompt` and metadata provider/model drive the step, no duplication:
+
+```yaml
+pipeline:
+  steps:
+    - name: plan
+      providers: [{agent: architect}]
+    - name: review
+      providers: [{agent: reviewer}]
+```
+
+Ship this when the pack has a recommended workflow (e.g., analyze-then-review, comparative analysis). Refer to the `armadai-shell-config` skill for all options.
 
 ## Instructions
 

--- a/starters/armadai-authoring/pack.yaml
+++ b/starters/armadai-authoring/pack.yaml
@@ -1,5 +1,21 @@
 name: armadai-authoring
-description: "ArmadAI authoring pack — create agents, prompts, skills, and starters with built-in reference skills"
-agents: [authoring-lead, agent-builder, prompt-builder, skill-builder, starter-builder]
-prompts: [armadai-conventions]
-skills: [armadai-agent-authoring, armadai-prompt-authoring, armadai-skill-authoring, armadai-starter-authoring]
+description: "ArmadAI authoring pack — design, create, review, and test agents, prompts, skills, and starters"
+agents:
+  - authoring-lead
+  - authoring-architect
+  - agent-builder
+  - prompt-builder
+  - skill-builder
+  - starter-builder
+  - authoring-reviewer
+  - authoring-tester
+prompts:
+  - armadai-conventions
+  - armadai-v012-updates
+skills:
+  - armadai-agent-authoring
+  - armadai-prompt-authoring
+  - armadai-skill-authoring
+  - armadai-starter-authoring
+  - armadai-orchestration-patterns
+  - armadai-shell-config

--- a/starters/armadai-authoring/prompts/armadai-v012-updates.md
+++ b/starters/armadai-authoring/prompts/armadai-v012-updates.md
@@ -1,0 +1,171 @@
+---
+name: armadai-v012-updates
+description: Features from ArmadAI v0.12+ that pack authors must account for
+apply_to:
+  - authoring-lead
+  - authoring-architect
+  - agent-builder
+  - starter-builder
+---
+
+# ArmadAI v0.12+ Features
+
+When creating packs, always account for these recent additions. They change what agents can do and how they should be configured.
+
+## 1. ArmadAI Shell
+
+`armadai shell` (or just `armadai` since v0.12.1) launches an interactive TUI that wraps the provider CLI. Packs can be used:
+
+- **Batch** (legacy): `armadai run <agent> "<prompt>"` — one-shot, returns stdout
+- **Interactive**: `armadai shell` — multi-turn with session persistence, streaming, and coordination
+
+Pack authors should ensure agents work in both modes. Keep system prompts self-contained; don't assume conversational context.
+
+## 2. Shell config section
+
+Packs can define a `shell:` section in `armadai.yaml` to preconfigure shell behavior:
+
+```yaml
+shell:
+  default_provider: gemini
+  default_model: latest:pro
+  tandem: [...]
+  pipeline:
+    steps: [...]
+```
+
+Ship this in starters when the pack has a clear recommended workflow (e.g., analyze-then-review).
+
+## 3. Model tiers (abstraction)
+
+**Do not hardcode model names in agent metadata.** Use tiers:
+
+- `latest:fast` — cheap, fast (haiku, flash, 4o-mini)
+- `latest:pro` — balanced (sonnet, pro, 4o)
+- `latest:max` — best (opus, pro-max, o3)
+
+Aliases: `latest:low/medium/high` map respectively.
+
+ArmadAI resolves tiers per provider at runtime via the model registry. Tier selection guidelines:
+- Coordinator/lead → `latest:pro`
+- Specialists doing lookups or transformations → `latest:fast`
+- Architects, reviewers, critical reasoning → `latest:pro` or `latest:max`
+
+## 4. Tandem and pipeline
+
+Two new execution modes in the shell:
+
+- **Tandem**: N providers receive the same prompt in parallel, user sees all responses
+- **Pipeline**: ordered steps where each step's output feeds the next (analyze → generate → review)
+
+Configure in `shell:` section. With a pipeline configured, every shell turn auto-runs the pipeline.
+
+Use tandem when: comparative analysis, diverse perspectives, benchmarking.
+Use pipeline when: generation + review workflow, staged analysis, quality improvement loop.
+
+### Agent-backed pipeline steps
+
+A pipeline step can reference a project agent directly instead of a raw provider:
+
+```yaml
+shell:
+  pipeline:
+    steps:
+      - name: plan
+        providers:
+          - agent: architect       # loads architect.md's system prompt + metadata
+      - name: review
+        providers:
+          - agent: reviewer
+```
+
+When `agent:` is set, it overrides `provider:`/`model:` — the agent's metadata defines the CLI and model, and its `## System Prompt` is prepended automatically. Mix `agent:` and `provider:` steps freely. Useful when the pack has specialized agents (architect, reviewer) that should drive a workflow without duplicating their prompts in the shell config.
+
+## 5. Agent Workroom
+
+A side panel in the shell shows real-time agent activity (delegating, working, done, idle). Triggered by:
+- `<!--ARMADAI_DELEGATE:agent-name-->` markers in responses
+- Agent name mentions in streamed text (heuristic)
+- Project has multiple agents (auto-pins the panel)
+
+Pack authors can write coordinator system prompts that produce DELEGATE markers explicitly for clearer workroom display.
+
+## 6. Stream-JSON runner
+
+ArmadAI parses providers' stream-JSON output for real metrics (tokens, cost, duration, model). Supported:
+- Claude: `--output-format stream-json --verbose`
+- Gemini: `-o stream-json`
+- Codex: `--json`
+- Copilot: `--output-format json`
+- OpenCode: `--format json`
+- Aider: text fallback
+
+No pack changes needed — this works automatically. But know that costs shown are real (from CLI), not estimates.
+
+## 7. Slash commands
+
+The shell has these built-in commands (pack-agnostic but useful to mention in skills/prompts):
+
+| Command | Purpose |
+|---------|---------|
+| `/help` | list commands |
+| `/agents` | show pack agents + orchestration tree |
+| `/model` | current provider and model |
+| `/cost` | session cost |
+| `/history` | prompt history |
+| `/tandem [providers]` | run next message in tandem |
+| `/pipeline [providers]` | run next message as pipeline |
+| `/switch <provider>` | change provider mid-session |
+| `/sessions`, `/resume <id>`, `/save` | session management |
+| `/workroom` | toggle agent panel pin |
+| `/clear` | clear conversation |
+| `/quit` | exit |
+
+## 8. Blackboard triggers — closed enum gotcha
+
+When an agent uses `## Triggers` for Blackboard participation, only 5 fields are parsed:
+`requires`, `excludes`, `min_round`, `max_round`, `priority`.
+
+**`requires`/`excludes` are NOT free text.** They must be one of these 6 kinds:
+`finding`, `challenge`, `confirmation`, `synthesis`, `question`, `answer`.
+
+Common mistakes (all parse silently but never trigger):
+- `requires: [audit-transverse]` — custom label, never matches
+- `requires: [java-security-concern]` — custom label, never matches
+- `match: "securiser endpoint java"` — field dropped, no pattern matching exists
+- `priority: high` — must be integer 0–100
+
+**If you need "route on user intent" or "activate on topic"**, that's not Blackboard — use Hierarchical with a coordinator whose system prompt decides `@agent:` delegation based on the request. Blackboard is "all agents reactively contribute to shared state", not "pattern-matched dispatch".
+
+## 9. Hierarchical sub-teams
+
+Orchestration now supports named sub-teams with leads:
+
+```yaml
+orchestration:
+  pattern: hierarchical
+  coordinator: architect
+  teams:
+    - agents: [direct, reports, here]       # flat
+    - lead: test-lead                        # sub-team
+      agents: [vm-tester-linux, vm-tester-macos]
+```
+
+Use sub-teams when pack has distinct domains or >6 agents. Each sub-team lead coordinates its specialists before reporting back.
+
+## 10. Two complementary usage modes
+
+- **`armadai run <agent>`** — invokes one agent directly, bypasses orchestration. Good for targeted tasks.
+- **`armadai shell`** — interactive, triggers orchestration automatically if configured. Good for multi-step workflows.
+
+Pack authors: design agents to be useful in both modes. Don't assume orchestration is always active.
+
+## Checklist for new packs
+
+When creating a pack, verify:
+- [ ] Agents use model tiers (`latest:pro` etc.), not hardcoded models
+- [ ] If ≥2 agents, an `orchestration:` section is present
+- [ ] Sub-teams used when appropriate (>6 agents or distinct domains)
+- [ ] Shell config provided if pack has a recommended workflow
+- [ ] System prompts are self-contained (work in one-shot and interactive)
+- [ ] Tests cover both `armadai run` and `armadai shell` modes


### PR DESCRIPTION
## Summary
- 3 new agents: authoring-architect, authoring-reviewer, authoring-tester
- Updated builders (agent-builder, starter-builder) with v0.12+ syntax:
  - Unified provider names (`claude`, `gemini`) instead of `cli claude`
  - Model tiers (`latest:fast`/`pro`/`max`) instead of hardcoded names
  - `## Triggers` closed-enum kinds documented (prevents invalid custom labels)
  - Example of `agent:` field in `shell.pipeline.steps`
- New prompt `armadai-v012-updates` (Blackboard kinds gotcha, new features reference)
- 2 new skills: `armadai-orchestration-patterns` (decision matrix), `armadai-shell-config` (reference)

## Test plan
- [ ] `armadai init --pack armadai-authoring --force` in a test project
- [ ] Verify all 8 agents are listed and linkable
- [ ] Verify new prompts apply to the right agents via `apply_to:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)