### PR TITLE
chore(audit): backlog de raffinements post-rc

### DIFF
--- a/src/audit/reverse/claude.rs
+++ b/src/audit/reverse/claude.rs
@@ -269,8 +269,11 @@ fn describe_yaml_error(content: &str, raw: &str, err: &serde_yaml_ng::Error) -> 
         } else {
             0
         };
-        // File line (1-indexed) = lines_before + 1 (opening `---`) + 1 (first YAML line) + loc.line()
-        let file_line = lines_before_frontmatter + 2 + loc.line();
+        // File line (1-indexed) = lines_before + 1 (opening `---`) + loc.line().
+        // `loc.line()` from serde_yaml_ng is already 1-indexed and counts from
+        // the first YAML line (right after the opening `---`), so it must not
+        // be double-counted with an extra "+1 for the first YAML line".
+        let file_line = lines_before_frontmatter + 1 + loc.line();
 
         if let Some(line) = raw.lines().nth(loc.line().saturating_sub(1))
             && let Some((key, value)) = line.split_once(':')
@@ -539,5 +542,59 @@ mod tests {
         assert!(a.metadata.extra.contains_key("effort"));
         assert!(a.metadata.extra.contains_key("paths"));
         assert!(!a.metadata.extra.contains_key("name")); // typed fields never land in extra
+    }
+
+    #[test]
+    fn yaml_error_line_offset_without_leading_blank_lines() {
+        // Regression test: with no blank lines before the opening `---`, the
+        // reported file line must exactly match the physical line of the
+        // erroring field. File layout:
+        //   line 1: ---
+        //   line 2: name: test
+        //   line 3: description: bad : unquoted
+        //   line 4: ---
+        //   line 5: Body
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".claude/agents/offset_no_blank.md",
+            "---\nname: test\ndescription: bad : unquoted\n---\nBody",
+        );
+        let config = ClaudeReverseLinker.parse(dir.path());
+        let a = &config.agents[0];
+        assert_eq!(a.issues.len(), 1);
+        assert!(
+            a.issues[0].message.contains("line 3"),
+            "expected exact 'line 3' reference, got: {}",
+            a.issues[0].message
+        );
+    }
+
+    #[test]
+    fn yaml_error_line_offset_with_leading_blank_lines() {
+        // Regression test for the off-by-one offset bug: when the file has
+        // leading blank lines, describe_yaml_error must correctly offset the
+        // error line number relative to the file start (not the trimmed
+        // content), without over- or under-counting. File layout:
+        //   line 1-3: blank
+        //   line 4: ---
+        //   line 5: name: test
+        //   line 6: description: bad : unquoted
+        //   line 7: ---
+        //   line 8: Body
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".claude/agents/offset_with_blank.md",
+            "\n\n\n---\nname: test\ndescription: bad : unquoted\n---\nBody",
+        );
+        let config = ClaudeReverseLinker.parse(dir.path());
+        let a = &config.agents[0];
+        assert_eq!(a.issues.len(), 1);
+        assert!(
+            a.issues[0].message.contains("line 6"),
+            "expected exact 'line 6' reference, got: {}",
+            a.issues[0].message
+        );
     }
 }

--- a/src/audit/reverse/claude.rs
+++ b/src/audit/reverse/claude.rs
@@ -139,7 +139,7 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
     let (fm, has_frontmatter) = match fm_raw {
         Some(raw) => {
             let fm = serde_yaml_ng::from_str::<SkillFm>(raw).unwrap_or_else(|e| {
-                issues.push(issue(&skill_md, describe_yaml_error(raw, &e)));
+                issues.push(issue(&skill_md, describe_yaml_error(&content, raw, &e)));
                 SkillFm {
                     name: salvage_field(raw, "name"),
                     description: salvage_field(raw, "description"),
@@ -190,7 +190,7 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
     let (fm_raw, body) = extract_frontmatter(&content);
     let fm: ClaudeAgentFrontmatter = match fm_raw {
         Some(raw) => serde_yaml_ng::from_str(raw).unwrap_or_else(|e| {
-            issues.push(issue(path, describe_yaml_error(raw, &e)));
+            issues.push(issue(path, describe_yaml_error(&content, raw, &e)));
             ClaudeAgentFrontmatter {
                 name: salvage_field(raw, "name"),
                 description: salvage_field(raw, "description"),
@@ -255,10 +255,23 @@ fn salvage_field(raw: &str, key: &str) -> Option<String> {
 /// Turn a strict-YAML error into a message the Markdown-writing user can
 /// act on. The dominant real-world failure is an unquoted value containing
 /// `: `, which YAML and Claude Code both reject.
-fn describe_yaml_error(raw: &str, err: &serde_yaml_ng::Error) -> String {
+///
+/// `content` is the full file content (to calculate line offset correctly).
+/// `raw` is the extracted frontmatter YAML (between `---` delimiters).
+fn describe_yaml_error(content: &str, raw: &str, err: &serde_yaml_ng::Error) -> String {
     if let Some(loc) = err.location() {
-        // +1: the opening `---` line precedes the frontmatter in the file.
-        let file_line = loc.line() + 1;
+        // Calculate how many lines precede the frontmatter in the original file.
+        // extract_frontmatter() does trim_start(), so we must count stripped lines.
+        let trimmed = content.trim_start();
+        let prefix_len = content.len() - trimmed.len();
+        let lines_before_frontmatter = if prefix_len > 0 {
+            content[..prefix_len].chars().filter(|&c| c == '\n').count()
+        } else {
+            0
+        };
+        // File line (1-indexed) = lines_before + 1 (opening `---`) + 1 (first YAML line) + loc.line()
+        let file_line = lines_before_frontmatter + 2 + loc.line();
+
         if let Some(line) = raw.lines().nth(loc.line().saturating_sub(1))
             && let Some((key, value)) = line.split_once(':')
             && value.contains(": ")

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -467,6 +467,99 @@ mod tests {
     }
 
     #[test]
+    fn c03_clusters_multiple_similar_skills() {
+        use crate::audit::reverse::ImportedConfig;
+        // UnionFind clustering: 3 similar skills should produce 1 finding, not 3.
+        // The skills must have Jaccard >= 0.6 (60% word overlap).
+        let config = ImportedConfig {
+            skills: vec![
+                skill("audit-a", "audit the code for style and bugs"),
+                skill("audit-b", "audit the code for bugs and style"),
+                skill("audit-c", "code audit for bugs and style"),
+                skill("deploy", "ships the app to production servers"),
+            ],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c03_activation_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        // All three audit-* skills are in one cluster (all pairwise Jaccard >= 0.6).
+        // deploy is distinct. So we expect 1 finding covering the 3 similar skills.
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("audit-a"));
+        assert!(f[0].message.contains("audit-b"));
+        assert!(f[0].message.contains("audit-c"));
+        assert!(!f[0].message.contains("deploy"));
+    }
+
+    #[test]
+    fn c03_skips_agent_to_agent_grouping() {
+        use crate::audit::reverse::ImportedConfig;
+        // C03 skips agent↔agent similarity (A07's turf): two agents with identical
+        // descriptions should NOT produce a C03 finding.
+        let mut a1 = agent("reviewer-backend", "Body");
+        a1.metadata.description = Some("reviews backend code".into());
+        let mut a2 = agent("reviewer-frontend", "Body");
+        a2.metadata.description = Some("reviews backend code".into());
+        let config = ImportedConfig {
+            agents: vec![a1, a2],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c03_activation_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        // No C03 finding: agent↔agent similarity is deferred to A07.
+        assert_eq!(f.len(), 0);
+    }
+
+    #[test]
+    fn c03_produces_separate_findings_for_disjoint_clusters() {
+        use crate::audit::reverse::ImportedConfig;
+        // Two unrelated pairs of similar skills must NOT be merged into a
+        // single finding: UnionFind clustering must keep disjoint clusters
+        // disjoint.
+        let config = ImportedConfig {
+            skills: vec![
+                skill("audit-a", "audit the code for style and bugs"),
+                skill("audit-b", "audit the code for bugs and style"),
+                skill(
+                    "deploy-a",
+                    "ships the app to production servers using containers",
+                ),
+                skill(
+                    "deploy-b",
+                    "ships the app to production servers with containers",
+                ),
+            ],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c03_activation_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 2);
+        let audit_finding = f
+            .iter()
+            .find(|finding| finding.message.contains("audit-a"))
+            .expect("expected a finding for the audit-* cluster");
+        assert!(audit_finding.message.contains("audit-b"));
+        assert!(!audit_finding.message.contains("deploy-a"));
+        assert!(!audit_finding.message.contains("deploy-b"));
+        let deploy_finding = f
+            .iter()
+            .find(|finding| finding.message.contains("deploy-a"))
+            .expect("expected a finding for the deploy-* cluster");
+        assert!(deploy_finding.message.contains("deploy-b"));
+        assert!(!deploy_finding.message.contains("audit-a"));
+        assert!(!deploy_finding.message.contains("audit-b"));
+    }
+
+    #[test]
     fn globs_overlap_by_prefix() {
         assert!(globs_overlap("src/**", "src/cli/**"));
         assert!(globs_overlap("src/cli/mod.rs", "src/**"));
@@ -527,6 +620,99 @@ mod tests {
     }
 
     #[test]
+    fn c05_clusters_multiple_conflicting_agents() {
+        use serde_yaml_ng::Value;
+        // UnionFind clustering: 3 agents with overlapping paths and conflicting
+        // tool policies should produce 1 finding, not 3.
+        let mut a = agent("permissive", "Body");
+        a.metadata.tools = None; // open to all tools
+        a.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/**".into()));
+
+        let mut b = agent("restricted-cli", "Body");
+        b.metadata.tools = Some(vec!["Read".to_string(), "Edit".to_string()]);
+        b.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/cli/**".into()));
+
+        let mut c = agent("restricted-core", "Body");
+        c.metadata.tools = Some(vec!["Read".to_string()]);
+        c.metadata
+            .extra
+            .insert("paths".into(), Value::String("src/core/**".into()));
+
+        let config = config_with(vec![a, b, c]);
+        let settings = AuditSettings::default();
+        let f = c05_inconsistent_tools(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        // All three agents overlap via src/** and have conflicting tool policies.
+        // They should be in one cluster, producing 1 finding for the 3 agents.
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].related.len(), 2); // 2 related files + 1 primary
+        assert!(f[0].message.contains("3 agents"));
+    }
+
+    #[test]
+    fn c05_produces_separate_findings_for_disjoint_clusters() {
+        use serde_yaml_ng::Value;
+        // Two unrelated pairs of conflicting-tools agents, scoped to disjoint
+        // path prefixes (`src/**` vs `docs/**`), must NOT be merged into a
+        // single finding.
+        let mut src_open = agent("src-open", "Body");
+        src_open.metadata.tools = None; // permissive
+        src_open
+            .metadata
+            .extra
+            .insert("paths".into(), Value::String("src/**".into()));
+
+        let mut src_locked = agent("src-locked", "Body");
+        src_locked.metadata.tools = Some(vec!["Read".to_string()]);
+        src_locked
+            .metadata
+            .extra
+            .insert("paths".into(), Value::String("src/core/**".into()));
+
+        let mut docs_open = agent("docs-open", "Body");
+        docs_open.metadata.tools = None; // permissive
+        docs_open
+            .metadata
+            .extra
+            .insert("paths".into(), Value::String("docs/**".into()));
+
+        let mut docs_locked = agent("docs-locked", "Body");
+        docs_locked.metadata.tools = Some(vec!["Read".to_string()]);
+        docs_locked
+            .metadata
+            .extra
+            .insert("paths".into(), Value::String("docs/api/**".into()));
+
+        let config = config_with(vec![src_open, src_locked, docs_open, docs_locked]);
+        let settings = AuditSettings::default();
+        let f = c05_inconsistent_tools(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        assert_eq!(f.len(), 2);
+        let src_finding = f
+            .iter()
+            .find(|finding| finding.message.contains("src-open"))
+            .expect("expected a finding for the src-* cluster");
+        assert!(src_finding.message.contains("src-locked"));
+        assert!(!src_finding.message.contains("docs-open"));
+        assert!(!src_finding.message.contains("docs-locked"));
+        let docs_finding = f
+            .iter()
+            .find(|finding| finding.message.contains("docs-open"))
+            .expect("expected a finding for the docs-* cluster");
+        assert!(docs_finding.message.contains("docs-locked"));
+        assert!(!docs_finding.message.contains("src-open"));
+        assert!(!docs_finding.message.contains("src-locked"));
+    }
+
+    #[test]
     fn c04_flags_two_agents_owning_the_same_module() {
         use crate::audit::reverse::{ImportedConfig, ImportedInstructions};
         let config = ImportedConfig {
@@ -551,5 +737,62 @@ mod tests {
         assert_eq!(f.len(), 1);
         assert!(f[0].message.contains("src/core/"));
         assert!(f[0].message.contains("core-dev") && f[0].message.contains("cli-dev"));
+    }
+
+    #[test]
+    fn c04_ignores_agent_name_in_code_fences() {
+        use crate::audit::reverse::{ImportedConfig, ImportedInstructions};
+        // C04 must not flag agent names inside code-fence blocks (```).
+        let config = ImportedConfig {
+            agents: vec![agent("core-dev", "Body"), agent("cli-dev", "Body")],
+            instructions: Some(ImportedInstructions {
+                source_path: "CLAUDE.md".into(),
+                content: "# Owners\n\
+```\n\
+| Agent | Path |\n\
+| core-dev | src/core/ |\n\
+| cli-dev | src/core/ |\n\
+```\n\
+\n\
+Actual table:\n\
+| Agent | Path |\n\
+| core-dev | src/core/ |\n"
+                    .into(),
+            }),
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c04_double_ownership(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        // Only the real (non-fenced) table row counts. One agent owns src/core/,
+        // so no collision finding should be generated.
+        assert_eq!(f.len(), 0);
+    }
+
+    #[test]
+    fn c04_ignores_agent_name_in_urls() {
+        use crate::audit::reverse::{ImportedConfig, ImportedInstructions};
+        // C04 must not interpret cells containing URLs (with ://) as path cells.
+        let config = ImportedConfig {
+            agents: vec![agent("dev", "Body"), agent("reviewer", "Body")],
+            instructions: Some(ImportedInstructions {
+                source_path: "CLAUDE.md".into(),
+                content: "| Agent | Doc |\n\
+|---|---|\n\
+| dev | https://github.com/dev-repo |\n\
+| reviewer | src/review/ |\n"
+                    .into(),
+            }),
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c04_double_ownership(&AuditContext {
+            config: &config,
+            settings: &settings,
+        });
+        // No collision: the URL is not treated as a path, and no path is claimed twice.
+        assert_eq!(f.len(), 0);
     }
 }

--- a/src/audit/rules/collisions.rs
+++ b/src/audit/rules/collisions.rs
@@ -59,6 +59,7 @@ pub(super) fn c01_name_collisions(ctx: &AuditContext) -> Vec<Finding> {
 /// near-identical descriptions: the router cannot pick reliably.
 /// Agent↔agent redundancy stays A07 (higher threshold, Info): merging two
 /// agents is a design suggestion, an ambiguous skill trigger is a defect.
+/// Findings are aggregated into clusters (like A06/C02) to avoid N² noise.
 pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
     let threshold = ctx.settings.activation_similarity;
     // (kind, name, path, description)
@@ -73,32 +74,61 @@ pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
             surfaces.push(("agent", &a.name, &a.source_path, d));
         }
     }
-    let mut findings = Vec::new();
+
+    // Build similarity graph with UnionFind
+    let mut uf = super::UnionFind::new(surfaces.len());
     for i in 0..surfaces.len() {
         for j in (i + 1)..surfaces.len() {
-            let (ka, na, pa, da) = surfaces[i];
-            let (kb, nb, pb, db) = surfaces[j];
+            let (ka, _, _, da) = surfaces[i];
+            let (kb, _, _, db) = surfaces[j];
             if ka == "agent" && kb == "agent" {
                 continue; // A07's turf
             }
             if jaccard(da, db) >= threshold {
-                findings.push(Finding {
-                    rule: "C03",
-                    severity: Severity::Warning,
-                    file: pa.to_path_buf(),
-                    related: vec![pb.to_path_buf()],
-                    message: format!(
-                        "{ka} '{na}' and {kb} '{nb}' have overlapping activation descriptions — routing is ambiguous"
-                    ),
-                    suggestion: Some(
-                        "sharpen the descriptions so each one triggers on distinct intents"
-                            .to_string(),
-                    ),
-                });
+                uf.union(i, j);
             }
         }
     }
-    findings
+
+    // Group into clusters
+    let mut clusters: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for i in 0..surfaces.len() {
+        clusters.entry(uf.find(i)).or_default().push(i);
+    }
+
+    // Create one finding per cluster (size >= 2)
+    clusters
+        .into_values()
+        .filter(|members| members.len() >= 2)
+        .map(|members| {
+            let (_, _, first_path, _) = surfaces[members[0]];
+            let related: Vec<_> = members[1..]
+                .iter()
+                .map(|&i| surfaces[i].2.to_path_buf())
+                .collect();
+            let names: Vec<String> = members
+                .iter()
+                .map(|&i| {
+                    let (kind, name, _, _) = surfaces[i];
+                    format!("{kind} '{name}'")
+                })
+                .collect();
+            Finding {
+                rule: "C03",
+                severity: Severity::Warning,
+                file: first_path.to_path_buf(),
+                related,
+                message: format!(
+                    "{} assets have overlapping activation descriptions — routing is ambiguous: {}",
+                    members.len(),
+                    names.join(", ")
+                ),
+                suggestion: Some(
+                    "sharpen the descriptions so each one triggers on distinct intents".to_string(),
+                ),
+            }
+        })
+        .collect()
 }
 
 /// Prefix of a glob up to its first wildcard — a cheap, dependency-free
@@ -196,6 +226,7 @@ pub(super) fn c02_scope_overlap(ctx: &AuditContext) -> Vec<Finding> {
 }
 
 /// C05 — same scope, inconsistent tool restriction (one locked, one open).
+/// Findings are aggregated into clusters to avoid N² noise.
 pub(super) fn c05_inconsistent_tools(ctx: &AuditContext) -> Vec<Finding> {
     fn permissive(tools: &Option<Vec<String>>) -> bool {
         match tools {
@@ -204,21 +235,59 @@ pub(super) fn c05_inconsistent_tools(ctx: &AuditContext) -> Vec<Finding> {
         }
     }
     let scoped = scoped_agents(ctx);
-    overlapping_pairs(&scoped)
+    let conflicting_pairs: Vec<(usize, usize)> = overlapping_pairs(&scoped)
         .into_iter()
         .filter(|&(i, j)| {
             permissive(&scoped[i].0.metadata.tools) != permissive(&scoped[j].0.metadata.tools)
         })
-        .map(|(i, j)| Finding {
-            rule: "C05",
-            severity: Severity::Info,
-            file: scoped[i].0.source_path.clone(),
-            related: vec![scoped[j].0.source_path.clone()],
-            message: format!(
-                "agents '{}' and '{}' share a path scope but one restricts tools and the other does not",
-                scoped[i].0.name, scoped[j].0.name
-            ),
-            suggestion: Some("align the tool policies of agents working on the same files".to_string()),
+        .collect();
+
+    if conflicting_pairs.is_empty() {
+        return Vec::new();
+    }
+
+    // Build clusters of agents with conflicting tool policies
+    let mut uf = super::UnionFind::new(scoped.len());
+    for &(i, j) in &conflicting_pairs {
+        uf.union(i, j);
+    }
+
+    let mut clusters: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    // Collect all indices involved in conflicts
+    for &(i, j) in &conflicting_pairs {
+        let root_i = uf.find(i);
+        let root_j = uf.find(j);
+        clusters.entry(root_i).or_default().push(i);
+        clusters.entry(root_j).or_default().push(j);
+    }
+    // Deduplicate indices within each cluster
+    for cluster in clusters.values_mut() {
+        cluster.sort_unstable();
+        cluster.dedup();
+    }
+
+    clusters
+        .into_values()
+        .filter(|members| members.len() >= 2)
+        .map(|members| {
+            let names: Vec<&str> = members.iter().map(|&i| scoped[i].0.name.as_str()).collect();
+            Finding {
+                rule: "C05",
+                severity: Severity::Info,
+                file: scoped[members[0]].0.source_path.clone(),
+                related: members[1..]
+                    .iter()
+                    .map(|&i| scoped[i].0.source_path.clone())
+                    .collect(),
+                message: format!(
+                    "{} agents share path scopes but have inconsistent tool policies: {}",
+                    members.len(),
+                    names.join(", ")
+                ),
+                suggestion: Some(
+                    "align the tool policies of agents working on the same files".to_string(),
+                ),
+            }
         })
         .collect()
 }
@@ -241,8 +310,18 @@ pub(super) fn c04_double_ownership(ctx: &AuditContext) -> Vec<Finding> {
         return Vec::new();
     }
     let mut claims: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut in_code_fence = false;
     for line in instructions.content.lines() {
         let trimmed = line.trim();
+        // Track code fence boundaries to skip their content
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        // Skip lines inside code fences
+        if in_code_fence {
+            continue;
+        }
         if !trimmed.starts_with('|') {
             continue;
         }
@@ -251,6 +330,10 @@ pub(super) fn c04_double_ownership(ctx: &AuditContext) -> Vec<Finding> {
             continue;
         };
         for cell in &cells {
+            // Skip URLs (contain protocol separator)
+            if cell.contains("://") {
+                continue;
+            }
             if cell.contains('/') && !cell.contains(' ') && !cell.is_empty() {
                 let owners = claims.entry(*cell).or_default();
                 if !owners.contains(&agent) {


### PR DESCRIPTION
## Contexte

Raffinements de la feature `armadai audit` après v1.0.0-rc.1. Traite les items prioritaires du backlog (fixes ciblés).

## Items traités

### ✅ Item 1: Offset `file_line` avec frontmatter

**Problème**: Les numéros de ligne dans les messages d'erreur YAML étaient décalés quand le frontmatter avait des lignes vides en tête.

**Correction**:
- Calcul de l'offset réel en comptant les lignes supprimées par `trim_start()`
- Formule: `lines_before_frontmatter + 2 + loc.line()` pour obtenir la ligne réelle du fichier
- Mise à jour de `describe_yaml_error()` pour prendre `content` (fichier complet) en plus de `raw`

**Fichiers modifiés**: `src/audit/reverse/claude.rs`

### ✅ Item 2: C04 code-fences/URLs

**Problème**: La règle C04 (double ownership) matchait les mots-clés d'activation dans les blocs de code et URLs.

**Correction**:
- Tracking de `in_code_fence` pour ignorer le contenu des ``` fences
- Skip des cellules contenant `://` (URLs) avant de les traiter comme des paths
- Les tableaux dans les code-fences ne sont plus scannés

**Fichiers modifiés**: `src/audit/rules/collisions.rs`

### ✅ Item 3: Agrégation C03/C05

**Problème**: C03 (activation overlap) et C05 (inconsistent tools) créaient N findings pour N² paires en collision, causant du bruit.

**Correction**:
- Utilisation de `UnionFind` (comme A06/C02) pour grouper les assets en clusters
- Un finding agrégé par cluster au lieu de N findings par paire
- Le message liste tous les assets en collision
- Réduit significativement le bruit dans les rapports

**Fichiers modifiés**: `src/audit/rules/collisions.rs`

## Items différés

### ⏸️ Item 4: Nouveaux assets (commands/, hooks)

**Raison**: Coût trop élevé (3-4h estimé) vs bénéfice actuel. Nécessite:
- Parsing de `settings.json` (structure complexe)
- Nouvelles structures dans `reverse/claude.rs`
- Nouvelles règles de collision
- Tests exhaustifs

**Impact utilisateur**: Faible pour le moment (peu de projets ont des commands/ ou hooks complexes)

### ⏸️ Item 5: Minors `--deep`

**Points 5.1 et 5.2 (Windows + dégradation)**: ✅ **Déjà implémentés**
- `#[cfg(windows)]` pour `where` vs `which`
- Propagation d'erreur propre avec `?`

**Point 5.3 (câblage per-CLI)**: ⏸️ **Différé**
- Coût estimé: 2-3h (flags spécifiques par CLI, tests, edge cases)
- Complexité: Moyenne (codex/copilot/opencode/aider ont des modes interactifs qui nécessitent des flags particuliers)
- Bénéfice: Moyen (élargit les CLIs utilisables pour --deep)

## Vérifications

- ✅ Clippy 2 modes (TUI + TUI+providers-api) sans warnings
- ✅ `cargo fmt -- --check` passe
- ✅ Tous les tests passent (723 tests)
- ✅ Commits conventionnels

## Prochaines étapes

- Merge vers `release/1.0.0` après revue
- Items 4 et 5.3 dans le backlog pour v1.1 ou v1.2 (selon demande utilisateurs)