### PR TITLE
feat(audit): collision engine — C01-C05, frontmatter passthrough, collision matrix

### DIFF
--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -203,8 +203,8 @@ impl AuditReport {
                     f.rule,
                     self.rel(&f.file),
                     related,
-                    f.message,
-                    f.suggestion.as_deref().unwrap_or("—")
+                    md_cell(&f.message),
+                    md_cell(f.suggestion.as_deref().unwrap_or("—"))
                 );
             }
             let _ = writeln!(md);
@@ -223,6 +223,29 @@ impl AuditReport {
                 }
                 let _ = writeln!(md, "\n</details>\n");
             }
+        }
+        let collisions: Vec<&Finding> = self
+            .findings
+            .iter()
+            .filter(|f| f.rule.starts_with('C'))
+            .collect();
+        if !collisions.is_empty() {
+            let _ = writeln!(md, "## Collision matrix\n");
+            let _ = writeln!(md, "| Rule | Assets | Claim | Suggestion |");
+            let _ = writeln!(md, "|---|---|---|---|");
+            for f in &collisions {
+                let mut assets = vec![self.rel(&f.file)];
+                assets.extend(f.related.iter().map(|p| self.rel(p)));
+                let _ = writeln!(
+                    md,
+                    "| {} | `{}` | {} | {} |",
+                    f.rule,
+                    assets.join("`, `"),
+                    md_cell(&f.message),
+                    md_cell(f.suggestion.as_deref().unwrap_or("—"))
+                );
+            }
+            let _ = writeln!(md);
         }
         let funnel = self.funnel_lines();
         if !funnel.is_empty() {
@@ -337,6 +360,53 @@ impl AuditReport {
             html.push_str("</tbody>\n</table>\n");
         }
 
+        let collisions: Vec<&Finding> = self
+            .findings
+            .iter()
+            .filter(|f| f.rule.starts_with('C'))
+            .collect();
+        if !collisions.is_empty() {
+            html.push_str(
+                r#"<h2>Collision matrix</h2>
+<table>
+<thead>
+<tr><th>Rule</th><th>Assets</th><th>Claim</th><th>Suggestion</th></tr>
+</thead>
+<tbody>
+"#,
+            );
+            for f in &collisions {
+                let mut assets = format!(
+                    "<code class=\"path\">{}</code>",
+                    html_escape(&self.rel(&f.file))
+                );
+                for p in &f.related {
+                    let _ = write!(
+                        assets,
+                        ", <code class=\"path\">{}</code>",
+                        html_escape(&self.rel(p))
+                    );
+                }
+                let _ = writeln!(
+                    html,
+                    r#"<tr>
+<td>{rule}</td>
+<td>{assets}</td>
+<td>{claim}</td>
+<td>{suggestion}</td>
+</tr>"#,
+                    rule = html_escape(f.rule),
+                    claim = html_escape(&f.message),
+                    suggestion = f
+                        .suggestion
+                        .as_deref()
+                        .map(html_escape)
+                        .unwrap_or_else(|| "—".to_string()),
+                );
+            }
+            html.push_str("</tbody>\n</table>\n");
+        }
+
         let funnel = self.funnel_lines();
         if !funnel.is_empty() {
             html.push_str(
@@ -432,6 +502,11 @@ footer {
   font-size: 0.85rem;
 }
 "#;
+
+/// Escape a string for a GFM table cell: pipes and newlines break rows.
+fn md_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ")
+}
 
 /// Escape the five HTML special characters so untrusted findings text
 /// (file paths, messages, suggestions) can never break out of markup.
@@ -576,5 +651,33 @@ mod tests {
         assert!(html.contains("&amp;"));
         assert!(html.contains("&quot;"));
         assert!(!html.contains("<b>"));
+    }
+
+    #[test]
+    fn markdown_escapes_pipes_in_cells() {
+        let mut f = finding("A01", Severity::Critical);
+        f.message = "value contains | a pipe".into();
+        let r = report_with(vec![f]);
+        let md = r.to_markdown();
+        assert!(md.contains("value contains \\| a pipe"));
+    }
+
+    #[test]
+    fn collision_matrix_lists_c_findings() {
+        let mut c = finding("C02", Severity::Warning);
+        c.related = vec![".claude/agents/b.md".into()];
+        let a = finding("A01", Severity::Critical);
+        let r = report_with(vec![a, c]);
+        let md = r.to_markdown();
+        assert!(md.contains("## Collision matrix"));
+        assert!(md.contains("| C02 |"));
+        let html = r.to_html();
+        assert!(html.contains("Collision matrix"));
+    }
+
+    #[test]
+    fn no_collision_matrix_without_c_findings() {
+        let r = report_with(vec![finding("A01", Severity::Critical)]);
+        assert!(!r.to_markdown().contains("Collision matrix"));
     }
 }

--- a/src/audit/reverse/claude.rs
+++ b/src/audit/reverse/claude.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::Deserialize;
@@ -18,6 +19,8 @@ struct ClaudeAgentFrontmatter {
     description: Option<String>,
     model: Option<String>,
     tools: Option<ToolsField>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
 /// Claude Code accepts `tools: Read, Grep` (CSV) or a YAML list.
@@ -96,6 +99,8 @@ fn collect_agent_files(dir: &Path, depth: u32, out: &mut Vec<std::path::PathBuf>
 struct SkillFm {
     name: Option<String>,
     description: Option<String>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
 fn parse_skills(dir: &Path) -> Vec<ImportedSkill> {
@@ -126,6 +131,7 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
             has_skill_md: false,
             has_frontmatter: false,
             issues: Vec::new(),
+            extra: BTreeMap::new(),
         };
     };
     let mut issues = Vec::new();
@@ -137,6 +143,7 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
                 SkillFm {
                     name: salvage_field(raw, "name"),
                     description: salvage_field(raw, "description"),
+                    extra: BTreeMap::new(),
                 }
             });
             (fm, true)
@@ -150,6 +157,7 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
         has_skill_md: true,
         has_frontmatter,
         issues,
+        extra: fm.extra,
     }
 }
 
@@ -188,6 +196,7 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
                 description: salvage_field(raw, "description"),
                 model: salvage_field(raw, "model"),
                 tools: salvage_field(raw, "tools").map(ToolsField::Csv),
+                extra: BTreeMap::new(),
             }
         }),
         None => {
@@ -202,6 +211,7 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
             description: fm.description,
             model: fm.model,
             tools: fm.tools.map(ToolsField::into_vec),
+            extra: fm.extra,
         },
         system_prompt: body.trim().to_string(),
         issues,
@@ -501,5 +511,20 @@ mod tests {
         let skill = &config.skills[0];
         assert!(skill.has_skill_md && !skill.has_frontmatter);
         assert!(skill.issues.is_empty()); // standard violation, not a parse error
+    }
+
+    #[test]
+    fn unknown_frontmatter_fields_are_kept_in_extra() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".claude/agents/scoped.md",
+            "---\nname: scoped\ndescription: d\npaths:\n  - src/cli/**\n  - docs/\neffort: medium\n---\nBody",
+        );
+        let config = ClaudeReverseLinker.parse(dir.path());
+        let a = &config.agents[0];
+        assert!(a.metadata.extra.contains_key("effort"));
+        assert!(a.metadata.extra.contains_key("paths"));
+        assert!(!a.metadata.extra.contains_key("name")); // typed fields never land in extra
     }
 }

--- a/src/audit/reverse/mod.rs
+++ b/src/audit/reverse/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 pub mod claude;
@@ -10,6 +11,9 @@ pub struct PartialMetadata {
     pub model: Option<String>,
     /// `None` means the agent inherits all tools (no restriction declared).
     pub tools: Option<Vec<String>>,
+    /// Frontmatter fields we do not type (kept verbatim for --propose and
+    /// custom-field rules). Never populated by salvage.
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
 /// Something in a native file that could not be mapped.
@@ -38,6 +42,9 @@ pub struct ImportedSkill {
     pub has_skill_md: bool,
     pub has_frontmatter: bool,
     pub issues: Vec<ParseIssue>,
+    /// Frontmatter fields we do not type (kept verbatim for --propose and
+    /// custom-field rules). Never populated by salvage.
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
 /// Root instructions file (e.g. CLAUDE.md).

--- a/src/audit/reverse/mod.rs
+++ b/src/audit/reverse/mod.rs
@@ -16,6 +16,24 @@ pub struct PartialMetadata {
     pub extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
+impl PartialMetadata {
+    /// Path claims from the non-standard `paths:` field (YAML list or CSV string).
+    pub fn scope_globs(&self) -> Vec<String> {
+        match self.extra.get("paths") {
+            Some(serde_yaml_ng::Value::Sequence(seq)) => seq
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect(),
+            Some(serde_yaml_ng::Value::String(s)) => s
+                .split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+}
+
 /// Something in a native file that could not be mapped.
 #[derive(Debug, Clone)]
 pub struct ParseIssue {
@@ -82,5 +100,35 @@ mod tests {
         assert!(config.agents.is_empty());
         assert!(config.skills.is_empty());
         assert!(config.instructions.is_none());
+    }
+
+    #[test]
+    fn scope_globs_reads_yaml_list_csv_string_or_absent() {
+        use serde_yaml_ng::Value;
+
+        let mut with_list = PartialMetadata::default();
+        with_list.extra.insert(
+            "paths".into(),
+            Value::Sequence(vec![
+                Value::String("src/cli/**".into()),
+                Value::String("docs/".into()),
+            ]),
+        );
+        assert_eq!(
+            with_list.scope_globs(),
+            vec!["src/cli/**".to_string(), "docs/".to_string()]
+        );
+
+        let mut with_csv = PartialMetadata::default();
+        with_csv
+            .extra
+            .insert("paths".into(), Value::String("src/**, tests/".into()));
+        assert_eq!(
+            with_csv.scope_globs(),
+            vec!["src/**".to_string(), "tests/".to_string()]
+        );
+
+        let absent = PartialMetadata::default();
+        assert!(absent.scope_globs().is_empty());
     }
 }

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -154,13 +154,33 @@ const DOCUMENTED_AGENT_FIELDS: &[&str] = &[
     "skills",
     "hooks",
     "memory",
+    "mcpServers",
+    "background",
+    "isolation",
+    "initialPrompt",
 ];
+// `tools` is deliberately excluded from the skill allowlist: it is
+// non-standard for skills (Claude Code ignores it there) — `allowed-tools`
+// is the documented field for restricting a skill's tool access.
 const DOCUMENTED_SKILL_FIELDS: &[&str] = &[
     "version",
     "allowed-tools",
     "license",
     "metadata",
     "argument-hint",
+    "model",
+    "context",
+    "agent",
+    "disable-model-invocation",
+    "user-invocable",
+    "disallowed-tools",
+    "effort",
+    "hooks",
+    "paths",
+    "shell",
+    "when_to_use",
+    "arguments",
+    "compatibility",
 ];
 
 /// A12 — non-standard frontmatter fields, one aggregated Info finding.

--- a/src/audit/rules/assets.rs
+++ b/src/audit/rules/assets.rs
@@ -144,6 +144,85 @@ pub(super) fn a09_malformed_skill(ctx: &AuditContext) -> Vec<Finding> {
         .collect()
 }
 
+/// Frontmatter fields documented by Claude Code (beyond the typed ones).
+const DOCUMENTED_AGENT_FIELDS: &[&str] = &[
+    "effort",
+    "color",
+    "permissionMode",
+    "disallowedTools",
+    "maxTurns",
+    "skills",
+    "hooks",
+    "memory",
+];
+const DOCUMENTED_SKILL_FIELDS: &[&str] = &[
+    "version",
+    "allowed-tools",
+    "license",
+    "metadata",
+    "argument-hint",
+];
+
+/// A12 — non-standard frontmatter fields, one aggregated Info finding.
+/// They are kept verbatim (`extra`) so `--propose` can round-trip them;
+/// this rule only surfaces their existence.
+pub(super) fn a12_nonstandard_fields(ctx: &AuditContext) -> Vec<Finding> {
+    use std::collections::BTreeMap;
+    let mut per_field: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let agent_fields = ctx
+        .config
+        .agents
+        .iter()
+        .filter(|a| a.issues.is_empty())
+        .flat_map(|a| {
+            a.metadata
+                .extra
+                .keys()
+                .filter(|k| !DOCUMENTED_AGENT_FIELDS.contains(&k.as_str()))
+                .map(|k| (k.as_str(), a.source_path.clone()))
+        });
+    let skill_fields = ctx
+        .config
+        .skills
+        .iter()
+        .filter(|s| s.issues.is_empty())
+        .flat_map(|s| {
+            s.extra
+                .keys()
+                .filter(|k| !DOCUMENTED_SKILL_FIELDS.contains(&k.as_str()))
+                .map(|k| (k.as_str(), s.source_path.clone()))
+        });
+    for (field, path) in agent_fields.chain(skill_fields) {
+        *per_field.entry(field).or_insert(0) += 1;
+        if seen.insert(path.clone()) {
+            files.push(path);
+        }
+    }
+    let Some(first) = files.first().cloned() else {
+        return Vec::new();
+    };
+    let breakdown: Vec<String> = per_field
+        .iter()
+        .map(|(field, count)| format!("{field} ({count})"))
+        .collect();
+    vec![Finding {
+        rule: "A12",
+        severity: Severity::Info,
+        file: first,
+        related: files[1..].to_vec(),
+        message: format!(
+            "non-standard frontmatter field(s) across {} file(s): {}",
+            files.len(),
+            breakdown.join(", ")
+        ),
+        suggestion: Some(
+            "fields are kept as-is; document them or align with Claude Code standards".to_string(),
+        ),
+    }]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +315,7 @@ mod tests {
     #[test]
     fn a09_flags_broken_skills_once_each() {
         use crate::audit::reverse::{ImportedConfig, ImportedSkill};
+        use std::collections::BTreeMap;
         let config = ImportedConfig {
             skills: vec![
                 ImportedSkill {
@@ -245,6 +325,7 @@ mod tests {
                     has_skill_md: false,
                     has_frontmatter: false,
                     issues: Vec::new(),
+                    extra: BTreeMap::new(),
                 },
                 ImportedSkill {
                     name: "fine".into(),
@@ -253,6 +334,7 @@ mod tests {
                     has_skill_md: true,
                     has_frontmatter: true,
                     issues: Vec::new(),
+                    extra: BTreeMap::new(),
                 },
             ],
             ..Default::default()
@@ -269,6 +351,7 @@ mod tests {
     #[test]
     fn a09_missing_skill_md_does_not_stack_missing_description() {
         use crate::audit::reverse::{ImportedConfig, ImportedSkill};
+        use std::collections::BTreeMap;
         let config = ImportedConfig {
             skills: vec![ImportedSkill {
                 name: "no-md".into(),
@@ -277,6 +360,7 @@ mod tests {
                 has_skill_md: false,
                 has_frontmatter: false,
                 issues: Vec::new(),
+                extra: BTreeMap::new(),
             }],
             ..Default::default()
         };
@@ -293,6 +377,7 @@ mod tests {
     #[test]
     fn a01_covers_skill_parse_issues() {
         use crate::audit::reverse::{ImportedConfig, ImportedSkill, ParseIssue};
+        use std::collections::BTreeMap;
         let config = ImportedConfig {
             skills: vec![ImportedSkill {
                 name: "triage".into(),
@@ -304,6 +389,7 @@ mod tests {
                     file: ".claude/skills/triage/SKILL.md".into(),
                     message: "unquoted value".into(),
                 }],
+                extra: BTreeMap::new(),
             }],
             ..Default::default()
         };
@@ -319,6 +405,7 @@ mod tests {
     #[test]
     fn a09_does_not_double_report_parse_broken_skills() {
         use crate::audit::reverse::{ImportedConfig, ImportedSkill, ParseIssue};
+        use std::collections::BTreeMap;
         let config = ImportedConfig {
             skills: vec![
                 // Parse-broken skill: A01's job, A09 stays silent.
@@ -332,6 +419,7 @@ mod tests {
                         file: ".claude/skills/broken/SKILL.md".into(),
                         message: "bad".into(),
                     }],
+                    extra: BTreeMap::new(),
                 },
                 // No frontmatter at all: A09 Warning.
                 ImportedSkill {
@@ -341,6 +429,7 @@ mod tests {
                     has_skill_md: true,
                     has_frontmatter: false,
                     issues: Vec::new(),
+                    extra: BTreeMap::new(),
                 },
             ],
             ..Default::default()
@@ -372,5 +461,36 @@ mod tests {
         };
         assert!(a02_missing_fields(&ctx).is_empty());
         assert!(a08_permissive_tools(&ctx).is_empty());
+    }
+
+    #[test]
+    fn a12_aggregates_nonstandard_fields_fleet_wide() {
+        use serde_yaml_ng::Value;
+        let mut a = agent("one", "Body");
+        a.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/**".into()));
+        a.metadata
+            .extra
+            .insert("effort".into(), Value::String("medium".into())); // documented
+        let mut b = agent("two", "Body");
+        b.metadata
+            .extra
+            .insert("paths".into(), Value::String("docs/**".into()));
+        b.metadata
+            .extra
+            .insert("phase".into(), Value::String("2".into()));
+        let config = config_with(vec![a, b]);
+        let settings = AuditSettings::default();
+        let f = a12_nonstandard_fields(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Info);
+        assert!(f[0].message.contains("paths (2)"));
+        assert!(f[0].message.contains("phase (1)"));
+        assert!(!f[0].message.contains("effort"));
+        assert_eq!(f[0].related.len(), 1);
     }
 }

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -1,6 +1,7 @@
 //! Collision rules (C01-C05): conflicting claims between agentic assets.
 use std::collections::BTreeMap;
 
+use super::similarity::jaccard;
 use super::{AuditContext, Finding, Severity};
 
 /// C01 — two assets claim the same name.
@@ -54,6 +55,52 @@ pub(super) fn c01_name_collisions(ctx: &AuditContext) -> Vec<Finding> {
     findings
 }
 
+/// C03 — two activation surfaces (skill↔skill or agent↔skill) with
+/// near-identical descriptions: the router cannot pick reliably.
+/// Agent↔agent redundancy stays A07 (higher threshold, Info): merging two
+/// agents is a design suggestion, an ambiguous skill trigger is a defect.
+pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
+    let threshold = ctx.settings.activation_similarity;
+    // (kind, name, path, description)
+    let mut surfaces: Vec<(&str, &str, &std::path::Path, &str)> = Vec::new();
+    for s in ctx.config.skills.iter().filter(|s| s.issues.is_empty()) {
+        if let Some(d) = &s.description {
+            surfaces.push(("skill", &s.name, &s.source_path, d));
+        }
+    }
+    for a in ctx.config.agents.iter().filter(|a| a.issues.is_empty()) {
+        if let Some(d) = &a.metadata.description {
+            surfaces.push(("agent", &a.name, &a.source_path, d));
+        }
+    }
+    let mut findings = Vec::new();
+    for i in 0..surfaces.len() {
+        for j in (i + 1)..surfaces.len() {
+            let (ka, na, pa, da) = surfaces[i];
+            let (kb, nb, pb, db) = surfaces[j];
+            if ka == "agent" && kb == "agent" {
+                continue; // A07's turf
+            }
+            if jaccard(da, db) >= threshold {
+                findings.push(Finding {
+                    rule: "C03",
+                    severity: Severity::Warning,
+                    file: pa.to_path_buf(),
+                    related: vec![pb.to_path_buf()],
+                    message: format!(
+                        "{ka} '{na}' and {kb} '{nb}' have overlapping activation descriptions — routing is ambiguous"
+                    ),
+                    suggestion: Some(
+                        "sharpen the descriptions so each one triggers on distinct intents"
+                            .to_string(),
+                    ),
+                });
+            }
+        }
+    }
+    findings
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,5 +149,56 @@ mod tests {
         });
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].severity, Severity::Warning);
+    }
+
+    fn skill(name: &str, description: &str) -> crate::audit::reverse::ImportedSkill {
+        crate::audit::reverse::ImportedSkill {
+            name: name.into(),
+            source_path: format!(".claude/skills/{name}/SKILL.md").into(),
+            description: Some(description.into()),
+            has_skill_md: true,
+            has_frontmatter: true,
+            issues: Vec::new(),
+            extra: std::collections::BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn c03_flags_ambiguous_skill_descriptions() {
+        use crate::audit::reverse::ImportedConfig;
+        let config = ImportedConfig {
+            skills: vec![
+                skill("audit-a", "runs a full audit of the project quality"),
+                skill("audit-b", "runs a full quality audit of the project"),
+                skill("deploy", "ships the app to production servers"),
+            ],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default(); // activation_similarity 0.6
+        let f = c03_activation_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Warning);
+        assert!(f[0].message.contains("audit-a") && f[0].message.contains("audit-b"));
+    }
+
+    #[test]
+    fn c03_crosses_agents_and_skills() {
+        use crate::audit::reverse::ImportedConfig;
+        let mut a = agent("checker", "Body");
+        a.metadata.description = Some("reviews rust code for style and bugs".into());
+        let config = ImportedConfig {
+            agents: vec![a],
+            skills: vec![skill("review", "reviews rust code for bugs and style")],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c03_activation_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
     }
 }

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -109,9 +109,19 @@ fn glob_prefix(g: &str) -> &str {
     &g[..idx]
 }
 
+fn prefix_contains(short: &str, long: &str) -> bool {
+    if !long.starts_with(short) {
+        return false;
+    }
+    short.is_empty()
+        || short.ends_with('/')
+        || long.len() == short.len()
+        || long[short.len()..].starts_with('/')
+}
+
 fn globs_overlap(a: &str, b: &str) -> bool {
     let (pa, pb) = (glob_prefix(a), glob_prefix(b));
-    pa.starts_with(pb) || pb.starts_with(pa)
+    prefix_contains(pa, pb) || prefix_contains(pb, pa)
 }
 
 fn scoped_agents<'a>(
@@ -379,6 +389,10 @@ mod tests {
         assert!(globs_overlap("src/cli/mod.rs", "src/**"));
         assert!(!globs_overlap("src/**", "docs/**"));
         assert!(globs_overlap("**", "docs/**")); // catch-all overlaps everything
+        assert!(!globs_overlap("api", "api-gateway/**"));
+        assert!(!globs_overlap("src/cli", "src/climate/**"));
+        assert!(globs_overlap("src/", "src/cli/**"));
+        assert!(globs_overlap("src/cli", "src/cli/**"));
     }
 
     #[test]

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -1,0 +1,106 @@
+//! Collision rules (C01-C05): conflicting claims between agentic assets.
+use std::collections::BTreeMap;
+
+use super::{AuditContext, Finding, Severity};
+
+/// C01 — two assets claim the same name.
+/// Same-kind duplicates are Critical (routing is ambiguous); an agent/skill
+/// homonym is Warning (different namespaces, but confusing).
+pub(super) fn c01_name_collisions(ctx: &AuditContext) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut agents_by_name: BTreeMap<&str, Vec<&std::path::Path>> = BTreeMap::new();
+    for a in ctx.config.agents.iter().filter(|a| a.issues.is_empty()) {
+        agents_by_name
+            .entry(a.name.as_str())
+            .or_default()
+            .push(&a.source_path);
+    }
+    let mut skills_by_name: BTreeMap<&str, Vec<&std::path::Path>> = BTreeMap::new();
+    for s in ctx.config.skills.iter().filter(|s| s.issues.is_empty()) {
+        skills_by_name
+            .entry(s.name.as_str())
+            .or_default()
+            .push(&s.source_path);
+    }
+    for (kind, by_name) in [("agent", &agents_by_name), ("skill", &skills_by_name)] {
+        for (name, paths) in by_name {
+            if paths.len() > 1 {
+                findings.push(Finding {
+                    rule: "C01",
+                    severity: Severity::Critical,
+                    file: paths[0].to_path_buf(),
+                    related: paths[1..].iter().map(|p| p.to_path_buf()).collect(),
+                    message: format!(
+                        "{} {kind} files share the name '{name}' — routing is ambiguous",
+                        paths.len()
+                    ),
+                    suggestion: Some("rename or remove the duplicates".to_string()),
+                });
+            }
+        }
+    }
+    for (name, agent_paths) in &agents_by_name {
+        if let Some(skill_paths) = skills_by_name.get(name) {
+            findings.push(Finding {
+                rule: "C01",
+                severity: Severity::Warning,
+                file: agent_paths[0].to_path_buf(),
+                related: skill_paths.iter().map(|p| p.to_path_buf()).collect(),
+                message: format!("agent and skill share the name '{name}'"),
+                suggestion: Some("give the skill or the agent a distinct name".to_string()),
+            });
+        }
+    }
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::rules::test_support::{agent, config_with};
+    use crate::audit::rules::{AuditContext, AuditSettings, Severity};
+
+    #[test]
+    fn c01_flags_duplicate_agent_names() {
+        let mut a = agent("reviewer", "Body");
+        a.source_path = ".claude/agents/backend/reviewer.md".into();
+        let b = agent("reviewer", "Body");
+        let c = agent("other", "Body");
+        let config = config_with(vec![a, b, c]);
+        let settings = AuditSettings::default();
+        let f = c01_name_collisions(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Critical);
+        assert!(f[0].message.contains("reviewer"));
+        assert_eq!(f[0].related.len(), 1);
+    }
+
+    #[test]
+    fn c01_flags_agent_skill_homonym_as_warning() {
+        use crate::audit::reverse::{ImportedConfig, ImportedSkill};
+        use std::collections::BTreeMap;
+        let config = ImportedConfig {
+            agents: vec![agent("deploy", "Body")],
+            skills: vec![ImportedSkill {
+                name: "deploy".into(),
+                source_path: ".claude/skills/deploy/SKILL.md".into(),
+                description: Some("d".into()),
+                has_skill_md: true,
+                has_frontmatter: true,
+                issues: Vec::new(),
+                extra: BTreeMap::new(),
+            }],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c01_name_collisions(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Warning);
+    }
+}

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -213,6 +213,65 @@ pub(super) fn c05_inconsistent_tools(ctx: &AuditContext) -> Vec<Finding> {
         .collect()
 }
 
+/// C04 — two agents are declared owners of the same module in CLAUDE.md
+/// coordination tables. Deliberately strict (exact agent-name cell + a
+/// path-looking cell on the same row): low recall, near-zero noise.
+pub(super) fn c04_double_ownership(ctx: &AuditContext) -> Vec<Finding> {
+    let Some(instructions) = &ctx.config.instructions else {
+        return Vec::new();
+    };
+    let known: std::collections::HashSet<&str> = ctx
+        .config
+        .agents
+        .iter()
+        .filter(|a| a.issues.is_empty())
+        .map(|a| a.name.as_str())
+        .collect();
+    if known.is_empty() {
+        return Vec::new();
+    }
+    let mut claims: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for line in instructions.content.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            continue;
+        }
+        let cells: Vec<&str> = trimmed.split('|').map(str::trim).collect();
+        let Some(agent) = cells.iter().find(|c| known.contains(**c)).copied() else {
+            continue;
+        };
+        for cell in &cells {
+            if cell.contains('/') && !cell.contains(' ') && !cell.is_empty() {
+                let owners = claims.entry(*cell).or_default();
+                if !owners.contains(&agent) {
+                    owners.push(agent);
+                }
+            }
+        }
+    }
+    claims
+        .into_iter()
+        .filter(|(_, owners)| owners.len() > 1)
+        .map(|(path, owners)| Finding {
+            rule: "C04",
+            severity: Severity::Warning,
+            file: instructions.source_path.clone(),
+            related: Vec::new(),
+            message: format!(
+                "agents {} are all declared owners of '{path}'",
+                owners
+                    .iter()
+                    .map(|o| format!("'{o}'"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            suggestion: Some(
+                "pick a single owner per module or document the shared ownership".to_string(),
+            ),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -368,5 +427,32 @@ mod tests {
         });
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn c04_flags_two_agents_owning_the_same_module() {
+        use crate::audit::reverse::{ImportedConfig, ImportedInstructions};
+        let config = ImportedConfig {
+            agents: vec![agent("core-dev", "Body"), agent("cli-dev", "Body")],
+            instructions: Some(ImportedInstructions {
+                source_path: "CLAUDE.md".into(),
+                content: "\
+| Agent | Scope |\n\
+|---|---|\n\
+| core-dev | src/core/ |\n\
+| cli-dev | src/core/ |\n\
+| cli-dev | src/cli/ |\n"
+                    .into(),
+            }),
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c04_double_ownership(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("src/core/"));
+        assert!(f[0].message.contains("core-dev") && f[0].message.contains("cli-dev"));
     }
 }

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -101,6 +101,118 @@ pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
     findings
 }
 
+/// Prefix of a glob up to its first wildcard — a cheap, dependency-free
+/// overlap test: two globs can match a common path iff one literal prefix
+/// contains the other.
+fn glob_prefix(g: &str) -> &str {
+    let idx = g.find(['*', '?', '[']).unwrap_or(g.len());
+    &g[..idx]
+}
+
+fn globs_overlap(a: &str, b: &str) -> bool {
+    let (pa, pb) = (glob_prefix(a), glob_prefix(b));
+    pa.starts_with(pb) || pb.starts_with(pa)
+}
+
+fn scoped_agents<'a>(
+    ctx: &'a AuditContext,
+) -> Vec<(&'a crate::audit::reverse::ImportedAgent, Vec<String>)> {
+    ctx.config
+        .agents
+        .iter()
+        .filter(|a| a.issues.is_empty())
+        .filter_map(|a| {
+            let globs = a.metadata.scope_globs();
+            (!globs.is_empty()).then_some((a, globs))
+        })
+        .collect()
+}
+
+fn overlapping_pairs(
+    scoped: &[(&crate::audit::reverse::ImportedAgent, Vec<String>)],
+) -> Vec<(usize, usize)> {
+    let mut pairs = Vec::new();
+    for i in 0..scoped.len() {
+        for j in (i + 1)..scoped.len() {
+            let overlap = scoped[i]
+                .1
+                .iter()
+                .any(|ga| scoped[j].1.iter().any(|gb| globs_overlap(ga, gb)));
+            if overlap {
+                pairs.push((i, j));
+            }
+        }
+    }
+    pairs
+}
+
+/// C02 — agents claim overlapping path scopes (custom `paths:` field),
+/// clustered like A06.
+pub(super) fn c02_scope_overlap(ctx: &AuditContext) -> Vec<Finding> {
+    let scoped = scoped_agents(ctx);
+    let pairs = overlapping_pairs(&scoped);
+    let mut uf = super::UnionFind::new(scoped.len());
+    for &(i, j) in &pairs {
+        uf.union(i, j);
+    }
+    let mut clusters: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for i in 0..scoped.len() {
+        clusters.entry(uf.find(i)).or_default().push(i);
+    }
+    clusters
+        .into_values()
+        .filter(|members| members.len() >= 2)
+        .map(|members| {
+            let names: Vec<&str> = members.iter().map(|&i| scoped[i].0.name.as_str()).collect();
+            Finding {
+                rule: "C02",
+                severity: Severity::Warning,
+                file: scoped[members[0]].0.source_path.clone(),
+                related: members[1..]
+                    .iter()
+                    .map(|&i| scoped[i].0.source_path.clone())
+                    .collect(),
+                message: format!(
+                    "{} agents claim overlapping path scopes: {}",
+                    members.len(),
+                    names.join(", ")
+                ),
+                suggestion: Some(
+                    "split the scopes or make the ownership hierarchy explicit".to_string(),
+                ),
+            }
+        })
+        .collect()
+}
+
+/// C05 — same scope, inconsistent tool restriction (one locked, one open).
+pub(super) fn c05_inconsistent_tools(ctx: &AuditContext) -> Vec<Finding> {
+    fn permissive(tools: &Option<Vec<String>>) -> bool {
+        match tools {
+            None => true,
+            Some(t) => t.iter().any(|x| x == "*"),
+        }
+    }
+    let scoped = scoped_agents(ctx);
+    overlapping_pairs(&scoped)
+        .into_iter()
+        .filter(|&(i, j)| {
+            permissive(&scoped[i].0.metadata.tools) != permissive(&scoped[j].0.metadata.tools)
+        })
+        .map(|(i, j)| Finding {
+            rule: "C05",
+            severity: Severity::Info,
+            file: scoped[i].0.source_path.clone(),
+            related: vec![scoped[j].0.source_path.clone()],
+            message: format!(
+                "agents '{}' and '{}' share a path scope but one restricts tools and the other does not",
+                scoped[i].0.name, scoped[j].0.name
+            ),
+            suggestion: Some("align the tool policies of agents working on the same files".to_string()),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,5 +312,61 @@ mod tests {
             settings: &settings,
         });
         assert_eq!(f.len(), 1);
+    }
+
+    #[test]
+    fn globs_overlap_by_prefix() {
+        assert!(globs_overlap("src/**", "src/cli/**"));
+        assert!(globs_overlap("src/cli/mod.rs", "src/**"));
+        assert!(!globs_overlap("src/**", "docs/**"));
+        assert!(globs_overlap("**", "docs/**")); // catch-all overlaps everything
+    }
+
+    #[test]
+    fn c02_clusters_agents_with_overlapping_paths() {
+        use serde_yaml_ng::Value;
+        let mut a = agent("wide", "Body");
+        a.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/**".into()));
+        let mut b = agent("narrow", "Body");
+        b.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/cli/**".into()));
+        let mut c = agent("docs", "Body");
+        c.metadata
+            .extra
+            .insert("paths".into(), Value::String("docs/**".into()));
+        let config = config_with(vec![a, b, c]);
+        let settings = AuditSettings::default();
+        let f = c02_scope_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("wide") && f[0].message.contains("narrow"));
+        assert!(!f[0].message.contains("docs"));
+    }
+
+    #[test]
+    fn c05_flags_inconsistent_tools_on_shared_scope() {
+        use serde_yaml_ng::Value;
+        let mut a = agent("locked", "Body"); // tools: [Read]
+        a.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/**".into()));
+        let mut b = agent("open", "Body");
+        b.metadata.tools = None;
+        b.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/cli/**".into()));
+        let config = config_with(vec![a, b]);
+        let settings = AuditSettings::default();
+        let f = c05_inconsistent_tools(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Info);
     }
 }

--- a/src/audit/rules/mod.rs
+++ b/src/audit/rules/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use super::reverse::ImportedConfig;
 
 mod assets;
+mod collisions;
 mod models;
 mod references;
 mod similarity;
@@ -43,12 +44,16 @@ pub struct Finding {
 pub struct AuditSettings {
     /// A05: estimated token count above which a prompt is flagged.
     pub prompt_token_threshold: usize,
+    /// C03: Jaccard similarity above which two activation descriptions are
+    /// considered ambiguous for routing.
+    pub activation_similarity: f64,
 }
 
 impl Default for AuditSettings {
     fn default() -> Self {
         Self {
             prompt_token_threshold: 4000,
+            activation_similarity: 0.6,
         }
     }
 }
@@ -66,6 +71,7 @@ impl AuditSettings {
         #[serde(default)]
         struct AuditSection {
             prompt_token_threshold: Option<usize>,
+            activation_similarity: Option<f64>,
         }
         let mut settings = Self::default();
         for candidate in ["armadai.yaml", ".armadai/config.yaml"] {
@@ -74,13 +80,43 @@ impl AuditSettings {
             };
             if let Ok(parsed) = serde_yaml_ng::from_str::<AuditYaml>(&raw)
                 && let Some(section) = parsed.audit
-                && let Some(t) = section.prompt_token_threshold
             {
-                settings.prompt_token_threshold = t;
+                if let Some(t) = section.prompt_token_threshold {
+                    settings.prompt_token_threshold = t;
+                }
+                if let Some(s) = section.activation_similarity {
+                    settings.activation_similarity = s;
+                }
             }
             break;
         }
         settings
+    }
+}
+
+/// Minimal union-find over asset indices (no dependency needed).
+pub(super) struct UnionFind {
+    parent: Vec<usize>,
+}
+
+impl UnionFind {
+    pub(super) fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+        }
+    }
+    pub(super) fn find(&mut self, i: usize) -> usize {
+        if self.parent[i] != i {
+            let root = self.find(self.parent[i]);
+            self.parent[i] = root;
+        }
+        self.parent[i]
+    }
+    pub(super) fn union(&mut self, a: usize, b: usize) {
+        let (ra, rb) = (self.find(a), self.find(b));
+        if ra != rb {
+            self.parent[rb] = ra;
+        }
     }
 }
 
@@ -106,6 +142,7 @@ fn registry() -> Vec<RuleFn> {
         references::a10_broken_references,
         references::a11_plaintext_secret,
         assets::a12_nonstandard_fields,
+        collisions::c01_name_collisions,
     ]
 }
 
@@ -182,11 +219,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("armadai.yaml"),
-            "audit:\n  prompt_token_threshold: 1234\n",
+            "audit:\n  prompt_token_threshold: 1234\n  activation_similarity: 0.75\n",
         )
         .unwrap();
         let s = AuditSettings::from_project(dir.path());
         assert_eq!(s.prompt_token_threshold, 1234);
+        assert!((s.activation_similarity - 0.75).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -194,6 +232,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let s = AuditSettings::from_project(dir.path());
         assert_eq!(s.prompt_token_threshold, 4000);
+        assert!((s.activation_similarity - 0.6).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/audit/rules/mod.rs
+++ b/src/audit/rules/mod.rs
@@ -105,6 +105,7 @@ fn registry() -> Vec<RuleFn> {
         assets::a09_malformed_skill,
         references::a10_broken_references,
         references::a11_plaintext_secret,
+        assets::a12_nonstandard_fields,
     ]
 }
 
@@ -122,6 +123,7 @@ pub(crate) fn estimate_tokens(text: &str) -> usize {
 
 #[cfg(test)]
 pub(crate) mod test_support {
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
     use crate::audit::reverse::*;
@@ -134,6 +136,7 @@ pub(crate) mod test_support {
                 description: Some(format!("{name} description")),
                 model: Some("claude-sonnet-5".to_string()),
                 tools: Some(vec!["Read".to_string()]),
+                extra: BTreeMap::new(),
             },
             system_prompt: prompt.to_string(),
             issues: Vec::new(),

--- a/src/audit/rules/mod.rs
+++ b/src/audit/rules/mod.rs
@@ -143,7 +143,9 @@ fn registry() -> Vec<RuleFn> {
         references::a11_plaintext_secret,
         assets::a12_nonstandard_fields,
         collisions::c01_name_collisions,
+        collisions::c02_scope_overlap,
         collisions::c03_activation_overlap,
+        collisions::c05_inconsistent_tools,
     ]
 }
 

--- a/src/audit/rules/mod.rs
+++ b/src/audit/rules/mod.rs
@@ -145,6 +145,7 @@ fn registry() -> Vec<RuleFn> {
         collisions::c01_name_collisions,
         collisions::c02_scope_overlap,
         collisions::c03_activation_overlap,
+        collisions::c04_double_ownership,
         collisions::c05_inconsistent_tools,
     ]
 }

--- a/src/audit/rules/mod.rs
+++ b/src/audit/rules/mod.rs
@@ -143,6 +143,7 @@ fn registry() -> Vec<RuleFn> {
         references::a11_plaintext_secret,
         assets::a12_nonstandard_fields,
         collisions::c01_name_collisions,
+        collisions::c03_activation_overlap,
     ]
 }
 

--- a/src/audit/rules/similarity.rs
+++ b/src/audit/rules/similarity.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
-use super::{AuditContext, Finding, Severity};
+use super::{AuditContext, Finding, Severity, UnionFind};
 
 pub(super) const DUPLICATION_WINDOW: usize = 8;
 pub(super) const REDUNDANCY_THRESHOLD: f64 = 0.8;
@@ -37,32 +37,6 @@ pub(super) fn jaccard(a: &str, b: &str) -> f64 {
     let inter = sa.intersection(&sb).count() as f64;
     let union = sa.union(&sb).count() as f64;
     inter / union
-}
-
-/// Minimal union-find over agent indices (no dependency needed).
-struct UnionFind {
-    parent: Vec<usize>,
-}
-
-impl UnionFind {
-    fn new(n: usize) -> Self {
-        Self {
-            parent: (0..n).collect(),
-        }
-    }
-    fn find(&mut self, i: usize) -> usize {
-        if self.parent[i] != i {
-            let root = self.find(self.parent[i]);
-            self.parent[i] = root;
-        }
-        self.parent[i]
-    }
-    fn union(&mut self, a: usize, b: usize) {
-        let (ra, rb) = (self.find(a), self.find(b));
-        if ra != rb {
-            self.parent[rb] = ra;
-        }
-    }
 }
 
 /// A06 — duplicated content, one finding per connected cluster of agents


### PR DESCRIPTION
## Summary

Plan 3/5 of the agentic-audit design: the collision engine (spec §6) + the frontmatter passthrough that both C02/C05 and the upcoming `--propose` (Plan 4) need.

- **Frontmatter passthrough**: unknown fields kept verbatim (`extra: BTreeMap<String, Value>`, `#[serde(flatten)]`) on agents and skills; never populated by salvage.
- **A12** — non-standard fields: ONE aggregated Info finding fleet-wide, with allowlists verified against the official Claude Code / Agent Skills docs. Notably `tools:` on a *skill* is deliberately flagged: Claude Code silently ignores it (`allowed-tools` is the real field) — 13 true positives on the reference monorepo.
- **C01** name collisions (same-kind duplicates Critical, agent↔skill homonym Warning).
- **C02** overlapping `paths:` scopes — segment-boundary-aware prefix heuristic (no glob crate), union-find clusters. **True positive on the reference monorepo: 9 agents with overlapping scopes, one finding.**
- **C03** ambiguous activation descriptions (skill↔skill, agent↔skill; Jaccard ≥ `activation_similarity`, default 0.6, armadai.yaml-overridable; agent↔agent stays A07).
- **C04** double ownership in CLAUDE.md coordination tables (strict low-noise heuristic).
- **C05** inconsistent tool permissiveness on shared scopes (Info).
- **Collision matrix** section in markdown + HTML reports; GFM cell escaping (`|`, newlines) — clears a Plan-2 backlog item.
- Documented deviation: multi-linker `AssetId` provenance deferred until a second ReverseLinker exists (would be dead code today).

## Test plan

- [x] 626 tests green (`tui`), 640 (`tui,providers-api`) — ~15 new TDD tests; clippy `-D warnings` green both modes after every commit; fmt clean
- [x] No new dependencies, no `#[allow(dead_code)]`, no runtime `unwrap`/`expect`; anti-cascade on every rule; aggregation-first (`related`)
- [x] Real-world run (24 agents / 34 skills): 8 grouped findings incl. the C02 true positive; segment-boundary fix verified against `api`/`api-gateway`-style false positives
- [x] Whole-branch adversarial review + fix round (glob segment boundaries, completed A12 allowlists), re-review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)