### PR TITLE
fix(ci): security audit fails only on true vulnerabilities, not warnings

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   audit:
@@ -33,3 +32,4 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          deny: vulnerabilities


### PR DESCRIPTION
## Summary

Fixes the faux échec of the Security Audit workflow on `develop` scheduled runs. The workflow was failing with `##[error]Resource not accessible by integration - create-an-issue` despite finding 0 true vulnerabilities.

**Root cause:** `rustsec/audit-check@v2` attempted to create a GitHub issue to report unmaintained dependency warnings (bincode RUSTSEC-2025-0141, yaml-rust RUSTSEC-2024-0320). On scheduled runs, the GITHUB_TOKEN has limited permissions and cannot create issues.

## Solution

- Added `deny: vulnerabilities` to `rustsec/audit-check@v2` configuration
- Removed unnecessary `checks: write` permission (now only `contents: read`)
- CI now fails **only** on true CVE/vulnerabilities, not on informational warnings about unmaintained crates

The fix is minimal and targeted: it prevents the workflow from attempting issue creation while preserving vulnerability detection.

## Test plan

- [ ] PR CI passes (no false red on scheduled audit)
- [ ] Verify Security Audit job completes successfully (0 vulnerabilities → green)
- [ ] Confirm clippy passes in both feature modes
- [ ] Verify cargo fmt compliance

🤖 Generated with Claude Code