### PR TITLE
refactor(shell): extract is_cancel_key helper

### DIFF
--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -16,6 +16,13 @@ use super::runner::ShellRunner;
 use super::session::{SessionMessage, ShellSession};
 use super::tui::ShellApp;
 
+/// Check if a key event is a cancel key (Esc or Ctrl+C).
+fn is_cancel_key(key: &event::KeyEvent) -> bool {
+    key.code == KeyCode::Esc
+        || (key.code == KeyCode::Char('c')
+            && key.modifiers == crossterm::event::KeyModifiers::CONTROL)
+}
+
 /// Helper to save the current session state.
 fn save_current_session(
     session_id: &str,
@@ -531,9 +538,7 @@ async fn event_loop(
             if event::poll(Duration::from_millis(30))?
                 && let Event::Key(key) = event::read()?
                 && key.kind == KeyEventKind::Press
-                && (key.code == KeyCode::Esc
-                    || (key.code == KeyCode::Char('c')
-                        && key.modifiers == crossterm::event::KeyModifiers::CONTROL))
+                && is_cancel_key(&key)
             {
                 let _ = child.kill().await;
                 app.append_to_streaming("\n\n[Cancelled]");
@@ -971,9 +976,7 @@ async fn execute_pipeline_steps(
             if event::poll(Duration::from_millis(80))?
                 && let Event::Key(key) = event::read()?
                 && key.kind == KeyEventKind::Press
-                && (key.code == KeyCode::Esc
-                    || (key.code == KeyCode::Char('c')
-                        && key.modifiers == crossterm::event::KeyModifiers::CONTROL))
+                && is_cancel_key(&key)
             {
                 app.add_system_message("[Pipeline cancelled]");
                 app.set_loading(false);
@@ -1114,9 +1117,7 @@ async fn execute_pty_turn(
         if event::poll(Duration::from_millis(50))?
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
-            && (key.code == KeyCode::Esc
-                || (key.code == KeyCode::Char('c')
-                    && key.modifiers == crossterm::event::KeyModifiers::CONTROL))
+            && is_cancel_key(&key)
         {
             pty.kill();
             app.append_to_streaming("\n\n[Cancelled]");


### PR DESCRIPTION
## Summary
- Adds `is_cancel_key(key: &KeyEvent) -> bool` helper in `src/shell/app.rs`
- Replaces 3 duplicated Esc/Ctrl+C detection blocks (`event_loop`, `execute_pipeline_steps`, `execute_pty_turn`)
- Behavior preserved: cancels on Esc OR Ctrl+C, nothing else

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --no-default-features --features tui -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings`
- [x] `cargo test --no-default-features --features tui,providers-api shell` (72 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)