### PR TITLE
chore(release): bump to 1.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v1.0.0-beta.2 (2026-07-17)
+
+Second beta of the 1.0.0 release. Resolves the four P0 blockers from the
+v1.0.0 review and integrates the RUSTSEC security fixes carried over from the
+dependency syncs.
+
+### Fixed
+
+- **[B1] Real streaming in Pipeline and Tandem modes** (#169): progressive
+  output rendering with a final drain, concurrent stderr capture that is also
+  shown on failure, and removal of the previous output duplication.
+- **[B2] Cursor wrapping on multi-line input** (#170): correct cursor position
+  on wrapped lines using `unicode-width`, with scroll support.
+- **[B3] Poisoned mutex handling in the hierarchical orchestration engine**
+  (#168): recovery and `Result`-based propagation instead of panicking.
+- **[B4] I/O errors are logged instead of silently ignored** (#167): failures
+  are surfaced via `tracing::warn!` / `tracing::debug!`.
+
+### Security
+
+- **RUSTSEC**: transitive advisories in `quick-xml` and `quinn-proto` resolved
+  via dependency sync bumps.
+
 ## v0.12.0 (2026-04-09)
 
 ### New: `armadai shell` — Interactive Conversational TUI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "armadai"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 edition = "2024"
 description = "ArmadAI — AI agent orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
Bump `1.0.0-beta.1` → `1.0.0-beta.2` + entrée CHANGELOG dédiée.

## Contenu de beta.2 (déjà mergé sur release/1.0.0)
- **B1** (#169) — streaming réel Pipeline/Tandem (progressif, drain final, stderr concurrent + affiché sur échec, plus de duplication)
- **B2** (#170) — wrapping curseur multi-ligne (unicode-width + scroll)
- **B3** (#168) — mutex empoisonnés dans le moteur hiérarchique (recovery + Result, plus de panic)
- **B4** (#167) — erreurs I/O loggées au lieu d'être avalées
- **Sécurité** — RUSTSEC quick-xml / quinn-proto (via syncs de deps)

## Vérifs locales
- `cargo fmt -- --check` ✅
- clippy 2 modes (`tui`, `tui,providers-api`) ✅
- `cargo test` → 689 passed ✅

Pas de tag posé dans cette PR (le tag `v1.0.0-beta.2` sera décidé après merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)