### PR TITLE
refactor(shell): extract collect_text_from_jsonl helper

### DIFF
--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -765,29 +765,11 @@ async fn execute_tandem(
         match output_result {
             Ok(output) if output.status.success() => {
                 let raw = String::from_utf8_lossy(&output.stdout).to_string();
-
-                // Parse JSONL stream to extract clean text
-                let content = if super::json_runner::supports_json(&cmd) {
-                    use super::json_runner::{StreamEvent, parse_stream_event};
-                    let mut text = String::new();
-                    for line in raw.lines() {
-                        match parse_stream_event(&cmd, line) {
-                            StreamEvent::Delta(t) | StreamEvent::Message(t) => {
-                                text.push_str(&t);
-                            }
-                            StreamEvent::Result(resp) if !resp.content.is_empty() => {
-                                text.push_str(&resp.content);
-                            }
-                            _ => {}
-                        }
-                    }
-                    if text.is_empty() {
-                        super::parser::parse_response(&raw).content
-                    } else {
-                        super::parser::parse_response(&text).content
-                    }
-                } else {
+                let text = super::json_runner::collect_text_from_jsonl(&cmd, &raw);
+                let content = if text.is_empty() {
                     super::parser::parse_response(&raw).content
+                } else {
+                    super::parser::parse_response(&text).content
                 };
 
                 app.add_assistant_message_with_label(&name, &content);
@@ -987,27 +969,11 @@ async fn execute_pipeline_steps(
                 match output_result {
                     Ok(output) if output.status.success() => {
                         let raw = String::from_utf8_lossy(&output.stdout).to_string();
-                        let content = if super::json_runner::supports_json(&resolved.cmd) {
-                            use super::json_runner::{StreamEvent, parse_stream_event};
-                            let mut text = String::new();
-                            for line in raw.lines() {
-                                match parse_stream_event(&resolved.cmd, line) {
-                                    StreamEvent::Delta(t) | StreamEvent::Message(t) => {
-                                        text.push_str(&t);
-                                    }
-                                    StreamEvent::Result(resp) if !resp.content.is_empty() => {
-                                        text.push_str(&resp.content);
-                                    }
-                                    _ => {}
-                                }
-                            }
-                            if text.is_empty() {
-                                super::parser::parse_response(&raw).content
-                            } else {
-                                super::parser::parse_response(&text).content
-                            }
-                        } else {
+                        let text = super::json_runner::collect_text_from_jsonl(&resolved.cmd, &raw);
+                        let content = if text.is_empty() {
                             super::parser::parse_response(&raw).content
+                        } else {
+                            super::parser::parse_response(&text).content
                         };
 
                         let label = if is_last {

--- a/src/shell/json_runner.rs
+++ b/src/shell/json_runner.rs
@@ -80,6 +80,26 @@ pub fn supports_json(provider: &str) -> bool {
     json_output_flags(provider).is_some()
 }
 
+/// Extract the visible text from a CLI's raw JSONL stdout.
+///
+/// Returns the raw stdout unchanged if the CLI does not emit JSON (e.g. `aider`).
+/// Returns an empty string if the CLI emits JSON but no text events matched —
+/// callers can then fall back to text parsing on the raw stdout.
+pub fn collect_text_from_jsonl(cmd: &str, raw: &str) -> String {
+    if !supports_json(cmd) {
+        return raw.to_string();
+    }
+    let mut text = String::new();
+    for line in raw.lines() {
+        match parse_stream_event(cmd, line) {
+            StreamEvent::Delta(t) | StreamEvent::Message(t) => text.push_str(&t),
+            StreamEvent::Result(resp) if !resp.content.is_empty() => text.push_str(&resp.content),
+            _ => {}
+        }
+    }
+    text
+}
+
 /// A streaming event parsed from a single JSONL line.
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
@@ -602,6 +622,31 @@ mod tests {
         } else {
             text_fallback(raw)
         }
+    }
+
+    #[test]
+    fn test_collect_text_from_jsonl_non_json_returns_raw() {
+        let raw = "just plain text from aider";
+        assert_eq!(collect_text_from_jsonl("aider", raw), raw);
+    }
+
+    #[test]
+    fn test_collect_text_from_jsonl_claude_concatenates_deltas() {
+        let jsonl = concat!(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello"}]}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":", "}]}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"world"}]}}"#,
+        );
+        assert_eq!(collect_text_from_jsonl("claude", jsonl), "Hello, world");
+    }
+
+    #[test]
+    fn test_collect_text_from_jsonl_empty_when_no_text_events() {
+        // Valid JSON for claude but no delta/message/result text events
+        let jsonl = r#"{"type":"system","subtype":"init","session_id":"x","tools":[]}"#;
+        assert_eq!(collect_text_from_jsonl("claude", jsonl), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `json_runner::collect_text_from_jsonl(cmd, raw) -> String`
- Replaces duplicated JSONL parsing in `execute_tandem` and `execute_pipeline_steps` (~25 lines → 7 at each site)
- Behavior preserved: empty text triggers fallback to `parser::parse_response(raw)`, non-JSON providers still return raw

## Test plan
- [x] 3 new unit tests in `json_runner::tests`
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --no-default-features --features tui -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings`
- [x] `cargo test shell` (75 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)