### PR TITLE
fix(shell): enable streaming in Pipeline and Tandem modes [B1]

### DIFF
--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -10,6 +10,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::runner::ShellRunner;
@@ -740,6 +741,7 @@ async fn execute_tandem(
         child: tokio::process::Child,
         stream_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
         result_event: Option<super::json_runner::CliResponse>,
+        stderr_buffer: Arc<Mutex<String>>,
     }
 
     let mut streams = Vec::new();
@@ -784,6 +786,10 @@ async fn execute_tandem(
             }
         });
 
+        // Buffer to capture stderr for error reporting
+        let stderr_buffer = Arc::new(Mutex::new(String::new()));
+        let stderr_buf = stderr_buffer.clone();
+
         // Spawn reader task for stderr (to prevent buffer deadlock)
         tokio::spawn(async move {
             use tokio::io::AsyncReadExt;
@@ -792,8 +798,10 @@ async fn execute_tandem(
             loop {
                 match stderr.read(&mut buf).await {
                     Ok(0) | Err(_) => break,
-                    Ok(_n) => {
-                        // Discard stderr during streaming (errors handled via status code)
+                    Ok(n) => {
+                        if let Ok(s) = String::from_utf8(buf[..n].to_vec()) {
+                            stderr_buf.lock().unwrap().push_str(&s);
+                        }
                     }
                 }
             }
@@ -808,6 +816,7 @@ async fn execute_tandem(
             child,
             stream_rx,
             result_event: None,
+            stderr_buffer,
         });
     }
 
@@ -945,10 +954,13 @@ async fn execute_tandem(
                 combined_content.push_str(&parsed.content);
             }
             Ok(status) => {
-                app.append_to_tandem_stream(
-                    &stream.display_name,
-                    &format!("\n\n[Failed with status: {}]", status),
-                );
+                let stderr_content = stream.stderr_buffer.lock().unwrap();
+                let error_msg = if stderr_content.is_empty() {
+                    format!("\n\n[Failed with status: {}]", status)
+                } else {
+                    format!("\n\n[Failed with status: {}]\n{}", status, stderr_content)
+                };
+                app.append_to_tandem_stream(&stream.display_name, &error_msg);
             }
             Err(e) => {
                 app.append_to_tandem_stream(&stream.display_name, &format!("\n\n[Error: {}]", e));
@@ -1151,6 +1163,10 @@ async fn execute_pipeline_steps(
             }
         });
 
+        // Buffer to capture stderr for error reporting
+        let stderr_buffer = Arc::new(Mutex::new(String::new()));
+        let stderr_buf = stderr_buffer.clone();
+
         // Spawn reader task for stderr (to prevent buffer deadlock)
         tokio::spawn(async move {
             use tokio::io::AsyncReadExt;
@@ -1159,8 +1175,10 @@ async fn execute_pipeline_steps(
             loop {
                 match stderr.read(&mut buf).await {
                     Ok(0) | Err(_) => break,
-                    Ok(_n) => {
-                        // Discard stderr during streaming (errors handled via status code)
+                    Ok(n) => {
+                        if let Ok(s) = String::from_utf8(buf[..n].to_vec()) {
+                            stderr_buf.lock().unwrap().push_str(&s);
+                        }
                     }
                 }
             }
@@ -1264,10 +1282,19 @@ async fn execute_pipeline_steps(
                         current_input = parsed.content;
                     } else {
                         // Process failed
-                        app.append_to_streaming(&format!(
-                            "\n\n[Pipeline step '{}' failed with status: {}]",
-                            step.name, status
-                        ));
+                        let stderr_content = stderr_buffer.lock().unwrap();
+                        let error_msg = if stderr_content.is_empty() {
+                            format!(
+                                "\n\n[Pipeline step '{}' failed with status: {}]",
+                                step.name, status
+                            )
+                        } else {
+                            format!(
+                                "\n\n[Pipeline step '{}' failed with status: {}]\n{}",
+                                step.name, status, stderr_content
+                            )
+                        };
+                        app.append_to_streaming(&error_msg);
                         app.set_loading(false);
                         return Ok(());
                     }

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -739,7 +739,7 @@ async fn execute_tandem(
         cmd: String,
         child: tokio::process::Child,
         stream_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
-        accumulated_text: String,
+        result_event: Option<super::json_runner::CliResponse>,
     }
 
     let mut streams = Vec::new();
@@ -764,9 +764,10 @@ async fn execute_tandem(
         };
 
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
         let (stream_tx, stream_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-        // Spawn reader task for this provider
+        // Spawn reader task for stdout
         tokio::spawn(async move {
             use tokio::io::AsyncBufReadExt;
             let mut reader = tokio::io::BufReader::new(stdout);
@@ -783,12 +784,30 @@ async fn execute_tandem(
             }
         });
 
+        // Spawn reader task for stderr (to prevent buffer deadlock)
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut stderr = stderr;
+            let mut buf = vec![0u8; 4096];
+            loop {
+                match stderr.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_n) => {
+                        // Discard stderr during streaming (errors handled via status code)
+                    }
+                }
+            }
+        });
+
+        // Create empty streaming message for this provider
+        app.start_tandem_stream(&display_name);
+
         streams.push(ProviderStream {
             display_name,
             cmd,
             child,
             stream_rx,
-            accumulated_text: String::new(),
+            result_event: None,
         });
     }
 
@@ -830,27 +849,43 @@ async fn execute_tandem(
             return Ok(());
         }
 
-        // Drain all provider streams
+        // Drain all provider streams and append progressively
         let mut got_data = false;
         for stream in &mut streams {
             while let Ok(line) = stream.stream_rx.try_recv() {
+                super::session::log_stream_event(session_id, line.trim());
+
                 let is_json_mode = super::json_runner::supports_json(&stream.cmd);
                 if is_json_mode {
                     use super::json_runner::{StreamEvent, parse_stream_event};
                     match parse_stream_event(&stream.cmd, &line) {
-                        StreamEvent::Delta(text) | StreamEvent::Message(text) => {
-                            stream.accumulated_text.push_str(&text);
+                        StreamEvent::Delta(text) => {
+                            app.workroom.detect_mentions(&text);
+                            app.append_to_tandem_stream(&stream.display_name, &text);
                             got_data = true;
                         }
-                        StreamEvent::Result(resp) if !resp.content.is_empty() => {
-                            stream.accumulated_text.push_str(&resp.content);
+                        StreamEvent::Message(text) => {
+                            app.workroom.detect_mentions(&text);
+                            app.append_to_tandem_stream(&stream.display_name, &text);
                             got_data = true;
                         }
-                        _ => {}
+                        StreamEvent::Result(resp) => {
+                            // Store result event for metrics, do NOT append content
+                            stream.result_event = Some(resp);
+                        }
+                        StreamEvent::Error(msg) => {
+                            app.append_to_tandem_stream(
+                                &stream.display_name,
+                                &format!("\n\nError: {}", msg),
+                            );
+                            got_data = true;
+                        }
+                        StreamEvent::Ignored | StreamEvent::Init { .. } => {}
                     }
                 } else {
                     // Text mode fallback
-                    stream.accumulated_text.push_str(&line);
+                    app.workroom.parse_streaming_line(&line);
+                    app.append_to_tandem_stream(&stream.display_name, &line);
                     got_data = true;
                 }
             }
@@ -880,45 +915,43 @@ async fn execute_tandem(
         tokio::time::sleep(Duration::from_millis(30)).await;
     }
 
-    // Wait for all children to complete and collect final results
+    // Finalize: drain remaining events and wait for all children to complete
     let mut combined_content = String::new();
     for mut stream in streams {
+        // Drain any remaining stream events
+        let is_json_mode = super::json_runner::supports_json(&stream.cmd);
+        while let Ok(line) = stream.stream_rx.try_recv() {
+            if is_json_mode {
+                use super::json_runner::{StreamEvent, parse_stream_event};
+                match parse_stream_event(&stream.cmd, &line) {
+                    StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                        app.append_to_tandem_stream(&stream.display_name, &text);
+                    }
+                    StreamEvent::Result(resp) => {
+                        stream.result_event = Some(resp);
+                    }
+                    _ => {}
+                }
+            } else {
+                app.append_to_tandem_stream(&stream.display_name, &line);
+            }
+        }
+
         match stream.child.wait().await {
             Ok(status) if status.success() => {
-                let content = if stream.accumulated_text.is_empty() {
-                    // Fallback: read from final output if nothing was streamed
-                    let stderr = stream.child.stderr.take();
-                    if let Some(mut stderr) = stderr {
-                        use tokio::io::AsyncReadExt;
-                        let mut stderr_text = String::new();
-                        let _ = stderr.read_to_string(&mut stderr_text).await;
-                        super::parser::parse_response(&stderr_text).content
-                    } else {
-                        String::new()
-                    }
-                } else {
-                    super::parser::parse_response(&stream.accumulated_text).content
-                };
-
-                app.add_assistant_message_with_label(&stream.display_name, &content);
-                combined_content.push_str(&content);
+                // Content was already streamed progressively, just parse and clean markers
+                let content = app.get_assistant_content_by_label(&stream.display_name);
+                let parsed = super::parser::parse_response(&content);
+                combined_content.push_str(&parsed.content);
             }
-            Ok(_status) => {
-                let mut stderr_text = String::new();
-                if let Some(mut stderr) = stream.child.stderr.take() {
-                    use tokio::io::AsyncReadExt;
-                    let _ = stderr.read_to_string(&mut stderr_text).await;
-                }
-                app.add_assistant_message_with_label(
+            Ok(status) => {
+                app.append_to_tandem_stream(
                     &stream.display_name,
-                    &format!("Error: {}", stderr_text),
+                    &format!("\n\n[Failed with status: {}]", status),
                 );
             }
             Err(e) => {
-                app.add_assistant_message_with_label(
-                    &stream.display_name,
-                    &format!("Error: {}", e),
-                );
+                app.append_to_tandem_stream(&stream.display_name, &format!("\n\n[Error: {}]", e));
             }
         }
         terminal.draw(|f| app.render(f))?;
@@ -1078,6 +1111,9 @@ async fn execute_pipeline_steps(
             ));
         }
 
+        // Start streaming for this step
+        app.start_streaming_response();
+
         // Spawn process with streaming stdout
         let mut child = match tokio::process::Command::new(&resolved.cmd)
             .args(&resolved.args)
@@ -1088,19 +1124,17 @@ async fn execute_pipeline_steps(
         {
             Ok(child) => child,
             Err(e) => {
-                app.add_assistant_message_with_label(
-                    &resolved.display_label,
-                    &format!("Failed to spawn: {}", e),
-                );
+                app.update_last_assistant(&format!("Failed to spawn: {}", e));
                 app.set_loading(false);
                 return Ok(());
             }
         };
 
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
         let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-        // Spawn reader task
+        // Spawn reader task for stdout
         tokio::spawn(async move {
             use tokio::io::AsyncBufReadExt;
             let mut reader = tokio::io::BufReader::new(stdout);
@@ -1117,8 +1151,24 @@ async fn execute_pipeline_steps(
             }
         });
 
-        let mut accumulated_text = String::new();
+        // Spawn reader task for stderr (to prevent buffer deadlock)
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut stderr = stderr;
+            let mut buf = vec![0u8; 4096];
+            loop {
+                match stderr.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_n) => {
+                        // Discard stderr during streaming (errors handled via status code)
+                    }
+                }
+            }
+        });
+
         let is_json_mode = super::json_runner::supports_json(&resolved.cmd);
+        // Store result event (currently unused, could be used for per-step metrics in future)
+        let mut _result_event: Option<super::json_runner::CliResponse> = None;
 
         // Stream loop
         loop {
@@ -1132,29 +1182,43 @@ async fn execute_pipeline_steps(
                 && is_cancel_key(&key)
             {
                 let _ = child.kill().await;
-                app.add_system_message("[Pipeline cancelled]");
+                app.append_to_streaming("\n\n[Pipeline cancelled]");
                 app.set_loading(false);
                 return Ok(());
             }
 
-            // Drain stream and accumulate text
+            // Drain stream and append to UI progressively
             let mut got_data = false;
             while let Ok(line) = stream_rx.try_recv() {
+                super::session::log_stream_event(session_id, line.trim());
+
                 if is_json_mode {
                     use super::json_runner::{StreamEvent, parse_stream_event};
                     match parse_stream_event(&resolved.cmd, &line) {
-                        StreamEvent::Delta(text) | StreamEvent::Message(text) => {
-                            accumulated_text.push_str(&text);
+                        StreamEvent::Delta(text) => {
+                            app.workroom.detect_mentions(&text);
+                            app.append_to_streaming(&text);
                             got_data = true;
                         }
-                        StreamEvent::Result(resp) if !resp.content.is_empty() => {
-                            accumulated_text.push_str(&resp.content);
+                        StreamEvent::Message(text) => {
+                            app.workroom.detect_mentions(&text);
+                            app.append_to_streaming(&text);
                             got_data = true;
                         }
-                        _ => {}
+                        StreamEvent::Result(resp) => {
+                            // Store result event for metrics, do NOT append content
+                            _result_event = Some(resp);
+                        }
+                        StreamEvent::Error(msg) => {
+                            app.append_to_streaming(&format!("\n\nError: {}", msg));
+                            got_data = true;
+                        }
+                        StreamEvent::Ignored | StreamEvent::Init { .. } => {}
                     }
                 } else {
-                    accumulated_text.push_str(&line);
+                    // Text mode fallback
+                    app.workroom.parse_streaming_line(&line);
+                    app.append_to_streaming(&line);
                     got_data = true;
                 }
             }
@@ -1166,31 +1230,44 @@ async fn execute_pipeline_steps(
             // Check if child finished
             match child.try_wait() {
                 Ok(Some(status)) => {
-                    if status.success() {
-                        let content = if accumulated_text.is_empty() {
-                            // Fallback if nothing was streamed
-                            String::new()
+                    // Drain remaining stream events
+                    while let Ok(line) = stream_rx.try_recv() {
+                        if is_json_mode {
+                            use super::json_runner::{StreamEvent, parse_stream_event};
+                            match parse_stream_event(&resolved.cmd, &line) {
+                                StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                                    app.append_to_streaming(&text);
+                                }
+                                StreamEvent::Result(resp) => {
+                                    _result_event = Some(resp);
+                                }
+                                _ => {}
+                            }
                         } else {
-                            super::parser::parse_response(&accumulated_text).content
-                        };
+                            app.append_to_streaming(&line);
+                        }
+                    }
 
+                    if status.success() {
+                        // Get the streamed content
+                        let content = app.get_last_assistant_content();
+                        let parsed = super::parser::parse_response(&content);
+
+                        // Update message with label and parsed content
                         let label = if is_last {
                             format!("{} (final)", resolved.display_label)
                         } else {
                             format!("{} (step {})", resolved.display_label, i + 1)
                         };
-                        app.add_assistant_message_with_label(&label, &content);
-                        current_input = content;
+
+                        app.update_last_assistant_with_label(&label, &parsed.content);
+                        current_input = parsed.content;
                     } else {
-                        let mut stderr_text = String::new();
-                        if let Some(mut stderr) = child.stderr.take() {
-                            use tokio::io::AsyncReadExt;
-                            let _ = stderr.read_to_string(&mut stderr_text).await;
-                        }
-                        app.add_assistant_message_with_label(
-                            &resolved.display_label,
-                            &format!("Error: {}", stderr_text),
-                        );
+                        // Process failed
+                        app.append_to_streaming(&format!(
+                            "\n\n[Pipeline step '{}' failed with status: {}]",
+                            step.name, status
+                        ));
                         app.set_loading(false);
                         return Ok(());
                     }
@@ -1200,10 +1277,7 @@ async fn execute_pipeline_steps(
                     // Still running, continue loop
                 }
                 Err(e) => {
-                    app.add_assistant_message_with_label(
-                        &resolved.display_label,
-                        &format!("Error checking process: {}", e),
-                    );
+                    app.update_last_assistant(&format!("Error checking process: {}", e));
                     app.set_loading(false);
                     return Ok(());
                 }

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -733,60 +733,192 @@ async fn execute_tandem(
     app.set_loading(true);
     let prompt = runner.build_prompt_for(input);
 
-    // Spawn all providers in parallel
-    let mut handles = Vec::new();
+    // Spawn all providers in parallel with streaming
+    struct ProviderStream {
+        display_name: String,
+        cmd: String,
+        child: tokio::process::Child,
+        stream_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+        accumulated_text: String,
+    }
+
+    let mut streams = Vec::new();
     for provider in &resolved {
         let cmd = provider.command.clone();
         let args = provider.args.clone();
         let prompt = prompt.clone();
         let display_name = provider.display_name.clone();
 
-        handles.push(tokio::spawn(async move {
-            let output = tokio::process::Command::new(&cmd)
-                .args(&args)
-                .arg(&prompt)
-                .output()
-                .await;
-            (display_name, cmd, output)
-        }));
+        let mut child = match tokio::process::Command::new(&cmd)
+            .args(&args)
+            .arg(&prompt)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                app.add_system_message(&format!("Failed to spawn {}: {}", display_name, e));
+                continue;
+            }
+        };
+
+        let stdout = child.stdout.take().unwrap();
+        let (stream_tx, stream_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+        // Spawn reader task for this provider
+        tokio::spawn(async move {
+            use tokio::io::AsyncBufReadExt;
+            let mut reader = tokio::io::BufReader::new(stdout);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        let _ = stream_tx.send(line.clone());
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        streams.push(ProviderStream {
+            display_name,
+            cmd,
+            child,
+            stream_rx,
+            accumulated_text: String::new(),
+        });
+    }
+
+    if streams.is_empty() {
+        app.add_system_message("No providers could be started for tandem.");
+        app.set_loading(false);
+        return Ok(());
     }
 
     // Show spinner while waiting
     app.add_system_message(&format!(
         "⚡ Tandem: sending to {} in parallel...",
-        resolved
+        streams
             .iter()
-            .map(|p| p.display_name.as_str())
+            .map(|s| s.display_name.as_str())
             .collect::<Vec<_>>()
             .join(" + ")
     ));
     terminal.draw(|f| app.render(f))?;
 
-    // Collect results
-    let mut combined_content = String::new();
-    for handle in handles {
-        let (name, cmd, output_result) = handle
-            .await
-            .map_err(|e| anyhow::anyhow!("Join error: {e}"))?;
-        match output_result {
-            Ok(output) if output.status.success() => {
-                let raw = String::from_utf8_lossy(&output.stdout).to_string();
-                let text = super::json_runner::collect_text_from_jsonl(&cmd, &raw);
-                let content = if text.is_empty() {
-                    super::parser::parse_response(&raw).content
+    // Stream loop: drain all channels and render incrementally
+    let mut active_streams = streams.len();
+    while active_streams > 0 {
+        app.tick_spinner();
+        app.workroom.tick();
+        terminal.draw(|f| app.render(f))?;
+
+        // Check for cancel
+        if event::poll(Duration::from_millis(30))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && is_cancel_key(&key)
+        {
+            for stream in &mut streams {
+                let _ = stream.child.kill().await;
+            }
+            app.add_system_message("[Tandem cancelled]");
+            app.set_loading(false);
+            return Ok(());
+        }
+
+        // Drain all provider streams
+        let mut got_data = false;
+        for stream in &mut streams {
+            while let Ok(line) = stream.stream_rx.try_recv() {
+                let is_json_mode = super::json_runner::supports_json(&stream.cmd);
+                if is_json_mode {
+                    use super::json_runner::{StreamEvent, parse_stream_event};
+                    match parse_stream_event(&stream.cmd, &line) {
+                        StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                            stream.accumulated_text.push_str(&text);
+                            got_data = true;
+                        }
+                        StreamEvent::Result(resp) if !resp.content.is_empty() => {
+                            stream.accumulated_text.push_str(&resp.content);
+                            got_data = true;
+                        }
+                        _ => {}
+                    }
                 } else {
-                    super::parser::parse_response(&text).content
+                    // Text mode fallback
+                    stream.accumulated_text.push_str(&line);
+                    got_data = true;
+                }
+            }
+        }
+
+        if got_data {
+            terminal.draw(|f| app.render(f))?;
+        }
+
+        // Check if any child has finished
+        active_streams = 0;
+        for stream in &mut streams {
+            match stream.child.try_wait() {
+                Ok(Some(_status)) => {
+                    // Child finished, continue to next
+                }
+                Ok(None) => {
+                    // Still running
+                    active_streams += 1;
+                }
+                Err(_) => {
+                    // Error checking status, assume finished
+                }
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+    }
+
+    // Wait for all children to complete and collect final results
+    let mut combined_content = String::new();
+    for mut stream in streams {
+        match stream.child.wait().await {
+            Ok(status) if status.success() => {
+                let content = if stream.accumulated_text.is_empty() {
+                    // Fallback: read from final output if nothing was streamed
+                    let stderr = stream.child.stderr.take();
+                    if let Some(mut stderr) = stderr {
+                        use tokio::io::AsyncReadExt;
+                        let mut stderr_text = String::new();
+                        let _ = stderr.read_to_string(&mut stderr_text).await;
+                        super::parser::parse_response(&stderr_text).content
+                    } else {
+                        String::new()
+                    }
+                } else {
+                    super::parser::parse_response(&stream.accumulated_text).content
                 };
 
-                app.add_assistant_message_with_label(&name, &content);
+                app.add_assistant_message_with_label(&stream.display_name, &content);
                 combined_content.push_str(&content);
             }
-            Ok(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                app.add_assistant_message_with_label(&name, &format!("Error: {}", stderr));
+            Ok(_status) => {
+                let mut stderr_text = String::new();
+                if let Some(mut stderr) = stream.child.stderr.take() {
+                    use tokio::io::AsyncReadExt;
+                    let _ = stderr.read_to_string(&mut stderr_text).await;
+                }
+                app.add_assistant_message_with_label(
+                    &stream.display_name,
+                    &format!("Error: {}", stderr_text),
+                );
             }
             Err(e) => {
-                app.add_assistant_message_with_label(&name, &format!("Error: {}", e));
+                app.add_assistant_message_with_label(
+                    &stream.display_name,
+                    &format!("Error: {}", e),
+                );
             }
         }
         terminal.draw(|f| app.render(f))?;
@@ -946,43 +1078,100 @@ async fn execute_pipeline_steps(
             ));
         }
 
-        let (tx, mut rx) = tokio::sync::oneshot::channel();
-        let cmd_clone = resolved.cmd.clone();
-        let args_clone = resolved.args.clone();
-        let prompt_clone = full_prompt.clone();
+        // Spawn process with streaming stdout
+        let mut child = match tokio::process::Command::new(&resolved.cmd)
+            .args(&resolved.args)
+            .arg(&full_prompt)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                app.add_assistant_message_with_label(
+                    &resolved.display_label,
+                    &format!("Failed to spawn: {}", e),
+                );
+                app.set_loading(false);
+                return Ok(());
+            }
+        };
 
+        let stdout = child.stdout.take().unwrap();
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+        // Spawn reader task
         tokio::spawn(async move {
-            let output = tokio::process::Command::new(&cmd_clone)
-                .args(&args_clone)
-                .arg(&prompt_clone)
-                .output()
-                .await;
-            let _ = tx.send(output);
+            use tokio::io::AsyncBufReadExt;
+            let mut reader = tokio::io::BufReader::new(stdout);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        let _ = stream_tx.send(line.clone());
+                    }
+                    Err(_) => break,
+                }
+            }
         });
 
+        let mut accumulated_text = String::new();
+        let is_json_mode = super::json_runner::supports_json(&resolved.cmd);
+
+        // Stream loop
         loop {
             app.tick_spinner();
+            app.workroom.tick();
             terminal.draw(|f| app.render(f))?;
 
-            if event::poll(Duration::from_millis(80))?
+            if event::poll(Duration::from_millis(30))?
                 && let Event::Key(key) = event::read()?
                 && key.kind == KeyEventKind::Press
                 && is_cancel_key(&key)
             {
+                let _ = child.kill().await;
                 app.add_system_message("[Pipeline cancelled]");
                 app.set_loading(false);
                 return Ok(());
             }
 
-            if let Ok(output_result) = rx.try_recv() {
-                match output_result {
-                    Ok(output) if output.status.success() => {
-                        let raw = String::from_utf8_lossy(&output.stdout).to_string();
-                        let text = super::json_runner::collect_text_from_jsonl(&resolved.cmd, &raw);
-                        let content = if text.is_empty() {
-                            super::parser::parse_response(&raw).content
+            // Drain stream and accumulate text
+            let mut got_data = false;
+            while let Ok(line) = stream_rx.try_recv() {
+                if is_json_mode {
+                    use super::json_runner::{StreamEvent, parse_stream_event};
+                    match parse_stream_event(&resolved.cmd, &line) {
+                        StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                            accumulated_text.push_str(&text);
+                            got_data = true;
+                        }
+                        StreamEvent::Result(resp) if !resp.content.is_empty() => {
+                            accumulated_text.push_str(&resp.content);
+                            got_data = true;
+                        }
+                        _ => {}
+                    }
+                } else {
+                    accumulated_text.push_str(&line);
+                    got_data = true;
+                }
+            }
+
+            if got_data {
+                terminal.draw(|f| app.render(f))?;
+            }
+
+            // Check if child finished
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if status.success() {
+                        let content = if accumulated_text.is_empty() {
+                            // Fallback if nothing was streamed
+                            String::new()
                         } else {
-                            super::parser::parse_response(&text).content
+                            super::parser::parse_response(&accumulated_text).content
                         };
 
                         let label = if is_last {
@@ -992,27 +1181,35 @@ async fn execute_pipeline_steps(
                         };
                         app.add_assistant_message_with_label(&label, &content);
                         current_input = content;
-                    }
-                    Ok(output) => {
-                        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    } else {
+                        let mut stderr_text = String::new();
+                        if let Some(mut stderr) = child.stderr.take() {
+                            use tokio::io::AsyncReadExt;
+                            let _ = stderr.read_to_string(&mut stderr_text).await;
+                        }
                         app.add_assistant_message_with_label(
                             &resolved.display_label,
-                            &format!("Error: {}", stderr),
+                            &format!("Error: {}", stderr_text),
                         );
                         app.set_loading(false);
                         return Ok(());
                     }
-                    Err(e) => {
-                        app.add_assistant_message_with_label(
-                            &resolved.display_label,
-                            &format!("Error: {}", e),
-                        );
-                        app.set_loading(false);
-                        return Ok(());
-                    }
+                    break;
                 }
-                break;
+                Ok(None) => {
+                    // Still running, continue loop
+                }
+                Err(e) => {
+                    app.add_assistant_message_with_label(
+                        &resolved.display_label,
+                        &format!("Error checking process: {}", e),
+                    );
+                    app.set_loading(false);
+                    return Ok(());
+                }
             }
+
+            tokio::time::sleep(Duration::from_millis(30)).await;
         }
         terminal.draw(|f| app.render(f))?;
     }

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -179,12 +179,49 @@ impl ShellApp {
         }
     }
 
+    /// Start a streaming response for a specific provider in tandem mode
+    pub fn start_tandem_stream(&mut self, provider_label: &str) {
+        self.messages.push(DisplayMessage {
+            role: provider_label.to_string(),
+            content: String::new(),
+            is_user: false,
+            is_system: false,
+        });
+        self.manual_scroll = false;
+        self.scroll = 0;
+    }
+
+    /// Append text to a specific provider's streaming response in tandem mode
+    pub fn append_to_tandem_stream(&mut self, provider_label: &str, text: &str) {
+        // Find the message with matching role (search from end for latest)
+        if let Some(msg) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find(|m| m.role == provider_label && !m.is_user && !m.is_system)
+        {
+            msg.content.push_str(text);
+            self.manual_scroll = false;
+            self.scroll = 0;
+        }
+    }
+
     /// Get content of the last assistant message
     pub fn get_last_assistant_content(&self) -> String {
         self.messages
             .iter()
             .rev()
             .find(|m| !m.is_user && !m.is_system)
+            .map(|m| m.content.clone())
+            .unwrap_or_default()
+    }
+
+    /// Get content of an assistant message by label (for tandem mode)
+    pub fn get_assistant_content_by_label(&self, label: &str) -> String {
+        self.messages
+            .iter()
+            .rev()
+            .find(|m| m.role == label && !m.is_user && !m.is_system)
             .map(|m| m.content.clone())
             .unwrap_or_default()
     }
@@ -197,6 +234,19 @@ impl ShellApp {
             .rev()
             .find(|m| !m.is_user && !m.is_system)
         {
+            last.content = content.to_string();
+        }
+    }
+
+    /// Update the last assistant message label and content
+    pub fn update_last_assistant_with_label(&mut self, label: &str, content: &str) {
+        if let Some(last) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find(|m| !m.is_user && !m.is_system)
+        {
+            last.role = label.to_string();
             last.content = content.to_string();
         }
     }


### PR DESCRIPTION
## Contexte
Bloquant P0 **B1 — Streaming Pipeline/Tandem** pour la beta.2.

## Problème
Les modes Pipeline et Tandem restaient bufferisés (spinner tourne mais pas de texte progressif), alors que le mode normal streame correctement.

**Cause racine** : utilisation de `.output()` qui bloque jusqu'à la fin du processus, au lieu de `.spawn()` + lecture incrémentale.

## Solution
Remplacer `.output()` par `.spawn()` avec lecture incrémentale du stdout dans les deux fonctions :
1. **`execute_tandem`** (L687) : spawn chaque provider avec stdout pipeé, créer un channel de streaming par provider, drainer tous les channels en parallèle pendant l'exécution
2. **`execute_pipeline_steps`** (L834) : remplacer le oneshot channel par spawn + stream, parser les events JSONL de manière incrémentale, appeler `workroom.tick()` dans la boucle de render

## Modifications techniques
- Réutilisation de l'infrastructure de streaming existante (`src/shell/json_runner.rs`)
- Parser chaque ligne avec `parse_stream_event` pour extraire les deltas de texte
- Appel à `workroom.tick()` pour maintenir l'UI réactive
- Support du mode JSON (claude, gemini, codex, etc.) ET du mode texte (aider)
- Gestion des erreurs et des annulations (Esc / Ctrl+C)

## Tests
✅ Clippy passe dans les deux modes features (`tui` et `tui,providers-api`)  
✅ Tous les tests existants passent (678 tests)  
✅ Code formaté avec `cargo fmt`

## Impact utilisateur
Les utilisateurs voient maintenant du texte progressif au lieu d'un spinner jusqu'à la fin de l'exécution dans les modes Pipeline et Tandem.

## Checklist
- [x] Clippy (2 modes) : ✅
- [x] Tests : ✅ 678 passed
- [x] Formatage : ✅
- [x] Commit conventionnel : ✅ `fix(shell):`
- [ ] Validation utilisateur requise (test manuel)