### PR TITLE
feat(orchestration): consolidate OH3/OH4 (JSONL events + latest:auto routing)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -791,8 +791,13 @@ async fn run_orchestrated(
                 agent_map.len()
             );
 
-            let mut engine =
-                HierarchicalEngine::new(orch_config, agent_map, provider_map, Arc::clone(sink));
+            let mut engine = HierarchicalEngine::with_routing_rules(
+                orch_config,
+                agent_map,
+                provider_map,
+                Arc::clone(sink),
+                routing_rules,
+            );
             let result = engine.run(input).await?;
 
             eprintln!(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -601,7 +601,7 @@ async fn run_orchestrated(
                 config.max_rounds
             );
 
-            run_blackboard(&mut board, &board_agents, &providers, &config).await?;
+            run_blackboard(&mut board, &board_agents, &providers, &config, sink).await?;
 
             eprintln!("[blackboard] Halted: {:?}", board.state());
 
@@ -648,7 +648,7 @@ async fn run_orchestrated(
                 config.max_laps
             );
 
-            run_ring(&mut token, &ring_agents, &providers, &config).await?;
+            run_ring(&mut token, &ring_agents, &providers, &config, sink).await?;
 
             #[cfg(feature = "storage")]
             record_orchestration_ring(&token, &config, input);
@@ -766,7 +766,8 @@ async fn run_orchestrated(
                 agent_map.len()
             );
 
-            let mut engine = HierarchicalEngine::new(orch_config, agent_map, provider_map);
+            let mut engine =
+                HierarchicalEngine::new(orch_config, agent_map, provider_map, Arc::clone(sink));
             let result = engine.run(input).await?;
 
             eprintln!(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -531,7 +531,7 @@ async fn run_orchestrated(
     use crate::core::orchestration::blackboard::{
         BlackboardConfig, Board, BoardAgent, run_blackboard,
     };
-    use crate::core::orchestration::llm_agents::{LlmBoardAgent, LlmRingAgent};
+    use crate::core::orchestration::llm_agents::{LlmBoardAgent, LlmRingAgent, RoutingCtx};
     use crate::core::orchestration::ring::{
         RingAgent, RingConfig, RingOutcome, RingToken, TokenStatus, run_ring,
     };
@@ -548,6 +548,15 @@ async fn run_orchestrated(
             config.defaults.orchestration.clone().unwrap_or_default()
         }
         _ => OrchestrationDefaults::default(),
+    };
+
+    // Routing rules for `latest:auto` LlmBoardAgent/LlmRingAgent, mirroring
+    // the sequential path in `run_single_agent`: project config wins, else
+    // the embedded default. The per-engine budget (see `RoutingCtx::new`) is
+    // derived below from each config's `token_budget` once it is known.
+    let routing_rules = match resolution {
+        AgentResolution::Project { config, .. } => config.routing.clone().unwrap_or_default(),
+        _ => crate::core::routing::RoutingRules::default(),
     };
 
     sink.emit(&RunEvent::RunStart {
@@ -587,12 +596,20 @@ async fn run_orchestrated(
 
     match pattern {
         "blackboard" => {
+            let config = apply_blackboard_overrides(BlackboardConfig::default(), &orch_defaults);
+            let routing_ctx = RoutingCtx::new(routing_rules, config.token_budget);
+
             let board_agents: Vec<Arc<dyn BoardAgent>> = agents
                 .into_iter()
-                .map(|a| Arc::new(LlmBoardAgent::new(a)) as Arc<dyn BoardAgent>)
+                .map(|a| {
+                    Arc::new(LlmBoardAgent::with_routing(
+                        a,
+                        routing_ctx.clone(),
+                        Arc::clone(sink),
+                    )) as Arc<dyn BoardAgent>
+                })
                 .collect();
 
-            let config = apply_blackboard_overrides(BlackboardConfig::default(), &orch_defaults);
             let mut board = Board::new(input.to_string(), config.token_budget);
 
             eprintln!(
@@ -631,15 +648,23 @@ async fn run_orchestrated(
             });
         }
         "ring" => {
+            let config = apply_ring_overrides(RingConfig::default(), &orch_defaults);
+            let routing_ctx = RoutingCtx::new(routing_rules, config.token_budget);
+
             let ring_agents: Vec<Arc<dyn RingAgent>> = agents
                 .into_iter()
-                .map(|a| Arc::new(LlmRingAgent::new(a)) as Arc<dyn RingAgent>)
+                .map(|a| {
+                    Arc::new(LlmRingAgent::with_routing(
+                        a,
+                        routing_ctx.clone(),
+                        Arc::clone(sink),
+                    )) as Arc<dyn RingAgent>
+                })
                 .collect();
 
             let agent_order: Vec<String> =
                 ring_agents.iter().map(|a| a.name().to_string()).collect();
 
-            let config = apply_ring_overrides(RingConfig::default(), &orch_defaults);
             let mut token = RingToken::new(input.to_string(), agent_order, config.token_budget);
 
             eprintln!(

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -48,6 +48,18 @@ pub enum RunEvent {
         tier: String,
         reason: String,
     },
+    Delegate {
+        from: String,
+        to: String,
+    },
+    Vote {
+        agent: String,
+        conf: f32,
+    },
+    Board {
+        agent: String,
+        kind: String,
+    },
 }
 
 /// Sink for run events. `NullSink` is a zero-cost no-op; `JsonlSink` writes JSONL to a writer.
@@ -210,6 +222,42 @@ mod tests {
         );
         let last: serde_json::Value = serde_json::from_str(lines.last().unwrap()).unwrap();
         assert_eq!(last["t"], "result");
+    }
+
+    #[test]
+    fn delegate_serializes_with_short_keys() {
+        let ev = RunEvent::Delegate {
+            from: "dev-lead".into(),
+            to: "core-specialist".into(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            s,
+            r#"{"t":"delegate","from":"dev-lead","to":"core-specialist"}"#
+        );
+    }
+
+    #[test]
+    fn vote_serializes_with_short_keys() {
+        let ev = RunEvent::Vote {
+            agent: "reviewer".into(),
+            conf: 0.95,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(s, r#"{"t":"vote","agent":"reviewer","conf":0.95}"#);
+    }
+
+    #[test]
+    fn board_serializes_with_short_keys() {
+        let ev = RunEvent::Board {
+            agent: "qa-specialist".into(),
+            kind: "passed".into(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            s,
+            r#"{"t":"board","agent":"qa-specialist","kind":"passed"}"#
+        );
     }
 
     // Test helper: a Write that appends to a shared buffer.

--- a/src/core/orchestration/blackboard.rs
+++ b/src/core/orchestration/blackboard.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::core::events::{EventSink, RunEvent};
 use crate::providers::traits::Provider;
 
 // ── Data structures ──────────────────────────────────────────────
@@ -70,6 +71,19 @@ pub enum EntryKind {
     Synthesis { sources: Vec<usize> },
     Question,
     Answer { question: usize },
+}
+
+/// Map an `EntryKind` variant to a lowercase name (used for JSONL events and
+/// trigger matching in `llm_agents`).
+pub(crate) fn entry_kind_name(kind: &EntryKind) -> &'static str {
+    match kind {
+        EntryKind::Finding => "finding",
+        EntryKind::Challenge { .. } => "challenge",
+        EntryKind::Confirmation { .. } => "confirmation",
+        EntryKind::Synthesis { .. } => "synthesis",
+        EntryKind::Question => "question",
+        EntryKind::Answer { .. } => "answer",
+    }
 }
 
 /// Token usage and cost for a single contribution.
@@ -482,6 +496,7 @@ pub async fn run_blackboard(
     agents: &[Arc<dyn BoardAgent>],
     providers: &[Arc<dyn Provider>],
     config: &BlackboardConfig,
+    sink: &Arc<dyn EventSink>,
 ) -> anyhow::Result<()> {
     config.validate()?;
 
@@ -531,8 +546,26 @@ pub async fn run_blackboard(
             match result {
                 Ok(Ok(deltas)) => {
                     for delta in deltas {
-                        if let Err(e) = board.apply(delta) {
-                            tracing::warn!(agent = %agent_name, error = %e, "invalid delta");
+                        // Capture the entry kind before `apply` consumes the delta, so we
+                        // can emit `Board{agent, kind}` only once the entry is actually posted.
+                        let posted_kind = match &delta {
+                            BoardDelta::AddEntry(entry) => {
+                                Some(entry_kind_name(&entry.kind).to_string())
+                            }
+                            _ => None,
+                        };
+                        match board.apply(delta) {
+                            Ok(()) => {
+                                if let Some(kind) = posted_kind {
+                                    sink.emit(&RunEvent::Board {
+                                        agent: agent_name.clone(),
+                                        kind,
+                                    });
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(agent = %agent_name, error = %e, "invalid delta");
+                            }
                         }
                     }
                 }
@@ -600,6 +633,11 @@ pub async fn run_blackboard(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// No-op sink for tests that don't assert on emitted events.
+    fn null_sink() -> Arc<dyn EventSink> {
+        Arc::new(crate::core::events::NullSink)
+    }
 
     #[test]
     fn test_token_budget_new() {
@@ -1212,7 +1250,7 @@ mod tests {
         let agents: Vec<Arc<dyn BoardAgent>> = vec![];
         let providers: Vec<Arc<dyn Provider>> = vec![];
         let config = BlackboardConfig::default();
-        let result = run_blackboard(&mut board, &agents, &providers, &config).await;
+        let result = run_blackboard(&mut board, &agents, &providers, &config, &null_sink()).await;
         assert!(result.is_err());
     }
 
@@ -1222,7 +1260,7 @@ mod tests {
         let agents: Vec<Arc<dyn BoardAgent>> = vec![];
         let providers = crate::core::orchestration::test_helpers::noop_providers();
         let config = BlackboardConfig::default();
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
         assert_eq!(
@@ -1306,7 +1344,7 @@ mod tests {
         let providers = crate::core::orchestration::test_helpers::noop_providers();
         let config = BlackboardConfig::default();
 
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -1317,6 +1355,60 @@ mod tests {
             } => {}
             other => panic!("Expected Consensus halt, got {other:?}"),
         }
+    }
+
+    /// A sink that captures every emitted event as its JSONL-serialized form,
+    /// for assertions on which events fired and with what payload.
+    struct CaptureSink(std::sync::Mutex<Vec<String>>);
+
+    impl CaptureSink {
+        fn new() -> Self {
+            Self(std::sync::Mutex::new(Vec::new()))
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl EventSink for CaptureSink {
+        fn emit(&self, ev: &RunEvent) {
+            if let Ok(s) = serde_json::to_string(ev) {
+                self.0.lock().unwrap().push(s);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_blackboard_emits_board_event_on_add_entry() {
+        let mut board = Board::new("review code".to_string(), 50_000);
+        let agents: Vec<Arc<dyn BoardAgent>> = vec![Arc::new(FindThenConfirmAgent {
+            id: "agent-a".into(),
+        })];
+        let providers = crate::core::orchestration::test_helpers::noop_providers();
+        let config = BlackboardConfig::default();
+        let capture = Arc::new(CaptureSink::new());
+        let sink: Arc<dyn EventSink> = capture.clone();
+
+        run_blackboard(&mut board, &agents, &providers, &config, &sink)
+            .await
+            .unwrap();
+
+        let events = capture.events();
+        // Round 0: agent-a posts a Finding -> Board{agent:"agent-a", kind:"finding"}.
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"board""#)
+                && e.contains(r#""agent":"agent-a""#)
+                && e.contains(r#""kind":"finding""#)),
+            "expected a board finding event, got: {events:?}"
+        );
+        // Later rounds: agent-a confirms -> Board{agent:"agent-a", kind:"confirmation"}.
+        assert!(
+            events
+                .iter()
+                .any(|e| e.contains(r#""t":"board""#) && e.contains(r#""kind":"confirmation""#)),
+            "expected a board confirmation event, got: {events:?}"
+        );
     }
 
     /// Mock agent that always times out.
@@ -1351,7 +1443,7 @@ mod tests {
             ..Default::default()
         };
 
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -1370,7 +1462,7 @@ mod tests {
             ..Default::default()
         };
 
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -1391,7 +1483,7 @@ mod tests {
         let providers = crate::core::orchestration::test_helpers::noop_providers();
         let config = BlackboardConfig::default();
 
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -1481,7 +1573,7 @@ mod tests {
         };
         board.apply(BoardDelta::AddEntry(entry)).unwrap();
 
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 

--- a/src/core/orchestration/e2e_tests.rs
+++ b/src/core/orchestration/e2e_tests.rs
@@ -13,6 +13,7 @@ mod tests {
     use async_trait::async_trait;
 
     use crate::core::agent::{Agent, AgentMetadata};
+    use crate::core::events::{EventSink, NullSink};
     use crate::core::orchestration::classifier::classify_with_config;
     use crate::core::orchestration::context_injection::{AgentInfo, build_orchestration_prompt};
     use crate::core::orchestration::hierarchical::HierarchicalEngine;
@@ -22,6 +23,11 @@ mod tests {
     use crate::providers::traits::{
         CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
     };
+
+    /// No-op sink for tests that don't assert on emitted events.
+    fn null_sink() -> Arc<dyn EventSink> {
+        Arc::new(NullSink)
+    }
 
     // ── Test infrastructure ──────────────────────────────────────
 
@@ -222,7 +228,7 @@ timeout: 120
         );
 
         // Step 5: Run the engine
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Build a user management system").await.unwrap();
 
         // Step 6: Verify results
@@ -311,7 +317,7 @@ timeout: 120
         providers.insert("coord".to_string(), coord_provider);
         providers.insert("worker".to_string(), worker_provider);
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let _ = engine.run("Do something").await.unwrap();
 
         // The coordinator's system prompt should contain orchestration context
@@ -363,7 +369,7 @@ teams:
             Arc::new(ScriptedProvider::new("boss", vec!["I've decided: 42."])),
         );
 
-        let mut engine = HierarchicalEngine::new(run_config, agents, providers);
+        let mut engine = HierarchicalEngine::new(run_config, agents, providers, null_sink());
         let result = engine.run("What is the answer?").await.unwrap();
         assert_eq!(result.content, "I've decided: 42.");
     }
@@ -457,7 +463,7 @@ teams:
             )),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Build the feature").await.unwrap();
 
         assert!(!result.content.is_empty());
@@ -506,7 +512,7 @@ teams:
             Arc::new(ScriptedProvider::new("b", vec!["B done."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do both").await.unwrap();
 
         // 4 LLM calls: coord(delegate) + a + b + coord(synthesize)
@@ -562,7 +568,7 @@ teams:
             Arc::new(ScriptedProvider::new("worker", vec!["First result."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let _ = engine.run("Do the work").await.unwrap();
 
         // Coordinator was called twice (delegate then synthesize)
@@ -601,7 +607,7 @@ teams:
             Arc::new(ScriptedProvider::new("worker", vec!["ok"])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Test unknown agent").await;
 
         // Should error because ghost-agent has no provider
@@ -674,7 +680,7 @@ teams:
             )),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Review the application").await.unwrap();
 
         assert!(!result.content.is_empty());

--- a/src/core/orchestration/gemini_integration_tests.rs
+++ b/src/core/orchestration/gemini_integration_tests.rs
@@ -23,6 +23,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::core::agent::{Agent, AgentMetadata};
+use crate::core::events::{EventSink, NullSink};
 use crate::core::orchestration::hierarchical::HierarchicalEngine;
 use crate::core::orchestration::{OrchestrationConfig, OrchestrationPattern, TeamConfig};
 use crate::providers::api::google::GoogleProvider;
@@ -33,6 +34,11 @@ use crate::providers::traits::Provider;
 /// Helper to check if we should skip tests (no API key available).
 fn skip_unless_gemini() -> bool {
     std::env::var("GOOGLE_API_KEY").is_err()
+}
+
+/// No-op sink for tests that don't assert on emitted events.
+fn null_sink() -> Arc<dyn EventSink> {
+    Arc::new(NullSink)
 }
 
 /// Create a minimal agent for testing.
@@ -105,7 +111,7 @@ async fn test_direct_agent_responds() {
     };
 
     // Create engine and run
-    let mut engine = HierarchicalEngine::new(config, agents, providers);
+    let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
     let result = engine.run("What is 2+2?").await;
 
     // Verify success
@@ -199,7 +205,7 @@ async fn test_hierarchical_delegation_works() {
     };
 
     // Create engine and run
-    let mut engine = HierarchicalEngine::new(config, agents, providers);
+    let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
     let result = engine
         .run("Review this function: fn add(a: i32, b: i32) -> i32 { a + b }")
         .await;
@@ -286,7 +292,7 @@ async fn test_budget_halts_gracefully() {
     };
 
     // Create engine and run
-    let mut engine = HierarchicalEngine::new(config, agents, providers);
+    let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
     let result = engine
         .run("Please provide an exhaustive analysis of the political, economic, social, and technological implications of artificial intelligence across all sectors of modern society.")
         .await;
@@ -377,7 +383,7 @@ async fn test_agents_follow_roles() {
     };
 
     // Create engine and run
-    let mut engine = HierarchicalEngine::new(config, agents, providers);
+    let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
     let result = engine
         .run("Process this text: The quick brown fox jumps over the lazy dog")
         .await;

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -13,6 +13,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use crate::core::agent::Agent;
+use crate::core::events::{EventSink, RunEvent};
 use crate::providers::traits::{ChatMessage, CompletionRequest, CompletionResponse, Provider};
 
 use super::OrchestrationConfig;
@@ -52,6 +53,7 @@ struct EngineContext {
     agents: HashMap<String, Agent>,
     providers: HashMap<String, Arc<dyn Provider>>,
     agents_info: HashMap<String, AgentInfo>,
+    sink: Arc<dyn EventSink>,
 }
 
 /// Mutable state protected by a mutex for concurrent access.
@@ -78,10 +80,15 @@ pub struct HierarchicalEngine {
 
 impl HierarchicalEngine {
     /// Create a new engine from config, agents, and their providers.
+    ///
+    /// `sink` receives `RunEvent::Delegate{from, to}` for every agent invocation
+    /// (initial coordinator call and every recursive delegation/ask-peer/escalate).
+    /// Pass `Arc::new(NullSink)` when JSONL event emission is not needed.
     pub fn new(
         config: OrchestrationConfig,
         agents: HashMap<String, Agent>,
         providers: HashMap<String, Arc<dyn Provider>>,
+        sink: Arc<dyn EventSink>,
     ) -> Self {
         let agents_info = agents
             .iter()
@@ -107,6 +114,7 @@ impl HierarchicalEngine {
                 agents,
                 providers,
                 agents_info,
+                sink,
             }),
             state: Arc::new(Mutex::new(EngineState {
                 conversations: HashMap::new(),
@@ -227,6 +235,10 @@ fn invoke_agent(
                 to: agent_name.clone(),
                 message: truncate(&input, 200),
                 depth,
+            });
+            ctx.sink.emit(&RunEvent::Delegate {
+                from: sender.clone(),
+                to: agent_name.clone(),
             });
             let conv = s.conversations.entry(agent_name.clone()).or_default();
             conv.push(ChatMessage {
@@ -514,10 +526,16 @@ fn truncate(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::events::NullSink;
     use crate::core::orchestration::TeamConfig;
     use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
     use async_trait::async_trait;
     use std::path::PathBuf;
+
+    /// No-op sink for tests that don't assert on emitted events.
+    fn null_sink() -> Arc<dyn EventSink> {
+        Arc::new(NullSink)
+    }
 
     /// A mock provider that returns scripted responses in order.
     struct MockProvider {
@@ -629,7 +647,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["The answer is 42."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("What is the answer?").await.unwrap();
 
         assert_eq!(result.content, "The answer is 42.");
@@ -663,12 +681,81 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Result from agent A."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do something").await.unwrap();
 
         assert_eq!(result.content, "Final synthesis from coord.");
         assert_eq!(result.invocation_count, 3); // coord + agent-a + coord synthesis
         assert!(result.trace.len() >= 2);
+    }
+
+    /// A sink that captures every emitted event as its JSONL-serialized form,
+    /// for assertions on which events fired and with what payload.
+    struct CaptureSink(std::sync::Mutex<Vec<String>>);
+
+    impl CaptureSink {
+        fn new() -> Self {
+            Self(std::sync::Mutex::new(Vec::new()))
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl EventSink for CaptureSink {
+        fn emit(&self, ev: &RunEvent) {
+            if let Ok(s) = serde_json::to_string(ev) {
+                self.0.lock().unwrap().push(s);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_delegation_emits_delegate_events() {
+        let config = sample_config();
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "You coordinate."),
+        );
+        agents.insert("agent-a".to_string(), make_agent("agent-a", "You do A."));
+        agents.insert("agent-b".to_string(), make_agent("agent-b", "You do B."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(MockProvider::new(vec![
+                "@agent-a: do the task",
+                "Final synthesis from coord.",
+            ])),
+        );
+        providers.insert(
+            "agent-a".to_string(),
+            Arc::new(MockProvider::new(vec!["Result from agent A."])),
+        );
+
+        let capture = Arc::new(CaptureSink::new());
+        let sink: Arc<dyn EventSink> = capture.clone();
+        let mut engine = HierarchicalEngine::new(config, agents, providers, sink);
+        let _ = engine.run("Do something").await.unwrap();
+
+        let events = capture.events();
+        // Entry point: user -> coordinator.
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"delegate""#)
+                && e.contains(r#""from":"user""#)
+                && e.contains(r#""to":"coordinator""#)),
+            "expected user->coordinator delegate event, got: {events:?}"
+        );
+        // Recursive delegation: coordinator -> agent-a.
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"delegate""#)
+                && e.contains(r#""from":"coordinator""#)
+                && e.contains(r#""to":"agent-a""#)),
+            "expected coordinator->agent-a delegate event, got: {events:?}"
+        );
     }
 
     #[tokio::test]
@@ -700,7 +787,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["B done."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do both tasks").await.unwrap();
 
         assert_eq!(result.content, "Combined result from both agents.");
@@ -743,7 +830,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["done"])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let err = engine.run("deep task").await.unwrap_err();
         assert!(err.to_string().contains("Max delegation depth"));
     }
@@ -779,7 +866,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["done 1"])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let err = engine.run("keep going").await.unwrap_err();
         assert!(err.to_string().contains("Max iterations"));
     }
@@ -802,7 +889,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Direct answer."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Simple question").await.unwrap();
 
         assert_eq!(result.total_tokens_in, 10);
@@ -880,7 +967,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Result B."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do both tasks").await.unwrap();
 
         let total_tokens = result.total_tokens_in as u64 + result.total_tokens_out as u64;
@@ -937,7 +1024,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Result B."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do something").await.unwrap();
 
         assert!(
@@ -985,7 +1072,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Result A."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do something").await.unwrap();
 
         assert!(!result.content.contains("Budget exceeded"));
@@ -1032,7 +1119,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Done B."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do both tasks").await;
 
         assert!(result.is_ok(), "Budget limit should return Ok, not Err");
@@ -1091,7 +1178,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Gamma result."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
         let result = engine.run("Do all three tasks").await.unwrap();
 
         assert_eq!(
@@ -1121,7 +1208,7 @@ mod tests {
             Arc::new(MockProvider::new(vec!["Direct answer."])),
         );
 
-        let mut engine = HierarchicalEngine::new(config, agents, providers);
+        let mut engine = HierarchicalEngine::new(config, agents, providers, null_sink());
 
         // Poison the mutex by panicking while holding the lock
         let state = Arc::clone(&engine.state);
@@ -1273,6 +1360,7 @@ mod tests {
                 agents,
                 providers,
                 agents_info,
+                sink: null_sink(),
             }),
             state,
         };

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::core::agent::Agent;
 use crate::core::events::{EventSink, RunEvent};
+use crate::core::routing::{BudgetState, RoutingRules, route};
 use crate::providers::traits::{ChatMessage, CompletionRequest, CompletionResponse, Provider};
 
 use super::OrchestrationConfig;
@@ -54,6 +55,12 @@ struct EngineContext {
     providers: HashMap<String, Arc<dyn Provider>>,
     agents_info: HashMap<String, AgentInfo>,
     sink: Arc<dyn EventSink>,
+    /// Rules for routing `latest:auto` agents (spec: OH4 router in orchestration,
+    /// mirroring `RoutingCtx` in `llm_agents.rs` for board/ring). Defaults to
+    /// the embedded `RoutingRules::default()` when the engine is built via
+    /// `new()`; `with_routing_rules()` allows callers (e.g. `run_orchestrated`)
+    /// to supply the project's `armadai.yaml` `routing:` section instead.
+    routing_rules: RoutingRules,
 }
 
 /// Mutable state protected by a mutex for concurrent access.
@@ -84,11 +91,32 @@ impl HierarchicalEngine {
     /// `sink` receives `RunEvent::Delegate{from, to}` for every agent invocation
     /// (initial coordinator call and every recursive delegation/ask-peer/escalate).
     /// Pass `Arc::new(NullSink)` when JSONL event emission is not needed.
+    ///
+    /// Uses the embedded `RoutingRules::default()` for any `latest:auto` agent
+    /// in the fleet — use `with_routing_rules` to supply project-configured
+    /// rules instead (see `run_orchestrated` in `cli/run.rs`).
     pub fn new(
         config: OrchestrationConfig,
         agents: HashMap<String, Agent>,
         providers: HashMap<String, Arc<dyn Provider>>,
         sink: Arc<dyn EventSink>,
+    ) -> Self {
+        Self::with_routing_rules(config, agents, providers, sink, RoutingRules::default())
+    }
+
+    /// Like `new`, but with explicit `RoutingRules` for `latest:auto` agents.
+    ///
+    /// Mirrors `RoutingCtx` in `llm_agents.rs` (Task 3): `call_llm` routes
+    /// `latest:auto` through `core::routing::route`, using these rules and a
+    /// `BudgetState` derived from the engine's configured `token_budget` vs.
+    /// tokens consumed so far. Budget only ever *downgrades* the tier — it
+    /// never introduces a new failure/halt path.
+    pub fn with_routing_rules(
+        config: OrchestrationConfig,
+        agents: HashMap<String, Agent>,
+        providers: HashMap<String, Arc<dyn Provider>>,
+        sink: Arc<dyn EventSink>,
+        routing_rules: RoutingRules,
     ) -> Self {
         let agents_info = agents
             .iter()
@@ -115,6 +143,7 @@ impl HierarchicalEngine {
                 providers,
                 agents_info,
                 sink,
+                routing_rules,
             }),
             state: Arc::new(Mutex::new(EngineState {
                 conversations: HashMap::new(),
@@ -454,18 +483,61 @@ async fn call_llm(
         .get(agent_name)
         .ok_or_else(|| anyhow::anyhow!("Agent '{agent_name}' not found"))?;
 
-    let messages = {
+    let (messages, tokens_consumed) = {
         let s = state.lock().map_err(|e| {
             anyhow::anyhow!("Mutex poisoned in call_llm (read conversation): {:?}", e)
         })?;
-        s.conversations.get(agent_name).cloned().unwrap_or_default()
+        let messages = s.conversations.get(agent_name).cloned().unwrap_or_default();
+        let tokens_consumed = s.total_tokens_in as u64 + s.total_tokens_out as u64;
+        (messages, tokens_consumed)
     }; // unlock before async call
 
-    let model = agent
+    let raw_model = agent
         .metadata
         .model
         .clone()
         .unwrap_or_else(|| "default".to_string());
+
+    // Route `latest:auto` the same way `run_single_agent`/board/ring do (OH4
+    // router). Concrete models and `latest:pro/fast/max` placeholders pass
+    // through unchanged — only the exact `latest:auto` string is special-cased,
+    // matching `agent_model` in `llm_agents.rs`.
+    let model = if raw_model == "latest:auto" {
+        // Use the last message in the conversation (the task/message this
+        // call is about to answer — either the incoming delegation or the
+        // re-injected results for synthesis) as the routing input. Falls
+        // back to the system prompt if the conversation is somehow empty.
+        let routing_input = messages
+            .last()
+            .map(|m| m.content.as_str())
+            .unwrap_or(system_prompt);
+
+        // Budget is derived from the engine's *configured* token_budget vs.
+        // tokens consumed so far across the whole run. `None` (no budget
+        // configured, or configured as 0) disables downgrade — `route()` is
+        // still called, just without a `BudgetState`.
+        let budget = ctx.config.token_budget.filter(|&b| b > 0).map(|total| {
+            let remaining = total.saturating_sub(tokens_consumed);
+            BudgetState {
+                remaining_ratio: remaining as f64 / total as f64,
+            }
+        });
+
+        let (tier, reason) = route(
+            routing_input,
+            &agent.metadata.tags,
+            budget,
+            &ctx.routing_rules,
+        );
+        ctx.sink.emit(&RunEvent::Route {
+            agent: agent_name.to_string(),
+            tier: format!("{tier:?}"),
+            reason: format!("{reason:?}"),
+        });
+        crate::linker::model_resolution::resolve_model_for_tier(&agent.metadata.provider, tier)
+    } else {
+        raw_model
+    };
 
     let request = CompletionRequest {
         model,
@@ -761,6 +833,182 @@ mod tests {
                 .iter()
                 .any(|e| e.contains(r#""t":"delegate""#) && e.contains(r#""from":"user""#)),
             "root call user->coordinator should not emit a Delegate event, got: {events:?}"
+        );
+    }
+
+    // ── latest:auto routing in hierarchical (Task 4) ─────────────
+
+    /// Records the `model` of every `CompletionRequest` it receives, so tests
+    /// can assert what `call_llm` resolved `latest:auto` to (mirrors
+    /// `CapturingProvider` in `llm_agents.rs`'s own test module).
+    struct CapturingProvider {
+        models: std::sync::Mutex<Vec<String>>,
+        tokens_in: u32,
+        tokens_out: u32,
+        response: String,
+    }
+
+    impl CapturingProvider {
+        fn new(response: &str, tokens_in: u32, tokens_out: u32) -> Self {
+            Self {
+                models: std::sync::Mutex::new(Vec::new()),
+                tokens_in,
+                tokens_out,
+                response: response.to_string(),
+            }
+        }
+
+        fn models(&self) -> Vec<String> {
+            self.models.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl Provider for CapturingProvider {
+        async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+            self.models.lock().unwrap().push(request.model.clone());
+            Ok(CompletionResponse {
+                content: self.response.clone(),
+                model: request.model,
+                tokens_in: self.tokens_in,
+                tokens_out: self.tokens_out,
+                cost: 0.0,
+            })
+        }
+
+        async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+            anyhow::bail!("streaming not supported in mock")
+        }
+
+        fn metadata(&self) -> ProviderMetadata {
+            ProviderMetadata {
+                name: "capturing".to_string(),
+                models: vec![],
+                supports_streaming: false,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_latest_auto_routes_in_hierarchical_and_downgrades_on_low_budget() {
+        // Coordinator uses a concrete model and delegates to agent-a, which is
+        // configured with `latest:auto` + a "critical" tag (-> Max tier under
+        // default RoutingRules). MockProvider's coordinator response consumes
+        // 10 input + 20 output = 30 tokens before agent-a is ever invoked. A
+        // `token_budget` of 35 therefore leaves only 5 tokens remaining
+        // (ratio ~0.14) once agent-a's `call_llm` runs, under the 0.2
+        // `budget_downgrade_ratio` threshold -- the router must downgrade
+        // agent-a's tag-driven Max tier to Fast and report
+        // `RouteReason::Budget`, exactly as `agent_model` does for board/ring.
+        let mut config = sample_config();
+        config.token_budget = Some(35);
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "You coordinate."),
+        );
+        let mut agent_a = make_agent("agent-a", "You do A.");
+        agent_a.metadata.model = Some("latest:auto".to_string());
+        agent_a.metadata.tags = vec!["critical".to_string()];
+        agents.insert("agent-a".to_string(), agent_a);
+        agents.insert("agent-b".to_string(), make_agent("agent-b", "You do B."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(MockProvider::new(vec![
+                "@agent-a: do the task",
+                "Final synthesis from coord.",
+            ])),
+        );
+        let capturing = Arc::new(CapturingProvider::new("Result from agent A.", 1, 1));
+        providers.insert(
+            "agent-a".to_string(),
+            capturing.clone() as Arc<dyn Provider>,
+        );
+
+        let sink = Arc::new(CaptureSink::new());
+        let mut engine = HierarchicalEngine::with_routing_rules(
+            config,
+            agents,
+            providers,
+            sink.clone() as Arc<dyn EventSink>,
+            RoutingRules::default(),
+        );
+
+        let result = engine.run("Do something").await.unwrap();
+        assert_eq!(result.content, "Final synthesis from coord.");
+
+        let models = capturing.models();
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0],
+            crate::linker::model_resolution::resolve_model_for_tier(
+                "mock",
+                crate::linker::model_resolution::ModelTier::Fast,
+            ),
+            "latest:auto with tag 'critical' (Max) must downgrade to Fast under low budget"
+        );
+
+        let events = sink.events();
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"route""#)
+                && e.contains(r#""agent":"agent-a""#)
+                && e.contains(r#""tier":"Fast""#)
+                && e.contains(r#""reason":"Budget""#)),
+            "expected a Route event with tier=Fast reason=Budget for agent-a, got: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_concrete_model_and_latest_pro_unaffected_by_hierarchical_routing() {
+        // Non-regression: concrete models and `latest:pro/fast/max` are NOT
+        // routed through `route()` in hierarchical either -- they must reach
+        // the provider unchanged even under the exact budget scenario
+        // (`token_budget: Some(35)`, same as the downgrade test above) that
+        // *would* force a downgrade if agent-a's model were `latest:auto`.
+        // Only the exact `latest:auto` string is special-cased (see `call_llm`).
+        let mut config = sample_config();
+        config.token_budget = Some(35);
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "You coordinate."),
+        );
+        let mut agent_a = make_agent("agent-a", "You do A.");
+        agent_a.metadata.model = Some("latest:pro".to_string());
+        agents.insert("agent-a".to_string(), agent_a);
+        agents.insert("agent-b".to_string(), make_agent("agent-b", "You do B."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(MockProvider::new(vec![
+                "@agent-a: do the task",
+                "Final synthesis from coord.",
+            ])),
+        );
+        let capturing = Arc::new(CapturingProvider::new("Result from agent A.", 1, 1));
+        providers.insert(
+            "agent-a".to_string(),
+            capturing.clone() as Arc<dyn Provider>,
+        );
+
+        let mut engine = HierarchicalEngine::with_routing_rules(
+            config,
+            agents,
+            providers,
+            null_sink(),
+            RoutingRules::default(),
+        );
+        engine.run("Do something").await.unwrap();
+
+        assert_eq!(
+            capturing.models(),
+            vec!["latest:pro".to_string()],
+            "latest:pro must pass through call_llm unchanged"
         );
     }
 
@@ -1367,6 +1615,7 @@ mod tests {
                 providers,
                 agents_info,
                 sink: null_sink(),
+                routing_rules: RoutingRules::default(),
             }),
             state,
         };

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -236,10 +236,15 @@ fn invoke_agent(
                 message: truncate(&input, 200),
                 depth,
             });
-            ctx.sink.emit(&RunEvent::Delegate {
-                from: sender.clone(),
-                to: agent_name.clone(),
-            });
+            // Only emit `Delegate` for real agent-to-agent delegations. The root
+            // call (`user` -> coordinator) is not a delegation and would otherwise
+            // inflate delegation counts for JSONL consumers.
+            if sender != "user" {
+                ctx.sink.emit(&RunEvent::Delegate {
+                    from: sender.clone(),
+                    to: agent_name.clone(),
+                });
+            }
             let conv = s.conversations.entry(agent_name.clone()).or_default();
             conv.push(ChatMessage {
                 role: "user".to_string(),
@@ -742,19 +747,20 @@ mod tests {
         let _ = engine.run("Do something").await.unwrap();
 
         let events = capture.events();
-        // Entry point: user -> coordinator.
-        assert!(
-            events.iter().any(|e| e.contains(r#""t":"delegate""#)
-                && e.contains(r#""from":"user""#)
-                && e.contains(r#""to":"coordinator""#)),
-            "expected user->coordinator delegate event, got: {events:?}"
-        );
-        // Recursive delegation: coordinator -> agent-a.
+        // Real agent-to-agent delegation: coordinator -> agent-a.
         assert!(
             events.iter().any(|e| e.contains(r#""t":"delegate""#)
                 && e.contains(r#""from":"coordinator""#)
                 && e.contains(r#""to":"agent-a""#)),
             "expected coordinator->agent-a delegate event, got: {events:?}"
+        );
+        // Root call (user -> coordinator) is NOT a real delegation and must not
+        // be emitted as a `Delegate` event.
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.contains(r#""t":"delegate""#) && e.contains(r#""from":"user""#)),
+            "root call user->coordinator should not emit a Delegate event, got: {events:?}"
         );
     }
 

--- a/src/core/orchestration/llm_agents.rs
+++ b/src/core/orchestration/llm_agents.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::Utc;
 
@@ -6,16 +8,91 @@ use super::blackboard::{
 };
 use super::ring::{Contribution, ContributionAction, RingAgent, RingRole, TokenSnapshot, Vote};
 use crate::core::agent::Agent;
+use crate::core::events::{EventSink, NullSink, RunEvent};
+use crate::core::routing::{BudgetState, RoutingRules, route};
 use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
-/// Resolve the model string from agent metadata.
-fn agent_model(agent: &Agent) -> String {
-    agent
+/// Routing context threaded through the orchestration engines so
+/// `LlmBoardAgent`/`LlmRingAgent` can route `latest:auto` models the same way
+/// `run_single_agent` does (spec: OH4 router in orchestration).
+///
+/// `rules` is shared via `Arc` since one context is cloned into every agent
+/// built for a run. `total_budget` is the board/ring's *configured*
+/// `token_budget` (constant for the run) — not the remaining amount, which
+/// changes every round/lap and is read from the snapshot at route time.
+/// `None` (or a configured budget of `0`) disables budget-aware downgrade
+/// entirely: `route()` is still called, just with `budget: None`.
+#[derive(Clone)]
+pub struct RoutingCtx {
+    rules: Arc<RoutingRules>,
+    total_budget: Option<u64>,
+}
+
+impl RoutingCtx {
+    /// `total_budget` is the board/ring's configured token budget (e.g.
+    /// `BlackboardConfig::token_budget` / `RingConfig::token_budget`).
+    pub fn new(rules: RoutingRules, total_budget: u64) -> Self {
+        Self {
+            rules: Arc::new(rules),
+            total_budget: (total_budget > 0).then_some(total_budget),
+        }
+    }
+
+    /// Derive the router's `BudgetState` from tokens remaining vs. the
+    /// configured total. `None` when no budget is configured for this run.
+    fn budget_state(&self, remaining: u64) -> Option<BudgetState> {
+        self.total_budget.map(|total| BudgetState {
+            remaining_ratio: remaining as f64 / total as f64,
+        })
+    }
+}
+
+impl Default for RoutingCtx {
+    fn default() -> Self {
+        Self {
+            rules: Arc::new(RoutingRules::default()),
+            total_budget: None,
+        }
+    }
+}
+
+/// Resolve the model string for a completion request.
+///
+/// Concrete models, `command`-based agents, and `latest:pro/fast/max`
+/// placeholders pass through unchanged — those are resolved later by the
+/// linker (`resolve_model_for_tier` is only reached here for `latest:auto`;
+/// `parse_latest_placeholder` deliberately does not recognize it, see
+/// `linker::model_resolution`). `latest:auto` is routed through the OH4
+/// router (`core::routing::route`) using `input` (the prompt about to be
+/// sent), the agent's tags, and the budget derived from `budget_remaining`
+/// via `routing`. Emits `RunEvent::Route` on the routed path — budget only
+/// ever *downgrades* the tier (see `route`), it never fails the run.
+fn agent_model(
+    agent: &Agent,
+    input: &str,
+    budget_remaining: u64,
+    routing: &RoutingCtx,
+    sink: &Arc<dyn EventSink>,
+) -> String {
+    let raw = agent
         .metadata
         .model
         .clone()
         .or_else(|| agent.metadata.command.clone())
-        .unwrap_or_else(|| "default".to_string())
+        .unwrap_or_else(|| "default".to_string());
+
+    if raw != "latest:auto" {
+        return raw;
+    }
+
+    let budget = routing.budget_state(budget_remaining);
+    let (tier, reason) = route(input, &agent.metadata.tags, budget, &routing.rules);
+    sink.emit(&RunEvent::Route {
+        agent: agent.name.clone(),
+        tier: format!("{tier:?}"),
+        reason: format!("{reason:?}"),
+    });
+    crate::linker::model_resolution::resolve_model_for_tier(&agent.metadata.provider, tier)
 }
 
 // ── Structured-response parsers ─────────────────────────────────
@@ -191,11 +268,29 @@ fn parse_index_list(s: &Option<String>) -> Vec<usize> {
 /// otherwise the agent participates in every round.
 pub struct LlmBoardAgent {
     agent: Agent,
+    routing: RoutingCtx,
+    sink: Arc<dyn EventSink>,
 }
 
 impl LlmBoardAgent {
     pub fn new(agent: Agent) -> Self {
-        Self { agent }
+        Self {
+            agent,
+            routing: RoutingCtx::default(),
+            sink: Arc::new(NullSink),
+        }
+    }
+
+    /// Construct with an explicit routing context and event sink. Used by
+    /// `run_orchestrated` so `latest:auto` agents route through the
+    /// project's `RoutingRules` and the board's configured budget, emitting
+    /// `RunEvent::Route` via `sink`.
+    pub fn with_routing(agent: Agent, routing: RoutingCtx, sink: Arc<dyn EventSink>) -> Self {
+        Self {
+            agent,
+            routing,
+            sink,
+        }
     }
 }
 
@@ -289,7 +384,13 @@ impl BoardAgent for LlmBoardAgent {
         user_msg.push_str(BOARD_ACTION_INSTRUCTIONS);
 
         let request = CompletionRequest {
-            model: agent_model(&self.agent),
+            model: agent_model(
+                &self.agent,
+                &user_msg,
+                board.budget_remaining,
+                &self.routing,
+                &self.sink,
+            ),
             system_prompt: self.agent.system_prompt.clone(),
             messages: vec![ChatMessage {
                 role: "user".to_string(),
@@ -331,11 +432,29 @@ impl BoardAgent for LlmBoardAgent {
 /// `AgentRingConfig` if present, defaulting to `Specialist { domain: "general" }`.
 pub struct LlmRingAgent {
     agent: Agent,
+    routing: RoutingCtx,
+    sink: Arc<dyn EventSink>,
 }
 
 impl LlmRingAgent {
     pub fn new(agent: Agent) -> Self {
-        Self { agent }
+        Self {
+            agent,
+            routing: RoutingCtx::default(),
+            sink: Arc::new(NullSink),
+        }
+    }
+
+    /// Construct with an explicit routing context and event sink. Used by
+    /// `run_orchestrated` so `latest:auto` agents route through the
+    /// project's `RoutingRules` and the ring's configured budget, emitting
+    /// `RunEvent::Route` via `sink`.
+    pub fn with_routing(agent: Agent, routing: RoutingCtx, sink: Arc<dyn EventSink>) -> Self {
+        Self {
+            agent,
+            routing,
+            sink,
+        }
     }
 }
 
@@ -387,7 +506,13 @@ impl RingAgent for LlmRingAgent {
         user_msg.push_str(RING_ACTION_INSTRUCTIONS);
 
         let request = CompletionRequest {
-            model: agent_model(&self.agent),
+            model: agent_model(
+                &self.agent,
+                &user_msg,
+                token.budget_remaining,
+                &self.routing,
+                &self.sink,
+            ),
             system_prompt: self.agent.system_prompt.clone(),
             messages: vec![ChatMessage {
                 role: "user".to_string(),
@@ -446,7 +571,13 @@ impl RingAgent for LlmRingAgent {
         );
 
         let request = CompletionRequest {
-            model: agent_model(&self.agent),
+            model: agent_model(
+                &self.agent,
+                &user_msg,
+                token.budget_remaining,
+                &self.routing,
+                &self.sink,
+            ),
             system_prompt: self.agent.system_prompt.clone(),
             messages: vec![ChatMessage {
                 role: "user".to_string(),
@@ -1104,5 +1235,252 @@ mod tests {
     fn test_parse_index_list_mixed_invalid() {
         // Skips invalid entries
         assert_eq!(parse_index_list(&Some("1, abc, 3".to_string())), vec![1, 3]);
+    }
+
+    // ── latest:auto routing in orchestration (RoutingCtx) ────────────
+
+    /// Records the `model` of every `CompletionRequest` it receives, so tests
+    /// can assert what `agent_model` resolved `latest:auto` to.
+    struct CapturingProvider(std::sync::Mutex<Vec<String>>);
+
+    impl CapturingProvider {
+        fn new() -> Self {
+            Self(std::sync::Mutex::new(Vec::new()))
+        }
+
+        fn models(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl Provider for CapturingProvider {
+        async fn complete(
+            &self,
+            request: CompletionRequest,
+        ) -> anyhow::Result<crate::providers::traits::CompletionResponse> {
+            self.0.lock().unwrap().push(request.model.clone());
+            Ok(crate::providers::traits::CompletionResponse {
+                content: "ACTION: FINDING\nCONFIDENCE: 0.8\nCONTENT: ok".to_string(),
+                model: request.model,
+                tokens_in: 1,
+                tokens_out: 1,
+                cost: 0.0,
+            })
+        }
+
+        async fn stream(
+            &self,
+            _request: CompletionRequest,
+        ) -> anyhow::Result<crate::providers::traits::TokenStream> {
+            unimplemented!("not exercised by these tests")
+        }
+
+        fn metadata(&self) -> crate::providers::traits::ProviderMetadata {
+            crate::providers::traits::ProviderMetadata {
+                name: "capturing".to_string(),
+                models: vec![],
+                supports_streaming: false,
+            }
+        }
+    }
+
+    /// Capture-only sink so tests can assert on emitted `RunEvent`s (mirrors
+    /// the `CaptureSink` used in `ring.rs`'s own test module).
+    struct CaptureSink(std::sync::Mutex<Vec<String>>);
+
+    impl CaptureSink {
+        fn new() -> Self {
+            Self(std::sync::Mutex::new(Vec::new()))
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl EventSink for CaptureSink {
+        fn emit(&self, ev: &RunEvent) {
+            if let Ok(s) = serde_json::to_string(ev) {
+                self.0.lock().unwrap().push(s);
+            }
+        }
+    }
+
+    fn make_agent_latest_auto(name: &str, tags: Vec<String>) -> Agent {
+        let mut agent = make_agent(name);
+        agent.metadata.model = Some("latest:auto".to_string());
+        agent.metadata.tags = tags;
+        agent
+    }
+
+    #[tokio::test]
+    async fn test_board_agent_latest_auto_downgrades_on_low_budget() {
+        // The "critical" tag maps to Max under default RoutingRules, but the
+        // board's remaining budget is far below `budget_downgrade_ratio`
+        // (default 0.2) — the router must downgrade to Fast and report
+        // RouteReason::Budget, exactly as it would for run_single_agent.
+        let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
+        let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
+        let sink = Arc::new(CaptureSink::new());
+        let board_agent =
+            LlmBoardAgent::with_routing(agent, routing, sink.clone() as Arc<dyn EventSink>);
+
+        let snapshot = BoardSnapshot {
+            task: "test task".to_string(),
+            entries: Arc::new(vec![]),
+            round: 0,
+            state: BoardState::Open,
+            context: Default::default(),
+            budget_remaining: 50, // 50 / 1_000 = 0.05 <= 0.2 downgrade threshold
+        };
+
+        let provider = CapturingProvider::new();
+        board_agent.contribute(&snapshot, &provider).await.unwrap();
+
+        let models = provider.models();
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0],
+            crate::linker::model_resolution::resolve_model_for_tier(
+                "anthropic",
+                crate::linker::model_resolution::ModelTier::Fast,
+            ),
+            "latest:auto should resolve to the Fast tier's model when budget is low"
+        );
+
+        let events = sink.events();
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"route""#)
+                && e.contains(r#""agent":"agent-a""#)
+                && e.contains(r#""tier":"Fast""#)
+                && e.contains(r#""reason":"Budget""#)),
+            "expected a Route event with tier=Fast reason=Budget, got: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_board_agent_latest_auto_no_downgrade_when_budget_healthy() {
+        // Same "critical" tag (→ Max) but a healthy budget: no downgrade,
+        // reason stays Tag — proves the budget check is not unconditional.
+        let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
+        let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
+        let sink = Arc::new(CaptureSink::new());
+        let board_agent =
+            LlmBoardAgent::with_routing(agent, routing, sink.clone() as Arc<dyn EventSink>);
+
+        let snapshot = BoardSnapshot {
+            task: "test task".to_string(),
+            entries: Arc::new(vec![]),
+            round: 0,
+            state: BoardState::Open,
+            context: Default::default(),
+            budget_remaining: 900, // 900 / 1_000 = 0.9, well above threshold
+        };
+
+        let provider = CapturingProvider::new();
+        board_agent.contribute(&snapshot, &provider).await.unwrap();
+
+        let models = provider.models();
+        assert_eq!(
+            models[0],
+            crate::linker::model_resolution::resolve_model_for_tier(
+                "anthropic",
+                crate::linker::model_resolution::ModelTier::Max,
+            )
+        );
+
+        let events = sink.events();
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"route""#)
+                && e.contains(r#""tier":"Max""#)
+                && e.contains(r#""reason":"Tag""#)),
+            "expected a Route event with tier=Max reason=Tag, got: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ring_agent_latest_auto_downgrades_on_low_budget() {
+        let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
+        let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
+        let sink = Arc::new(CaptureSink::new());
+        let ring_agent =
+            LlmRingAgent::with_routing(agent, routing, sink.clone() as Arc<dyn EventSink>);
+
+        let snapshot = TokenSnapshot {
+            task: "test task".to_string(),
+            contributions: Arc::new(vec![]),
+            lap: 0,
+            status: TokenStatus::Circulating,
+            ring_order: vec!["agent-a".to_string()],
+            current_position: 0,
+            budget_remaining: 30, // 30 / 1_000 = 0.03, well under threshold
+        };
+
+        let provider = CapturingProvider::new();
+        ring_agent.process(&snapshot, &provider).await.unwrap();
+
+        let models = provider.models();
+        assert_eq!(
+            models[0],
+            crate::linker::model_resolution::resolve_model_for_tier(
+                "anthropic",
+                crate::linker::model_resolution::ModelTier::Fast,
+            )
+        );
+
+        let events = sink.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.contains(r#""t":"route""#) && e.contains(r#""reason":"Budget""#)),
+            "expected a Route event with reason=Budget for the ring agent, got: {events:?}"
+        );
+    }
+
+    #[test]
+    fn test_agent_model_concrete_and_latest_pro_unaffected_by_routing() {
+        // Non-regression: concrete models and latest:pro/fast/max are NOT
+        // routed through `route()` — they pass through unchanged regardless
+        // of budget/RoutingCtx. Only `latest:auto` is special-cased.
+        let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
+        let sink: Arc<dyn EventSink> = Arc::new(NullSink);
+
+        let mut concrete = make_agent("agent-concrete");
+        concrete.metadata.model = Some("claude-sonnet-4-5-20250929".to_string());
+        assert_eq!(
+            agent_model(&concrete, "any input", 10, &routing, &sink),
+            "claude-sonnet-4-5-20250929"
+        );
+
+        let mut latest_pro = make_agent("agent-pro");
+        latest_pro.metadata.model = Some("latest:pro".to_string());
+        assert_eq!(
+            agent_model(&latest_pro, "any input", 10, &routing, &sink),
+            "latest:pro",
+            "latest:pro must NOT be routed here — only latest:auto is special-cased"
+        );
+    }
+
+    #[test]
+    fn test_routing_ctx_default_disables_budget_downgrade() {
+        // A `RoutingCtx::default()` (used by `LlmBoardAgent::new`/`LlmRingAgent::new`
+        // when no explicit routing context is supplied) must carry no budget,
+        // so `route()` never downgrades regardless of remaining tokens.
+        let routing = RoutingCtx::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullSink);
+
+        let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
+        // budget_remaining is irrelevant here since RoutingCtx::default() has
+        // no total_budget — the router never receives a `BudgetState`.
+        let model = agent_model(&agent, "hi", 0, &routing, &sink);
+        assert_eq!(
+            model,
+            crate::linker::model_resolution::resolve_model_for_tier(
+                "anthropic",
+                crate::linker::model_resolution::ModelTier::Max,
+            ),
+            "no budget configured → tag-driven Max tier must not be downgraded"
+        );
     }
 }

--- a/src/core/orchestration/llm_agents.rs
+++ b/src/core/orchestration/llm_agents.rs
@@ -1,24 +1,12 @@
 use async_trait::async_trait;
 use chrono::Utc;
 
-use super::blackboard::{BoardAgent, BoardDelta, BoardEntry, BoardSnapshot, EntryKind, TokenCount};
+use super::blackboard::{
+    BoardAgent, BoardDelta, BoardEntry, BoardSnapshot, EntryKind, TokenCount, entry_kind_name,
+};
 use super::ring::{Contribution, ContributionAction, RingAgent, RingRole, TokenSnapshot, Vote};
 use crate::core::agent::Agent;
 use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
-
-// ── Helpers ──────────────────────────────────────────────────────
-
-/// Map an `EntryKind` variant to a lowercase name for trigger matching.
-fn entry_kind_name(kind: &EntryKind) -> &str {
-    match kind {
-        EntryKind::Finding => "finding",
-        EntryKind::Challenge { .. } => "challenge",
-        EntryKind::Confirmation { .. } => "confirmation",
-        EntryKind::Synthesis { .. } => "synthesis",
-        EntryKind::Question => "question",
-        EntryKind::Answer { .. } => "answer",
-    }
-}
 
 /// Resolve the model string from agent metadata.
 fn agent_model(agent: &Agent) -> String {
@@ -490,6 +478,7 @@ mod tests {
 
     use super::*;
     use crate::core::agent::{Agent, AgentMetadata};
+    use crate::core::events::{EventSink, NullSink};
     use crate::core::orchestration::blackboard::{
         BlackboardConfig, Board, BoardState, run_blackboard,
     };
@@ -498,6 +487,11 @@ mod tests {
     };
     use crate::core::orchestration::test_helpers::noop_providers;
     use crate::core::orchestration::{AgentRingConfig, TriggerConfig};
+
+    /// No-op sink for tests that don't assert on emitted events.
+    fn null_sink() -> Arc<dyn EventSink> {
+        Arc::new(NullSink)
+    }
 
     fn make_agent(name: &str) -> Agent {
         Agent {
@@ -775,7 +769,7 @@ mod tests {
         };
         let mut board = Board::new("test task".to_string(), config.token_budget);
 
-        run_blackboard(&mut board, &agents, &providers, &config)
+        run_blackboard(&mut board, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -823,7 +817,7 @@ mod tests {
         let order = vec!["agent-a".to_string(), "agent-b".to_string()];
         let mut token = RingToken::new("test task".to_string(), order, config.token_budget);
 
-        run_ring(&mut token, &agents, &providers, &config)
+        run_ring(&mut token, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 

--- a/src/core/orchestration/ring.rs
+++ b/src/core/orchestration/ring.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use super::blackboard::TokenBudget;
 use super::blackboard::TokenCount;
+use crate::core::events::{EventSink, RunEvent};
 use crate::providers::traits::Provider;
 
 // ── Data structures ──────────────────────────────────────────────
@@ -472,6 +473,7 @@ pub async fn run_ring(
     agents: &[Arc<dyn RingAgent>],
     providers: &[Arc<dyn Provider>],
     config: &RingConfig,
+    sink: &Arc<dyn EventSink>,
 ) -> anyhow::Result<()> {
     config.validate()?;
 
@@ -569,6 +571,10 @@ pub async fn run_ring(
 
         match tokio::time::timeout(vote_timeout, agent.vote(&snapshot, provider)).await {
             Ok(Ok(vote)) => {
+                sink.emit(&RunEvent::Vote {
+                    agent: agent.name().to_string(),
+                    conf: vote.confidence,
+                });
                 token.votes.insert(agent.name().to_string(), vote);
             }
             Ok(Err(e)) => {
@@ -593,6 +599,11 @@ pub async fn run_ring(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// No-op sink for tests that don't assert on emitted events.
+    fn null_sink() -> Arc<dyn EventSink> {
+        Arc::new(crate::core::events::NullSink)
+    }
 
     #[test]
     fn test_ring_token_new() {
@@ -871,7 +882,7 @@ mod tests {
         let agents: Vec<Arc<dyn RingAgent>> = vec![];
         let providers: Vec<Arc<dyn Provider>> = vec![];
         let config = RingConfig::default();
-        let result = run_ring(&mut token, &agents, &providers, &config).await;
+        let result = run_ring(&mut token, &agents, &providers, &config, &null_sink()).await;
         assert!(result.is_err());
     }
 
@@ -881,7 +892,7 @@ mod tests {
         let agents: Vec<Arc<dyn RingAgent>> = vec![];
         let providers = crate::core::orchestration::test_helpers::noop_providers();
         let config = RingConfig::default();
-        run_ring(&mut token, &agents, &providers, &config)
+        run_ring(&mut token, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -964,7 +975,7 @@ mod tests {
             ..Default::default()
         };
 
-        run_ring(&mut token, &agents, &providers, &config)
+        run_ring(&mut token, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -976,6 +987,60 @@ mod tests {
                 assert!((score - 1.0).abs() < f32::EPSILON);
             }
             other => panic!("Expected Consensus, got {other:?}"),
+        }
+    }
+
+    /// A sink that captures every emitted event as its JSONL-serialized form,
+    /// for assertions on which events fired and with what payload.
+    struct CaptureSink(std::sync::Mutex<Vec<String>>);
+
+    impl CaptureSink {
+        fn new() -> Self {
+            Self(std::sync::Mutex::new(Vec::new()))
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl EventSink for CaptureSink {
+        fn emit(&self, ev: &RunEvent) {
+            if let Ok(s) = serde_json::to_string(ev) {
+                self.0.lock().unwrap().push(s);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_ring_emits_vote_event_per_agent() {
+        let order = vec!["a".to_string(), "b".to_string()];
+        let mut token = RingToken::new("design API".to_string(), order, 50_000);
+        let agents: Vec<Arc<dyn RingAgent>> = vec![
+            Arc::new(ProposeEnrichEndorseAgent { id: "a".into() }),
+            Arc::new(ProposeEnrichEndorseAgent { id: "b".into() }),
+        ];
+        let providers = crate::core::orchestration::test_helpers::noop_providers();
+        let config = RingConfig {
+            max_laps: 1,
+            ..Default::default()
+        };
+        let capture = Arc::new(CaptureSink::new());
+        let sink: Arc<dyn EventSink> = capture.clone();
+
+        run_ring(&mut token, &agents, &providers, &config, &sink)
+            .await
+            .unwrap();
+
+        let events = capture.events();
+        // ProposeEnrichEndorseAgent::vote() always returns confidence 0.9.
+        for agent in ["a", "b"] {
+            assert!(
+                events.iter().any(|e| e.contains(r#""t":"vote""#)
+                    && e.contains(&format!(r#""agent":"{agent}""#))
+                    && e.contains(r#""conf":0.9"#)),
+                "expected a vote event for agent {agent}, got: {events:?}"
+            );
         }
     }
 
@@ -1030,7 +1095,7 @@ mod tests {
         let providers = crate::core::orchestration::test_helpers::noop_providers();
         let config = RingConfig::default();
 
-        run_ring(&mut token, &agents, &providers, &config)
+        run_ring(&mut token, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -1051,7 +1116,7 @@ mod tests {
             ..Default::default()
         };
 
-        run_ring(&mut token, &agents, &providers, &config)
+        run_ring(&mut token, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 
@@ -1068,7 +1133,7 @@ mod tests {
         let providers = crate::core::orchestration::test_helpers::noop_providers();
         let config = RingConfig::default();
 
-        run_ring(&mut token, &agents, &providers, &config)
+        run_ring(&mut token, &agents, &providers, &config, &null_sink())
             .await
             .unwrap();
 


### PR DESCRIPTION
Consolidation OH3/OH4 dans l'orchestration (axe 1 du programme post-rc). Plan : `docs/superpowers/plans/2026-07-17-oh3-oh4-consolidation.md`.

## Ce que ça apporte
- **Events JSONL fins** dans les 3 moteurs : `RunEvent::Delegate{from,to}` (hierarchical, hors root user→coordinator), `Vote{agent,conf}` (ring), `Board{agent,kind}` (blackboard) — émis via le sink OH3, gated `--json`.
- **`latest:auto` routé DANS l'orchestration** : board/ring (via `agent_model`) et hierarchical (via `call_llm`) → `route()` → `resolve_model_for_tier` + event `Route{agent,tier,reason}`. Corrige un bug : `latest:auto` partait brut au provider en hierarchical.
- **Budget = downgrade du tier uniquement** : le `token_budget` restant alimente `BudgetState` → le routeur descend de tier quand le budget est bas. **Aucun exit 3, halt gracieux (exit 0) conservé.**

## Qualité
- 5 commits, 4 tâches TDD + revues par tâche (Task 2 & 3 revues indépendamment) + **revue finale de branche : READY TO MERGE**, aucun bloquant.
- Clippy **2 modes** `--all-targets -D warnings`, `cargo fmt --check`, compile all-features, **723 tests**.
- Non-régression : `NullSink` no-op hors `--json` ; modèles concrets / `latest:pro/fast/max` inchangés ; `latest:auto` non ajouté à `parse_latest_placeholder`.

## Minors (defer, documentés)
`token_budget: 0` explicite désactive le downgrade (marginal) ; `Delegate` émis aussi pour AskPeer/Escalate (échanges agent-agent) ; littéral `"user"` ×3 (nit). Note consumer : un event `route` ≠ une invocation (un coordinateur latest:auto qui délègue puis synthétise émet 2 `route`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)