### PR TITLE
fix(beta2): log I/O errors instead of silently ignoring them (B4)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-audit-plan-4-propose.md
+++ b/docs/superpowers/plans/2026-07-09-audit-plan-4-propose.md
@@ -1,0 +1,813 @@
+# Audit d'agentique — Plan 4/5 : `--propose` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `armadai audit --propose` génère `.armadai-proposal/` : un pack ArmadAI **standard et valide** (pack.yaml + agents convertis et corrigés + prompts mutualisés extraits des clusters A06 + skills copiés et réparés), installable via `armadai init --pack <chemin local>` (extension incluse). Invariant : le pack généré passe `pack_validation::validate_pack` sans erreur.
+
+**Architecture:** Nouveau module `src/audit/proposal.rs`. La conversion vers le format agent ArmadAI (H1 + `## Metadata` liste + `## System Prompt`) **élimine structurellement les A01** (plus de frontmatter YAML). Corrections appliquées : modèles → alias résolus puis tiers portables `latest:*` (via `classify_model_tier` rendue `pub(crate)` + nouveau `tier_placeholder`), `paths:` → `scope:` (champ ArmadAI natif), skills `tools:` → `allowed-tools:` (le hint validé au Plan 3), descriptions `: ` re-quotées dans les SKILL.md copiés. Extraction A06 : plus long bloc de lignes commun à tous les membres d'un cluster → `prompts/shared-*.md` avec `apply_to`, bloc retiré des prompts des agents générés.
+
+**Décisions actées** : `raw_frontmatter` NON ajouté (il servait au round-trip natif ; on génère du format ArmadAI, les champs parsés+salvagés suffisent) — YAGNI documenté. `- description:` émis dans `## Metadata` bien qu'ignoré par le parseur actuel (forward-compatible, self-documenting ; limitation consignée : le format agent ArmadAI n'a pas encore de champ description pour le routage).
+
+**Tech Stack:** Rust édition 2024. **Aucune nouvelle dépendance.**
+
+## Global Constraints
+
+- Base : `origin/release/1.0.0` (@ 446a694). Branche : `feat/audit-propose`.
+- Clippy `-D warnings` vert dans les DEUX modes après chaque commit ; `#[allow(dead_code)]` interdit ; pas d'`unwrap()`/`expect()` runtime (tests exceptés) ; pas de nouvelle dépendance ni feature flag ; Conventional Commits ; TDD.
+- `--propose` n'écrit QUE dans `<root>/.armadai-proposal/` ; si le répertoire existe déjà → `bail!` explicite (jamais d'écrasement silencieux). Jamais de modification des configs natives.
+- Les tests qui touchent l'installation utilisent des chemins tempdir — JAMAIS le vrai `~/.config/armadai`.
+- Agents avec `ParseIssue` : convertis quand le salvage a récupéré l'essentiel (name + prompt non vide), sinon listés dans le récapitulatif comme « skipped (unreadable) ».
+
+---
+
+### Task 0: Branche
+
+- [ ] **Step 1:**
+```bash
+cd /Users/bl209054/work/misc/armadai-audit-wt && git checkout -b feat/audit-propose origin/release/1.0.0
+cargo test --no-default-features --features tui,providers-api 2>&1 | tail -1
+```
+Expected: `640 passed`.
+
+---
+
+### Task 1: `import_surfaces` — exposer l'ImportedConfig
+
+**Files:**
+- Modify: `src/audit/mod.rs`
+
+**Interfaces:**
+- Produces: `pub fn import_surfaces(root: &Path) -> (Vec<String>, reverse::ImportedConfig)` — la boucle détection/parse/fusion actuellement inline dans `run_audit` (mod.rs:15-33), extraite telle quelle. `run_audit` la consomme immédiatement (pas de dead code). `--propose` la réutilisera (double parse acceptable : ~30 fichiers).
+
+- [ ] **Step 1: Test qui échoue** (dans `src/audit/mod.rs`, nouveau `#[cfg(test)]`)
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn import_surfaces_returns_detected_and_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            agents.join("a.md"),
+            "---\nname: a\ndescription: d\n---\nBody",
+        )
+        .unwrap();
+        let (detected, config) = import_surfaces(dir.path());
+        assert_eq!(detected, vec!["claude".to_string()]);
+        assert_eq!(config.agents.len(), 1);
+    }
+}
+```
+- [ ] **Step 2:** Run `cargo test --no-default-features --features tui,providers-api audit::tests` — FAIL.
+- [ ] **Step 3:** Extraire de `run_audit` :
+```rust
+/// Detect and parse every native surface under `root`.
+/// Shared by the audit run and `--propose` (which needs the raw imports).
+pub fn import_surfaces(root: &Path) -> (Vec<String>, reverse::ImportedConfig) {
+    let linkers: Vec<Box<dyn ReverseLinker>> = vec![Box::new(reverse::claude::ClaudeReverseLinker)];
+    let mut detected = Vec::new();
+    let mut config = reverse::ImportedConfig::default();
+    for linker in &linkers {
+        if linker.detect(root) {
+            detected.push(linker.name().to_string());
+            let parsed = linker.parse(root);
+            config.agents.extend(parsed.agents);
+            config.skills.extend(parsed.skills);
+            if config.instructions.is_none() {
+                config.instructions = parsed.instructions;
+            }
+        }
+    }
+    (detected, config)
+}
+```
+et réécrire `run_audit` pour l'appeler (le reste inchangé).
+- [ ] **Step 4:** Suite complète + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "refactor(audit): extract import_surfaces for reuse by propose"`
+
+---
+
+### Task 2: Conversion agent → format ArmadAI + tiers portables
+
+**Files:**
+- Modify: `src/linker/model_resolution.rs` (`classify_model_tier` passe `pub(crate)` ; nouveau `pub(crate) fn tier_placeholder(t: ModelTier) -> &'static str`)
+- Create: `src/audit/proposal.rs` (+ `pub mod proposal;` dans `src/audit/mod.rs`)
+
+**Interfaces:**
+- Produces dans `proposal.rs` :
+  - `pub(crate) fn portable_model(model: Option<&str>) -> String` — `None` → `"latest:pro"` ; `latest:*` → inchangé ; sinon `resolve_alias` transitivement puis `classify_model_tier(m, "anthropic")` → `tier_placeholder` ; si inclassable → le modèle d'origine tel quel.
+  - `pub(crate) fn render_agent(agent: &ImportedAgent) -> String` — format ArmadAI exact (validé par `parser::validate_agent` en Task 5) :
+```markdown
+# {name}
+
+> {description ou "Imported from native Claude Code configuration."}
+
+## Metadata
+- provider: claude
+- model: {portable_model}
+- description: {description}          # si présente — ignoré par le parseur actuel, forward-compatible
+- tags: [imported]
+- scope: [{scope_globs joints par ", "}]   # seulement si non vide
+
+## System Prompt
+
+{system_prompt}
+```
+  (le champ `tools` natif n'a pas d'équivalent ArmadAI — non émis ; `extra` hors `paths` non émis.)
+- `tier_placeholder` : `Fast → "latest:fast"`, `Pro → "latest:pro"`, `Max → "latest:max"`.
+
+- [ ] **Step 1: Tests qui échouent** (`proposal.rs`)
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::rules::test_support::agent;
+
+    #[test]
+    fn portable_model_maps_concrete_models_to_tiers() {
+        assert_eq!(portable_model(Some("opus")), "latest:max");
+        assert_eq!(portable_model(Some("claude-sonnet-5")), "latest:pro");
+        assert_eq!(portable_model(Some("latest:fast")), "latest:fast");
+        assert_eq!(portable_model(None), "latest:pro");
+        // Deprecated alias resolved first, then classified.
+        assert_eq!(portable_model(Some("gemini-3.0-pro")), "latest:pro");
+    }
+
+    #[test]
+    fn render_agent_produces_armadai_format() {
+        let mut a = agent("reviewer", "You review code.");
+        a.metadata.model = Some("opus".to_string());
+        a.metadata
+            .extra
+            .insert("paths".into(), serde_yaml_ng::Value::String("src/**".into()));
+        let md = render_agent(&a);
+        assert!(md.starts_with("# reviewer\n"));
+        assert!(md.contains("## Metadata"));
+        assert!(md.contains("- provider: claude"));
+        assert!(md.contains("- model: latest:max"));
+        assert!(md.contains("- scope: [src/**]"));
+        assert!(md.contains("## System Prompt"));
+        assert!(md.contains("You review code."));
+    }
+}
+```
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3: Implémentation** — `model_resolution.rs` : changer `fn classify_model_tier` en `pub(crate) fn`, ajouter :
+```rust
+/// The portable placeholder string for a tier (inverse of parse_latest_placeholder).
+pub(crate) fn tier_placeholder(tier: ModelTier) -> &'static str {
+    match tier {
+        ModelTier::Fast => "latest:fast",
+        ModelTier::Pro => "latest:pro",
+        ModelTier::Max => "latest:max",
+    }
+}
+```
+`proposal.rs` :
+```rust
+//! Generation of an ArmadAI proposal pack from imported native configs.
+use std::fmt::Write as _;
+
+use super::reverse::ImportedAgent;
+use crate::linker::model_aliases::resolve_alias;
+use crate::linker::model_resolution::{
+    classify_model_tier, is_latest_placeholder, tier_placeholder,
+};
+
+/// Map a native model to a portable ArmadAI tier when possible.
+pub(crate) fn portable_model(model: Option<&str>) -> String {
+    let Some(model) = model else {
+        return "latest:pro".to_string();
+    };
+    if is_latest_placeholder(model) {
+        return model.to_string();
+    }
+    let resolved = resolve_alias(model).unwrap_or_else(|| model.to_string());
+    if is_latest_placeholder(&resolved) {
+        return resolved;
+    }
+    match classify_model_tier(&resolved, "anthropic") {
+        Some(tier) => tier_placeholder(tier).to_string(),
+        None => resolved,
+    }
+}
+
+/// Render an imported agent in the ArmadAI agent format
+/// (H1 + `## Metadata` list + `## System Prompt`).
+pub(crate) fn render_agent(agent: &ImportedAgent) -> String {
+    let mut md = String::new();
+    let _ = writeln!(md, "# {}\n", agent.name);
+    let description = agent
+        .metadata
+        .description
+        .as_deref()
+        .unwrap_or("Imported from native Claude Code configuration.");
+    let _ = writeln!(md, "> {description}\n");
+    let _ = writeln!(md, "## Metadata");
+    let _ = writeln!(md, "- provider: claude");
+    let _ = writeln!(md, "- model: {}", portable_model(agent.metadata.model.as_deref()));
+    if agent.metadata.description.is_some() {
+        // Ignored by today's parser (unknown key -> debug log); forward-compatible.
+        let _ = writeln!(md, "- description: {description}");
+    }
+    let _ = writeln!(md, "- tags: [imported]");
+    let globs = agent.metadata.scope_globs();
+    if !globs.is_empty() {
+        let _ = writeln!(md, "- scope: [{}]", globs.join(", "));
+    }
+    let _ = writeln!(md, "\n## System Prompt\n");
+    let _ = writeln!(md, "{}", agent.system_prompt);
+    md
+}
+```
+Dans `audit/mod.rs` : `pub mod proposal;`. Note : `classify_model_tier(model, provider)` — vérifier l'ordre exact des paramètres dans model_resolution.rs:61 et s'y conformer.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS. (`render_agent`/`portable_model` sont `pub(crate)` consommés par leurs tests ET par la Task 5 ; si clippy râle dead-code sur ce commit isolé, committer combiné avec la Task 3.)
+- [ ] **Step 5:** `git add src/audit/ src/linker/ && git commit -m "feat(audit): propose converts agents to ArmadAI format with portable tiers"`
+
+---
+
+### Task 3: Extraction des prompts partagés (clusters A06)
+
+**Files:**
+- Modify: `src/audit/rules/similarity.rs` (exposer la découverte de clusters) + `src/audit/rules/mod.rs` (re-export)
+- Modify: `src/audit/proposal.rs`
+
+**Interfaces:**
+- Dans `similarity.rs` : extraire de `a06_duplicated_blocks` une fonction réutilisable `pub(crate) fn duplication_clusters(agents: &[ImportedAgent]) -> Vec<Vec<usize>>` (calcul fenêtres + union-find, retourne les composantes ≥2 triées) ; `a06_duplicated_blocks` la consomme (pas de duplication de logique). Re-export dans `rules/mod.rs` : `pub(crate) use similarity::duplication_clusters;`.
+- Dans `proposal.rs` :
+  - `pub(crate) struct SharedFragment { pub name: String, pub apply_to: Vec<String>, pub body: String }`
+  - `pub(crate) fn extract_shared_fragment(agents: &[&ImportedAgent], index: usize) -> Option<SharedFragment>` — plus long bloc contigu de lignes (trimées, non vides) présent chez TOUS les membres, longueur ≥ 8 ; `name = format!("shared-conventions-{}", index + 1)` ; `apply_to` = noms des membres ; `None` si aucun bloc commun ≥ 8.
+  - `pub(crate) fn strip_fragment(prompt: &str, fragment_body: &str) -> String` — retire du prompt la première occurrence du bloc (correspondance sur lignes trimées non vides, suppression des lignes brutes correspondantes), et compacte les lignes vides triples résultantes.
+  - `pub(crate) fn render_prompt(f: &SharedFragment) -> String` — format fragment ArmadAI :
+```markdown
+---
+name: {name}
+description: Shared conventions extracted from {n} agents by armadai audit --propose
+apply_to:
+  - {agent...}
+---
+{body}
+```
+
+- [ ] **Step 1: Tests qui échouent** (`proposal.rs`)
+```rust
+    fn block() -> String {
+        (1..=10).map(|i| format!("Convention line {i}\n")).collect()
+    }
+
+    #[test]
+    fn extract_shared_fragment_finds_longest_common_block() {
+        let b = block();
+        let a1 = agent("g1", &format!("Intro one.\n\n{b}Outro one."));
+        let a2 = agent("g2", &format!("{b}Outro two."));
+        let refs: Vec<&ImportedAgent> = vec![&a1, &a2];
+        let f = extract_shared_fragment(&refs, 0).unwrap();
+        assert_eq!(f.name, "shared-conventions-1");
+        assert_eq!(f.apply_to, vec!["g1".to_string(), "g2".to_string()]);
+        assert!(f.body.contains("Convention line 1"));
+        assert!(f.body.contains("Convention line 10"));
+        assert!(!f.body.contains("Intro"));
+    }
+
+    #[test]
+    fn extract_returns_none_below_window() {
+        let a1 = agent("s1", "short\ncommon\ntext");
+        let a2 = agent("s2", "short\ncommon\ntext");
+        let refs: Vec<&ImportedAgent> = vec![&a1, &a2];
+        // 3 common lines < 8-line window: not worth a shared fragment.
+        assert!(extract_shared_fragment(&refs, 0).is_none());
+    }
+
+    #[test]
+    fn strip_fragment_removes_block_and_keeps_rest() {
+        let b = block();
+        let prompt = format!("Intro.\n\n{b}\nOutro.");
+        let f_body = b.trim_end().to_string();
+        let stripped = strip_fragment(&prompt, &f_body);
+        assert!(stripped.contains("Intro."));
+        assert!(stripped.contains("Outro."));
+        assert!(!stripped.contains("Convention line 5"));
+    }
+
+    #[test]
+    fn render_prompt_has_frontmatter_and_apply_to() {
+        let f = SharedFragment {
+            name: "shared-conventions-1".into(),
+            apply_to: vec!["g1".into(), "g2".into()],
+            body: "Some shared text.".into(),
+        };
+        let md = render_prompt(&f);
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("apply_to:\n  - g1\n  - g2"));
+        assert!(md.contains("Some shared text."));
+    }
+```
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3: Implémentation** — algorithme d'extraction :
+```rust
+fn norm_lines(text: &str) -> Vec<&str> {
+    text.lines().map(str::trim).filter(|l| !l.is_empty()).collect()
+}
+
+/// Longest contiguous run of normalized lines from `base` that appears
+/// (as a contiguous run) in every other member. O(n²·m) on small prompts.
+fn longest_common_block<'a>(members: &[Vec<&'a str>]) -> Vec<&'a str> {
+    let Some((base, others)) = members.split_first() else {
+        return Vec::new();
+    };
+    let mut best: (usize, usize) = (0, 0); // (start, len)
+    let n = base.len();
+    for start in 0..n {
+        if n - start <= best.1 {
+            break;
+        }
+        let mut len = n - start;
+        while len > best.1 {
+            let candidate = &base[start..start + len];
+            if others.iter().all(|o| contains_run(o, candidate)) {
+                best = (start, len);
+                break;
+            }
+            len -= 1;
+        }
+    }
+    base[best.0..best.0 + best.1].to_vec()
+}
+
+fn contains_run(haystack: &[&str], needle: &[&str]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+```
+`extract_shared_fragment` : construit `norm_lines` par membre, `longest_common_block`, `None` si `< 8` lignes, sinon body = lignes jointes par `\n`. `strip_fragment` : reconstruit l'indexation lignes brutes ↔ lignes normalisées du prompt, trouve la première fenêtre de lignes normalisées égale au bloc, supprime les lignes brutes correspondantes, puis remplace les séquences de ≥3 sauts de ligne par 2 :
+```rust
+pub(crate) fn strip_fragment(prompt: &str, fragment_body: &str) -> String {
+    let needle: Vec<&str> = norm_lines(fragment_body);
+    let raw: Vec<&str> = prompt.lines().collect();
+    // raw indices of non-empty lines
+    let idx: Vec<usize> = raw
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| !l.trim().is_empty())
+        .map(|(i, _)| i)
+        .collect();
+    let norm: Vec<&str> = idx.iter().map(|&i| raw[i].trim()).collect();
+    let Some(pos) = norm
+        .windows(needle.len().max(1))
+        .position(|w| w == needle.as_slice())
+    else {
+        return prompt.to_string();
+    };
+    let (from, to) = (idx[pos], idx[pos + needle.len() - 1]);
+    let kept: Vec<&str> = raw
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i < from || *i > to)
+        .map(|(_, l)| *l)
+        .collect();
+    let mut out = kept.join("\n");
+    while out.contains("\n\n\n") {
+        out = out.replace("\n\n\n", "\n\n");
+    }
+    out
+}
+```
+Perf : garde-fou dans l'appelant (Task 5) — extraction seulement pour les clusters dont les prompts font < 100 000 caractères chacun (sinon skip avec note dans le récapitulatif).
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "feat(audit): propose extracts shared prompt fragments from duplication clusters"`
+
+---
+
+### Task 4: Copie des skills + réparations SKILL.md
+
+**Files:**
+- Modify: `src/audit/proposal.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub(crate) fn fix_skill_md(content: &str) -> (String, Vec<&'static str>)` — deux réparations textuelles du frontmatter (entre les deux premiers `---`) : (a) renommer la clé `tools:` → `allowed-tools:` (le champ que Claude Code lit réellement — hint du Plan 3) ; (b) quoter les valeurs de `description:`/`name:` non quotées contenant `: `. Retourne le contenu réparé + la liste des fixes appliqués (`"tools->allowed-tools"`, `"quoted-value"`).
+  - `pub(crate) fn copy_skill_dir(src: &Path, dest: &Path) -> anyhow::Result<Vec<&'static str>>` — copie récursive (profondeur ≤ 5), applique `fix_skill_md` au `SKILL.md` racine, retourne les fixes.
+
+- [ ] **Step 1: Tests qui échouent**
+```rust
+    #[test]
+    fn fix_skill_md_renames_tools_and_quotes_colons() {
+        let content = "---\nname: triage\ndescription: triage is HUMAN — the skill : just assists\ntools: Read, Grep\n---\nBody";
+        let (fixed, fixes) = fix_skill_md(content);
+        assert!(fixed.contains("allowed-tools: Read, Grep"));
+        assert!(fixed.contains("description: \"triage is HUMAN — the skill : just assists\""));
+        assert!(!fixed.contains("\ntools:"));
+        assert_eq!(fixes.len(), 2);
+    }
+
+    #[test]
+    fn fix_skill_md_leaves_clean_files_alone() {
+        let content = "---\nname: ok\ndescription: fine\nallowed-tools: Read\n---\nBody";
+        let (fixed, fixes) = fix_skill_md(content);
+        assert_eq!(fixed, content);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn copy_skill_dir_copies_recursively_and_fixes() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(src.path().join("references")).unwrap();
+        std::fs::write(
+            src.path().join("SKILL.md"),
+            "---\nname: s\ndescription: d\ntools: Read\n---\nBody",
+        )
+        .unwrap();
+        std::fs::write(src.path().join("references/ref.md"), "ref").unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let dest_dir = dest.path().join("s");
+        let fixes = copy_skill_dir(src.path(), &dest_dir).unwrap();
+        assert_eq!(fixes, vec!["tools->allowed-tools"]);
+        assert!(dest_dir.join("references/ref.md").exists());
+        let skill = std::fs::read_to_string(dest_dir.join("SKILL.md")).unwrap();
+        assert!(skill.contains("allowed-tools: Read"));
+    }
+```
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3: Implémentation** — `fix_skill_md` opère ligne à ligne UNIQUEMENT à l'intérieur du premier bloc `---`…`---` :
+```rust
+pub(crate) fn fix_skill_md(content: &str) -> (String, Vec<&'static str>) {
+    let mut fixes = Vec::new();
+    let mut in_frontmatter = false;
+    let mut seen_delims = 0u8;
+    let lines: Vec<String> = content
+        .lines()
+        .map(|line| {
+            if line.trim() == "---" && seen_delims < 2 {
+                seen_delims += 1;
+                in_frontmatter = seen_delims == 1;
+                return line.to_string();
+            }
+            if !in_frontmatter || seen_delims != 1 {
+                return line.to_string();
+            }
+            if let Some(rest) = line.strip_prefix("tools:") {
+                fixes.push("tools->allowed-tools");
+                return format!("allowed-tools:{rest}");
+            }
+            if let Some((key, value)) = line.split_once(':')
+                && matches!(key.trim(), "description" | "name")
+            {
+                let v = value.trim();
+                if v.contains(": ") && !v.starts_with('"') && !v.starts_with('\'') {
+                    fixes.push("quoted-value");
+                    return format!("{}: \"{v}\"", key.trim_end());
+                }
+            }
+            line.to_string()
+        })
+        .collect();
+    (lines.join("\n") + if content.ends_with('\n') { "\n" } else { "" }, fixes)
+}
+```
+`copy_skill_dir` : récursion bornée avec `std::fs` (create_dir_all + copy), `SKILL.md` de la racine passé par `fix_skill_md` et écrit réparé.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS. (Fonctions consommées par les tests + Task 5 ; même consigne combine-si-rouge.)
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "feat(audit): propose copies skills with allowed-tools and quoting fixes"`
+
+---
+
+### Task 5: Assemblage du pack + invariant validate
+
+**Files:**
+- Modify: `src/audit/proposal.rs`
+- Modify: `src/core/pack_validation.rs` (si `validate_pack` porte encore `#[allow(dead_code)]` : le retirer — `--propose` devient son consommateur programmatique)
+
+**Interfaces:**
+- Produces:
+```rust
+pub struct ProposalSummary {
+    pub out_dir: PathBuf,
+    pub agents: usize,
+    pub prompts: usize,
+    pub skills: usize,
+    pub skill_fixes: usize,
+    pub skipped_agents: Vec<String>,
+}
+
+pub fn generate_proposal(
+    root: &Path,
+    config: &ImportedConfig,
+) -> anyhow::Result<ProposalSummary>
+```
+Comportement : `out_dir = root.join(".armadai-proposal")` ; `bail!` si existe déjà. Étapes : (1) clusters A06 via `rules::duplication_clusters` (sur agents convertibles) → fragments extraits (garde-fou 100k chars/prompt) ; (2) agents rendus avec prompts strippés des fragments qui les concernent → `agents/{name}.md` (noms slugifiés via `crate::linker::slugify` si dispo, sinon nom tel quel — les noms importés sont déjà des slugs) ; agents illisibles (issues non vides ET (name vide OU prompt vide)) → skipped ; (3) fragments → `prompts/{name}.md` ; (4) skills avec `has_skill_md` → `copy_skill_dir` vers `skills/{name}/` ; (5) `pack.yaml` :
+```yaml
+name: {root dir name sanitisé}-agents
+description: "Generated by `armadai audit --propose` from the native Claude Code configuration"
+agents: [...]
+prompts: [...]
+skills: [...]
+```
+(6) **invariant** : `let issues = crate::core::pack_validation::validate_pack(&out_dir);` — si une issue `Severity::Error` → `bail!` en listant les erreurs (le générateur ne livre jamais un pack invalide).
+
+- [ ] **Step 1: Test qui échoue** (e2e dans `proposal.rs`)
+```rust
+    #[test]
+    fn generate_proposal_produces_valid_installable_pack() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        let block = block();
+        std::fs::write(
+            agents.join("gate-a.md"),
+            format!("---\nname: gate-a\ndescription: Gate A\nmodel: opus\n---\nIntro A.\n\n{block}"),
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("gate-b.md"),
+            format!("---\nname: gate-b\ndescription: Gate B\n---\n{block}Outro B."),
+        )
+        .unwrap();
+        let skill = dir.path().join(".claude/skills/deploy");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: deploy\ndescription: Deploys\ntools: Read\n---\nSteps.",
+        )
+        .unwrap();
+
+        let (_, config) = crate::audit::import_surfaces(dir.path());
+        let summary = generate_proposal(dir.path(), &config).unwrap();
+        assert_eq!(summary.agents, 2);
+        assert_eq!(summary.prompts, 1);
+        assert_eq!(summary.skills, 1);
+        assert_eq!(summary.skill_fixes, 1);
+
+        let out = dir.path().join(".armadai-proposal");
+        // The generated agents parse with the real ArmadAI parser.
+        for name in ["gate-a", "gate-b"] {
+            let parsed =
+                crate::parser::validate_agent(&out.join(format!("agents/{name}.md"))).unwrap();
+            assert_eq!(parsed.metadata.provider, "claude");
+        }
+        // Shared block was factored out of the agents.
+        let a = std::fs::read_to_string(out.join("agents/gate-a.md")).unwrap();
+        assert!(!a.contains("Convention line 5"));
+        let p = std::fs::read_to_string(out.join("prompts/shared-conventions-1.md")).unwrap();
+        assert!(p.contains("Convention line 5"));
+        // Second run refuses to overwrite.
+        assert!(generate_proposal(dir.path(), &config).is_err());
+    }
+```
+(Vérifier la signature réelle de `crate::parser::validate_agent` — le module parser l'expose pour la commande validate ; adapter l'appel si elle prend `&Path`.)
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Implémentation complète :
+```rust
+pub struct ProposalSummary {
+    pub out_dir: std::path::PathBuf,
+    pub agents: usize,
+    pub prompts: usize,
+    pub skills: usize,
+    pub skill_fixes: usize,
+    pub skipped_agents: Vec<String>,
+}
+
+const MAX_PROMPT_CHARS_FOR_EXTRACTION: usize = 100_000;
+
+pub fn generate_proposal(
+    root: &std::path::Path,
+    config: &super::reverse::ImportedConfig,
+) -> anyhow::Result<ProposalSummary> {
+    let out_dir = root.join(".armadai-proposal");
+    if out_dir.exists() {
+        anyhow::bail!(
+            "{} already exists — remove it first (the proposal never overwrites)",
+            out_dir.display()
+        );
+    }
+    // Convertible agents: salvage must have recovered the essentials.
+    let mut skipped_agents = Vec::new();
+    let convertible: Vec<&super::reverse::ImportedAgent> = config
+        .agents
+        .iter()
+        .filter(|a| {
+            let ok = !a.name.is_empty() && !a.system_prompt.is_empty();
+            if !ok {
+                skipped_agents.push(a.name.clone());
+            }
+            ok
+        })
+        .collect();
+
+    // Shared fragments from duplication clusters (guard very large prompts).
+    let owned: Vec<super::reverse::ImportedAgent> =
+        convertible.iter().map(|a| (*a).clone()).collect();
+    let clusters = crate::audit::rules::duplication_clusters(&owned);
+    let mut fragments: Vec<SharedFragment> = Vec::new();
+    for (i, members) in clusters.iter().enumerate() {
+        let refs: Vec<&super::reverse::ImportedAgent> =
+            members.iter().map(|&m| &owned[m]).collect();
+        if refs
+            .iter()
+            .any(|a| a.system_prompt.len() > MAX_PROMPT_CHARS_FOR_EXTRACTION)
+        {
+            continue;
+        }
+        if let Some(f) = extract_shared_fragment(&refs, i) {
+            fragments.push(f);
+        }
+    }
+
+    std::fs::create_dir_all(out_dir.join("agents"))?;
+    // Agents: render with their shared fragments stripped out.
+    for a in &owned {
+        let mut agent = a.clone();
+        for f in &fragments {
+            if f.apply_to.iter().any(|n| n == &agent.name) {
+                agent.system_prompt = strip_fragment(&agent.system_prompt, &f.body);
+            }
+        }
+        let file = out_dir
+            .join("agents")
+            .join(format!("{}.md", crate::linker::slugify(&agent.name)));
+        std::fs::write(file, render_agent(&agent))?;
+    }
+    // Prompts.
+    if !fragments.is_empty() {
+        std::fs::create_dir_all(out_dir.join("prompts"))?;
+        for f in &fragments {
+            std::fs::write(
+                out_dir.join("prompts").join(format!("{}.md", f.name)),
+                render_prompt(f),
+            )?;
+        }
+    }
+    // Skills.
+    let mut skill_fixes = 0usize;
+    let installable_skills: Vec<&super::reverse::ImportedSkill> =
+        config.skills.iter().filter(|s| s.has_skill_md).collect();
+    if !installable_skills.is_empty() {
+        std::fs::create_dir_all(out_dir.join("skills"))?;
+        for s in &installable_skills {
+            // source_path points at SKILL.md; the skill dir is its parent.
+            let src = s
+                .source_path
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_else(|| s.source_path.clone());
+            let dest = out_dir.join("skills").join(&s.name);
+            skill_fixes += copy_skill_dir(&src, &dest)?.len();
+        }
+    }
+    // pack.yaml
+    let pack_name = root
+        .file_name()
+        .map(|n| crate::linker::slugify(&n.to_string_lossy()))
+        .unwrap_or_else(|| "imported".to_string());
+    let mut pack = String::new();
+    use std::fmt::Write as _;
+    let _ = writeln!(pack, "name: {pack_name}-agents");
+    let _ = writeln!(
+        pack,
+        "description: \"Generated by `armadai audit --propose` from the native Claude Code configuration\""
+    );
+    let _ = writeln!(pack, "agents:");
+    for a in &owned {
+        let _ = writeln!(pack, "  - {}", crate::linker::slugify(&a.name));
+    }
+    if !fragments.is_empty() {
+        let _ = writeln!(pack, "prompts:");
+        for f in &fragments {
+            let _ = writeln!(pack, "  - {}", f.name);
+        }
+    }
+    if !installable_skills.is_empty() {
+        let _ = writeln!(pack, "skills:");
+        for s in &installable_skills {
+            let _ = writeln!(pack, "  - {}", s.name);
+        }
+    }
+    std::fs::write(out_dir.join("pack.yaml"), pack)?;
+
+    // Invariant: the generator never ships an invalid pack.
+    let errors: Vec<String> = crate::core::pack_validation::validate_pack(&out_dir)
+        .into_iter()
+        .filter(|i| matches!(i.severity, crate::core::pack_validation::Severity::Error))
+        .map(|i| format!("{}: {}", i.location, i.message))
+        .collect();
+    if !errors.is_empty() {
+        anyhow::bail!("generated proposal failed validation:\n{}", errors.join("\n"));
+    }
+
+    Ok(ProposalSummary {
+        out_dir,
+        agents: owned.len(),
+        prompts: fragments.len(),
+        skills: installable_skills.len(),
+        skill_fixes,
+        skipped_agents,
+    })
+}
+```
+Prérequis de visibilité : `duplication_clusters` re-exporté `pub(crate)` par `rules/mod.rs` (Task 3) ; `crate::linker::slugify` est `pub` (linker/mod.rs:99) ; retirer les `#[allow(dead_code)]` devenus faux dans `pack_validation.rs` (au minimum `validate_pack` et `Severity`/`ValidationIssue`). Attention au conflit de nom : `pack_validation::Severity` ≠ `rules::Severity` — utiliser les chemins qualifiés comme ci-dessus.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ src/core/ && git commit -m "feat(audit): generate validated ArmadAI proposal pack"`
+
+---
+
+### Task 6: CLI `--propose` + `init --pack` chemin local
+
+**Files:**
+- Modify: `src/cli/mod.rs` (flag sur `Audit` ; help de `--pack` sur Init)
+- Modify: `src/cli/audit.rs`
+- Modify: `src/cli/init.rs` (résolution chemin local)
+- Modify: `src/audit/report.rs` (message funnel : retirer « (coming soon) »)
+
+**Interfaces:**
+- `Audit` gagne `#[arg(long)] propose: bool` ; `execute(path, report, min_severity, quiet, propose)`. Flow : audit normal, puis si `propose` : `let (_, config) = import_surfaces(&root);` → `generate_proposal` → affiche le récapitulatif + la commande d'adoption exacte :
+```
+  Proposal written to {out}/
+    {n} agent(s), {n} shared prompt(s), {n} skill(s) ({n} fixed)
+  Install it with:
+    armadai init --pack {out} --project
+```
+  Le `bail!` sur findings critiques reste APRÈS la génération (un repo à criticals peut justement vouloir la proposition).
+- `init --pack` : dans `install_pack` (init.rs:66), AVANT `find_pack_dir` :
+```rust
+    let candidate = std::path::Path::new(name);
+    let pack_dir = if candidate.join("pack.yaml").is_file() {
+        candidate.to_path_buf()
+    } else {
+        match find_pack_dir(name) { ... existant ... }
+    };
+```
+- Funnel (`report.rs`) : la ligne `Run \`armadai audit --propose\` (coming soon)...` devient `Run \`armadai audit --propose\` to generate the config.`
+
+- [ ] **Step 1: Tests qui échouent**
+Dans `cli/audit.rs` :
+```rust
+    #[tokio::test]
+    async fn execute_with_propose_writes_proposal() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            agents.join("ok.md"),
+            "---\nname: ok\ndescription: Fine\nmodel: latest:pro\ntools: Read\n---\nShort prompt.",
+        )
+        .unwrap();
+        let result = execute(
+            Some(dir.path().to_path_buf()),
+            None,
+            "info".to_string(),
+            false,
+            true,
+        )
+        .await;
+        assert!(result.is_ok());
+        assert!(dir.path().join(".armadai-proposal/pack.yaml").is_file());
+        assert!(dir.path().join(".armadai-proposal/agents/ok.md").is_file());
+    }
+```
+Dans `cli/init.rs` (test de la résolution locale — extraire la résolution en `pub(crate) fn resolve_pack_dir(name: &str) -> Option<PathBuf>` pour la tester sans installer) :
+```rust
+    #[test]
+    fn resolve_pack_dir_accepts_local_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pack.yaml"),
+            "name: local-pack\ndescription: d\n",
+        )
+        .unwrap();
+        let resolved = resolve_pack_dir(dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(resolved, dir.path());
+    }
+```
+Dans `report.rs` : adapter l'assertion funnel si un test contient « coming soon ».
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Implémenter (les 4 tests e2e existants de `cli/audit.rs` gagnent l'argument `false` pour `propose`). `install_pack` utilise `resolve_pack_dir`.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS. Mettre à jour le help clap de `--pack` : « Starter pack name, or path to a directory containing pack.yaml ».
+- [ ] **Step 5:** `git add src/cli/ src/audit/ && git commit -m "feat(cli): audit --propose generates pack, init --pack accepts local paths"`
+
+---
+
+### Task 7: Vérification finale, démo cls, PR
+
+- [ ] **Step 1:** fmt + clippy 2 modes + tests 2 modes — tout vert (~660+ tests).
+- [ ] **Step 2: Démo bout-en-bout sur le repo réel**
+```bash
+cargo run --no-default-features --features tui -- audit /Users/bl209054/work/blg/applications/frontlibreservice/components/cls-monorepo --propose 2>&1 | tail -20
+ls /Users/bl209054/work/blg/applications/frontlibreservice/components/cls-monorepo/.armadai-proposal/
+cargo run --no-default-features --features tui -- validate /Users/bl209054/work/blg/applications/frontlibreservice/components/cls-monorepo/.armadai-proposal
+```
+Consigner : nb d'agents convertis (~22 + 2 salvagés), fragments extraits (≥1, le cluster des 4 gates), skills copiés (34) et fixes (≥13 tools→allowed-tools + 1 quote). **Puis supprimer `.armadai-proposal/` du repo cls** (c'était une démo, pas une adoption) :
+```bash
+rm -rf /Users/bl209054/work/blg/applications/frontlibreservice/components/cls-monorepo/.armadai-proposal
+```
+- [ ] **Step 3:** `git push -u origin feat/audit-propose` + PR vers `release/1.0.0` : `feat(audit): --propose generates a validated ArmadAI pack from native configs`.
+
+---
+
+## Hors périmètre (rappel)
+
+- `raw_frontmatter` (round-trip natif) : non nécessaire pour la conversion ArmadAI — attendra un vrai besoin de régénération native.
+- Champ `description` de première classe dans le format agent ArmadAI (limitation documentée — émis en clé ignorée).
+- Plan 5 : `--deep`. Backlog robustesse restant : agrégation C03/C05, C04 code-fences, offset file_line, Lot 3 propale (commands/, settings hooks).

--- a/docs/superpowers/plans/2026-07-15-audit-plan-5-deep.md
+++ b/docs/superpowers/plans/2026-07-15-audit-plan-5-deep.md
@@ -1,0 +1,275 @@
+# Audit d'agentique — Plan 5/5 : `--deep` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `armadai audit --deep` : passe LLM optionnelle qui envoie les configs importées + findings statiques + collisions à un agent auditeur embarqué (via un CLI LLM détecté), parse ses findings D01-D05 et les fusionne dans le rapport. Erreur explicite si aucun provider CLI n'est disponible ; dégradation propre (section brute) si le JSON de retour est invalide.
+
+**Architecture:** Nouveau module `src/audit/deep.rs`. L'appel LLM est **injecté via une closure** `run: impl Fn(&str) -> Result<String>` → payload et parsing sont testables sans provider réel ; seule la glue CLI est non testée en CI. Instructions de l'auditeur embarquées via `include_str!` (aucune installation). Le CLI provider ignore le system_prompt → instructions + données vont dans le message. Chemin CLI disponible sans `providers-api` (bon pour le mode CI). DTOs sérialisables dédiés (les types `Imported*` ne dérivent pas Serde).
+
+**Décisions actées (utilisateur)** : scope complet D01-D05 ; **erreur explicite** si `--deep` demandé sans provider CLI détecté (pas de skip silencieux) ; JSON de retour invalide → section « Deep analysis (unparsed) » + pas d'échec (spec §7/§9).
+
+**Tech Stack:** Rust édition 2024, `serde`/`serde_json` (déjà en deps, non gated), `async-trait`, `include_str!`. **Aucune nouvelle dépendance.**
+
+## Global Constraints
+
+- Base : `origin/release/1.0.0` (@ 7953702). Branche : `feat/audit-deep`.
+- Clippy `-D warnings` vert dans les DEUX modes (`--features tui` et `tui,providers-api`) après chaque commit ; `#[allow(dead_code)]` interdit ; pas d'`unwrap()`/`expect()` runtime (tests exceptés) ; pas de nouvelle dépendance ni feature flag ; Conventional Commits ; TDD.
+- `--deep` NE tourne JAMAIS en CI (nécessite un CLI LLM) : tout le testable passe par une closure injectée ; la détection CLI + l'invocation réelle sont la seule partie non couverte, et elle doit rester minime.
+- Détection provider : self-contained dans `deep.rs` (`which`-check sur claude/gemini/codex/copilot/opencode/aider) — pas de couplage au module `shell/` (dont le gating est incertain).
+- Findings D0x : `Finding.rule` est `&'static str` → utiliser des constantes `"D01".."D05"` (jamais de `Box::leak`, jamais de string dynamique).
+- Le payload envoyé au LLM tronque chaque system prompt à `deep_prompt_truncation` caractères (nouveau champ `AuditSettings`, défaut 2000).
+
+---
+
+### Task 0: Branche
+
+- [ ] **Step 1:**
+```bash
+cd /Users/bl209054/work/misc/armadai-audit-wt && git checkout -b feat/audit-deep origin/release/1.0.0
+cargo test --no-default-features --features tui,providers-api 2>&1 | tail -1
+```
+Expected: `667 passed`.
+
+---
+
+### Task 1: `deep_prompt_truncation` + DTOs + `build_payload`
+
+**Files:**
+- Modify: `src/audit/rules/mod.rs` (`AuditSettings.deep_prompt_truncation`, from_project + tests)
+- Create: `src/audit/deep.rs` (+ `pub mod deep;` dans `src/audit/mod.rs`)
+
+**Interfaces:**
+- `AuditSettings` gagne `pub deep_prompt_truncation: usize` (défaut **2000**), lu depuis `armadai.yaml > audit:` comme les autres.
+- Dans `deep.rs` : DTOs `#[derive(Serialize)]` : `PayloadAgent { name, description: Option<String>, model: Option<String>, tools: Option<Vec<String>>, scope: Vec<String>, prompt_excerpt: String }`, `PayloadFinding { rule, severity, file, message }`, `DeepPayload { agents: Vec<PayloadAgent>, skills: Vec<PayloadSkill { name, description }>, instructions_excerpt: Option<String>, static_findings: Vec<PayloadFinding> }`.
+- `pub(crate) fn build_payload(config: &ImportedConfig, findings: &[Finding], truncation: usize) -> String` — sérialise un `DeepPayload` en JSON compact ; `prompt_excerpt` = les `truncation` premiers caractères du system_prompt (respecter les frontières de char : `chars().take(truncation).collect()`), `instructions_excerpt` idem sur CLAUDE.md. Agents avec `ParseIssue` inclus (le LLM peut commenter), prompt tronqué quand même.
+
+- [ ] **Step 1: Tests qui échouent**
+Dans `rules/mod.rs` (étendre les 2 tests `from_project`) :
+```rust
+        // dans from_project_reads_audit_section (armadai.yaml enrichi):
+        //   audit:\n  ...\n  deep_prompt_truncation: 500\n
+        assert_eq!(s.deep_prompt_truncation, 500);
+        // dans from_project_defaults_without_config:
+        assert_eq!(s.deep_prompt_truncation, 2000);
+```
+Dans `deep.rs` :
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::rules::test_support::{agent, config_with};
+    use crate::audit::rules::{Finding, Severity};
+
+    #[test]
+    fn build_payload_truncates_prompts_and_includes_findings() {
+        let a = agent("reviewer", &"x".repeat(5000));
+        let config = config_with(vec![a]);
+        let findings = vec![Finding {
+            rule: "A08",
+            severity: Severity::Info,
+            file: ".claude/agents/reviewer.md".into(),
+            related: vec![],
+            message: "inherits all tools".into(),
+            suggestion: None,
+        }];
+        let json = build_payload(&config, &findings, 100);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["agents"][0]["name"], "reviewer");
+        assert_eq!(v["agents"][0]["prompt_excerpt"].as_str().unwrap().chars().count(), 100);
+        assert_eq!(v["static_findings"][0]["rule"], "A08");
+    }
+}
+```
+- [ ] **Step 2:** Run `cargo test --no-default-features --features tui,providers-api audit::` — FAIL.
+- [ ] **Step 3:** Ajouter le champ `deep_prompt_truncation` à `AuditSettings` + `Default` (2000) + parsing `from_project` (nouveau champ `Option<usize>` dans `AuditSection`). Créer `deep.rs` avec les DTOs `#[derive(serde::Serialize)]` et `build_payload` (utilise `chars().take(truncation).collect::<String>()`, `serde_json::to_string`). `pub mod deep;` dans `mod.rs`.
+  Anti-dead-code : `build_payload` est `pub(crate)`, consommé par son test ET par la Task 3 ; si clippy dead-code bloque ce commit isolé, combiner avec la Task 2.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "feat(audit): deep-pass payload builder and truncation setting"`
+
+---
+
+### Task 2: Instructions auditeur embarquées + `parse_deep_response`
+
+**Files:**
+- Create: `src/audit/deep_auditor.md` (instructions de l'agent auditeur, embarquées via `include_str!`)
+- Modify: `src/audit/deep.rs`
+
+**Interfaces:**
+- `const AUDITOR_INSTRUCTIONS: &str = include_str!("deep_auditor.md");`
+- `pub(crate) const DEEP_RULES: [&str; 5] = ["D01", "D02", "D03", "D04", "D05"];`
+- `pub(crate) fn build_prompt(payload_json: &str) -> String` — `AUDITOR_INSTRUCTIONS` + un bloc « INPUT JSON: » + `payload_json` + rappel du format de sortie attendu (JSON `{"findings":[{"kind":"D01","severity":"warning","file":"...","message":"...","suggestion":"..."}]}`).
+- `pub(crate) enum DeepOutcome { Findings(Vec<Finding>), Raw(String) }`
+- `pub(crate) fn parse_deep_response(text: &str) -> DeepOutcome` — extrait le premier bloc JSON de `text` (le CLI peut entourer de prose / fences ```json) ; si parse OK → mappe chaque item vers un `Finding` (rule = constante D0x correspondant à `kind` en majuscules, sinon l'item est ignoré ; severity : "critical"→Critical, "warning"→Warning, sinon Info ; `related` vide ; message préfixé `[deep] `) ; si aucun JSON parsable → `Raw(text.trim().to_string())`.
+
+Fichier `deep_auditor.md` — instructions concises demandant : analyser les agents/skills/instructions fournis + les findings statiques, et retourner UNIQUEMENT du JSON avec des findings de type D01 (overlap de rôles entre agents), D02 (system prompt flou/contradictoire), D03 (mutualisation sémantique au-delà de la duplication littérale), D04 (topologie d'équipe suggérée : coordinator/teams), D05 (directives de CLAUDE.md contredisant un agent). Chaque finding : `kind`, `severity` (critical|warning|info), `file`, `message`, `suggestion`. Interdiction de répéter les findings statiques fournis.
+
+- [ ] **Step 1: Tests qui échouent** (`deep.rs`)
+```rust
+    #[test]
+    fn parse_deep_response_maps_valid_json_to_findings() {
+        let text = "Here is my analysis:\n```json\n{\"findings\":[{\"kind\":\"D01\",\"severity\":\"warning\",\"file\":\"a.md\",\"message\":\"roles overlap\",\"suggestion\":\"merge\"}]}\n```\nDone.";
+        let DeepOutcome::Findings(f) = parse_deep_response(text) else {
+            panic!("expected findings");
+        };
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].rule, "D01");
+        assert_eq!(f[0].severity, crate::audit::rules::Severity::Warning);
+        assert!(f[0].message.starts_with("[deep] "));
+    }
+
+    #[test]
+    fn parse_deep_response_unknown_kind_is_dropped() {
+        let text = "{\"findings\":[{\"kind\":\"D99\",\"severity\":\"info\",\"file\":\"a\",\"message\":\"m\"}]}";
+        let DeepOutcome::Findings(f) = parse_deep_response(text) else {
+            panic!("expected findings (possibly empty)");
+        };
+        assert!(f.is_empty());
+    }
+
+    #[test]
+    fn parse_deep_response_invalid_json_falls_back_to_raw() {
+        let text = "The config looks fine overall, no structured output.";
+        let DeepOutcome::Raw(r) = parse_deep_response(text) else {
+            panic!("expected raw");
+        };
+        assert!(r.contains("looks fine"));
+    }
+```
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Implémenter. Extraction du JSON : chercher la première `{` et la dernière `}` (ou un bloc ```json … ```), tenter `serde_json::from_str::<DeepResponse>` sur la sous-chaîne ; `DeepResponse { findings: Vec<DeepItem> }`, `DeepItem { kind, severity, file, message, suggestion: Option<String> }` (`#[derive(Deserialize)]`). Mapper kind→constante via `DEEP_RULES.iter().find(|r| **r == kind.to_uppercase())`. Écrire `deep_auditor.md`.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "feat(audit): embedded auditor instructions and deep response parser"`
+
+---
+
+### Task 3: `run_deep` orchestrateur + détection CLI
+
+**Files:**
+- Modify: `src/audit/deep.rs`
+
+**Interfaces:**
+- `pub(crate) fn available_cli() -> Option<&'static str>` — retourne le premier de `["claude", "gemini", "codex", "copilot", "opencode", "aider"]` trouvé via un `which`-check (`std::process::Command::new("which").arg(c)...` sous unix ; `where` sous windows). Self-contained.
+- `pub(crate) fn run_deep(config: &ImportedConfig, findings: &[Finding], truncation: usize, run: impl Fn(&str) -> anyhow::Result<String>) -> anyhow::Result<DeepOutcome>` — `build_payload` → `build_prompt` → `run(&prompt)` → `parse_deep_response`. Propage l'erreur de `run` (échec d'invocation LLM = erreur, distinct du JSON invalide qui donne `Raw`).
+- La construction du provider réel et le wiring CLI sont en Task 5 (ici, `run` est injecté → testable sans provider).
+
+- [ ] **Step 1: Tests qui échouent** (`deep.rs`)
+```rust
+    #[test]
+    fn run_deep_with_fake_runner_returns_findings() {
+        let config = config_with(vec![agent("a", "prompt")]);
+        let run = |_prompt: &str| {
+            Ok("{\"findings\":[{\"kind\":\"D02\",\"severity\":\"info\",\"file\":\"a.md\",\"message\":\"vague\"}]}".to_string())
+        };
+        let outcome = run_deep(&config, &[], 2000, run).unwrap();
+        let DeepOutcome::Findings(f) = outcome else { panic!() };
+        assert_eq!(f[0].rule, "D02");
+    }
+
+    #[test]
+    fn run_deep_propagates_runner_error() {
+        let config = config_with(vec![agent("a", "prompt")]);
+        let run = |_: &str| Err(anyhow::anyhow!("cli not found"));
+        assert!(run_deep(&config, &[], 2000, run).is_err());
+    }
+```
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Implémenter `run_deep` et `available_cli`.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "feat(audit): deep orchestrator with injectable runner and CLI detection"`
+
+---
+
+### Task 4: Rendu des findings D0x + section brute
+
+**Files:**
+- Modify: `src/audit/report.rs`
+
+**Interfaces:**
+- `AuditReport` gagne `pub deep_raw: Option<String>` (analyse brute quand le JSON était invalide). Les findings D0x sont ajoutés à `self.findings` (ils se rendent dans les groupes de sévérité normaux ; leur `rule` D0x + le préfixe `[deep]` du message les distinguent, et le breakdown les compte).
+- `to_markdown`/`to_html`/`print_terminal` : après les findings (et la collision matrix), si `deep_raw.is_some()`, rendre une section « ## Deep analysis (unstructured) » avec le texte brut (échappé en HTML). `critical_count` compte déjà tout Critical, y compris D0x.
+
+- [ ] **Step 1: Tests qui échouent** (`report.rs`)
+```rust
+    #[test]
+    fn deep_raw_renders_section() {
+        let mut r = report_with(vec![]);
+        r.deep_raw = Some("Free-form deep notes.".into());
+        let md = r.to_markdown();
+        assert!(md.contains("Deep analysis"));
+        assert!(md.contains("Free-form deep notes."));
+        let html = r.to_html();
+        assert!(html.contains("Deep analysis"));
+    }
+
+    #[test]
+    fn deep_findings_appear_in_severity_groups() {
+        let r = report_with(vec![finding("D01", Severity::Warning)]);
+        let md = r.to_markdown();
+        assert!(md.contains("| D01 |"));
+    }
+```
+(Adapter le helper `report_with`/`AuditReport` littéral partout : ajouter `deep_raw: None`.)
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Ajouter le champ `deep_raw: Option<String>` (défaut `None` dans `run_audit` de `mod.rs` et tous les littéraux de test), rendre la section dans les 3 formats (échappement HTML pour le brut). Le `md_cell`/`html_escape` existants s'appliquent.
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS.
+- [ ] **Step 5:** `git add src/audit/ && git commit -m "feat(audit): render deep findings and unstructured deep analysis section"`
+
+---
+
+### Task 5: CLI `--deep` + wiring provider réel
+
+**Files:**
+- Modify: `src/cli/mod.rs` (flag `deep` sur `Audit`), `src/cli/audit.rs`
+
+**Interfaces:**
+- `Audit` gagne `#[arg(long)] deep: bool` ; `execute(path, report, min_severity, quiet, propose, deep)`.
+- Flow `--deep` : APRÈS `run_audit` (findings statiques prêts) et AVANT le rendu : si `deep`, réutiliser `import_surfaces(&root)` (le config), détecter `available_cli()` ; si `None` → `anyhow::bail!("--deep requires an LLM CLI (claude, gemini, codex, copilot, opencode, aider); none found in PATH")` (erreur explicite, choix utilisateur) ; sinon construire un `Agent` auditeur en mémoire (`crate::core::agent::Agent` avec `metadata.provider = <cli détecté>`, `system_prompt` vide, `name` "deep-auditor") et une closure `run` qui : `create_provider(&agent)` → `CompletionRequest { model: detect_model_name-ou-"latest:pro", system_prompt: "", messages: vec![ChatMessage{role:"user", content: prompt}], temperature: 0.2, max_tokens: None }` → `provider.complete(req).await` (bloquant via le runtime tokio courant) → `Ok(resp.content)`. Passer cette closure à `run_deep`. Fusionner : `DeepOutcome::Findings(v)` → `audit.findings.extend(v); audit.findings.sort_by(...)` (re-trier par sévérité) ; `DeepOutcome::Raw(s)` → `audit.deep_raw = Some(s)`.
+- Note async : `run_deep` prend une closure sync `Fn(&str) -> Result<String>` mais `complete` est async. Solution : la closure bloque sur le futur via un handle du runtime (`tokio::runtime::Handle::current().block_on(...)`) — OU rendre `run_deep` async et la closure async. Choix le plus simple compatible test sync : garder `run_deep` sync, la closure CLI utilise `tokio::task::block_in_place` + `Handle::current().block_on`. Vérifier que `execute` tourne dans un runtime multi-thread (main tokio) ; sinon, alternative : rendre `run_deep` générique async. **Décision d'implémentation à la charge de l'implémenteur** : privilégier `run_deep` async prenant une closure retournant un `Future` si `block_in_place` pose problème — l'important est que les tests des Tasks 1-3 restent sync et verts. Documenter le choix retenu.
+- exit code inchangé : `critical_count() > 0` bail après fusion (un D0x Critical peut donc faire échouer — cohérent).
+
+- [ ] **Step 1: Tests qui échouent** (`cli/audit.rs`)
+```rust
+    #[tokio::test]
+    async fn deep_without_cli_errors_explicitly() {
+        // Force PATH empty so no CLI is found.
+        let dir = tempfile::tempdir().unwrap();
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("a.md"), "---\nname: a\ndescription: d\n---\nP.").unwrap();
+        // SAFETY: single-threaded test tweaking PATH; restore after.
+        let old = std::env::var_os("PATH");
+        unsafe { std::env::set_var("PATH", "") };
+        let result = execute(Some(dir.path().to_path_buf()), None, "info".into(), false, false, true).await;
+        unsafe { if let Some(p) = old { std::env::set_var("PATH", p) } }
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("--deep requires an LLM CLI"));
+    }
+```
+(Les autres tests e2e de `audit.rs` gagnent l'argument `false` pour `deep`.)
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Implémenter le flag, le dispatch (mod.rs), le wiring closure/provider. Aide clap `--deep` : « Run an optional LLM pass (needs an installed CLI: claude, gemini...) for semantic findings ».
+- [ ] **Step 4:** Suite + clippy 2 modes — PASS (le test PATH-vide vérifie l'erreur explicite ; l'appel LLM réel n'est pas couvert en CI).
+- [ ] **Step 5:** `git add src/cli/ src/audit/ && git commit -m "feat(cli): audit --deep runs an optional LLM pass via a detected CLI"`
+
+---
+
+### Task 6: Vérif finale, démo (si CLI dispo), revue, PR
+
+- [ ] **Step 1:** fmt + clippy 2 modes + tests 2 modes — tout vert.
+- [ ] **Step 2: Démo réelle si un CLI LLM est installé** (sinon documenter le skip)
+```bash
+which claude gemini 2>/dev/null | head -1
+# si présent :
+cargo run --no-default-features --features tui -- audit /Users/bl209054/work/blg/applications/frontlibreservice/components/cls-monorepo --deep --quiet 2>&1 | tail -30
+```
+Consigner : findings D0x obtenus (types, exemples), ou section brute si JSON invalide, ou — si aucun CLI — noter que l'erreur explicite a été vérifiée par le test unitaire. NE PAS committer d'artefact.
+- [ ] **Step 3:** Revue de branche adversariale (dispatch fable) sur `origin/release/1.0.0..HEAD` : focus sur l'injection du prompt (fuite de secrets vers le CLI ? les prompts tronqués peuvent contenir des secrets A11 → à noter), le parsing JSON robuste (findings malformés, kind manquant, tableau vide), le blocage async, l'absence de régression sur le chemin non-`--deep`.
+- [ ] **Step 4:** Corriger les findings bloquants, re-revue, puis `git push -u origin feat/audit-deep` + PR vers `release/1.0.0` : `feat(audit): --deep optional LLM pass (D01-D05)`.
+
+---
+
+## Hors périmètre / notes
+
+- **Fuite de secrets** : le payload envoie des extraits de prompts qui peuvent contenir des secrets (que A11 détecte justement). À surveiller en revue — au minimum documenter que `--deep` transmet le contenu au CLI LLM configuré. Un masquage des motifs A11 avant envoi est un candidat backlog.
+- **Providers API** : le wiring détecte un CLI ; l'usage via un provider API pur (sans CLI) n'est pas exposé par un flag dédié (cohérent avec « erreur explicite si pas de CLI »). Extension backlog si besoin.
+- Fin de la série de plans d'audit (1 socle, 2 signal, 3 collisions, 4 propose, 5 deep). Backlog robustesse restant : agrégation C03/C05, C04 code-fences, offset file_line, Lot 3 propale (commands/, settings hooks), masquage secrets `--deep`.

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -23,7 +23,9 @@ pub async fn execute(
         )
     })?;
 
-    let _ = crate::core::project_registry::register_project(&root);
+    if let Err(e) = crate::core::project_registry::register_project(&root) {
+        tracing::warn!("Failed to register project in registry: {:?}", e);
+    }
     crate::core::model_updater::auto_check_and_prompt(&root, std::io::stdin().is_terminal());
 
     if config.agents.is_empty() {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -328,7 +328,9 @@ fn resolve_agents_dir() -> AgentResolution {
             root.display(),
             config.agents.len()
         );
-        let _ = crate::core::project_registry::register_project(&root);
+        if let Err(e) = crate::core::project_registry::register_project(&root) {
+            tracing::warn!("Failed to register project in registry: {:?}", e);
+        }
         crate::core::model_updater::auto_check_and_prompt(&root, !atty_is_pipe());
         return AgentResolution::Project {
             root,

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -144,7 +144,9 @@ fn setup_path() {
             .map(|m| m.file_type().is_symlink())
             .unwrap_or(false)
         {
-            let _ = std::fs::remove_file(&link_path);
+            if let Err(e) = std::fs::remove_file(&link_path) {
+                tracing::debug!("Failed to remove existing symlink: {:?}", e);
+            }
         } else {
             eprintln!(
                 "  [PATH] {} already exists and is not a symlink — skipping.",

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -76,7 +76,9 @@ pub async fn execute() -> anyhow::Result<()> {
 
     if !status.success() {
         // Clean up
-        let _ = std::fs::remove_file(&tmp_path);
+        if let Err(e) = std::fs::remove_file(&tmp_path) {
+            tracing::debug!("Failed to remove temporary download file: {:?}", e);
+        }
         anyhow::bail!(
             "Download failed. Check your network connection or try: VERSION=v{latest_version} install.sh"
         );

--- a/src/core/embedded.rs
+++ b/src/core/embedded.rs
@@ -14,7 +14,9 @@ pub(crate) fn needs_update(dest: &Path) -> bool {
 
 /// Write the current binary version into `.armadai-version` inside `dest`.
 pub(crate) fn write_version_marker(dest: &Path) {
-    let _ = std::fs::write(dest.join(".armadai-version"), env!("CARGO_PKG_VERSION"));
+    if let Err(e) = std::fs::write(dest.join(".armadai-version"), env!("CARGO_PKG_VERSION")) {
+        tracing::warn!("Failed to write version marker: {:?}", e);
+    }
 }
 
 #[cfg(test)]

--- a/src/core/starter.rs
+++ b/src/core/starter.rs
@@ -228,7 +228,9 @@ pub fn builtin_starters_dir() -> PathBuf {
         {
             let dest = config_starters.join(name);
             if !dest.exists() || super::embedded::needs_update(&dest) {
-                let _ = crate::core::skill::extract_embedded_dir(dir, &dest);
+                if let Err(e) = crate::core::skill::extract_embedded_dir(dir, &dest) {
+                    tracing::warn!("Failed to extract embedded starter '{}': {:?}", name, e);
+                }
                 super::embedded::write_version_marker(&dest);
             }
         }

--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -130,11 +130,15 @@ fn load_cache_from(path: &Path) -> Option<CachedRegistry> {
 
 #[cfg(any(feature = "providers-api", test))]
 fn save_cache_to(path: &Path, registry: &CachedRegistry) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!("Failed to create model registry cache directory: {:?}", e);
     }
-    if let Ok(json) = serde_json::to_string(registry) {
-        let _ = std::fs::write(path, json);
+    if let Ok(json) = serde_json::to_string(registry)
+        && let Err(e) = std::fs::write(path, json)
+    {
+        tracing::warn!("Failed to write model registry cache: {:?}", e);
     }
 }
 

--- a/src/providers/api/anthropic.rs
+++ b/src/providers/api/anthropic.rs
@@ -208,7 +208,14 @@ impl Provider for AnthropicProvider {
                 let chunk = match chunk {
                     Ok(c) => c,
                     Err(e) => {
-                        let _ = tx.send(Err(anyhow::anyhow!("Stream error: {e}"))).await;
+                        if let Err(send_err) =
+                            tx.send(Err(anyhow::anyhow!("Stream error: {e}"))).await
+                        {
+                            tracing::debug!(
+                                "Failed to send stream error (receiver dropped): {:?}",
+                                send_err
+                            );
+                        }
                         return;
                     }
                 };

--- a/src/providers/api/google.rs
+++ b/src/providers/api/google.rs
@@ -201,7 +201,14 @@ impl Provider for GoogleProvider {
                 let chunk = match chunk {
                     Ok(c) => c,
                     Err(e) => {
-                        let _ = tx.send(Err(anyhow::anyhow!("Stream error: {e}"))).await;
+                        if let Err(send_err) =
+                            tx.send(Err(anyhow::anyhow!("Stream error: {e}"))).await
+                        {
+                            tracing::debug!(
+                                "Failed to send stream error (receiver dropped): {:?}",
+                                send_err
+                            );
+                        }
                         return;
                     }
                 };

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -98,8 +98,12 @@ impl Provider for CliProvider {
             .await;
 
             if result.is_err() {
-                let _ = tx.send(Err(anyhow::anyhow!("CLI command timed out"))).await;
-                let _ = child.kill().await;
+                if let Err(e) = tx.send(Err(anyhow::anyhow!("CLI command timed out"))).await {
+                    tracing::debug!("Failed to send timeout error (receiver dropped): {:?}", e);
+                }
+                if let Err(e) = child.kill().await {
+                    tracing::debug!("Failed to kill timed-out CLI command: {:?}", e);
+                }
             }
 
             let _ = child.wait().await;

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -66,14 +66,18 @@ fn save_current_session(
 
 /// Restore the terminal to normal state. Called on exit and on panic.
 fn restore_terminal() {
-    let _ = disable_raw_mode();
-    let _ = execute!(
+    if let Err(e) = disable_raw_mode() {
+        tracing::warn!("Failed to disable raw mode: {:?}", e);
+    }
+    if let Err(e) = execute!(
         io::stdout(),
         crossterm::event::DisableBracketedPaste,
         crossterm::event::DisableMouseCapture,
         LeaveAlternateScreen,
         crossterm::cursor::Show
-    );
+    ) {
+        tracing::warn!("Failed to restore terminal state: {:?}", e);
+    }
 }
 
 /// Main shell entry point.
@@ -164,13 +168,15 @@ pub async fn run_shell() -> Result<()> {
     .await;
 
     // Final save on exit
-    let _ = save_current_session(
+    if let Err(e) = save_current_session(
         &session_id,
         &project_dir,
         &provider_name,
         &wizard_result.model_name,
         &runner,
-    );
+    ) {
+        tracing::warn!("Failed to save session on exit: {:?}", e);
+    }
 
     // Cleanup
     restore_terminal();
@@ -540,7 +546,9 @@ async fn event_loop(
                 && key.kind == KeyEventKind::Press
                 && is_cancel_key(&key)
             {
-                let _ = child.kill().await;
+                if let Err(e) = child.kill().await {
+                    tracing::debug!("Failed to kill cancelled command: {:?}", e);
+                }
                 app.append_to_streaming("\n\n[Cancelled]");
                 app.set_loading(false);
                 break;
@@ -663,13 +671,11 @@ async fn event_loop(
                     duration,
                 );
 
-                let _ = save_current_session(
-                    session_id,
-                    project_dir,
-                    provider_name,
-                    model_name,
-                    runner,
-                );
+                if let Err(e) =
+                    save_current_session(session_id, project_dir, provider_name, model_name, runner)
+                {
+                    tracing::warn!("Failed to save session: {:?}", e);
+                }
 
                 app.workroom.on_complete();
                 app.set_loading(false);
@@ -798,7 +804,10 @@ async fn execute_tandem(
     );
     app.set_loading(false);
 
-    let _ = save_current_session(session_id, project_dir, provider_name, model_name, runner);
+    if let Err(e) = save_current_session(session_id, project_dir, provider_name, model_name, runner)
+    {
+        tracing::warn!("Failed to save session: {:?}", e);
+    }
     Ok(())
 }
 
@@ -1020,7 +1029,10 @@ async fn execute_pipeline_steps(
     );
     app.set_loading(false);
 
-    let _ = save_current_session(session_id, project_dir, provider_name, model_name, runner);
+    if let Err(e) = save_current_session(session_id, project_dir, provider_name, model_name, runner)
+    {
+        tracing::warn!("Failed to save session: {:?}", e);
+    }
     Ok(())
 }
 
@@ -1137,6 +1149,9 @@ async fn execute_pty_turn(
 
     app.workroom.on_complete();
     app.set_loading(false);
-    let _ = save_current_session(session_id, project_dir, provider_name, model_name, runner);
+    if let Err(e) = save_current_session(session_id, project_dir, provider_name, model_name, runner)
+    {
+        tracing::warn!("Failed to save session: {:?}", e);
+    }
     Ok(())
 }

--- a/src/shell/pty_runner.rs
+++ b/src/shell/pty_runner.rs
@@ -174,7 +174,9 @@ impl PtySession {
 
     /// Kill the PTY process.
     pub fn kill(&mut self) {
-        let _ = self.child.kill();
+        if let Err(e) = self.child.kill() {
+            tracing::debug!("Failed to kill PTY process: {:?}", e);
+        }
     }
 
     /// Check if the child process is still running.

--- a/src/shell/session.rs
+++ b/src/shell/session.rs
@@ -111,8 +111,9 @@ pub fn log_stream_event(session_id: &str, event: &str) {
         .create(true)
         .append(true)
         .open(path)
+        && let Err(e) = writeln!(file, "{}", event)
     {
-        let _ = writeln!(file, "{}", event);
+        tracing::warn!("Failed to write session event: {:?}", e);
     }
 }
 


### PR DESCRIPTION
## Résumé

Résorbe le bloquant **B4 — Erreurs I/O avalées** pour la beta.2 en remplaçant tous les `let _ = ...` critiques par un logging explicite pour prévenir les pertes silencieuses de données.

## Scope

Sweep exhaustif de **93 occurrences** de `let _ = ` dans `src/`, catégorisées et traitées selon leur criticité :

### Critiques (loggées en `warn`) — 15 occurrences
| Fichier | Ligne(s) | Opération | Impact |
|---------|----------|-----------|--------|
| `src/shell/app.rs` | 69-80, 167-178, 672-679, 808-811, 1032-1035, 1151-1154 | Session saves + terminal restore | Perte de session, corruption terminal |
| `src/core/embedded.rs` | 17 | Version marker write | Init incomplet, redéploiements répétés |
| `src/shell/session.rs` | 115-118 | Event log writes | Perte d'événements |
| `src/cli/link.rs` | 26 | Project registry update | Registry inconsistent |
| `src/cli/run.rs` | 331 | Project registry update | Registry inconsistent |
| `src/core/starter.rs` | 231 | Embedded starter extraction | Init incomplet |
| `src/model_registry/fetch.rs` | 134, 137 | Cache dir + file writes | Cache inconsistent |

### Semi-critiques (loggées en `debug`) — 9 occurrences
| Fichier | Ligne(s) | Opération | Justification |
|---------|----------|-----------|---------------|
| `src/cli/setup.rs` | 147 | Symlink cleanup | Best-effort cleanup |
| `src/cli/update.rs` | 79 | Temp file cleanup | Best-effort cleanup |
| `src/providers/api/anthropic.rs` | 211-218 | Stream error send | Canal peut être fermé |
| `src/providers/api/google.rs` | 204-211 | Stream error send | Canal peut être fermé |
| `src/providers/cli.rs` | 101-106 | Timeout error + kill | Best-effort cleanup |
| `src/shell/app.rs` | 549 | Process kill on cancel | Best-effort cleanup |
| `src/shell/pty_runner.rs` | 177 | PTY kill | Best-effort cleanup |

### Non-critiques — 69 occurrences (inchangées)
- `src/audit/{proposal,report}.rs` (48x) : `writeln!(String)` → in-memory, pas I/O
- Variables intentionnellement ignorées (21x) : `let _ = (agent, _from);` etc.

## Vérifications

- ✅ Clippy mode TUI : `cargo clippy --all-targets --no-default-features --features tui -- -D warnings`
- ✅ Clippy mode TUI+API : `cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings`
- ✅ Tests : `cargo test --no-default-features --features tui,providers-api` (678 passed)
- ✅ Fmt : `cargo fmt -- --check`

## Notes

- Utilise des let chains pour éviter les if imbriqués (clippy::collapsible_if)
- Aucun changement de version (sera fait séparément)
- PR laissée ouverte pour validation utilisateur

Bloquant beta.2 : P0 B4

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>