### PR TITLE
chore(release): bump to 1.0.0-rc.1 + migration guide/script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v1.0.0-rc.1 (2026-07-17)
+
+First release candidate for 1.0.0. Scope frozen (event-sourcing and the
+declarative-engine vision are deferred to 1.1/v2).
+
+### Fixed
+
+- **Beta.2/beta.3 technical debt resolved** (#176): exact metrics from
+  `result_event` now used in Pipeline/Tandem modes (previously
+  approximated), `deprecated_model` warning now emitted consistently in
+  orchestration mode (previously single-agent-only), plus assorted
+  cleanups (`content_out` clone avoidance, duplicate `exit_code_for` call,
+  obsolete `#[allow(dead_code)]` removal, documented lint suppressions,
+  redundant `#[serde(default)]` removal in `ProjectConfig`).
+
+### New: v0 → v1 Migration Guide
+
+- **[`docs/wiki/migration-v0-to-v1.md`](docs/wiki/migration-v0-to-v1.md)**:
+  step-by-step guide covering breaking changes for v0.x users — removal of
+  `fleet`, non-canonical `provider` syntax, deprecated models, the
+  `.armadai/` project format, and diagnostic tooling.
+- **[`scripts/migrate-v0-to-v1.sh`](scripts/migrate-v0-to-v1.sh)**: companion
+  automation script for the mechanical, deterministic parts of the
+  migration. Dry-run by default (nothing is written unless `--apply` is
+  passed), backs up every file it touches, and never deletes anything.
+
 ## v1.0.0-beta.3 (2026-07-17)
 
 Third beta of the 1.0.0 release. Adds two OpenHands-study features: a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "armadai"
-version = "1.0.0-beta.3"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "armadai"
-version = "1.0.0-beta.3"
+version = "1.0.0-rc.1"
 edition = "2024"
 description = "ArmadAI — AI agent orchestrator. Define, manage and run specialized agents from Markdown files."
 license = "PolyForm-Noncommercial-1.0.0"

--- a/docs/wiki/migration-v0-to-v1.md
+++ b/docs/wiki/migration-v0-to-v1.md
@@ -1,0 +1,355 @@
+# v0 → v1 Migration Guide
+
+This guide lists the breaking changes between ArmadAI v0.x and v1.0.0, and
+provides a step-by-step procedure for migrating an existing environment
+(user agents in `~/.config/armadai/`, projects using `armadai.yaml` /
+`.armadai/`).
+
+A partial automation script is available:
+[`scripts/migrate-v0-to-v1.sh`](../../scripts/migrate-v0-to-v1.sh). It only
+covers mechanical, deterministic migrations (see below) — read this guide
+before running it, especially for anything related to `fleet`.
+
+## Table of Contents
+
+- [1. Removal of `fleet`](#1-removal-of-fleet)
+- [2. Non-canonical `provider` syntax](#2-non-canonical-provider-syntax)
+- [3. Deprecated models](#3-deprecated-models)
+- [4. `.armadai/` project format (recommended, non-blocking)](#4-armadai-project-format-recommended-non-blocking)
+- [5. Diagnostic tools to use](#5-diagnostic-tools-to-use)
+- [6. What's new in v1 that makes migration worthwhile](#6-whats-new-in-v1-that-makes-migration-worthwhile)
+- [7. Migration checklist](#7-migration-checklist)
+
+---
+
+## 1. Removal of `fleet`
+
+**Confirmed** — commit [`ded362f`](../../) `chore(core): remove legacy
+fleet concept (#138)`, marked `BREAKING CHANGE` in its commit message.
+
+The legacy **`fleet`** concept was fully removed in v1.0.0-beta.1:
+
+- the `armadai fleet` command (create / link / list / show) no longer
+  exists;
+- the `FleetDefinition` type and the `src/core/fleet.rs` file were removed;
+- the `~/.config/armadai/fleets/` directory is no longer created (removed
+  from `ensure_config_dirs()`) and is no longer read anywhere in the code;
+- **automatic detection of the legacy YAML format was also removed.**
+  Before #138, `ProjectConfig::load()` detected a `fleet:` key at the top of
+  the file and silently converted the old format into a `ProjectConfig`
+  (with a warning). That safety net is gone: an `armadai.yaml` file still in
+  the `fleet:` format will **no longer be recognized** — it will simply be
+  interpreted (with empty default values) as a modern `ProjectConfig` with
+  no agents.
+
+Naming was also harmonized throughout the codebase and docs: *"AI agent
+fleet orchestrator"* → *"AI agent orchestrator"*, and *"fleet of agents"* →
+*"team of agents"* / *"agent library"*.
+
+### BEFORE (v0) — legacy `fleet` format
+
+```yaml
+# armadai.yaml (old format, auto-detected before #138)
+fleet: my-fleet
+agents:
+  - code-reviewer
+  - test-writer
+source: /home/user/armadai
+```
+
+```bash
+# Commands that no longer exist
+armadai fleet create my-fleet --all
+armadai fleet link my-fleet
+armadai fleet list
+armadai fleet show my-fleet
+```
+
+### AFTER (v1) — modern `armadai.yaml`
+
+```yaml
+# armadai.yaml (or .armadai/config.yaml, see section 4)
+agents:
+  - name: code-reviewer
+  - name: test-writer
+
+link:
+  target: claude
+  coordinator: dev-lead
+```
+
+### Migration steps
+
+1. Check whether you still have a legacy directory:
+   ```bash
+   ls ~/.config/armadai/fleets/ 2>/dev/null
+   ```
+   If it exists and contains files, note the fleet names and their
+   associated agents (`agents:` in each fleet file) — they will never be
+   read by ArmadAI again.
+2. For each fleet, recreate an equivalent entry:
+   - **Simple case** (a fleet = a group of agents used on an ad-hoc basis)
+     → a project `armadai.yaml` listing the same agents under `agents:`.
+   - **Multi-agent coordination case** (the fleet was used to orchestrate
+     several agents together) → an `orchestration:` block with `teams:` and
+     `coordinator:` (see the
+     [orchestration guide](orchestration-guide.md)), or a team in the agent
+     library (`~/.config/armadai/agents/`).
+3. Recreate the links to your AI tools with `armadai link --target <cli>`
+   (replaces `armadai fleet link`).
+4. Remove `~/.config/armadai/fleets/` once the conversion has been verified
+   (the migration script does *not* do this automatically — see below).
+
+> The fleet → teams conversion is not mechanical: it depends on how each
+> fleet was actually used. The migration script only **detects and
+> reports** this directory; it never rewrites anything blindly.
+
+---
+
+## 2. Non-canonical `provider` syntax
+
+**Confirmed** — `docs/SESSION-STATE.md` (item 44, agent library audit)
+flags 6 core ArmadAI agents (`dev-lead`,
+`core/provider/cli/ui/qa-specialist`) using the form `provider: cli claude`.
+This form has **never been supported** by the parser
+(`src/parser/metadata.rs` stores the raw value of the `provider` field
+as-is) nor by the provider factory (`src/providers/factory.rs::create_provider`):
+it produces the literal string `"cli claude"`, which does not match any
+branch of the `match` (`"cli"`, `"anthropic"/"openai"/"google"/"proxy"`, or
+a unified tool name like `"claude"`) and fails at runtime with `Unknown
+provider: 'cli claude'`.
+
+This is therefore not an API removal but a **configuration error
+inherited** from old templates/documentation — widespread enough in the
+agent library to warrant automated detection before moving to v1.
+
+Two canonical forms exist today:
+
+### BEFORE (v0, invalid syntax) — a single combined field
+
+```markdown
+## Metadata
+- provider: cli claude
+- timeout: 120
+```
+
+### AFTER (v1) — two canonical options
+
+**Option A — unified tool name (recommended)**: ArmadAI automatically
+detects whether the CLI is installed and falls back to the API otherwise.
+
+```markdown
+## Metadata
+- provider: claude
+- model: latest:pro
+- timeout: 120
+```
+
+**Option B — explicit CLI mode**: if you need a custom command or
+arguments.
+
+```markdown
+## Metadata
+- provider: cli
+- command: claude
+- args: ["-p", "--model", "sonnet", "--output-format", "json"]
+- timeout: 120
+```
+
+See [`docs/wiki/providers.md`](providers.md) for the complete list of
+unified names (`claude`, `gemini`, `gpt`, `aider`) and their CLI/API
+mapping.
+
+### Migration steps
+
+1. Search for affected agents:
+   ```bash
+   grep -rln '^- provider: cli [a-z]' ~/.config/armadai/agents/ 2>/dev/null
+   ```
+2. The `scripts/migrate-v0-to-v1.sh` script automatically rewrites
+   `provider: cli <tool>` → `provider: <tool>` for the 4 known tools
+   (`claude`, `gemini`, `gpt`, `aider`) — this is a purely textual,
+   deterministic rewrite (no information loss: there were no separate
+   `command:`/`args:` to preserve).
+3. If you deliberately needed explicit CLI mode with custom `args:`, use
+   option B above manually instead.
+
+---
+
+## 3. Deprecated models
+
+**Confirmed** — `src/linker/model_aliases.rs`, function
+`embedded_aliases()`. This is not an API removal but an ongoing
+replacement: with each version, the embedded table grows and the old model
+name is automatically resolved (with a warning) to its replacement.
+
+| Deprecated model | Replacement |
+|---|---|
+| `gemini-3.0-pro` (name never actually shipped, anticipated by mistake) | `latest:pro` |
+| `gemini-1.5-flash` | `gemini-2.5-flash` |
+| `gemini-1.5-pro` | `gemini-2.0-pro` |
+| `gemini-1.0-pro` | `gemini-2.0-pro` |
+| `gpt-4-turbo` | `gpt-4o` |
+| `gpt-3.5-turbo` | `gpt-4o-mini` |
+
+Resolution is transitive (A→B→C becomes A→C) and protected against cycles.
+You can also override/extend this table locally via
+`~/.config/armadai/model-aliases.json`.
+
+### BEFORE (v0)
+
+```markdown
+## Metadata
+- provider: google
+- model: gemini-3.0-pro
+```
+
+### AFTER (v1)
+
+```markdown
+## Metadata
+- provider: google
+- model: latest:pro
+```
+
+### Migration steps
+
+ArmadAI already resolves these aliases automatically at runtime (with a
+`tracing::warn!`) — so this is not blocking in itself. But to clean up your
+agent files and stop relying on implicit resolution:
+
+```bash
+# Diagnostic only (writes nothing)
+armadai models check --all
+
+# In-place rewrite of deprecated models in .md files
+armadai models update --all
+```
+
+`armadai models list` shows the registered projects these commands can
+iterate over (`--all`).
+
+---
+
+## 4. `.armadai/` project format (recommended, non-blocking)
+
+**Non-breaking, confirmed** — `src/core/project.rs`
+(`check_dotarmadai_migration_hint`) and
+[`docs/wiki/getting-started.md`](getting-started.md#legacy-format).
+Introduced in v0.7.0, this format **never removed** support for the old
+`armadai.yaml` at the project root: both coexist, with a simple
+informational message (a "hint") encouraging migration.
+
+```
+.armadai/
+├── config.yaml     # modern equivalent of armadai.yaml
+├── agents/
+├── prompts/
+├── skills/
+└── starters/
+```
+
+### Migration steps (optional)
+
+```bash
+armadai init --project
+```
+
+Then move the contents of your `armadai.yaml` to `.armadai/config.yaml`,
+and your local `agents/`, `prompts/`, `skills/` directories to
+`.armadai/agents/`, etc. The resource resolution order remains:
+`.armadai/{type}/` → `{type}/` (root, legacy) →
+`~/.config/armadai/{type}/` (user library).
+
+---
+
+## 5. Diagnostic tools to use
+
+Before and after the migration, use the existing commands to validate your
+configuration:
+
+| Command | Purpose |
+|---|---|
+| `armadai validate [path]` | Lints a starter `pack.yaml` or a project config (consistent agents/teams, coordinator, existing referenced prompts/skills, valid `Triggers`). |
+| `armadai models check --all` | Detects deprecated models in agents (diagnostic only). |
+| `armadai models update --all` | Rewrites detected deprecated models in place. |
+| `armadai audit [path] [--propose] [--deep]` | Static analysis of **native** agentic configs (Claude Code) — detects collisions, duplicates, broken references; `--propose` generates an installable ArmadAI pack, `--deep` adds an optional LLM pass. Does not replace this guide (different scope: native configs, not the legacy ArmadAI format), but useful as a complement once migration is done. |
+
+---
+
+## 6. What's new in v1 that makes migration worthwhile
+
+Beyond cleaning up v0 format debt, v1.0.0 brings several major new
+features:
+
+- **Conversational shell** (`armadai shell`, since v0.12.0) — interactive
+  multi-provider TUI (Claude, Gemini, Aider, Codex), prompt history,
+  persistent sessions resumed with `/resume`, slash commands (`/help`,
+  `/cost`, `/agents`, `/model`, `/switch`, …).
+- **Multi-pattern orchestration** — beyond `direct` mode (single agent),
+  `armadai.yaml` lets you declare:
+  - **Blackboard** — agents working in parallel on a shared board,
+    converging by consensus;
+  - **Ring** — sequential review with weighted voting;
+  - **Hierarchical** — coordinator + multi-level teams, parallel
+    delegation (`tokio::spawn`).
+  See the [orchestration guide](orchestration-guide.md) for full parameter
+  details and pattern selection.
+- **Headless mode for CI** (`armadai run --headless --json`,
+  v1.0.0-beta.3) — non-interactive execution (skips the model-update
+  prompt), structured JSONL event stream on stdout (`run_start`,
+  `agent_start`, `agent_end`, `warning`, `result`, `error`), `--quiet` to
+  keep only the final event, `--max-content N` to truncate intermediate
+  event content. Dedicated exit codes: `0` success, `1` execution error,
+  `2` usage error, `3` budget exhausted, `4` provider unavailable.
+- **Dynamic model router** (`model: latest:auto`, v1.0.0-beta.3) — an
+  agent's tier (`Fast`/`Pro`/`Max`) is chosen at runtime by static
+  heuristics (input length, keywords, agent tags, budget), configurable via
+  the `routing:` section of `armadai.yaml` (`length_thresholds`,
+  `keywords`, `tags`, `budget_downgrade_ratio`).
+
+### Complete v1 `armadai.yaml` example
+
+```yaml
+agents:
+  - name: dev-lead
+  - name: core-specialist
+
+orchestration:
+  enabled: true
+  pattern: hierarchical
+  coordinator: dev-lead
+  teams:
+    - name: core-team
+      agents: [core-specialist, qa-specialist]
+
+routing:
+  length_thresholds: { fast_max: 100, pro_max: 1000 }
+  tags: { hot: max }
+
+shell:
+  default_provider: claude
+
+link:
+  target: claude
+  coordinator: dev-lead
+```
+
+---
+
+## 7. Migration checklist
+
+- [ ] `ls ~/.config/armadai/fleets/` — if not empty, plan a manual
+      conversion to `teams:`/agent library (section 1), **do not delete
+      before verifying**.
+- [ ] `scripts/migrate-v0-to-v1.sh` (dry-run) on `~/.config/armadai/agents/`
+      and the current project(s) to spot `provider: cli <tool>` and
+      deprecated models.
+- [ ] `scripts/migrate-v0-to-v1.sh --apply` once the changes have been
+      reviewed (`.bak` files are created automatically).
+- [ ] `armadai models check --all` / `armadai models update --all`.
+- [ ] `armadai validate` on each project/pack.
+- [ ] (optional) `armadai init --project` then migrate to `.armadai/`.
+- [ ] Re-read [the orchestration guide](orchestration-guide.md) if you were
+      using multi-agent fleets, to choose the replacement pattern
+      (`blackboard`, `ring`, or `hierarchical`).

--- a/scripts/migrate-v0-to-v1.sh
+++ b/scripts/migrate-v0-to-v1.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+#
+# migrate-v0-to-v1.sh — mechanical, deterministic helpers for the ArmadAI
+# v0 -> v1 migration.
+#
+# Full guide (read this first): docs/wiki/migration-v0-to-v1.md
+#
+# This script is SAFE BY DESIGN:
+#   - Dry-run by default. Nothing is written unless you pass --apply.
+#   - Every file it touches is backed up first (see --apply below).
+#   - It never deletes anything.
+#   - Its scope is intentionally narrow — only the 3 checks below. Anything
+#     else in the migration guide (e.g. converting `fleet` -> `teams`) needs
+#     a human decision and is only *reported*, never rewritten.
+#
+# What it does:
+#   (a) Detect legacy `fleet` usage:
+#         - ~/.config/armadai/fleets/ directory (reported, never touched)
+#         - a top-level `fleet:` key in armadai.yaml / .armadai/config.yaml
+#           (reported, never touched — auto-detection of this format was
+#           removed in v1, see docs/wiki/migration-v0-to-v1.md#1)
+#   (b) Rewrite deprecated provider syntax in agent .md files:
+#         `- provider: cli claude` -> `- provider: claude`
+#       (only for the known unified tool names: claude, gemini, gpt, aider)
+#   (c) Detect deprecated model names in agent .md files and point to
+#       `armadai models update` (never rewritten here — that command is the
+#       authoritative source of truth for model aliases).
+#
+# Usage:
+#   scripts/migrate-v0-to-v1.sh [--apply] [OPTIONS]
+#
+# Options:
+#   --apply                  Actually write changes (default: dry-run).
+#   --user-agents-dir DIR    Override the user agent library directory
+#                            (default: ~/.config/armadai/agents).
+#   --user-fleets-dir DIR    Override the legacy fleets directory
+#                            (default: ~/.config/armadai/fleets).
+#   --project-dir DIR        Project directory to scan (default: current
+#                            directory). Looks for agents/, .armadai/agents/,
+#                            armadai.yaml, armadai.yml, .armadai/config.yaml.
+#   -h, --help               Show this help and exit.
+#
+# Exit codes:
+#   0  success (dry-run or apply completed; findings are printed, not an
+#      error condition by themselves)
+#   1  usage error (bad flag, missing argument)
+#   2  internal error (e.g. backup could not be created before a write)
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+CONFIG_DIR="${ARMADAI_CONFIG_DIR:-$HOME/.config/armadai}"
+USER_AGENTS_DIR="$CONFIG_DIR/agents"
+USER_FLEETS_DIR="$CONFIG_DIR/fleets"
+PROJECT_DIR="$(pwd)"
+APPLY=0
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+
+# Known unified tool names (src/providers/factory.rs::KNOWN_TOOLS).
+KNOWN_TOOLS=(claude gemini gpt aider)
+
+# Deprecated model names embedded in src/linker/model_aliases.rs at the time
+# this script was written. This list is for *detection only* — the
+# authoritative, always-up-to-date source is `armadai models check`.
+DEPRECATED_MODELS=(
+    gemini-3.0-pro
+    gemini-1.5-flash
+    gemini-1.5-pro
+    gemini-1.0-pro
+    gpt-4-turbo
+    gpt-3.5-turbo
+)
+
+# Counters for the final summary.
+COUNT_FLEET_DIR=0
+COUNT_FLEET_YAML=0
+COUNT_PROVIDER_FILES=0
+COUNT_PROVIDER_LINES=0
+COUNT_MODEL_FILES=0
+COUNT_MODEL_HITS=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+print_help() {
+    # Print the usage block at the top of this file (everything between the
+    # shebang and the `set -euo pipefail` line).
+    sed -n '2,/^set -euo pipefail/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+log()  { printf '%s\n' "$*"; }
+info() { printf '  %s\n' "$*"; }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
+
+section() {
+    printf '\n=== %s ===\n' "$*"
+}
+
+# backup_file <path>
+# Copies <path> to <path>.bak-<TIMESTAMP> before any in-place modification.
+# Aborts the whole script (exit 2) if the backup cannot be created — we never
+# want to modify a file we failed to back up.
+backup_file() {
+    local file="$1"
+    local backup="${file}.bak-${TIMESTAMP}"
+    if ! cp -p "$file" "$backup"; then
+        warn "could not create backup '$backup' for '$file' — aborting before any write."
+        exit 2
+    fi
+    info "backup created: $backup"
+}
+
+# find_md_files <dir...>
+# Recursively lists .md files under the given directories (skipping any that
+# don't exist). Safe to call with zero existing directories.
+find_md_files() {
+    local dir
+    for dir in "$@"; do
+        [ -d "$dir" ] || continue
+        find "$dir" -type f -name '*.md' 2>/dev/null
+    done
+}
+
+# ---------------------------------------------------------------------------
+# (a) Legacy fleet detection — report only, never modified.
+# ---------------------------------------------------------------------------
+
+check_fleet_legacy() {
+    section "Legacy fleet detection"
+
+    if [ -d "$USER_FLEETS_DIR" ]; then
+        local fleet_files
+        fleet_files="$(find "$USER_FLEETS_DIR" -type f 2>/dev/null || true)"
+        if [ -n "$fleet_files" ]; then
+            local n
+            n="$(printf '%s\n' "$fleet_files" | grep -c . || true)"
+            COUNT_FLEET_DIR="$n"
+            log "Found legacy fleet directory: $USER_FLEETS_DIR ($n file(s))"
+            printf '%s\n' "$fleet_files" | sed 's/^/  - /'
+            cat <<'EOF'
+
+  ArmadAI no longer reads this directory (removed in v1.0.0-beta.1, #138).
+  This script will NOT convert or delete these files: fleet -> teams
+  conversion depends on how each fleet was actually used and needs a human
+  decision. See docs/wiki/migration-v0-to-v1.md#1-removal-of-fleet for
+  the manual conversion steps, then remove this directory yourself once
+  you've verified the equivalent agents/teams/orchestration config works.
+EOF
+        else
+            log "Legacy fleet directory exists but is empty: $USER_FLEETS_DIR"
+        fi
+    else
+        log "No legacy fleet directory found ($USER_FLEETS_DIR) — OK."
+    fi
+
+    local cfg
+    for cfg in "$PROJECT_DIR/armadai.yaml" "$PROJECT_DIR/armadai.yml" \
+               "$PROJECT_DIR/.armadai/config.yaml"; do
+        [ -f "$cfg" ] || continue
+        if grep -qE '^fleet:[[:space:]]*[^[:space:]]' "$cfg"; then
+            COUNT_FLEET_YAML=$((COUNT_FLEET_YAML + 1))
+            log "Found legacy 'fleet:' key in: $cfg"
+            cat <<EOF
+
+  This file uses the pre-v1 fleet YAML format ('fleet:' + 'agents:' +
+  'source:'). ArmadAI v1 no longer detects or converts this format
+  automatically — it will be parsed as a modern (mostly empty)
+  ProjectConfig instead. This script will NOT rewrite it for you.
+  Convert it manually to the v1 agents:/orchestration: format — see
+  docs/wiki/migration-v0-to-v1.md#1-removal-of-fleet.
+EOF
+        fi
+    done
+
+    if [ "$COUNT_FLEET_DIR" -eq 0 ] && [ "$COUNT_FLEET_YAML" -eq 0 ]; then
+        log "No legacy fleet YAML config found in project — OK."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# (b) Deprecated provider syntax — `provider: cli <tool>` -> `provider: <tool>`
+# ---------------------------------------------------------------------------
+
+check_and_fix_provider_syntax() {
+    section "Deprecated provider syntax ('provider: cli <tool>')"
+
+    local tools_alt
+    tools_alt="$(IFS='|'; echo "${KNOWN_TOOLS[*]}")"
+    local pattern="^([[:space:]]*-[[:space:]]*provider:[[:space:]]*)cli[[:space:]]+(${tools_alt})[[:space:]]*\$"
+
+    local files
+    files="$(find_md_files "$USER_AGENTS_DIR" \
+                            "$PROJECT_DIR/agents" \
+                            "$PROJECT_DIR/.armadai/agents" | sort -u || true)"
+
+    if [ -z "$files" ]; then
+        log "No agent .md files found under:"
+        info "$USER_AGENTS_DIR"
+        info "$PROJECT_DIR/agents"
+        info "$PROJECT_DIR/.armadai/agents"
+        return 0
+    fi
+
+    local file matches n
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        matches="$(grep -nE "$pattern" "$file" 2>/dev/null || true)"
+        [ -n "$matches" ] || continue
+
+        n="$(printf '%s\n' "$matches" | grep -c . || true)"
+        COUNT_PROVIDER_FILES=$((COUNT_PROVIDER_FILES + 1))
+        COUNT_PROVIDER_LINES=$((COUNT_PROVIDER_LINES + n))
+
+        log "$file ($n line(s)):"
+        printf '%s\n' "$matches" | sed 's/^/  /'
+
+        if [ "$APPLY" -eq 1 ]; then
+            backup_file "$file"
+            local tmp
+            tmp="$(mktemp "${file}.tmp.XXXXXX")"
+            sed -E "s/$pattern/\\1\\2/" "$file" > "$tmp"
+            mv "$tmp" "$file"
+            info "rewritten: provider: cli <tool> -> provider: <tool>"
+        else
+            info "[dry-run] would rewrite the line(s) above (use --apply to write)"
+        fi
+    done <<< "$files"
+
+    if [ "$COUNT_PROVIDER_FILES" -eq 0 ]; then
+        log "No deprecated 'provider: cli <tool>' syntax found — OK."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# (c) Deprecated models — report only, points to `armadai models update`.
+# ---------------------------------------------------------------------------
+
+check_deprecated_models() {
+    section "Deprecated model references"
+
+    local files
+    files="$(find_md_files "$USER_AGENTS_DIR" \
+                            "$PROJECT_DIR/agents" \
+                            "$PROJECT_DIR/.armadai/agents" | sort -u || true)"
+
+    if [ -z "$files" ]; then
+        log "No agent .md files found to scan for deprecated models."
+        return 0
+    fi
+
+    local model_alt
+    model_alt="$(IFS='|'; echo "${DEPRECATED_MODELS[*]}")"
+    # Match on lines that mention "model" and contain one of the deprecated
+    # names (covers both `- model: X` and `- model_fallback: [X, ...]`).
+    local pattern="model.*(${model_alt})"
+
+    local file matches n
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        matches="$(grep -nE "$pattern" "$file" 2>/dev/null || true)"
+        [ -n "$matches" ] || continue
+
+        n="$(printf '%s\n' "$matches" | grep -c . || true)"
+        COUNT_MODEL_FILES=$((COUNT_MODEL_FILES + 1))
+        COUNT_MODEL_HITS=$((COUNT_MODEL_HITS + n))
+
+        log "$file ($n reference(s)):"
+        printf '%s\n' "$matches" | sed 's/^/  /'
+    done <<< "$files"
+
+    if [ "$COUNT_MODEL_FILES" -eq 0 ]; then
+        log "No known deprecated model references found — OK."
+    else
+        cat <<'EOF'
+
+  Deprecated models are resolved automatically at runtime (with a warning),
+  but you should clean them up explicitly:
+
+    armadai models check --all     # diagnostic only
+    armadai models update --all    # rewrites deprecated models in place
+
+  This script does not rewrite models itself — `armadai models update` is
+  the authoritative implementation (embedded alias table + local overrides
+  in ~/.config/armadai/model-aliases.json).
+EOF
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apply)
+            APPLY=1
+            shift
+            ;;
+        --user-agents-dir)
+            [ $# -ge 2 ] || { warn "--user-agents-dir requires an argument"; exit 1; }
+            USER_AGENTS_DIR="$2"
+            shift 2
+            ;;
+        --user-fleets-dir)
+            [ $# -ge 2 ] || { warn "--user-fleets-dir requires an argument"; exit 1; }
+            USER_FLEETS_DIR="$2"
+            shift 2
+            ;;
+        --project-dir)
+            [ $# -ge 2 ] || { warn "--project-dir requires an argument"; exit 1; }
+            PROJECT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        *)
+            warn "unknown argument: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+log "ArmadAI v0 -> v1 migration helper"
+log "Guide: docs/wiki/migration-v0-to-v1.md"
+if [ "$APPLY" -eq 1 ]; then
+    log "Mode: APPLY (files will be modified; backups written as <file>.bak-${TIMESTAMP})"
+else
+    log "Mode: DRY-RUN (nothing will be written — pass --apply to write changes)"
+fi
+log "User agents dir : $USER_AGENTS_DIR"
+log "User fleets dir : $USER_FLEETS_DIR"
+log "Project dir     : $PROJECT_DIR"
+
+check_fleet_legacy
+check_and_fix_provider_syntax
+check_deprecated_models
+
+section "Summary"
+log "Legacy fleet directory files found : $COUNT_FLEET_DIR"
+log "Legacy 'fleet:' YAML configs found  : $COUNT_FLEET_YAML"
+if [ "$APPLY" -eq 1 ]; then
+    log "Provider syntax lines rewritten     : $COUNT_PROVIDER_LINES (in $COUNT_PROVIDER_FILES file(s))"
+else
+    log "Provider syntax lines to rewrite    : $COUNT_PROVIDER_LINES (in $COUNT_PROVIDER_FILES file(s))"
+fi
+log "Deprecated model references found   : $COUNT_MODEL_HITS (in $COUNT_MODEL_FILES file(s))"
+
+if [ "$APPLY" -eq 0 ]; then
+    log ""
+    log "This was a dry-run. Re-run with --apply to write the provider-syntax fixes."
+    log "Fleet detection and deprecated-model detection are report-only regardless of --apply."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

First release candidate for 1.0.0. Scope is frozen for 1.0.0 (event-sourcing
and the declarative-engine vision are deferred to 1.1/v2). This PR only bumps
the version, adds the CHANGELOG entry, and ships the v0 -> v1 migration
guide/script — no functional code changes.

- Bump `Cargo.toml` / `Cargo.lock` version: `1.0.0-beta.3` -> `1.0.0-rc.1`.
- Add `docs/wiki/migration-v0-to-v1.md`: step-by-step guide for v0.x users
  (fleet removal, non-canonical `provider` syntax, deprecated models,
  `.armadai/` project format, diagnostic tools).
- Add `scripts/migrate-v0-to-v1.sh`: companion automation script, dry-run by
  default (`--apply` required to write), backs up every file it touches,
  never deletes anything.
- Add `CHANGELOG.md` section `v1.0.0-rc.1 (2026-07-17)` documenting the
  beta.2/beta.3 debt resolved in #176 and the new migration guide/script.

## Readiness checked before opening this PR

- `release/1.0.0` @ `ea9b41b` (includes #175 bump-to-beta.3, #176 debt
  cleanup). CI green: Formatting, Test, Clippy, Build, Security Audit all
  passed on `ea9b41b`.

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets --no-default-features --features tui -- -D warnings` — no issues
- [x] `cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings` — no issues
- [x] `cargo test --no-default-features --features tui,providers-api` — 710 passed
- [x] `bash -n scripts/migrate-v0-to-v1.sh` — syntax OK (script not compiled/executed)

## Explicitly NOT in this PR

- No tag `v1.0.0-rc.1` created.
- No merge performed.
- No changes to `master`/`develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)