### PR TITLE
feat(audit): signal quality — de-cascading, aggregation, grouped reports

### DIFF
--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -61,10 +61,10 @@ impl AuditReport {
                 "{remappable} deprecated model(s) remapped automatically (model aliases)"
             ));
         }
-        let dedupable = self.findings.iter().filter(|f| f.rule == "A06").count();
-        if dedupable > 0 {
+        let clusters = self.findings.iter().filter(|f| f.rule == "A06").count();
+        if clusters > 0 {
             lines.push(format!(
-                "{dedupable} duplicated block(s) turned into shared prompt fragments"
+                "{clusters} shared content cluster(s) factored into reusable prompt fragments"
             ));
         }
         let oversized = self.findings.iter().filter(|f| f.rule == "A05").count();
@@ -379,6 +379,13 @@ mod tests {
         assert!(md.contains("1 critical"));
         assert!(md.contains("What ArmadAI would give you"));
         assert!(md.contains("1 deprecated model(s) remapped automatically"));
+    }
+
+    #[test]
+    fn funnel_counts_clusters_not_pairs() {
+        let r = report_with(vec![finding("A06", Severity::Warning)]);
+        let md = r.to_markdown();
+        assert!(md.contains("1 shared content cluster(s)"));
     }
 
     #[test]

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -30,6 +30,28 @@ impl AuditReport {
         )
     }
 
+    /// Per-rule counts, e.g. `A01×2  A06×1(+3)  A08×1(+23)`.
+    fn breakdown_line(&self) -> String {
+        let mut per_rule: std::collections::BTreeMap<&str, (usize, usize)> =
+            std::collections::BTreeMap::new();
+        for f in &self.findings {
+            let entry = per_rule.entry(f.rule).or_insert((0, 0));
+            entry.0 += 1;
+            entry.1 += f.related.len();
+        }
+        per_rule
+            .into_iter()
+            .map(|(rule, (count, related))| {
+                if related > 0 {
+                    format!("{rule}×{count}(+{related})")
+                } else {
+                    format!("{rule}×{count}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("  ")
+    }
+
     /// Funnel block: what adopting ArmadAI would fix automatically.
     fn funnel_lines(&self) -> Vec<String> {
         let mut lines = Vec::new();
@@ -104,6 +126,7 @@ impl AuditReport {
             self.skill_count
         );
         let _ = writeln!(md, "**Summary: {}**\n", self.summary_line());
+        let _ = writeln!(md, "Breakdown: {}\n", self.breakdown_line());
         let _ = writeln!(md, "| Severity | Rule | File | Message | Suggestion |");
         let _ = writeln!(md, "|---|---|---|---|---|");
         for f in &self.findings {
@@ -324,9 +347,18 @@ mod tests {
             rule,
             severity,
             file: ".claude/agents/x.md".into(),
+            related: Vec::new(),
             message: "msg".into(),
             suggestion: Some("fix".into()),
         }
+    }
+
+    #[test]
+    fn markdown_contains_breakdown_line() {
+        let mut f = finding("A08", Severity::Info);
+        f.related = vec!["r1.md".into(), "r2.md".into()];
+        let r = report_with(vec![f]);
+        assert!(r.to_markdown().contains("Breakdown: A08×1(+2)"));
     }
 
     #[test]

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -143,7 +143,9 @@ impl AuditReport {
             .count();
         println!();
         println!("  Summary: {}", self.summary_line());
-        println!("  Breakdown: {}", self.breakdown_line());
+        if !self.findings.is_empty() {
+            println!("  Breakdown: {}", self.breakdown_line());
+        }
         if hidden > 0 {
             println!("  ({hidden} finding(s) hidden below the severity threshold)");
         }
@@ -169,7 +171,9 @@ impl AuditReport {
             self.skill_count
         );
         let _ = writeln!(md, "**Summary: {}**\n", self.summary_line());
-        let _ = writeln!(md, "Breakdown: {}\n", self.breakdown_line());
+        if !self.findings.is_empty() {
+            let _ = writeln!(md, "Breakdown: {}\n", self.breakdown_line());
+        }
         for severity in [Severity::Critical, Severity::Warning, Severity::Info] {
             let group: Vec<&Finding> = self
                 .findings
@@ -261,11 +265,13 @@ impl AuditReport {
             summary = html_escape(&self.summary_line()),
         );
 
-        let _ = writeln!(
-            html,
-            r#"<p class="summary">Breakdown: {}</p>"#,
-            html_escape(&self.breakdown_line())
-        );
+        if !self.findings.is_empty() {
+            let _ = writeln!(
+                html,
+                r#"<p class="summary">Breakdown: {}</p>"#,
+                html_escape(&self.breakdown_line())
+            );
+        }
         for severity in [Severity::Critical, Severity::Warning, Severity::Info] {
             let group: Vec<&Finding> = self
                 .findings

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -30,6 +30,22 @@ impl AuditReport {
         )
     }
 
+    /// Findings paths relative to the audited root (falls back to the raw path).
+    fn rel(&self, p: &std::path::Path) -> String {
+        p.strip_prefix(&self.root)
+            .unwrap_or(p)
+            .display()
+            .to_string()
+    }
+
+    fn severity_title(s: Severity) -> &'static str {
+        match s {
+            Severity::Critical => "Critical",
+            Severity::Warning => "Warning",
+            Severity::Info => "Info",
+        }
+    }
+
     /// Per-rule counts, e.g. `A01×2  A06×1(+3)  A08×1(+23)`.
     fn breakdown_line(&self) -> String {
         let mut per_rule: std::collections::BTreeMap<&str, (usize, usize)> =
@@ -80,7 +96,7 @@ impl AuditReport {
     /// (findings are already sorted by run_rules). The CLI's final
     /// `anyhow::bail!` on critical findings is what signals errors on
     /// stderr, so this only ever writes to stdout.
-    pub fn print_terminal(&self) {
+    pub fn print_terminal(&self, min_severity: Severity) {
         println!("armadai audit - {}", self.root.display());
         println!(
             "  Detected: {} ({} agent(s), {} skill(s))",
@@ -88,22 +104,49 @@ impl AuditReport {
             self.agent_count,
             self.skill_count
         );
-        println!();
-        for f in &self.findings {
-            let line = format!(
-                "  {:<5} {:<4} {:<40} {}",
-                f.severity.label(),
-                f.rule,
-                f.file.display(),
-                f.message
-            );
-            println!("{line}");
-            if let Some(s) = &f.suggestion {
-                println!("        -> {s}");
+        for severity in [Severity::Critical, Severity::Warning, Severity::Info] {
+            if severity > min_severity {
+                continue;
+            }
+            let group: Vec<&Finding> = self
+                .findings
+                .iter()
+                .filter(|f| f.severity == severity)
+                .collect();
+            if group.is_empty() {
+                continue;
+            }
+            println!();
+            println!("  {} ({})", Self::severity_title(severity), group.len());
+            for f in group {
+                let related = if f.related.is_empty() {
+                    String::new()
+                } else {
+                    format!(" (+{} others)", f.related.len())
+                };
+                println!(
+                    "    {:<4} {}{}  {}",
+                    f.rule,
+                    self.rel(&f.file),
+                    related,
+                    f.message
+                );
+                if let Some(s) = &f.suggestion {
+                    println!("         -> {s}");
+                }
             }
         }
+        let hidden = self
+            .findings
+            .iter()
+            .filter(|f| f.severity > min_severity)
+            .count();
         println!();
         println!("  Summary: {}", self.summary_line());
+        println!("  Breakdown: {}", self.breakdown_line());
+        if hidden > 0 {
+            println!("  ({hidden} finding(s) hidden below the severity threshold)");
+        }
         let funnel = self.funnel_lines();
         if !funnel.is_empty() {
             println!();
@@ -127,22 +170,59 @@ impl AuditReport {
         );
         let _ = writeln!(md, "**Summary: {}**\n", self.summary_line());
         let _ = writeln!(md, "Breakdown: {}\n", self.breakdown_line());
-        let _ = writeln!(md, "| Severity | Rule | File | Message | Suggestion |");
-        let _ = writeln!(md, "|---|---|---|---|---|");
-        for f in &self.findings {
+        for severity in [Severity::Critical, Severity::Warning, Severity::Info] {
+            let group: Vec<&Finding> = self
+                .findings
+                .iter()
+                .filter(|f| f.severity == severity)
+                .collect();
+            if group.is_empty() {
+                continue;
+            }
             let _ = writeln!(
                 md,
-                "| {} | {} | `{}` | {} | {} |",
-                f.severity.label(),
-                f.rule,
-                f.file.display(),
-                f.message,
-                f.suggestion.as_deref().unwrap_or("—")
+                "## {} ({})\n",
+                Self::severity_title(severity),
+                group.len()
             );
+            let _ = writeln!(md, "| Rule | File | Related | Message | Suggestion |");
+            let _ = writeln!(md, "|---|---|---|---|---|");
+            for f in &group {
+                let related = if f.related.is_empty() {
+                    "—".to_string()
+                } else {
+                    format!("+{}", f.related.len())
+                };
+                let _ = writeln!(
+                    md,
+                    "| {} | `{}` | {} | {} | {} |",
+                    f.rule,
+                    self.rel(&f.file),
+                    related,
+                    f.message,
+                    f.suggestion.as_deref().unwrap_or("—")
+                );
+            }
+            let _ = writeln!(md);
+            for f in &group {
+                if f.related.is_empty() {
+                    continue;
+                }
+                let _ = writeln!(
+                    md,
+                    "<details><summary>{} — {} related file(s)</summary>\n",
+                    f.rule,
+                    f.related.len()
+                );
+                for p in &f.related {
+                    let _ = writeln!(md, "- `{}`", self.rel(p));
+                }
+                let _ = writeln!(md, "\n</details>\n");
+            }
         }
         let funnel = self.funnel_lines();
         if !funnel.is_empty() {
-            let _ = writeln!(md, "\n## What ArmadAI would give you\n");
+            let _ = writeln!(md, "## What ArmadAI would give you\n");
             for l in funnel {
                 let _ = writeln!(md, "- {l}");
             }
@@ -174,11 +254,6 @@ impl AuditReport {
 <p class="detected">Detected: {detected} ({agent_count} agent(s), {skill_count} skill(s))</p>
 </header>
 <p class="summary"><strong>Summary: {summary}</strong></p>
-<table>
-<thead>
-<tr><th>Severity</th><th>Rule</th><th>File</th><th>Message</th><th>Suggestion</th></tr>
-</thead>
-<tbody>
 "#,
             css = HTML_CSS,
             agent_count = self.agent_count,
@@ -186,35 +261,75 @@ impl AuditReport {
             summary = html_escape(&self.summary_line()),
         );
 
-        for f in &self.findings {
-            let badge_class = match f.severity {
+        let _ = writeln!(
+            html,
+            r#"<p class="summary">Breakdown: {}</p>"#,
+            html_escape(&self.breakdown_line())
+        );
+        for severity in [Severity::Critical, Severity::Warning, Severity::Info] {
+            let group: Vec<&Finding> = self
+                .findings
+                .iter()
+                .filter(|f| f.severity == severity)
+                .collect();
+            if group.is_empty() {
+                continue;
+            }
+            let badge_class = match severity {
                 Severity::Critical => "badge-crit",
                 Severity::Warning => "badge-warn",
                 Severity::Info => "badge-info",
             };
             let _ = writeln!(
                 html,
-                r#"<tr>
-<td><span class="badge {badge_class}">{severity}</span></td>
+                r#"<h2><span class="badge {badge_class}">{}</span> {} ({})</h2>
+<table>
+<thead>
+<tr><th>Rule</th><th>File</th><th>Message</th><th>Suggestion</th></tr>
+</thead>
+<tbody>"#,
+                html_escape(severity.label()),
+                html_escape(Self::severity_title(severity)),
+                group.len()
+            );
+            for f in &group {
+                let related_html = if f.related.is_empty() {
+                    String::new()
+                } else {
+                    let mut d = format!(
+                        "<details><summary>+{} related</summary><ul>",
+                        f.related.len()
+                    );
+                    for p in &f.related {
+                        let _ = write!(
+                            d,
+                            "<li><code class=\"path\">{}</code></li>",
+                            html_escape(&self.rel(p))
+                        );
+                    }
+                    d.push_str("</ul></details>");
+                    d
+                };
+                let _ = writeln!(
+                    html,
+                    r#"<tr>
 <td>{rule}</td>
-<td><code class="path">{file}</code></td>
+<td><code class="path">{file}</code>{related_html}</td>
 <td>{message}</td>
 <td>{suggestion}</td>
 </tr>"#,
-                badge_class = badge_class,
-                severity = html_escape(f.severity.label()),
-                rule = html_escape(f.rule),
-                file = html_escape(&f.file.display().to_string()),
-                message = html_escape(&f.message),
-                suggestion = f
-                    .suggestion
-                    .as_deref()
-                    .map(html_escape)
-                    .unwrap_or_else(|| "—".to_string()),
-            );
+                    rule = html_escape(f.rule),
+                    file = html_escape(&self.rel(&f.file)),
+                    message = html_escape(&f.message),
+                    suggestion = f
+                        .suggestion
+                        .as_deref()
+                        .map(html_escape)
+                        .unwrap_or_else(|| "—".to_string()),
+                );
+            }
+            html.push_str("</tbody>\n</table>\n");
         }
-
-        html.push_str("</tbody>\n</table>\n");
 
         let funnel = self.funnel_lines();
         if !funnel.is_empty() {
@@ -301,6 +416,8 @@ code.path {
 .badge-crit { background: var(--crit-bg); color: var(--crit-fg); }
 .badge-warn { background: var(--warn-bg); color: var(--warn-fg); }
 .badge-info { background: var(--info-bg); color: var(--info-fg); }
+h2 { font-size: 1.05rem; margin-top: 1.5rem; }
+details ul { margin: 0.25rem 0 0 1rem; padding: 0; }
 .funnel { margin-top: 1.5rem; }
 .funnel h2 { font-size: 1.05rem; }
 footer {
@@ -351,6 +468,51 @@ mod tests {
             message: "msg".into(),
             suggestion: Some("fix".into()),
         }
+    }
+
+    fn finding_with_related(rule: &'static str, severity: Severity, related: usize) -> Finding {
+        Finding {
+            rule,
+            severity,
+            file: ".claude/agents/x.md".into(),
+            related: (0..related)
+                .map(|i| format!(".claude/agents/r{i}.md").into())
+                .collect(),
+            message: "msg".into(),
+            suggestion: Some("fix".into()),
+        }
+    }
+
+    #[test]
+    fn markdown_groups_by_severity_with_counts() {
+        let r = report_with(vec![
+            finding("A01", Severity::Critical),
+            finding_with_related("A08", Severity::Info, 3),
+        ]);
+        let md = r.to_markdown();
+        assert!(md.contains("## Critical (1)"));
+        assert!(md.contains("## Info (1)"));
+        assert!(md.contains("Breakdown:"));
+        assert!(md.contains("A08×1(+3)"));
+    }
+
+    #[test]
+    fn html_lists_related_files_in_details() {
+        let r = report_with(vec![finding_with_related("A06", Severity::Warning, 2)]);
+        let html = r.to_html();
+        assert!(html.contains("<details>"));
+        assert!(html.contains("r0.md"));
+        assert!(html.contains("+2"));
+    }
+
+    #[test]
+    fn paths_are_relative_to_root() {
+        let mut r = report_with(vec![finding("A01", Severity::Critical)]);
+        r.root = PathBuf::from("/repo");
+        r.findings[0].file = PathBuf::from("/repo/.claude/agents/x.md");
+        let md = r.to_markdown();
+        assert!(md.contains("`.claude/agents/x.md`"));
+        assert!(!md.contains("`/repo/.claude"));
     }
 
     #[test]

--- a/src/audit/reverse/claude.rs
+++ b/src/audit/reverse/claude.rs
@@ -170,8 +170,13 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
     let (fm_raw, body) = extract_frontmatter(&content);
     let fm: ClaudeAgentFrontmatter = match fm_raw {
         Some(raw) => serde_yaml_ng::from_str(raw).unwrap_or_else(|e| {
-            issues.push(issue(path, format!("invalid YAML frontmatter: {e}")));
-            ClaudeAgentFrontmatter::default()
+            issues.push(issue(path, describe_yaml_error(raw, &e)));
+            ClaudeAgentFrontmatter {
+                name: salvage_field(raw, "name"),
+                description: salvage_field(raw, "description"),
+                model: salvage_field(raw, "model"),
+                tools: salvage_field(raw, "tools").map(ToolsField::Csv),
+            }
         }),
         None => {
             issues.push(issue(path, "missing YAML frontmatter".to_string()));
@@ -189,6 +194,44 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
         system_prompt: body.trim().to_string(),
         issues,
     }
+}
+
+/// Best-effort recovery of one simple top-level `key: value` line from a
+/// frontmatter that strict YAML rejected. Broken flow scalars (`[`, `{`)
+/// are skipped so historical fallbacks (file stem) keep working.
+fn salvage_field(raw: &str, key: &str) -> Option<String> {
+    raw.lines().find_map(|line| {
+        let (k, v) = line.split_once(':')?;
+        if k.trim() != key {
+            return None;
+        }
+        let v = v.trim();
+        if v.is_empty() || v.starts_with('[') || v.starts_with('{') {
+            return None;
+        }
+        Some(v.trim_matches('"').trim_matches('\'').to_string())
+    })
+}
+
+/// Turn a strict-YAML error into a message the Markdown-writing user can
+/// act on. The dominant real-world failure is an unquoted value containing
+/// `: `, which YAML and Claude Code both reject.
+fn describe_yaml_error(raw: &str, err: &serde_yaml_ng::Error) -> String {
+    if let Some(loc) = err.location() {
+        // +1: the opening `---` line precedes the frontmatter in the file.
+        let file_line = loc.line() + 1;
+        if let Some(line) = raw.lines().nth(loc.line().saturating_sub(1))
+            && let Some((key, value)) = line.split_once(':')
+            && value.contains(": ")
+        {
+            return format!(
+                "unquoted '{}:' value contains ': ' (line {file_line}) — wrap the value in double quotes (YAML and Claude Code both reject it as-is)",
+                key.trim()
+            );
+        }
+        return format!("invalid YAML frontmatter (line {file_line}): {err}");
+    }
+    format!("invalid YAML frontmatter: {err}")
 }
 
 fn issue(path: &Path, message: String) -> ParseIssue {
@@ -334,6 +377,49 @@ mod tests {
             .unwrap();
         assert!(!empty.has_skill_md);
         assert!(config.instructions.unwrap().content.contains("@reviewer"));
+    }
+
+    #[test]
+    fn unquoted_colon_gets_pedagogical_message_and_salvage() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".claude/agents/gate.md",
+            "---\nname: gate\nmodel: opus\ndescription: wraps both phases (one engine : selection + cache)\n---\nBody",
+        );
+        let config = ClaudeReverseLinker.parse(dir.path());
+        let a = &config.agents[0];
+        assert_eq!(a.issues.len(), 1);
+        assert!(
+            a.issues[0]
+                .message
+                .contains("wrap the value in double quotes")
+        );
+        // Salvage recovered the real fields despite the strict-YAML failure.
+        assert_eq!(a.name, "gate");
+        assert_eq!(a.metadata.model.as_deref(), Some("opus"));
+        assert!(
+            a.metadata
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("wraps both phases")
+        );
+    }
+
+    #[test]
+    fn salvage_skips_broken_flow_scalars() {
+        // `name: [unclosed` must NOT be salvaged into the agent name —
+        // keeps the historical stem fallback intact.
+        assert_eq!(salvage_field("name: [unclosed", "name"), None);
+        assert_eq!(
+            salvage_field("model: opus", "model"),
+            Some("opus".to_string())
+        );
+        assert_eq!(
+            salvage_field("desc: \"quoted\"", "desc"),
+            Some("quoted".to_string())
+        );
     }
 
     #[test]

--- a/src/audit/reverse/claude.rs
+++ b/src/audit/reverse/claude.rs
@@ -124,20 +124,32 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
             source_path: dir.to_path_buf(),
             description: None,
             has_skill_md: false,
-            frontmatter_ok: false,
+            has_frontmatter: false,
+            issues: Vec::new(),
         };
     };
+    let mut issues = Vec::new();
     let (fm_raw, _body) = extract_frontmatter(&content);
-    let (fm, frontmatter_ok) = match fm_raw.map(serde_yaml_ng::from_str::<SkillFm>) {
-        Some(Ok(fm)) => (fm, true),
-        Some(Err(_)) | None => (SkillFm::default(), false),
+    let (fm, has_frontmatter) = match fm_raw {
+        Some(raw) => {
+            let fm = serde_yaml_ng::from_str::<SkillFm>(raw).unwrap_or_else(|e| {
+                issues.push(issue(&skill_md, describe_yaml_error(raw, &e)));
+                SkillFm {
+                    name: salvage_field(raw, "name"),
+                    description: salvage_field(raw, "description"),
+                }
+            });
+            (fm, true)
+        }
+        None => (SkillFm::default(), false),
     };
     ImportedSkill {
         name: fm.name.unwrap_or(dir_name),
         source_path: skill_md,
         description: fm.description,
         has_skill_md: true,
-        frontmatter_ok,
+        has_frontmatter,
+        issues,
     }
 }
 
@@ -368,7 +380,7 @@ mod tests {
         let config = ClaudeReverseLinker.parse(dir.path());
         assert_eq!(config.skills.len(), 2);
         let deploy = config.skills.iter().find(|s| s.name == "deploy").unwrap();
-        assert!(deploy.has_skill_md && deploy.frontmatter_ok);
+        assert!(deploy.has_skill_md && deploy.has_frontmatter && deploy.issues.is_empty());
         assert_eq!(deploy.description.as_deref(), Some("Deploys the app"));
         let empty = config
             .skills
@@ -423,18 +435,43 @@ mod tests {
     }
 
     #[test]
-    fn skill_with_invalid_yaml_falls_back_to_dir_name() {
+    fn skill_with_invalid_yaml_gets_issue_and_salvage() {
         let dir = tempfile::tempdir().unwrap();
         write(
             dir.path(),
-            ".claude/skills/broken-skill/SKILL.md",
-            "---\nname: [unclosed\n---\nBody",
+            ".claude/skills/triage/SKILL.md",
+            "---\nname: triage\ndescription: triage is HUMAN — the skill : just assists\n---\nBody",
         );
         let config = ClaudeReverseLinker.parse(dir.path());
-        assert_eq!(config.skills.len(), 1);
         let skill = &config.skills[0];
-        assert!(skill.has_skill_md);
-        assert!(!skill.frontmatter_ok);
-        assert_eq!(skill.name, "broken-skill");
+        assert!(skill.has_skill_md && skill.has_frontmatter);
+        assert_eq!(skill.issues.len(), 1);
+        assert!(
+            skill.issues[0]
+                .message
+                .contains("wrap the value in double quotes")
+        );
+        assert_eq!(skill.name, "triage"); // salvaged
+        assert!(
+            skill
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("triage is HUMAN")
+        );
+    }
+
+    #[test]
+    fn skill_without_frontmatter_has_no_issue() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".claude/skills/bare/SKILL.md",
+            "# Just a title\nBody.",
+        );
+        let config = ClaudeReverseLinker.parse(dir.path());
+        let skill = &config.skills[0];
+        assert!(skill.has_skill_md && !skill.has_frontmatter);
+        assert!(skill.issues.is_empty()); // standard violation, not a parse error
     }
 }

--- a/src/audit/reverse/claude.rs
+++ b/src/audit/reverse/claude.rs
@@ -210,15 +210,32 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
 
 /// Best-effort recovery of one simple top-level `key: value` line from a
 /// frontmatter that strict YAML rejected. Broken flow scalars (`[`, `{`)
-/// are skipped so historical fallbacks (file stem) keep working.
+/// and block scalars (`|`, `>`) are skipped so historical fallbacks (file
+/// stem) keep working, and indented lines (nested keys, block-scalar
+/// bodies) never masquerade as a top-level key.
 fn salvage_field(raw: &str, key: &str) -> Option<String> {
     raw.lines().find_map(|line| {
+        // A top-level key starts at column 0: nested keys and block-scalar
+        // bodies are indented and must not match.
+        if line.starts_with(char::is_whitespace) {
+            return None;
+        }
         let (k, v) = line.split_once(':')?;
         if k.trim() != key {
             return None;
         }
+        // Strip a trailing YAML comment before any further processing.
+        let v = match v.find(" #") {
+            Some(idx) => &v[..idx],
+            None => v,
+        };
         let v = v.trim();
-        if v.is_empty() || v.starts_with('[') || v.starts_with('{') {
+        if v.is_empty()
+            || v.starts_with('[')
+            || v.starts_with('{')
+            || v.starts_with('|')
+            || v.starts_with('>')
+        {
             return None;
         }
         Some(v.trim_matches('"').trim_matches('\'').to_string())
@@ -432,6 +449,17 @@ mod tests {
             salvage_field("desc: \"quoted\"", "desc"),
             Some("quoted".to_string())
         );
+    }
+
+    #[test]
+    fn salvage_skips_block_scalars_comments_and_indented_keys() {
+        assert_eq!(salvage_field("description: >-", "description"), None);
+        assert_eq!(salvage_field("description: |", "description"), None);
+        assert_eq!(
+            salvage_field("model: opus # fast", "model"),
+            Some("opus".to_string())
+        );
+        assert_eq!(salvage_field("  model: nested", "model"), None);
     }
 
     #[test]

--- a/src/audit/reverse/mod.rs
+++ b/src/audit/reverse/mod.rs
@@ -36,7 +36,8 @@ pub struct ImportedSkill {
     pub source_path: PathBuf,
     pub description: Option<String>,
     pub has_skill_md: bool,
-    pub frontmatter_ok: bool,
+    pub has_frontmatter: bool,
+    pub issues: Vec<ParseIssue>,
 }
 
 /// Root instructions file (e.g. CLAUDE.md).

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -103,7 +103,7 @@ pub(super) fn a08_permissive_tools(ctx: &AuditContext) -> Vec<Finding> {
             .map(|a| a.source_path.clone())
             .collect(),
         message: format!(
-            "{}/{} agents inherit all tools (no restriction)",
+            "{}/{} parsed agents inherit all tools (no restriction)",
             offenders.len(),
             agents.len()
         ),
@@ -264,6 +264,30 @@ mod tests {
         });
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].rule, "A09");
+    }
+
+    #[test]
+    fn a09_missing_skill_md_does_not_stack_missing_description() {
+        use crate::audit::reverse::{ImportedConfig, ImportedSkill};
+        let config = ImportedConfig {
+            skills: vec![ImportedSkill {
+                name: "no-md".into(),
+                source_path: ".claude/skills/no-md".into(),
+                description: None,
+                has_skill_md: false,
+                has_frontmatter: false,
+                issues: Vec::new(),
+            }],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = a09_malformed_skill(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("missing SKILL.md"));
+        assert!(!f[0].message.contains("missing description"));
     }
 
     #[test]

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -10,6 +10,7 @@ pub(super) fn a01_unparsable(ctx: &AuditContext) -> Vec<Finding> {
             rule: "A01",
             severity: Severity::Critical,
             file: i.file.clone(),
+            related: Vec::new(),
             message: i.message.clone(),
             suggestion: Some("fix the YAML frontmatter so tools can read this agent".to_string()),
         })
@@ -26,6 +27,7 @@ pub(super) fn a02_missing_fields(ctx: &AuditContext) -> Vec<Finding> {
             rule: "A02",
             severity: Severity::Warning,
             file: a.source_path.clone(),
+            related: Vec::new(),
             message: format!("agent '{}' has no description", a.name),
             suggestion: Some(
                 "add a `description:` field (used for routing and discovery)".to_string(),
@@ -45,6 +47,7 @@ pub(super) fn a05_oversized_prompt(ctx: &AuditContext) -> Vec<Finding> {
                 rule: "A05",
                 severity: Severity::Warning,
                 file: a.source_path.clone(),
+                related: Vec::new(),
                 message: format!(
                     "agent '{}' prompt is ~{estimate} tokens (threshold {})",
                     a.name, ctx.settings.prompt_token_threshold
@@ -70,6 +73,7 @@ pub(super) fn a08_permissive_tools(ctx: &AuditContext) -> Vec<Finding> {
             rule: "A08",
             severity: Severity::Info,
             file: a.source_path.clone(),
+            related: Vec::new(),
             message: format!("agent '{}' inherits all tools (no restriction)", a.name),
             suggestion: Some("declare the minimal `tools:` list this agent needs".to_string()),
         })
@@ -95,6 +99,7 @@ pub(super) fn a09_malformed_skill(ctx: &AuditContext) -> Vec<Finding> {
                 rule: "A09",
                 severity: Severity::Warning,
                 file: s.source_path.clone(),
+                related: Vec::new(),
                 message: format!("skill '{}': {}", s.name, problems.join(", ")),
                 suggestion: Some(
                     "follow the Agent Skills standard: SKILL.md with name + description"

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -1,4 +1,5 @@
 use super::{AuditContext, Finding, Severity};
+use crate::audit::reverse::ImportedAgent;
 
 /// A01 — a native file could not be fully parsed.
 pub(super) fn a01_unparsable(ctx: &AuditContext) -> Vec<Finding> {
@@ -66,27 +67,48 @@ pub(super) fn a05_oversized_prompt(ctx: &AuditContext) -> Vec<Finding> {
         .collect()
 }
 
-/// A08 — agent has no tool restriction at all.
+/// A08 — agents without any tool restriction, aggregated fleet-level.
+/// A uniform fleet is an assumed team choice (Info); a mixed fleet is a
+/// real inconsistency (Warning).
 pub(super) fn a08_permissive_tools(ctx: &AuditContext) -> Vec<Finding> {
-    ctx.config
+    // Anti-cascade: parse-broken agents are A01's job.
+    let agents: Vec<&ImportedAgent> = ctx
+        .config
         .agents
         .iter()
-        // Anti-cascade: parse-broken agents are A01's job (one root cause,
-        // one finding); their fields are unreliable defaults.
         .filter(|a| a.issues.is_empty())
+        .collect();
+    let offenders: Vec<&ImportedAgent> = agents
+        .iter()
+        .copied()
         .filter(|a| match &a.metadata.tools {
             None => true,
             Some(tools) => tools.iter().any(|t| t == "*"),
         })
-        .map(|a| Finding {
-            rule: "A08",
-            severity: Severity::Info,
-            file: a.source_path.clone(),
-            related: Vec::new(),
-            message: format!("agent '{}' inherits all tools (no restriction)", a.name),
-            suggestion: Some("declare the minimal `tools:` list this agent needs".to_string()),
-        })
-        .collect()
+        .collect();
+    let Some(first) = offenders.first() else {
+        return Vec::new();
+    };
+    let severity = if offenders.len() == agents.len() {
+        Severity::Info
+    } else {
+        Severity::Warning
+    };
+    vec![Finding {
+        rule: "A08",
+        severity,
+        file: first.source_path.clone(),
+        related: offenders[1..]
+            .iter()
+            .map(|a| a.source_path.clone())
+            .collect(),
+        message: format!(
+            "{}/{} agents inherit all tools (no restriction)",
+            offenders.len(),
+            agents.len()
+        ),
+        suggestion: Some("declare the minimal `tools:` list each agent needs".to_string()),
+    }]
 }
 
 /// A09 — skill directory does not follow the Agent Skills standard.
@@ -176,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn a08_flags_unrestricted_tools() {
+    fn a08_aggregates_mixed_fleet_as_warning() {
         let mut a = agent("wild", "Body");
         a.metadata.tools = None;
         let mut b = agent("star", "Body");
@@ -188,7 +210,27 @@ mod tests {
             config: &config,
             settings: &settings,
         });
-        assert_eq!(f.len(), 2);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Warning); // mixed fleet
+        assert!(f[0].message.contains("2/3"));
+        assert_eq!(f[0].related.len(), 1);
+    }
+
+    #[test]
+    fn a08_uniform_fleet_is_single_info() {
+        let mut a = agent("one", "Body");
+        a.metadata.tools = None;
+        let mut b = agent("two", "Body");
+        b.metadata.tools = None;
+        let config = config_with(vec![a, b]);
+        let settings = AuditSettings::default();
+        let f = a08_permissive_tools(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Info);
+        assert!(f[0].message.contains("2/2"));
     }
 
     #[test]

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -22,6 +22,9 @@ pub(super) fn a02_missing_fields(ctx: &AuditContext) -> Vec<Finding> {
     ctx.config
         .agents
         .iter()
+        // Anti-cascade: parse-broken agents are A01's job (one root cause,
+        // one finding); their fields are unreliable defaults.
+        .filter(|a| a.issues.is_empty())
         .filter(|a| a.metadata.description.is_none())
         .map(|a| Finding {
             rule: "A02",
@@ -41,6 +44,9 @@ pub(super) fn a05_oversized_prompt(ctx: &AuditContext) -> Vec<Finding> {
     ctx.config
         .agents
         .iter()
+        // Anti-cascade: parse-broken agents are A01's job (one root cause,
+        // one finding); their fields are unreliable defaults.
+        .filter(|a| a.issues.is_empty())
         .filter_map(|a| {
             let estimate = super::estimate_tokens(&a.system_prompt);
             (estimate > ctx.settings.prompt_token_threshold).then(|| Finding {
@@ -65,6 +71,9 @@ pub(super) fn a08_permissive_tools(ctx: &AuditContext) -> Vec<Finding> {
     ctx.config
         .agents
         .iter()
+        // Anti-cascade: parse-broken agents are A01's job (one root cause,
+        // one finding); their fields are unreliable defaults.
+        .filter(|a| a.issues.is_empty())
         .filter(|a| match &a.metadata.tools {
             None => true,
             Some(tools) => tools.iter().any(|t| t == "*"),
@@ -278,5 +287,24 @@ mod tests {
         assert_eq!(f.len(), 1);
         assert!(f[0].message.contains("bare"));
         assert!(f[0].message.contains("missing frontmatter"));
+    }
+
+    #[test]
+    fn field_rules_skip_agents_with_parse_issues() {
+        let mut a = agent("broken", "Body");
+        a.metadata.description = None;
+        a.metadata.tools = None;
+        a.issues.push(ParseIssue {
+            file: a.source_path.clone(),
+            message: "invalid".into(),
+        });
+        let config = config_with(vec![a]);
+        let settings = AuditSettings::default();
+        let ctx = AuditContext {
+            config: &config,
+            settings: &settings,
+        };
+        assert!(a02_missing_fields(&ctx).is_empty());
+        assert!(a08_permissive_tools(&ctx).is_empty());
     }
 }

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -2,17 +2,17 @@ use super::{AuditContext, Finding, Severity};
 
 /// A01 — a native file could not be fully parsed.
 pub(super) fn a01_unparsable(ctx: &AuditContext) -> Vec<Finding> {
-    ctx.config
-        .agents
-        .iter()
-        .flat_map(|a| a.issues.iter())
+    let agent_issues = ctx.config.agents.iter().flat_map(|a| a.issues.iter());
+    let skill_issues = ctx.config.skills.iter().flat_map(|s| s.issues.iter());
+    agent_issues
+        .chain(skill_issues)
         .map(|i| Finding {
             rule: "A01",
             severity: Severity::Critical,
             file: i.file.clone(),
             related: Vec::new(),
             message: i.message.clone(),
-            suggestion: Some("fix the YAML frontmatter so tools can read this agent".to_string()),
+            suggestion: Some("fix the YAML frontmatter so tools can read this file".to_string()),
         })
         .collect()
 }
@@ -81,18 +81,21 @@ pub(super) fn a08_permissive_tools(ctx: &AuditContext) -> Vec<Finding> {
 }
 
 /// A09 — skill directory does not follow the Agent Skills standard.
+/// Parse failures are A01's job: a skill carrying a ParseIssue is skipped
+/// here so one root cause yields one finding.
 pub(super) fn a09_malformed_skill(ctx: &AuditContext) -> Vec<Finding> {
     ctx.config
         .skills
         .iter()
+        .filter(|s| s.issues.is_empty())
         .filter_map(|s| {
             let mut problems = Vec::new();
             if !s.has_skill_md {
                 problems.push("missing SKILL.md");
-            } else if !s.frontmatter_ok {
-                problems.push("invalid or missing frontmatter");
+            } else if !s.has_frontmatter {
+                problems.push("missing frontmatter");
             }
-            if s.description.is_none() {
+            if s.has_skill_md && s.description.is_none() {
                 problems.push("missing description");
             }
             (!problems.is_empty()).then(|| Finding {
@@ -189,14 +192,16 @@ mod tests {
                     source_path: ".claude/skills/no-md".into(),
                     description: None,
                     has_skill_md: false,
-                    frontmatter_ok: false,
+                    has_frontmatter: false,
+                    issues: Vec::new(),
                 },
                 ImportedSkill {
                     name: "fine".into(),
                     source_path: ".claude/skills/fine/SKILL.md".into(),
                     description: Some("ok".into()),
                     has_skill_md: true,
-                    frontmatter_ok: true,
+                    has_frontmatter: true,
+                    issues: Vec::new(),
                 },
             ],
             ..Default::default()
@@ -208,5 +213,70 @@ mod tests {
         });
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].rule, "A09");
+    }
+
+    #[test]
+    fn a01_covers_skill_parse_issues() {
+        use crate::audit::reverse::{ImportedConfig, ImportedSkill, ParseIssue};
+        let config = ImportedConfig {
+            skills: vec![ImportedSkill {
+                name: "triage".into(),
+                source_path: ".claude/skills/triage/SKILL.md".into(),
+                description: Some("salvaged".into()),
+                has_skill_md: true,
+                has_frontmatter: true,
+                issues: vec![ParseIssue {
+                    file: ".claude/skills/triage/SKILL.md".into(),
+                    message: "unquoted value".into(),
+                }],
+            }],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = a01_unparsable(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn a09_does_not_double_report_parse_broken_skills() {
+        use crate::audit::reverse::{ImportedConfig, ImportedSkill, ParseIssue};
+        let config = ImportedConfig {
+            skills: vec![
+                // Parse-broken skill: A01's job, A09 stays silent.
+                ImportedSkill {
+                    name: "broken".into(),
+                    source_path: ".claude/skills/broken/SKILL.md".into(),
+                    description: None,
+                    has_skill_md: true,
+                    has_frontmatter: true,
+                    issues: vec![ParseIssue {
+                        file: ".claude/skills/broken/SKILL.md".into(),
+                        message: "bad".into(),
+                    }],
+                },
+                // No frontmatter at all: A09 Warning.
+                ImportedSkill {
+                    name: "bare".into(),
+                    source_path: ".claude/skills/bare/SKILL.md".into(),
+                    description: None,
+                    has_skill_md: true,
+                    has_frontmatter: false,
+                    issues: Vec::new(),
+                },
+            ],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = a09_malformed_skill(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("bare"));
+        assert!(f[0].message.contains("missing frontmatter"));
     }
 }

--- a/src/audit/rules/mod.rs
+++ b/src/audit/rules/mod.rs
@@ -31,6 +31,8 @@ pub struct Finding {
     pub rule: &'static str,
     pub severity: Severity,
     pub file: PathBuf,
+    /// Other files carried by an aggregated finding; `file` stays the anchor.
+    pub related: Vec<PathBuf>,
     pub message: String,
     pub suggestion: Option<String>,
 }
@@ -189,5 +191,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let s = AuditSettings::from_project(dir.path());
         assert_eq!(s.prompt_token_threshold, 4000);
+    }
+
+    #[test]
+    fn finding_carries_related_files() {
+        let f = Finding {
+            rule: "A06",
+            severity: Severity::Warning,
+            file: "a.md".into(),
+            related: vec!["b.md".into(), "c.md".into()],
+            message: String::new(),
+            suggestion: None,
+        };
+        assert_eq!(f.related.len(), 2);
     }
 }

--- a/src/audit/rules/models.rs
+++ b/src/audit/rules/models.rs
@@ -19,6 +19,7 @@ pub(super) fn a03_with_resolver(
                 rule: "A03",
                 severity: Severity::Critical,
                 file: a.source_path.clone(),
+                related: Vec::new(),
                 message: format!("agent '{}' uses deprecated model '{model}'", a.name),
                 suggestion: Some(format!("replace with '{replacement}'")),
             })
@@ -61,6 +62,7 @@ pub(super) fn a04_with_catalog<F: Fn(&str) -> bool>(
                 rule: "A04",
                 severity: Severity::Warning,
                 file: a.source_path.clone(),
+                related: Vec::new(),
                 message: format!("agent '{}' uses unknown model '{model}'", a.name),
                 suggestion: Some("check the spelling against `armadai models`".to_string()),
             })

--- a/src/audit/rules/models.rs
+++ b/src/audit/rules/models.rs
@@ -1,6 +1,8 @@
 use super::{AuditContext, Finding, Severity};
 
 /// A03 — model is a known deprecated alias.
+/// Deliberately fires on salvaged values too: a deprecated model is a
+/// distinct root cause worth reporting even on a parse-broken file.
 pub(super) fn a03_deprecated_model(ctx: &AuditContext) -> Vec<Finding> {
     a03_with_resolver(ctx, &crate::linker::model_aliases::resolve_alias)
 }
@@ -49,6 +51,8 @@ pub(super) fn a04_with_catalog<F: Fn(&str) -> bool>(
     ctx.config
         .agents
         .iter()
+        // Anti-cascade: salvaged fields on parse-broken agents are unreliable.
+        .filter(|a| a.issues.is_empty())
         .filter_map(|a| {
             let model = a.metadata.model.as_deref()?;
             // Portable tiers and deprecated aliases are handled elsewhere.
@@ -73,6 +77,7 @@ pub(super) fn a04_with_catalog<F: Fn(&str) -> bool>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audit::reverse::ParseIssue;
     use crate::audit::rules::test_support::{agent, config_with};
     use crate::audit::rules::{AuditContext, AuditSettings, Severity};
 
@@ -108,6 +113,24 @@ mod tests {
         let f = a04_with_catalog(&ctx, Some(&known));
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].rule, "A04");
+    }
+
+    #[test]
+    fn a04_skips_parse_broken_agents() {
+        let mut a = agent("broken", "Body");
+        a.metadata.model = Some("whatever-unknown".to_string());
+        a.issues.push(ParseIssue {
+            file: a.source_path.clone(),
+            message: "invalid".into(),
+        });
+        let config = config_with(vec![a]);
+        let settings = AuditSettings::default();
+        let ctx = AuditContext {
+            config: &config,
+            settings: &settings,
+        };
+        let known = |_: &str| false;
+        assert!(a04_with_catalog(&ctx, Some(&known)).is_empty());
     }
 
     #[test]

--- a/src/audit/rules/references.rs
+++ b/src/audit/rules/references.rs
@@ -50,6 +50,7 @@ pub(super) fn a10_broken_references(ctx: &AuditContext) -> Vec<Finding> {
             rule: "A10",
             severity: Severity::Warning,
             file: instructions.source_path.clone(),
+            related: Vec::new(),
             message: format!("mentions '@{slug}' but no such agent exists"),
             suggestion: Some("create the agent or remove the stale mention".to_string()),
         })
@@ -78,6 +79,7 @@ pub(super) fn a11_plaintext_secret(ctx: &AuditContext) -> Vec<Finding> {
             rule: "A11",
             severity: Severity::Critical,
             file: path.to_path_buf(),
+            related: Vec::new(),
             message: "contains what looks like a plaintext API key".to_string(),
             suggestion: Some("move the secret to an env var or a secrets manager".to_string()),
         })

--- a/src/audit/rules/similarity.rs
+++ b/src/audit/rules/similarity.rs
@@ -55,6 +55,7 @@ pub(super) fn a06_duplicated_blocks(ctx: &AuditContext) -> Vec<Finding> {
                     rule: "A06",
                     severity: Severity::Warning,
                     file: agents[i].source_path.clone(),
+                    related: Vec::new(),
                     message: format!("agents '{}' and '{}' share duplicated content ({shared} matching {DUPLICATION_WINDOW}-line window(s))", agents[i].name, agents[j].name),
                     suggestion: Some(
                         "extract the shared block into one reusable prompt fragment".to_string(),
@@ -83,6 +84,7 @@ pub(super) fn a07_redundant_agents(ctx: &AuditContext) -> Vec<Finding> {
                     rule: "A07",
                     severity: Severity::Info,
                     file: agents[i].source_path.clone(),
+                    related: Vec::new(),
                     message: format!(
                         "agents '{}' and '{}' have near-identical descriptions",
                         agents[i].name, agents[j].name

--- a/src/audit/rules/similarity.rs
+++ b/src/audit/rules/similarity.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use super::{AuditContext, Finding, Severity};
@@ -39,32 +39,87 @@ pub(super) fn jaccard(a: &str, b: &str) -> f64 {
     inter / union
 }
 
-/// A06 — the same block of lines appears in two or more agent prompts.
+/// Minimal union-find over agent indices (no dependency needed).
+struct UnionFind {
+    parent: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+        }
+    }
+    fn find(&mut self, i: usize) -> usize {
+        if self.parent[i] != i {
+            let root = self.find(self.parent[i]);
+            self.parent[i] = root;
+        }
+        self.parent[i]
+    }
+    fn union(&mut self, a: usize, b: usize) {
+        let (ra, rb) = (self.find(a), self.find(b));
+        if ra != rb {
+            self.parent[rb] = ra;
+        }
+    }
+}
+
+/// A06 — duplicated content, one finding per connected cluster of agents
+/// (pairwise output explodes in O(n²) on real fleets — cls-monorepo showed
+/// 6 findings for one shared block across 4 gate agents).
 pub(super) fn a06_duplicated_blocks(ctx: &AuditContext) -> Vec<Finding> {
     let agents = &ctx.config.agents;
     let hashes: Vec<HashSet<u64>> = agents
         .iter()
         .map(|a| window_hashes(&a.system_prompt, DUPLICATION_WINDOW))
         .collect();
-    let mut findings = Vec::new();
+    let mut uf = UnionFind::new(agents.len());
+    let mut pairs = Vec::new();
     for i in 0..agents.len() {
         for j in (i + 1)..agents.len() {
             let shared = hashes[i].intersection(&hashes[j]).count();
             if shared > 0 {
-                findings.push(Finding {
-                    rule: "A06",
-                    severity: Severity::Warning,
-                    file: agents[i].source_path.clone(),
-                    related: Vec::new(),
-                    message: format!("agents '{}' and '{}' share duplicated content ({shared} matching {DUPLICATION_WINDOW}-line window(s))", agents[i].name, agents[j].name),
-                    suggestion: Some(
-                        "extract the shared block into one reusable prompt fragment".to_string(),
-                    ),
-                });
+                uf.union(i, j);
+                pairs.push((i, shared));
             }
         }
     }
-    findings
+    let mut clusters: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for i in 0..agents.len() {
+        clusters.entry(uf.find(i)).or_default().push(i);
+    }
+    let mut max_shared: HashMap<usize, usize> = HashMap::new();
+    for (i, shared) in pairs {
+        let root = uf.find(i);
+        let entry = max_shared.entry(root).or_insert(0);
+        *entry = (*entry).max(shared);
+    }
+    clusters
+        .into_iter()
+        .filter(|(_, members)| members.len() >= 2)
+        .map(|(root, members)| {
+            let names: Vec<&str> = members.iter().map(|&i| agents[i].name.as_str()).collect();
+            let strength = max_shared.get(&root).copied().unwrap_or(0);
+            Finding {
+                rule: "A06",
+                severity: Severity::Warning,
+                file: agents[members[0]].source_path.clone(),
+                related: members[1..]
+                    .iter()
+                    .map(|&i| agents[i].source_path.clone())
+                    .collect(),
+                message: format!(
+                    "{} agents share duplicated content: {} (up to {strength} matching {DUPLICATION_WINDOW}-line windows)",
+                    members.len(),
+                    names.join(", ")
+                ),
+                suggestion: Some(
+                    "extract the shared block into one reusable prompt fragment".to_string(),
+                ),
+            }
+        })
+        .collect()
 }
 
 /// A07 — two agents look interchangeable (near-identical descriptions).
@@ -123,6 +178,45 @@ mod tests {
         });
         assert_eq!(f.len(), 1);
         assert!(f[0].message.contains("one") && f[0].message.contains("two"));
+    }
+
+    #[test]
+    fn a06_clusters_four_agents_into_one_finding() {
+        let block = shared_block();
+        let agents: Vec<_> = ["doc", "perf", "quality", "security"]
+            .iter()
+            .map(|n| agent(n, &format!("{block}Specific to {n}.")))
+            .collect();
+        let config = config_with(agents);
+        let settings = AuditSettings::default();
+        let f = a06_duplicated_blocks(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].related.len(), 3);
+        assert!(f[0].message.contains("4 agents"));
+        assert!(f[0].message.contains("quality"));
+    }
+
+    #[test]
+    fn a06_keeps_disjoint_clusters_separate() {
+        let block_a = shared_block();
+        let block_b: String = (1..=10)
+            .map(|i| format!("Other convention {i}\n"))
+            .collect();
+        let config = config_with(vec![
+            agent("a1", &block_a),
+            agent("a2", &block_a),
+            agent("b1", &block_b),
+            agent("b2", &block_b),
+        ]);
+        let settings = AuditSettings::default();
+        let f = a06_duplicated_blocks(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 2);
     }
 
     #[test]

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use crate::audit::{rules::AuditSettings, run_audit};
+use crate::audit::{
+    rules::{AuditSettings, Severity},
+    run_audit,
+};
 
 pub async fn execute(path: Option<PathBuf>, report: Option<PathBuf>) -> anyhow::Result<()> {
     let root = match path {
@@ -19,7 +22,7 @@ pub async fn execute(path: Option<PathBuf>, report: Option<PathBuf>) -> anyhow::
         );
         return Ok(());
     }
-    audit.print_terminal();
+    audit.print_terminal(Severity::Info);
     if let Some(out) = report {
         let is_html = out
             .extension()

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -5,7 +5,23 @@ use crate::audit::{
     run_audit,
 };
 
-pub async fn execute(path: Option<PathBuf>, report: Option<PathBuf>) -> anyhow::Result<()> {
+pub(crate) fn min_severity_from(flag: &str, quiet: bool) -> Severity {
+    if quiet {
+        return Severity::Warning;
+    }
+    match flag {
+        "crit" => Severity::Critical,
+        "warn" => Severity::Warning,
+        _ => Severity::Info,
+    }
+}
+
+pub async fn execute(
+    path: Option<PathBuf>,
+    report: Option<PathBuf>,
+    min_severity: String,
+    quiet: bool,
+) -> anyhow::Result<()> {
     let root = match path {
         Some(p) => p,
         None => std::env::current_dir()?,
@@ -22,7 +38,7 @@ pub async fn execute(path: Option<PathBuf>, report: Option<PathBuf>) -> anyhow::
         );
         return Ok(());
     }
-    audit.print_terminal(Severity::Info);
+    audit.print_terminal(min_severity_from(&min_severity, quiet));
     if let Some(out) = report {
         let is_html = out
             .extension()
@@ -47,9 +63,24 @@ pub async fn execute(path: Option<PathBuf>, report: Option<PathBuf>) -> anyhow::
 mod tests {
     use super::*;
 
+    #[test]
+    fn min_severity_mapping() {
+        use crate::audit::rules::Severity;
+        assert_eq!(min_severity_from("info", false), Severity::Info);
+        assert_eq!(min_severity_from("warn", false), Severity::Warning);
+        assert_eq!(min_severity_from("crit", false), Severity::Critical);
+        assert_eq!(min_severity_from("info", true), Severity::Warning); // --quiet wins
+    }
+
     #[tokio::test]
     async fn execute_fails_on_missing_path() {
-        let result = execute(Some(PathBuf::from("/nonexistent/xyz")), None).await;
+        let result = execute(
+            Some(PathBuf::from("/nonexistent/xyz")),
+            None,
+            "info".to_string(),
+            false,
+        )
+        .await;
         assert!(result.is_err());
     }
 
@@ -59,7 +90,13 @@ mod tests {
         let agents = dir.path().join(".claude/agents");
         std::fs::create_dir_all(&agents).unwrap();
         std::fs::write(agents.join("bad.md"), "---\nname: [broken\n---\nBody").unwrap();
-        let result = execute(Some(dir.path().to_path_buf()), None).await;
+        let result = execute(
+            Some(dir.path().to_path_buf()),
+            None,
+            "info".to_string(),
+            false,
+        )
+        .await;
         assert!(result.is_err()); // A01 critical -> non-zero exit
     }
 
@@ -74,7 +111,13 @@ mod tests {
         )
         .unwrap();
         let report_path = dir.path().join("audit.md");
-        let result = execute(Some(dir.path().to_path_buf()), Some(report_path.clone())).await;
+        let result = execute(
+            Some(dir.path().to_path_buf()),
+            Some(report_path.clone()),
+            "info".to_string(),
+            false,
+        )
+        .await;
         assert!(result.is_ok());
         let md = std::fs::read_to_string(report_path).unwrap();
         assert!(md.contains("# armadai audit"));
@@ -91,7 +134,13 @@ mod tests {
         )
         .unwrap();
         let report_path = dir.path().join("audit.html");
-        let result = execute(Some(dir.path().to_path_buf()), Some(report_path.clone())).await;
+        let result = execute(
+            Some(dir.path().to_path_buf()),
+            Some(report_path.clone()),
+            "info".to_string(),
+            false,
+        )
+        .await;
         assert!(result.is_ok());
         let html = std::fs::read_to_string(report_path).unwrap();
         assert!(html.starts_with("<!doctype html>"));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -147,6 +147,12 @@ pub enum Command {
         /// Write a report to this file (markdown, or HTML if the extension is .html)
         #[arg(long)]
         report: Option<std::path::PathBuf>,
+        /// Only display findings at or above this severity (exit code still counts everything)
+        #[arg(long, value_parser = ["crit", "warn", "info"], default_value = "info")]
+        min_severity: String,
+        /// Shortcut for --min-severity warn
+        #[arg(long, conflicts_with = "min_severity")]
+        quiet: bool,
     },
     /// View execution history
     #[command(after_help = "Examples:\n  \
@@ -429,7 +435,12 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         }
         Command::Inspect { agent } => inspect::execute(agent).await,
         Command::Validate { path } => validate::execute(path).await,
-        Command::Audit { path, report } => audit::execute(path, report).await,
+        Command::Audit {
+            path,
+            report,
+            min_severity,
+            quiet,
+        } => audit::execute(path, report, min_severity, quiet).await,
         Command::History { agent } => history::execute(agent).await,
         Command::Costs { agent, from } => costs::execute(agent, from).await,
         Command::Config { action } => config::execute(action).await,


### PR DESCRIPTION
## Summary

Plan 2/5 of the agentic-audit design: turns the audit report from a flat wall of findings into an actionable signal. Implements Lots 1+2 of `docs/proposals/2026-07-08-audit-robustness.md`, driven by the first real-world run (a 24-agent monorepo produced 36 findings for ~4 root causes).

**Measured effect on the same real-world repo: 36 findings → 6.**

### De-cascading (one root cause = one finding)
- **Lenient salvage** after strict-YAML failure: `salvage_field` recovers simple `key: value` pairs (column-0 keys only; block scalars, flow scalars, comments and quotes handled) so a broken frontmatter no longer wipes description/model/tools into false positives.
- **Pedagogical A01 messages**: the dominant real failure (unquoted value containing `: `) now reads *"wrap the value in double quotes (YAML and Claude Code both reject it as-is)"* with the exact file line.
- **Skills carry ParseIssues**: invalid YAML in SKILL.md → A01 Critical (was a lying A09 "missing description"); missing frontmatter stays A09 Warning.
- **Anti-cascade filters**: A02/A04/A05/A08 skip parse-broken agents (A03 deliberately still fires on salvaged values — documented).

### Aggregation & rendering
- `Finding.related`: one finding can carry N files.
- **A08 fleet-level**: `22/22 parsed agents inherit all tools` — one finding instead of 24; Warning only when the fleet is mixed (real inconsistency), Info when uniform.
- **A06 clustering** (union-find, no new dependency): one finding per connected component — `4 agents share duplicated content: cls-doc-gate, cls-perf-gate, cls-quality-gate, cls-security-gate` instead of 6 pairwise lines; funnel counts clusters honestly.
- **Grouped rendering** in all 3 formats (terminal/markdown/HTML): sections per severity with counts, paths relative to the audited root, per-rule `Breakdown:` line, related files in `<details>`.
- **`--min-severity <crit|warn|info>` / `--quiet`**: display filter only — exports and exit code always count everything.

## Test plan

- [x] 597 tests green (`tui`), 611 (`tui,providers-api`) — ~20 new TDD tests
- [x] clippy `-D warnings` green in both CI feature modes after every commit; fmt clean
- [x] No new dependencies, no `#[allow(dead_code)]`, no runtime `unwrap`/`expect`
- [x] Real-world check: 36 → 6 findings; the 3 criticals carry exact line numbers and actionable messages; `--quiet` hides Info; exit code preserved
- [x] Whole-branch adversarial review + fix round (salvage hardening against block scalars/comments/nested keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)