### PR TITLE
feat(authoring): mandate Write tool in builders + clarify sub-team QA

### DIFF
--- a/starters/armadai-authoring/agents/agent-builder.md
+++ b/starters/armadai-authoring/agents/agent-builder.md
@@ -77,5 +77,10 @@ Orchestration sections (optional, for orchestrated agents):
 
 ## Output Format
 
-Output the complete agent `.md` file content inside a code block, ready to be saved.
-Include the suggested filename as a comment before the code block.
+You MUST complete every agent generation by calling the `Write` tool with:
+- **Path**: `{pack-root}/agents/{agent-name}.md` (project pack) or `~/.config/armadai/agents/{agent-name}.md` (user library)
+- **Content**: The complete agent file content (H1 + ## Metadata + ## System Prompt + optional sections)
+
+**NEVER render the agent content only in chat.** The `Write` tool call is your output contract.
+
+If the target file already exists, ask the user for confirmation before overwriting.

--- a/starters/armadai-authoring/agents/authoring-lead.md
+++ b/starters/armadai-authoring/agents/authoring-lead.md
@@ -21,7 +21,7 @@ Your team:
 | skill-builder | Creates skill directories with SKILL.md and reference files |
 | starter-builder | Creates starter packs (curated bundles of agents, prompts, and skills) |
 
-Sub-team — QA (lead: authoring-qa-lead is implicit, delegate to these directly):
+Sub-team — QA (no dedicated lead; delegate to reviewer/tester directly from this coordinator):
 
 | Agent | Role |
 |-------|------|

--- a/starters/armadai-authoring/agents/skill-builder.md
+++ b/starters/armadai-authoring/agents/skill-builder.md
@@ -76,5 +76,13 @@ When creating a skill:
 
 ## Output Format
 
-Output each file in a separate code block with its path as a header.
-Start with the SKILL.md, then each reference file.
+You MUST complete every skill generation by calling the `Write` tool **for each file** in the skill:
+- **SKILL.md path**: `{skill-root}/SKILL.md`
+- **Reference file paths**: `{skill-root}/references/{file-name}.md`
+- **Content**: The complete content of each file (frontmatter + body for SKILL.md, body for references)
+
+Write SKILL.md first, then each reference file in turn.
+
+**NEVER render the skill files only in chat.** The `Write` tool calls are your output contract.
+
+If a target file already exists, ask the user for confirmation before overwriting.

--- a/starters/armadai-authoring/agents/starter-builder.md
+++ b/starters/armadai-authoring/agents/starter-builder.md
@@ -148,5 +148,18 @@ For the coordinator:
 
 ## Output Format
 
-Output each file in a separate code block with its full path as a header.
-Start with `pack.yaml`, then the coordinator agent, then specialists, then prompts.
+You MUST complete every pack generation by calling the `Write` tool **for each file** in the pack:
+- **`pack.yaml` path**: `{pack-root}/pack.yaml`
+- **Agent paths**: `{pack-root}/agents/{agent-name}.md`
+- **Prompt paths**: `{pack-root}/prompts/{prompt-name}.md`
+- **Bundled skill paths**: `{pack-root}/skills/{skill-name}/SKILL.md` and references under `{pack-root}/skills/{skill-name}/references/`
+
+For each agent in the pack, delegate to `@agent-builder:` (which will Write its own file).
+For each prompt, delegate to `@prompt-builder:` (which will Write its own file).
+For each bundled skill, delegate to `@skill-builder:` (which will Write its own files).
+
+Then Write the `pack.yaml` manifest yourself, listing all created agents/prompts/skills.
+
+**NEVER render pack files only in chat.** The `Write` tool calls (yours + delegated) are your output contract.
+
+If a target file already exists, ask the user for confirmation before overwriting.


### PR DESCRIPTION
## Summary

Aligns `agent-builder`, `skill-builder`, and `starter-builder` with the `Write` contract introduced for `prompt-builder` in PR #136. Closes 4 P1 findings from the 2026-05-19 audit of `starters/armadai-authoring/`.

### Why

Without an explicit `Write` mandate, the 3 remaining builders emit file content as chat code blocks (\"Output the complete file inside a code block, ready to be saved\"). Users then have to copy-paste manually, which:
- breaks the authoring loop (builder → reviewer → tester),
- creates rendering inconsistencies (formatting, escapes),
- contradicts the contract honored by `prompt-builder`.

### Changes

- **`agent-builder.md`** — `## Output Format` now mandates `Write` to `{pack-root}/agents/{name}.md` (or user library), with overwrite confirmation
- **`skill-builder.md`** — mandates `Write` for `SKILL.md` and each reference file
- **`starter-builder.md`** — mandates `Write` for `pack.yaml` and delegates file Writes to the other builders
- **`authoring-lead.md`** — clarifies that the QA sub-team has no dedicated lead (resolves R1/R2 ambiguity in `pack_validation`)

Stats: 4 files, +33 / -7 lines.

## Test plan

- [x] `cargo build --no-default-features --features tui`
- [x] `cargo fmt --check`
- [ ] Run `agent-builder` manually to verify it Writes its output (post-merge smoke test)
- [ ] Run `starter-builder` manually to verify delegation chain works (post-merge smoke test)

## Related

- PR #136 (`fix/prompt-builder-authoring`) — introduces the same pattern for `prompt-builder`
- Audit report: `docs/SESSION-STATE.md` items #47-50

🤖 Generated with [Claude Code](https://claude.com/claude-code)