### PR TITLE
build(deps): bump rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Unblocks the CI \`Audit Dependencies\` check on \`release/1.0.0\` by patching the only blocking advisory: **RUSTSEC-2026-0104**.

\`rustls-webpki 0.103.12\` has a reachable panic when parsing CRLs with an empty \`BIT STRING\` in \`onlySomeReasons\` — DoS surface. Patched in \`0.103.13\`.

Manual cherry-pick from Dependabot #128 (which targets \`develop\`) — direct cherry-pick conflicts on \`Cargo.lock\` because \`develop\` has diverged. Re-applied via \`cargo update -p rustls-webpki --precise 0.103.13\`.

## Changes

- \`Cargo.lock\`: \`rustls-webpki 0.103.12 → 0.103.13\` (transitive dep only)
- 1 file, +2 / -2

## Test plan

- [x] \`cargo build --no-default-features --features tui\`
- [x] CI will re-run \`cargo audit\` on this branch

## Context

This PR is the first step of a 6-PR merge train into \`release/1.0.0\`. It unblocks the audit gate for PRs #135, #136, #138, #139, #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)