### PR TITLE
chore(release): bump version to 1.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "armadai"
-version = "0.12.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "0.12.0"
+version = "1.0.0-beta.1"
 edition = "2024"
 description = "ArmadAI — AI agent orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary

Signals the start of the v1.0.0 release cycle. \`release/1.0.0\` now carries:

| PR | Sujet |
|----|-------|
| #138 | Removal of legacy \`fleet\` concept (BREAKING CHANGE) |
| #135 | \`armadai validate\` — lints \`pack.yaml\` + project config |
| #136 | \`prompt-builder\` Write mandate + reads \`pack.yaml\` |
| #139 | Same Write mandate applied to \`agent-builder\`, \`skill-builder\`, \`starter-builder\` + clarif sub-team QA |
| #140 | \`gemini-3.0-pro\` alias remapped to portable \`latest:pro\` tier |
| #141 | \`rustls-webpki\` bumped to 0.103.13 (fixes RUSTSEC-2026-0104) |

## Security audit

\`cargo audit\` on the current branch:

- **0 vulnerabilities** (RUSTSEC-2026-0104 fixed in #141)
- **5 non-blocking warnings**:
  - 3 unmaintained: \`bincode 1.3.3\`, \`serial 0.4.0\`, \`yaml-rust 0.4.5\` (transitive)
  - 2 unsound: \`rand 0.8.5\` and \`rand 0.9.2\` — RUSTSEC-2026-0097, only triggered by custom logger calling \`rand::rng()\` which ArmadAI does not do

## Test plan

- [x] \`cargo build --no-default-features --features tui,providers-api\`
- [x] \`cargo test --no-default-features --features tui,providers-api\` (553 passed)
- [x] \`cargo audit\` (0 vulnerabilities)

## Next steps after merge

- Tag \`v1.0.0-beta.1\` on \`release/1.0.0\`
- Track the 5 unmaintained/unsound warnings as item in the dead-code-audit backlog (\`docs/proposals/2026-05-12-dead-code-audit-and-plugin-strategy.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)