### PR TITLE
chore(debt): resolve beta.2/beta.3 minor technical debt

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -48,8 +48,9 @@ pub async fn execute(
 
     if let Err(e) = result {
         if headless {
+            let code = exit_code_for(&e);
             sink.emit(&RunEvent::Error {
-                code: match exit_code_for(&e) {
+                code: match code {
                     3 => "budget_exceeded",
                     4 => "provider_unavailable",
                     _ => "agent_failed",
@@ -57,7 +58,7 @@ pub async fn execute(
                 .into(),
                 msg: e.to_string(),
             });
-            std::process::exit(exit_code_for(&e));
+            std::process::exit(code);
         }
         return Err(e);
     }
@@ -368,11 +369,11 @@ async fn run_single_agent(
     };
     let duration = start.elapsed();
 
-    let content_out = match max_content {
-        Some(n) if !quiet => response.content.chars().take(n).collect::<String>(),
-        _ => response.content.clone(),
-    };
     if !quiet {
+        let content_out = match max_content {
+            Some(n) => response.content.chars().take(n).collect::<String>(),
+            None => response.content.clone(),
+        };
         sink.emit(&RunEvent::AgentEnd {
             agent: agent_name.to_string(),
             tin: response.tokens_in,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -555,10 +555,20 @@ async fn run_orchestrated(
     for name in agent_names {
         let agent_path = resolve_agent_path(resolution, name)?;
         let mut agent = crate::parser::parse_agent_file(&agent_path)?;
+
+        let model_before = agent.metadata.model.clone();
         crate::linker::model_aliases::resolve_model_deprecations(
             &mut agent.metadata.model,
             &mut agent.metadata.model_fallback,
         );
+        if agent.metadata.model != model_before {
+            sink.emit(&RunEvent::Warning {
+                code: "deprecated_model".to_string(),
+                from: model_before,
+                to: agent.metadata.model.clone(),
+            });
+        }
+
         sink.emit(&RunEvent::AgentStart {
             agent: name.clone(),
             prov: agent.metadata.provider.clone(),

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -18,6 +18,8 @@ significantly change your approach, ask 2-3 targeted clarifying questions first.
 Only proceed with your complete response once you have enough context to deliver \
 accurate, relevant output.";
 
+/// Execute a run command. Parameters are independent CLI options that map directly to
+/// configuration flags; grouping into a struct would obscure the caller's argument binding.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute(
     agent_name: String,
@@ -86,6 +88,7 @@ fn exit_code_for(err: &anyhow::Error) -> i32 {
 
 /// Core run logic (sequential or orchestrated). Kept separate from [`execute`] so that
 /// all error paths funnel through a single headless error-event + exit-code handler.
+/// Parameters are passed directly from `execute` and represent distinct configuration concerns.
 #[allow(clippy::too_many_arguments)]
 async fn run_inner(
     agent_name: String,
@@ -246,6 +249,9 @@ fn resolve_agent_path(resolution: &AgentResolution, agent_name: &str) -> anyhow:
     }
 }
 
+/// Execute a single agent with given input and configuration. Parameters represent
+/// environment (path, input), configuration (defaults, rules), and I/O (sink, quiet, max_content);
+/// grouping would obscure distinct concerns in request building and provider creation.
 #[allow(clippy::too_many_arguments)]
 async fn run_single_agent(
     agent_path: &Path,

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 use serde::Serialize;
 
 /// Structured run events emitted in headless/JSON mode. Short keys for token economy.
-#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 #[serde(tag = "t", rename_all = "snake_case")]
 pub enum RunEvent {
@@ -52,24 +51,20 @@ pub enum RunEvent {
 }
 
 /// Sink for run events. `NullSink` is a zero-cost no-op; `JsonlSink` writes JSONL to a writer.
-#[allow(dead_code)]
 pub trait EventSink: Send + Sync {
     fn emit(&self, ev: &RunEvent);
 }
 
-#[allow(dead_code)]
 pub struct NullSink;
 impl EventSink for NullSink {
     fn emit(&self, _ev: &RunEvent) {}
 }
 
-#[allow(dead_code)]
 pub struct JsonlSink {
     pub out: Mutex<Box<dyn std::io::Write + Send>>,
 }
 
 impl JsonlSink {
-    #[allow(dead_code)]
     pub fn stdout() -> Self {
         JsonlSink {
             out: Mutex::new(Box::new(std::io::stdout())),
@@ -88,7 +83,6 @@ impl EventSink for JsonlSink {
 }
 
 /// Build the sink for a run: JSONL to stdout when `json`, otherwise a no-op.
-#[allow(dead_code)]
 pub fn make_sink(json: bool) -> Arc<dyn EventSink> {
     if json {
         Arc::new(JsonlSink::stdout())

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -57,7 +57,6 @@ pub struct ProjectConfig {
     pub skills: Vec<SkillRef>,
     pub sources: Vec<String>,
     pub link: Option<LinkConfig>,
-    #[serde(default)]
     pub defaults: ProjectDefaults,
     /// Top-level orchestration configuration (teams, coordinator, pattern).
     pub orchestration: Option<Box<OrchestrationConfig>>,
@@ -67,7 +66,6 @@ pub struct ProjectConfig {
     /// for `latest:auto` agents. See `crate::core::routing::RoutingRules`.
     /// Consumed in `cli::run::execute` to build the `RoutingRules` passed to
     /// `run_single_agent` for `latest:auto` model resolution.
-    #[serde(default)]
     pub routing: Option<crate::core::routing::RoutingRules>,
 }
 

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -24,6 +24,28 @@ fn is_cancel_key(key: &event::KeyEvent) -> bool {
             && key.modifiers == crossterm::event::KeyModifiers::CONTROL)
 }
 
+/// Fold one pipeline step's exact metrics into the running aggregate.
+///
+/// Pipeline steps run in **series**, each on a different input (step *n*'s
+/// input is step *n-1*'s output), so `tokens_in` must be **summed** across
+/// steps. This is the opposite of tandem mode, where every provider receives
+/// the *same* input and only the first `tokens_in` should be kept to avoid
+/// double-counting.
+fn accumulate_pipeline_metrics(
+    aggregated_tokens_in: &mut Option<u64>,
+    aggregated_tokens_out: &mut u64,
+    aggregated_cost: &mut f64,
+    resp: &super::json_runner::CliResponse,
+) {
+    *aggregated_tokens_in = Some(aggregated_tokens_in.unwrap_or(0) + resp.tokens_in.unwrap_or(0));
+    if let Some(out) = resp.tokens_out {
+        *aggregated_tokens_out += out;
+    }
+    if let Some(cost) = resp.cost_usd {
+        *aggregated_cost += cost;
+    }
+}
+
 /// Helper to save the current session state.
 fn save_current_session(
     session_id: &str,
@@ -1365,17 +1387,17 @@ async fn execute_pipeline_steps(
                         app.update_last_assistant_with_label(&label, &parsed.content);
                         current_input = parsed.content;
 
-                        // Aggregate real metrics from result_event
-                        if let Some(resp) = step_result_event {
-                            if aggregated_tokens_in.is_none() {
-                                aggregated_tokens_in = resp.tokens_in;
-                            }
-                            if let Some(out) = resp.tokens_out {
-                                aggregated_tokens_out += out;
-                            }
-                            if let Some(cost) = resp.cost_usd {
-                                aggregated_cost += cost;
-                            }
+                        // Aggregate real metrics from result_event. Pipeline steps run in
+                        // series on different inputs, so tokens_in is summed across steps
+                        // (unlike tandem mode, where the first value is kept — see
+                        // `accumulate_pipeline_metrics`).
+                        if let Some(resp) = &step_result_event {
+                            accumulate_pipeline_metrics(
+                                &mut aggregated_tokens_in,
+                                &mut aggregated_tokens_out,
+                                &mut aggregated_cost,
+                                resp,
+                            );
                         }
                     } else {
                         // Process failed
@@ -1560,4 +1582,69 @@ async fn execute_pty_turn(
         tracing::warn!("Failed to save session: {:?}", e);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::json_runner::CliResponse;
+    use super::*;
+
+    /// Build a minimal `CliResponse` fixture with only the metrics fields set.
+    fn resp(tokens_in: Option<u64>, tokens_out: Option<u64>, cost_usd: Option<f64>) -> CliResponse {
+        CliResponse {
+            content: String::new(),
+            tokens_in,
+            tokens_out,
+            cost_usd,
+            duration_ms: None,
+            model: None,
+            session_id: None,
+            from_json: true,
+        }
+    }
+
+    #[test]
+    fn pipeline_metrics_sum_tokens_in_across_steps() {
+        // Regression test for PR #176: pipeline steps run in series on
+        // DIFFERENT inputs (each step's input is the previous step's
+        // output), so tokens_in must be summed, not taken from the first
+        // step only — otherwise steps 2..N's input tokens are silently lost.
+        let mut tokens_in = None;
+        let mut tokens_out = 0u64;
+        let mut cost = 0.0f64;
+
+        let steps = [
+            resp(Some(100), Some(20), Some(0.01)),
+            resp(Some(50), Some(10), Some(0.02)),
+            resp(Some(30), Some(5), Some(0.005)),
+        ];
+
+        for step in &steps {
+            accumulate_pipeline_metrics(&mut tokens_in, &mut tokens_out, &mut cost, step);
+        }
+
+        assert_eq!(tokens_in, Some(100 + 50 + 30));
+        assert_eq!(tokens_out, 20 + 10 + 5);
+        assert!((cost - (0.01 + 0.02 + 0.005)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn pipeline_metrics_treat_missing_tokens_in_as_zero_contribution() {
+        // A step whose result event doesn't report tokens_in shouldn't reset
+        // or block the running total — it contributes 0 and later steps'
+        // real values still get added on top.
+        let mut tokens_in = None;
+        let mut tokens_out = 0u64;
+        let mut cost = 0.0f64;
+
+        let steps = [resp(None, None, None), resp(Some(42), Some(7), Some(0.1))];
+
+        for step in &steps {
+            accumulate_pipeline_metrics(&mut tokens_in, &mut tokens_out, &mut cost, step);
+        }
+
+        assert_eq!(tokens_in, Some(42));
+        assert_eq!(tokens_out, 7);
+        assert!((cost - 0.1).abs() < f64::EPSILON);
+    }
 }

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -969,6 +969,10 @@ async fn execute_tandem(
 
     // Finalize: drain remaining events and wait for all children to complete
     let mut combined_content = String::new();
+    let mut aggregated_tokens_in: Option<u64> = None;
+    let mut aggregated_tokens_out: u64 = 0;
+    let mut aggregated_cost: f64 = 0.0;
+
     for mut stream in streams {
         // Drain any remaining stream events
         let is_json_mode = super::json_runner::supports_json(&stream.cmd);
@@ -997,6 +1001,19 @@ async fn execute_tandem(
                 // Update message with cleaned content (item 4: marker cleanup)
                 app.update_assistant_by_stream_id(&stream.stream_id, &parsed.content);
                 combined_content.push_str(&parsed.content);
+
+                // Aggregate real metrics from result_event
+                if let Some(resp) = stream.result_event {
+                    if aggregated_tokens_in.is_none() {
+                        aggregated_tokens_in = resp.tokens_in;
+                    }
+                    if let Some(out) = resp.tokens_out {
+                        aggregated_tokens_out += out;
+                    }
+                    if let Some(cost) = resp.cost_usd {
+                        aggregated_cost += cost;
+                    }
+                }
             }
             Ok(status) => {
                 let stderr_content = stream.stderr_buffer.lock().unwrap();
@@ -1014,11 +1031,20 @@ async fn execute_tandem(
         terminal.draw(|f| app.render(f))?;
     }
 
-    // TODO(debt): Each stream.result_event contains real metrics, but we use estimated record_turn.
-    // To improve: aggregate result_events (sum tokens_out/cost, use first tokens_in) and call record_turn_exact.
-    // Challenge: streams may have mix of json/text modes, some may fail without result_event.
+    // Use exact metrics from aggregated result_events, or fall back to estimation
     let duration = start_time.elapsed();
-    runner.record_turn(input, &combined_content, duration);
+    if let Some(tokens_in) = aggregated_tokens_in {
+        runner.record_turn_exact(
+            input,
+            &combined_content,
+            duration,
+            tokens_in,
+            aggregated_tokens_out,
+            aggregated_cost,
+        );
+    } else {
+        runner.record_turn(input, &combined_content, duration);
+    }
     let metrics = runner.session_metrics();
     app.set_session_metrics(
         metrics.total_tokens_in,
@@ -1086,6 +1112,9 @@ async fn execute_pipeline_steps(
 
     let mut current_input = input.to_string();
     let total_steps = steps.len();
+    let mut aggregated_tokens_in: Option<u64> = None;
+    let mut aggregated_tokens_out: u64 = 0;
+    let mut aggregated_cost: f64 = 0.0;
 
     for (i, step) in steps.iter().enumerate() {
         let is_last = i == total_steps - 1;
@@ -1233,10 +1262,7 @@ async fn execute_pipeline_steps(
         });
 
         let is_json_mode = super::json_runner::supports_json(&resolved.cmd);
-        // TODO(debt): result_event is captured but not used for record_turn_exact.
-        // To use it: accumulate metrics from all steps and call record_turn_exact at L1369.
-        // Challenge: need to aggregate tokens/cost across steps.
-        let mut _result_event: Option<super::json_runner::CliResponse> = None;
+        let mut step_result_event: Option<super::json_runner::CliResponse> = None;
 
         // Stream loop
         loop {
@@ -1283,7 +1309,7 @@ async fn execute_pipeline_steps(
                         }
                         StreamEvent::Result(resp) => {
                             // Store result event for metrics, do NOT append content
-                            _result_event = Some(resp);
+                            step_result_event = Some(resp);
                         }
                         StreamEvent::Error(msg) => {
                             app.append_to_streaming(&format!("\n\nError: {}", msg));
@@ -1315,7 +1341,7 @@ async fn execute_pipeline_steps(
                                     app.append_to_streaming(&text);
                                 }
                                 StreamEvent::Result(resp) => {
-                                    _result_event = Some(resp);
+                                    step_result_event = Some(resp);
                                 }
                                 _ => {}
                             }
@@ -1338,6 +1364,19 @@ async fn execute_pipeline_steps(
 
                         app.update_last_assistant_with_label(&label, &parsed.content);
                         current_input = parsed.content;
+
+                        // Aggregate real metrics from result_event
+                        if let Some(resp) = step_result_event {
+                            if aggregated_tokens_in.is_none() {
+                                aggregated_tokens_in = resp.tokens_in;
+                            }
+                            if let Some(out) = resp.tokens_out {
+                                aggregated_tokens_out += out;
+                            }
+                            if let Some(cost) = resp.cost_usd {
+                                aggregated_cost += cost;
+                            }
+                        }
                     } else {
                         // Process failed
                         let stderr_content = stderr_buffer.lock().unwrap();
@@ -1374,7 +1413,18 @@ async fn execute_pipeline_steps(
     }
 
     let duration = start_time.elapsed();
-    runner.record_turn(input, &current_input, duration);
+    if let Some(tokens_in) = aggregated_tokens_in {
+        runner.record_turn_exact(
+            input,
+            &current_input,
+            duration,
+            tokens_in,
+            aggregated_tokens_out,
+            aggregated_cost,
+        );
+    } else {
+        runner.record_turn(input, &current_input, duration);
+    }
     let metrics = runner.session_metrics();
     app.set_session_metrics(
         metrics.total_tokens_in,


### PR DESCRIPTION
## Summary

Resolves deferred minor technical debt from beta.2/beta.3 code reviews (8 items identified).

**Items addressed** (7 corrected, 1 deferred):
- ✅ #1: Exploit exact metrics from `result_event` in pipeline/tandem modes (fix)
- ✅ #2: Emit `deprecated_model` warning consistently in orchestration mode (fix)
- ✅ #3: Move `content_out` calculation inside `if !quiet` to avoid unnecessary clone (perf)
- ✅ #4: Remove obsolete `#[allow(dead_code)]` from `events.rs` (chore)
- ✅ #5: Document `#[allow(clippy::too_many_arguments)]` in `run.rs` (chore)
- ✅ #6: Hoist `exit_code_for(&e)` to avoid duplicate calculation (perf)
- ✅ #7: Remove redundant `#[serde(default)]` in `ProjectConfig` fields (chore)
- ⏸️ #8: Ring Cancelled → informative content (deferred: low value, invasive change)

## Changes by module

| Module | Item | Type | Impact |
|--------|------|------|--------|
| `src/shell/app.rs` | #1 | fix | Exact metrics in pipeline/tandem |
| `src/cli/run.rs` | #2 | fix | Warning consistency in orchestration |
| `src/cli/run.rs` | #3, #6 | perf | Avoid clone + duplicate call |
| `src/cli/run.rs` | #5 | chore | Document lint suppressions |
| `src/core/events.rs` | #4 | chore | Remove obsolete allows |
| `src/core/project.rs` | #7 | chore | Remove redundant serde attrs |

## Test plan

- ✅ Clippy (CI mode: `--features tui`) — no warnings
- ✅ Clippy (full: `--features tui,providers-api`) — no warnings
- ✅ `cargo fmt --check` — clean
- ✅ `cargo test` (708 tests) — all pass

## Commits

1. `636db9c` fix(shell): use exact metrics from result_event in pipeline/tandem modes
2. `317b5f0` perf(cli): avoid unnecessary clones and duplicate calls in run
3. `9a87bad` fix(cli): emit deprecated_model warning in orchestration mode
4. `bc54f50` chore(lint): cleanup allow attributes in events and run
5. `0dc5245` chore(serde): remove redundant field-level defaults in ProjectConfig

🤖 Created by dev-lead agent with specialized team delegation