### PR TITLE
feat(web): C6 — orchestration traces tab (list + mermaid + timeline)

### DIFF
--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -622,23 +622,23 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
     #[cfg(feature = "storage")]
     {
         use crate::storage::{init_db, queries};
-        if let Ok(db) = init_db() {
-            if let Ok(runs) = queries::get_orchestration_runs(&db, 50) {
-                let traces: Vec<serde_json::Value> = runs
-                    .iter()
-                    .map(|r| {
-                        serde_json::json!({
-                            "id": r.run_id,
-                            "pattern": r.pattern,
-                            "config": r.config_json,
-                            "outcome": r.outcome_json,
-                            "rounds": r.rounds,
-                            "halt_reason": r.halt_reason,
-                        })
+        if let Ok(db) = init_db()
+            && let Ok(runs) = queries::get_orchestration_runs(&db, 50)
+        {
+            let traces: Vec<serde_json::Value> = runs
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "id": r.run_id,
+                        "pattern": r.pattern,
+                        "config": r.config_json,
+                        "outcome": r.outcome_json,
+                        "rounds": r.rounds,
+                        "halt_reason": r.halt_reason,
                     })
-                    .collect();
-                return Json(serde_json::json!({ "traces": traces }));
-            }
+                })
+                .collect();
+            return Json(serde_json::json!({ "traces": traces }));
         }
     }
 
@@ -668,6 +668,109 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "traces": [],
         "sessions": session_traces,
+    }))
+}
+
+/// Get orchestration run detail (board entries, ring contributions, ring votes)
+/// for a single run identified by `run_id`.
+#[cfg(feature = "storage")]
+pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<serde_json::Value> {
+    use crate::storage::{init_db, queries};
+
+    let empty = || {
+        serde_json::json!({
+            "run": null,
+            "board_entries": [],
+            "ring_contributions": [],
+            "ring_votes": [],
+        })
+    };
+
+    let db = match init_db() {
+        Ok(db) => db,
+        Err(_) => return Json(empty()),
+    };
+
+    let run = queries::get_orchestration_run(&db, &run_id)
+        .ok()
+        .flatten()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.run_id,
+                "pattern": r.pattern,
+                "config": r.config_json,
+                "outcome": r.outcome_json,
+                "rounds": r.rounds,
+                "halt_reason": r.halt_reason,
+            })
+        });
+
+    let board_entries: Vec<serde_json::Value> = queries::get_board_entries(&db, &run_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|e| {
+            serde_json::json!({
+                "agent": e.agent,
+                "round": e.round,
+                "kind": e.kind,
+                "content": e.content,
+                "refs": e.refs_json,
+                "confidence": e.confidence,
+                "tokens_in": e.tokens_in,
+                "tokens_out": e.tokens_out,
+            })
+        })
+        .collect();
+
+    let ring_contributions: Vec<serde_json::Value> = queries::get_ring_contributions(&db, &run_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| {
+            serde_json::json!({
+                "agent": c.agent,
+                "lap": c.lap,
+                "position_in_lap": c.position_in_lap,
+                "action": c.action,
+                "content": c.content,
+                "reactions": c.reactions_json,
+                "tokens_in": c.tokens_in,
+                "tokens_out": c.tokens_out,
+            })
+        })
+        .collect();
+
+    let ring_votes: Vec<serde_json::Value> = queries::get_ring_votes(&db, &run_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|v| {
+            serde_json::json!({
+                "agent": v.agent,
+                "position": v.position,
+                "confidence": v.confidence,
+                "supports": v.supports,
+                "concerns": v.concerns,
+            })
+        })
+        .collect();
+
+    Json(serde_json::json!({
+        "run": run,
+        "board_entries": board_entries,
+        "ring_contributions": ring_contributions,
+        "ring_votes": ring_votes,
+    }))
+}
+
+/// Get orchestration run detail — storage disabled, always returns empty shell.
+#[cfg(not(feature = "storage"))]
+pub async fn get_orchestration_trace_detail(
+    Path(_run_id): Path<String>,
+) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "run": null,
+        "board_entries": [],
+        "ring_contributions": [],
+        "ring_votes": [],
     }))
 }
 
@@ -721,4 +824,168 @@ pub async fn get_orchestration_topology() -> Json<serde_json::Value> {
         teams,
         agents: all_agents,
     })
+}
+
+#[cfg(all(test, feature = "storage"))]
+mod tests {
+    use super::*;
+    use crate::core::config::ENV_MUTEX;
+    use crate::storage::queries::{
+        BoardEntryRecord, OrchestrationRunRecord, RingVoteRecord, RunRecord, insert_board_entry,
+        insert_orchestration_run, insert_ring_vote, insert_run_with_id,
+    };
+
+    /// Guard that points `ARMADAI_CONFIG_DIR` at a fresh temp dir with a
+    /// `config.yaml` redirecting storage to a scratch sqlite file, so
+    /// `init_db()` (as called by the handler under test) reads/writes there
+    /// instead of the real user config. Restores the original env var and
+    /// releases the shared env-mutation lock (`ENV_MUTEX`) on drop.
+    struct TempStorageGuard {
+        _dir: tempfile::TempDir,
+        orig: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl TempStorageGuard {
+        fn new() -> Self {
+            let lock = ENV_MUTEX.lock().unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("test.sqlite");
+            let config_yaml = format!(
+                "storage:\n  mode: embedded\n  path: \"{}\"\n",
+                db_path.display()
+            );
+            std::fs::write(dir.path().join("config.yaml"), config_yaml).unwrap();
+
+            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            unsafe {
+                std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+            }
+
+            Self {
+                _dir: dir,
+                orig,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for TempStorageGuard {
+        fn drop(&mut self) {
+            match self.orig.take() {
+                // SAFETY: restoring original env state at end of test scope.
+                Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+                None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_orchestration_trace_detail_returns_run_and_entries() {
+        let _guard = TempStorageGuard::new();
+        let db = crate::storage::init_db().unwrap();
+
+        // `orchestration_runs.run_id` references `runs(id)`, so seed the
+        // parent row first (mirrors how the orchestration engine writes both
+        // tables under the same id).
+        insert_run_with_id(
+            &db,
+            "run-42",
+            RunRecord {
+                agent: "coordinator".to_string(),
+                input: "orchestrate".to_string(),
+                output: "done".to_string(),
+                provider: "anthropic".to_string(),
+                model: "claude-sonnet".to_string(),
+                tokens_in: 10,
+                tokens_out: 20,
+                cost: 0.01,
+                duration_ms: 500,
+                status: "success".to_string(),
+            },
+        )
+        .unwrap();
+
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: "run-42".to_string(),
+                pattern: "ring".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: Some("{\"status\":\"ok\"}".to_string()),
+                rounds: 3,
+                halt_reason: None,
+            },
+        )
+        .unwrap();
+
+        insert_board_entry(
+            &db,
+            BoardEntryRecord {
+                run_id: "run-42".to_string(),
+                agent: "core-specialist".to_string(),
+                round: 1,
+                kind: "proposal".to_string(),
+                content: "Use trait Provider".to_string(),
+                refs_json: "[]".to_string(),
+                confidence: 0.9,
+                tokens_in: 10,
+                tokens_out: 20,
+            },
+        )
+        .unwrap();
+
+        insert_ring_vote(
+            &db,
+            RingVoteRecord {
+                run_id: "run-42".to_string(),
+                agent: "qa-specialist".to_string(),
+                position: "approve".to_string(),
+                confidence: 0.8,
+                supports: "core-specialist".to_string(),
+                concerns: "none".to_string(),
+            },
+        )
+        .unwrap();
+
+        // Drop the connection so the handler's own `init_db()` call can open
+        // the same sqlite file freed of any exclusive lock.
+        drop(db);
+
+        let response = get_orchestration_trace_detail(Path("run-42".to_string())).await;
+        let value = response.0;
+
+        let run = &value["run"];
+        assert_eq!(run["id"], "run-42");
+        assert_eq!(run["pattern"], "ring");
+        assert_eq!(run["rounds"], 3);
+
+        let board_entries = value["board_entries"].as_array().unwrap();
+        assert_eq!(board_entries.len(), 1);
+        assert_eq!(board_entries[0]["agent"], "core-specialist");
+        assert_eq!(board_entries[0]["kind"], "proposal");
+        assert_eq!(board_entries[0]["tokens_out"], 20);
+
+        let ring_votes = value["ring_votes"].as_array().unwrap();
+        assert_eq!(ring_votes.len(), 1);
+        assert_eq!(ring_votes[0]["agent"], "qa-specialist");
+        assert_eq!(ring_votes[0]["position"], "approve");
+
+        assert!(value["ring_contributions"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_orchestration_trace_detail_unknown_run_is_null() {
+        let _guard = TempStorageGuard::new();
+        // Ensure the DB/schema exists even though no run is inserted.
+        drop(crate::storage::init_db().unwrap());
+
+        let response = get_orchestration_trace_detail(Path("does-not-exist".to_string())).await;
+        let value = response.0;
+        assert!(value["run"].is_null());
+        assert!(value["board_entries"].as_array().unwrap().is_empty());
+        assert!(value["ring_contributions"].as_array().unwrap().is_empty());
+        assert!(value["ring_votes"].as_array().unwrap().is_empty());
+    }
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -105,6 +105,7 @@
     <button onclick="showTab('costs')">Costs</button>
     <button onclick="showTab('models')">Models</button>
     <button onclick="showTab('orchestration')">Orchestration</button>
+    <button onclick="showTab('traces')">Traces</button>
   </nav>
   <button id="theme-btn" onclick="toggleTheme()" title="Toggle dark/light mode">🌙</button>
 </header>
@@ -117,6 +118,7 @@
   <div id="costs" class="card" style="display:none"></div>
   <div id="models" class="card" style="display:none"></div>
   <div id="orchestration" class="card" style="display:none"></div>
+  <div id="traces" class="card" style="display:none"></div>
   <div id="view" class="card"></div>
 </main>
 <script>
@@ -257,10 +259,10 @@ function createSearchBar(tableId) {
 
 function showTab(tab) {
   document.querySelectorAll('nav button').forEach((b, i) => {
-    const tabs = ['agents','prompts','skills','starters','history','costs','models','orchestration'];
+    const tabs = ['agents','prompts','skills','starters','history','costs','models','orchestration','traces'];
     b.classList.toggle('active', tabs[i] === tab);
   });
-  ['agents','prompts','skills','starters','history','costs','models','orchestration','view'].forEach(id => document.getElementById(id).style.display = 'none');
+  ['agents','prompts','skills','starters','history','costs','models','orchestration','traces','view'].forEach(id => document.getElementById(id).style.display = 'none');
   document.getElementById(tab).style.display = 'block';
   currentTab = tab;
   if (tab === 'agents') loadAgents();
@@ -271,6 +273,7 @@ function showTab(tab) {
   if (tab === 'costs') loadCosts();
   if (tab === 'models') loadModels();
   if (tab === 'orchestration') loadOrchestration();
+  if (tab === 'traces') loadTraces();
 }
 
 async function loadAgents() {
@@ -816,6 +819,242 @@ function escapeHtml(text) {
     "'": '&#039;'
   };
   return text.replace(/[&<>"']/g, m => map[m]);
+}
+
+// ── Traces tab ───────────────────────────────────────────────────
+
+function truncateText(text, maxLen) {
+  if (!text) return '';
+  const s = String(text);
+  return s.length > maxLen ? s.slice(0, maxLen - 1) + '…' : s;
+}
+
+function parseJsonSafe(value) {
+  if (value == null) return null;
+  if (typeof value !== 'string') return value;
+  try { return JSON.parse(value); } catch (e) { return null; }
+}
+
+function extractCost(outcomeObj) {
+  if (!outcomeObj || typeof outcomeObj !== 'object') return null;
+  if (typeof outcomeObj.cost === 'number') return outcomeObj.cost;
+  if (typeof outcomeObj.total_cost === 'number') return outcomeObj.total_cost;
+  return null;
+}
+
+function summarizeOutcome(outcomeObj) {
+  if (outcomeObj == null) return '(none)';
+  if (typeof outcomeObj !== 'object') return truncateText(String(outcomeObj), 60);
+  const parts = [];
+  if (outcomeObj.state) parts.push(String(outcomeObj.state));
+  if (outcomeObj.status) parts.push(String(outcomeObj.status));
+  if (outcomeObj.summary) parts.push(truncateText(String(outcomeObj.summary), 50));
+  if (parts.length) return parts.join(' · ');
+  const keys = Object.keys(outcomeObj);
+  if (!keys.length) return '(empty)';
+  return truncateText(keys.map(k => `${k}=${JSON.stringify(outcomeObj[k])}`).join(', '), 60);
+}
+
+// Sanitize an arbitrary agent name into a valid Mermaid participant id
+// (letters/digits/underscore only, must not start with a digit).
+function mermaidSanitizeId(name) {
+  let id = String(name == null ? 'unknown' : name).replace(/[^a-zA-Z0-9_]/g, '_');
+  if (!id || /^[0-9]/.test(id)) id = 'p_' + id;
+  return id;
+}
+
+// Escape a label so it can't break Mermaid sequenceDiagram syntax
+// (colons, semicolons, newlines, arrows, quotes) and truncate it.
+function mermaidEscapeLabel(text, maxLen) {
+  if (text == null) return '';
+  let s = String(text)
+    .replace(/\r?\n/g, ' ')
+    .replace(/-{1,2}>{1,2}/g, '-')
+    .replace(/[:;"<>]/g, ',')
+    .trim();
+  if (maxLen && s.length > maxLen) s = s.slice(0, maxLen - 1) + '…';
+  return s;
+}
+
+async function loadTraces() {
+  const res = await fetch('/api/orchestration/trace');
+  const data = await res.json();
+  const traces = data.traces || [];
+  const el = document.getElementById('traces');
+  if (!traces.length) {
+    el.innerHTML = '<div class="empty">No orchestration traces yet. Run an orchestrated agent (e.g. `armadai run --orchestrate blackboard ...`) to generate one.</div>';
+    return;
+  }
+  el.innerHTML = `
+    <div class="card-header">${traces.length} orchestration runs</div>
+    <table>
+      <tr><th>Run ID</th><th>Pattern</th><th>Rounds</th><th>Halt Reason</th><th>Outcome</th><th>Cost</th></tr>
+      <tbody>
+        ${traces.map(t => {
+          const outcomeObj = parseJsonSafe(t.outcome);
+          const cost = extractCost(outcomeObj);
+          const idStr = String(t.id != null ? t.id : '');
+          return `
+          <tr class="clickable" onclick="viewTraceRun('${idStr.replace(/'/g, "\\'")}')">
+            <td style="font-family:monospace">${escapeHtmlContent(idStr)}</td>
+            <td>${escapeHtmlContent(t.pattern || '-')}</td>
+            <td>${t.rounds != null ? t.rounds : '-'}</td>
+            <td>${escapeHtmlContent(t.halt_reason || '-')}</td>
+            <td>${escapeHtmlContent(summarizeOutcome(outcomeObj))}</td>
+            <td class="cost">${cost != null ? '$' + cost.toFixed(6) : '-'}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>`;
+  createSearchBar('traces');
+}
+
+// Build the ordered list of trace "events" shared by both the sequence
+// diagram and the timeline, from whichever pattern produced data
+// (blackboard board entries or ring contributions).
+function buildTraceEvents(boardEntries, ringContributions) {
+  const isBlackboard = boardEntries.length > 0;
+  const events = isBlackboard
+    ? boardEntries.map(e => ({
+        order: e.round || 0,
+        sub: 0,
+        orderLabel: `Round ${e.round}`,
+        agent: e.agent,
+        kind: e.kind,
+        content: e.content,
+        confidence: e.confidence,
+      }))
+    : ringContributions.map(c => ({
+        order: c.lap || 0,
+        sub: c.position_in_lap || 0,
+        orderLabel: `Lap ${c.lap} · #${c.position_in_lap}`,
+        agent: c.agent,
+        kind: c.action,
+        content: c.content,
+        confidence: null,
+      }));
+  events.sort((a, b) => (a.order - b.order) || (a.sub - b.sub));
+  return { isBlackboard, events };
+}
+
+function generateTraceSequenceDiagram(boardEntries, ringContributions, ringVotes) {
+  const { isBlackboard, events } = buildTraceEvents(boardEntries, ringContributions);
+  const hub = isBlackboard ? 'Board' : 'Ring';
+
+  // Collect distinct agent names in first-appearance order.
+  const seen = new Set();
+  const agentNames = [];
+  const registerAgent = (name) => {
+    const key = String(name == null ? 'unknown' : name);
+    if (!seen.has(key)) { seen.add(key); agentNames.push(key); }
+  };
+  events.forEach(e => registerAgent(e.agent));
+  ringVotes.forEach(v => registerAgent(v.agent));
+
+  const lines = ['sequenceDiagram'];
+  lines.push(`participant ${hub}`);
+  agentNames.forEach(name => {
+    const id = mermaidSanitizeId(name);
+    const label = mermaidEscapeLabel(name, 30) || id;
+    lines.push(`participant ${id} as ${label}`);
+  });
+
+  events.forEach(e => {
+    const agentId = mermaidSanitizeId(e.agent);
+    const label = mermaidEscapeLabel(`${e.kind || 'entry'}: ${e.content || ''}`, 70) || '(empty)';
+    lines.push(`${agentId}->>${hub}: ${label}`);
+    if (e.confidence != null) {
+      lines.push(`Note right of ${agentId}: confidence ${Number(e.confidence).toFixed(2)}`);
+    }
+  });
+
+  ringVotes.forEach(v => {
+    const agentId = mermaidSanitizeId(v.agent);
+    const conf = v.confidence != null ? Number(v.confidence).toFixed(2) : 'n/a';
+    const note = mermaidEscapeLabel(`vote ${v.position || ''} (confidence ${conf})`, 70);
+    lines.push(`Note right of ${agentId}: ${note}`);
+  });
+
+  return lines.join('\n');
+}
+
+function generateTraceTimeline(boardEntries, ringContributions, ringVotes) {
+  const { events } = buildTraceEvents(boardEntries, ringContributions);
+
+  const rows = events.map(e => `
+    <tr>
+      <td style="white-space:nowrap;color:var(--muted)">${escapeHtmlContent(e.orderLabel)}</td>
+      <td style="font-family:monospace">${escapeHtmlContent(e.agent || '-')}</td>
+      <td>${escapeHtmlContent(e.kind || '-')}</td>
+      <td>${renderMarkdown(truncateText(e.content || '', 300))}</td>
+      <td>${e.confidence != null ? Number(e.confidence).toFixed(2) : '-'}</td>
+    </tr>`).join('');
+
+  const voteRows = ringVotes.map(v => `
+    <tr>
+      <td style="white-space:nowrap;color:var(--muted)">Vote</td>
+      <td style="font-family:monospace">${escapeHtmlContent(v.agent || '-')}</td>
+      <td>${escapeHtmlContent(v.position || '-')}</td>
+      <td>${escapeHtmlContent(truncateText(v.supports || '', 150))}${v.concerns ? ' — concerns: ' + escapeHtmlContent(truncateText(v.concerns, 150)) : ''}</td>
+      <td>${v.confidence != null ? Number(v.confidence).toFixed(2) : '-'}</td>
+    </tr>`).join('');
+
+  return `
+    <table>
+      <tr><th>Order</th><th>Agent</th><th>Type</th><th>Content</th><th>Confidence</th></tr>
+      <tbody>${rows}${voteRows}</tbody>
+    </table>`;
+}
+
+async function viewTraceRun(id) {
+  const res = await fetch(`/api/orchestration/trace/${encodeURIComponent(id)}`);
+  const d = await res.json();
+  viewBackTab = 'traces';
+  ['agents','prompts','skills','starters','history','costs','models','orchestration','traces'].forEach(tid => document.getElementById(tid).style.display = 'none');
+  const el = document.getElementById('view');
+  el.style.display = 'block';
+
+  const run = d.run;
+  if (!run) {
+    el.innerHTML = `
+      <div class="detail">
+        <button class="back-btn" onclick="backToList()">&larr; Back to traces</button>
+        <div class="empty">Run not found.</div>
+      </div>`;
+    return;
+  }
+
+  const boardEntries = d.board_entries || [];
+  const ringContributions = d.ring_contributions || [];
+  const ringVotes = d.ring_votes || [];
+  const hasEntries = boardEntries.length > 0 || ringContributions.length > 0;
+  const outcomeObj = parseJsonSafe(run.outcome);
+
+  let bodyHtml;
+  if (!hasEntries) {
+    bodyHtml = '<div class="empty">This run has no recorded board/ring entries (direct pattern, or an empty trace).</div>';
+  } else {
+    const diagram = generateTraceSequenceDiagram(boardEntries, ringContributions, ringVotes);
+    const timeline = generateTraceTimeline(boardEntries, ringContributions, ringVotes);
+    bodyHtml = `
+      <div class="list-section"><h3>Sequence Diagram</h3><div class="mermaid">${escapeHtml(diagram)}</div></div>
+      <div class="list-section"><h3>Timeline</h3>${timeline}</div>`;
+  }
+
+  el.innerHTML = `
+    <div class="detail">
+      <button class="back-btn" onclick="backToList()">&larr; Back to traces</button>
+      <h2 style="font-family:monospace">${escapeHtmlContent(String(run.id || ''))}</h2>
+      <div class="detail-grid">
+        <div class="detail-field"><label>Pattern</label><span>${escapeHtmlContent(run.pattern || '-')}</span></div>
+        <div class="detail-field"><label>Rounds</label><span>${run.rounds != null ? run.rounds : '-'}</span></div>
+        <div class="detail-field"><label>Halt Reason</label><span>${escapeHtmlContent(run.halt_reason || '-')}</span></div>
+        <div class="detail-field"><label>Outcome</label><span>${escapeHtmlContent(summarizeOutcome(outcomeObj))}</span></div>
+      </div>
+      ${bodyHtml}
+    </div>`;
+
+  if (hasEntries) mermaid.run();
 }
 
 // Initial load

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -36,6 +36,10 @@ pub async fn serve(port: u16) -> anyhow::Result<()> {
             get(api::get_orchestration_trace),
         )
         .route(
+            "/api/orchestration/trace/{run_id}",
+            get(api::get_orchestration_trace_detail),
+        )
+        .route(
             "/api/orchestration/topology",
             get(api::get_orchestration_topology),
         )


### PR DESCRIPTION
C6 (axe 2 features) — Web trace UI. Plan : `docs/superpowers/plans/2026-07-20-c6-web-trace-ui.md`.

## Ce que ça apporte
- **Backend** : `GET /api/orchestration/trace/{run_id}` → `{run, board_entries[], ring_contributions[], ring_votes[]}` (réutilise les queries storage existantes ; gated `storage`, no-op sans). Endpoint liste inchangé.
- **Frontend** : onglet « Traces » dans la SPA — liste des runs (pattern/rounds/halt/outcome/coût, recherche) + détail au clic : **diagramme Mermaid `sequenceDiagram`** (labels/IDs échappés+tronqués) + **timeline** (round/lap · agent · type · contenu · confiance des votes). Cas vides gérés.
- Périmètre : blackboard/ring/direct. **hierarchical hors scope** (pas persisté dans `orchestration_runs`).

## Qualité
- 2 commits, revue par tâche + **revue finale de branche : READY TO MERGE** (re-vérifiée indépendamment).
- Clippy **3 modes** (`tui`, `tui,providers-api`, `tui,web,storage`) `-D warnings` + `cargo fmt --check` + `cargo build --release` + **730 tests** (2 nouveaux backend). JS validé structurellement (Node/vm, DOM stubbé).
- Fix au passage : `collapsible_if` clippy pré-existant dans `get_orchestration_trace` (latent — le web n'était jamais clippé en CI).

## À valider (non bloquant, surface isolée)
Rendu Mermaid **au navigateur** : `cargo run --release -- web` → onglet Traces → clic sur un run (DB avec un run d'orchestration). Correctif de rendu = suivi facile si besoin.

## Minors (defer)
`allow(dead_code)` désormais superflus sur les queries orchestration ; markdown timeline sans sanitize HTML (identique à `viewAgent`/etc., pas une régression) ; `mermaidSanitizeId` collision théorique (négligeable, noms = slugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)