### PR TITLE
chore(release): bump to 1.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## v1.0.0-beta.3 (2026-07-17)
+
+Third beta of the 1.0.0 release. Adds two OpenHands-study features: a
+CI-first headless mode for `armadai run` and a dynamic model-tier router.
+
+### Feat
+
+- **[OH3] Headless CI mode for `armadai run`** (#173): new `--headless`
+  (non-interactive, CI exit codes, skips the model-updater prompt), `--json`
+  (structured JSONL event stream on stdout), `--quiet` (result event only),
+  and `--max-content N` (truncates intermediate event content) flags.
+  Introduces `RunEvent`/`EventSink` (`NullSink`/`JsonlSink`) in
+  `core/events.rs`, with short JSON keys for token economy. High-level
+  events — `run_start`, `agent_start`, `agent_end`, `warning`, `result`,
+  `error` — are instrumented on the single-agent path, `--pipe`, and
+  orchestration (blackboard/ring/hierarchical) at the per-agent level. CI
+  exit codes: `0` success, `1` execution error, `2` usage error, `3` budget
+  exhaustion (`Err`-propagating paths only — orchestration budget halts
+  remain a graceful partial result with exit `0`), `4` provider unavailable.
+- **[OH4] Dynamic model-tier router (`model: latest:auto`)** (#174): an
+  agent declaring `model: latest:auto` has its tier (`Fast`/`Pro`/`Max`)
+  selected at run time by zero-token static heuristics — input length,
+  keyword matching, agent tags (override), and budget (cap) — then resolved
+  to a concrete model via `resolve_model_for_tier`. Signal precedence:
+  tag override → `max(length, keywords)` → budget cap. Defaults are
+  embedded and overridable per-field via `armadai.yaml > routing:`.
+  `ModelTier` is now orderable (`Fast < Pro < Max`). Emits
+  `RunEvent::Route { agent, tier, reason }` in `--json` mode (OH3 synergy).
+  Scoped to the single-agent/`--pipe` path in this release; orchestration
+  continues to use its own `agent_model` resolution.
+
 ## v1.0.0-beta.2 (2026-07-17)
 
 Second beta of the 1.0.0 release. Resolves the four P0 blockers from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "armadai"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 edition = "2024"
 description = "ArmadAI — AI agent orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
Third beta of the 1.0.0 release. Bumps version and documents the two beta.3 features already merged into `release/1.0.0`:

- **OH3** (#173): CI-first headless mode for `armadai run` — `--headless`/`--json`/`--quiet`/`--max-content`, `RunEvent`/`EventSink` JSONL contract, CI exit codes.
- **OH4** (#174): dynamic model-tier router — `model: latest:auto`, static heuristics (length/keywords/tags/budget), `armadai.yaml > routing:` config, `RunEvent::Route`.

## Changes
- `Cargo.toml` / `Cargo.lock`: `1.0.0-beta.2` → `1.0.0-beta.3` (no other dependency bumps)
- `CHANGELOG.md`: new `v1.0.0-beta.3 (2026-07-17)` section

## Verification (local, this branch)
- `cargo fmt -- --check`: pass
- `cargo clippy --all-targets --no-default-features --features tui -- -D warnings`: pass
- `cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings`: pass
- `cargo test --no-default-features --features tui,providers-api`: 708 passed, 0 failed

## Not in this PR
No tag, no merge — release manager process: this PR only prepares the bump. Tag + merge handled separately after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)