### PR TITLE
feat(registries): B2 Lot A — custom registries (agents/skills/models)

### DIFF
--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -163,11 +163,7 @@ async fn cmd_add(agent: &str, force: bool) -> anyhow::Result<()> {
         .entries
         .iter()
         .find(|e| e.name == agent || e.path == agent)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Agent '{agent}' not found in registry. Try `armadai registry search {agent}`"
-            )
-        })?;
+        .ok_or_else(|| not_found_error(agent, &index))?;
 
     println!("Converting {} ...", entry.name);
     let dst = convert::import_to_library(&entry.source, &entry.path, force)?;
@@ -185,7 +181,7 @@ async fn cmd_info(agent: &str) -> anyhow::Result<()> {
         .entries
         .iter()
         .find(|e| e.name == agent || e.path == agent)
-        .ok_or_else(|| anyhow::anyhow!("Agent '{agent}' not found in registry."))?;
+        .ok_or_else(|| not_found_error(agent, &index))?;
 
     println!("Name:        {}", entry.name);
     println!("Path:        {}", entry.path);
@@ -224,9 +220,74 @@ async fn cmd_info(agent: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Print a hint if the registry is stale (> 7 days old).
+/// Build an actionable "agent not found" error for `registry add`/`info`.
+///
+/// When the index is empty — which is also what an ignored legacy cache
+/// resolves to (see `cache::load_or_build_index`) — this points the user at
+/// `registry sync` instead of the generic "not found" message, which would
+/// be confusing when the real cause is "there is no registry data at all
+/// yet" rather than "this specific agent doesn't exist".
+fn not_found_error(agent: &str, index: &cache::Index) -> anyhow::Error {
+    if index.entries.is_empty() {
+        anyhow::anyhow!(
+            "Registry is empty (no data synced yet, or the cache is from an older ArmadAI \
+             version). Run `armadai registry sync`, then retry."
+        )
+    } else {
+        anyhow::anyhow!(
+            "Agent '{agent}' not found in registry. Try `armadai registry search {agent}`"
+        )
+    }
+}
+
+/// Print a hint if the registry cache is stale or from an older ArmadAI
+/// version.
 fn check_staleness() {
+    if cache::has_legacy_cache() {
+        eprintln!(
+            "hint: registry cache is from an older ArmadAI version and will be ignored. Run `armadai registry sync` to refresh."
+        );
+        return;
+    }
+
     if sync::is_stale(7) && sync::sources_dir().is_dir() {
         eprintln!("hint: registry may be outdated. Run `armadai registry sync` to refresh.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found_error_on_empty_index_points_to_sync_not_search() {
+        let err = not_found_error("some-agent", &cache::Index::default());
+        let msg = err.to_string();
+        assert!(
+            msg.contains("registry sync"),
+            "expected an actionable sync hint, got: {msg}"
+        );
+        assert!(
+            !msg.contains("search"),
+            "suggesting a search on an empty registry is not actionable, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn not_found_error_on_non_empty_index_suggests_search() {
+        let index = cache::Index {
+            entries: vec![cache::IndexEntry {
+                path: "agents/other.md".to_string(),
+                name: "other".to_string(),
+                description: None,
+                tags: vec![],
+                category: None,
+                source: "github/awesome-copilot-abc12345".to_string(),
+            }],
+        };
+        let err = not_found_error("missing-agent", &index);
+        let msg = err.to_string();
+        assert!(msg.contains("missing-agent"));
+        assert!(msg.contains("registry search"));
     }
 }

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -46,17 +46,19 @@ pub async fn execute(action: RegistryAction) -> anyhow::Result<()> {
 }
 
 async fn cmd_sync() -> anyhow::Result<()> {
-    println!("Syncing community registry...");
-    sync::registry_sync(None)?;
+    let sources = sync::effective_sources();
+    println!("Syncing {} agent registry source(s)...", sources.len());
+    sync::registry_sync(&sources)?;
     println!("Building search index...");
-    let index = cache::build_index()?;
+    let index = cache::build_index(&sources)?;
     println!("Indexed {} agent(s).", index.entries.len());
     Ok(())
 }
 
 async fn cmd_search(query: &str, category: Option<&str>) -> anyhow::Result<()> {
     check_staleness();
-    let index = cache::load_or_build_index()?;
+    let sources = sync::effective_sources();
+    let index = cache::load_or_build_index(&sources)?;
 
     let entries = match category {
         Some(cat) => {
@@ -95,7 +97,8 @@ async fn cmd_search(query: &str, category: Option<&str>) -> anyhow::Result<()> {
 
 async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
     check_staleness();
-    let index = cache::load_or_build_index()?;
+    let sources = sync::effective_sources();
+    let index = cache::load_or_build_index(&sources)?;
 
     let entries: Vec<&cache::IndexEntry> = match category {
         Some(cat) => search::filter_by_category(&index.entries, cat),
@@ -104,7 +107,7 @@ async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
 
     if entries.is_empty() {
         println!("No agents in registry.");
-        if !sync::repo_dir().join(".git").is_dir() {
+        if !sync::sources_dir().is_dir() {
             println!("Run `armadai registry sync` to fetch the registry.");
         }
         return Ok(());
@@ -152,7 +155,8 @@ async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
 
 async fn cmd_add(agent: &str, force: bool) -> anyhow::Result<()> {
     check_staleness();
-    let index = cache::load_or_build_index()?;
+    let sources = sync::effective_sources();
+    let index = cache::load_or_build_index(&sources)?;
 
     // Find the agent in the index by name or path
     let entry = index
@@ -166,7 +170,7 @@ async fn cmd_add(agent: &str, force: bool) -> anyhow::Result<()> {
         })?;
 
     println!("Converting {} ...", entry.name);
-    let dst = convert::import_to_library(&entry.path, force)?;
+    let dst = convert::import_to_library(&entry.source, &entry.path, force)?;
     println!("Installed: {}", dst.display());
     println!("\nAgent '{}' added to your library.", entry.name);
     Ok(())
@@ -174,7 +178,8 @@ async fn cmd_add(agent: &str, force: bool) -> anyhow::Result<()> {
 
 async fn cmd_info(agent: &str) -> anyhow::Result<()> {
     check_staleness();
-    let index = cache::load_or_build_index()?;
+    let sources = sync::effective_sources();
+    let index = cache::load_or_build_index(&sources)?;
 
     let entry = index
         .entries
@@ -184,6 +189,9 @@ async fn cmd_info(agent: &str) -> anyhow::Result<()> {
 
     println!("Name:        {}", entry.name);
     println!("Path:        {}", entry.path);
+    if !entry.source.is_empty() {
+        println!("Source:      {}", entry.source);
+    }
     if let Some(ref cat) = entry.category {
         println!("Category:    {cat}");
     }
@@ -195,7 +203,7 @@ async fn cmd_info(agent: &str) -> anyhow::Result<()> {
     }
 
     // Show the raw content
-    let repo = sync::repo_dir();
+    let repo = sync::dir_for_key(&entry.source);
     let src = repo.join(&entry.path);
     if src.is_file() {
         println!("\n--- Content ---");
@@ -218,7 +226,7 @@ async fn cmd_info(agent: &str) -> anyhow::Result<()> {
 
 /// Print a hint if the registry is stale (> 7 days old).
 fn check_staleness() {
-    if sync::is_stale(7) && sync::repo_dir().join(".git").is_dir() {
+    if sync::is_stale(7) && sync::sources_dir().is_dir() {
         eprintln!("hint: registry may be outdated. Run `armadai registry sync` to refresh.");
     }
 }

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -1,5 +1,10 @@
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 
+use crate::core::config::registries_config_path;
+use crate::core::project::find_project_config;
+use crate::core::registries::{
+    RegistriesConfig, RegistryKind, RegistrySource, load_user_registries,
+};
 use crate::registry::{cache, convert, search, sync};
 
 #[derive(Subcommand)]
@@ -33,6 +38,53 @@ pub enum RegistryAction {
         /// Agent name or path in registry
         agent: String,
     },
+    /// Manage custom registry sources (URLs)
+    Sources {
+        #[command(subcommand)]
+        action: SourcesAction,
+    },
+}
+
+/// Custom registry source actions (list/add/remove URLs).
+#[derive(Subcommand)]
+pub enum SourcesAction {
+    /// List all registry sources and their origins
+    List,
+    /// Add a custom registry source to user config
+    Add {
+        /// Registry kind (agents/skills/models)
+        kind: SourceKind,
+        /// Registry source URL
+        url: String,
+    },
+    /// Remove a custom registry source from user config
+    Remove {
+        /// Registry kind (agents/skills/models)
+        kind: SourceKind,
+        /// Registry source URL
+        url: String,
+    },
+}
+
+/// Registry kind for custom sources.
+#[derive(Clone, Copy, ValueEnum)]
+pub enum SourceKind {
+    /// Agent registry sources
+    Agents,
+    /// Skill registry sources
+    Skills,
+    /// Model catalog sources
+    Models,
+}
+
+impl From<SourceKind> for RegistryKind {
+    fn from(kind: SourceKind) -> Self {
+        match kind {
+            SourceKind::Agents => RegistryKind::Agents,
+            SourceKind::Skills => RegistryKind::Skills,
+            SourceKind::Models => RegistryKind::Models,
+        }
+    }
 }
 
 pub async fn execute(action: RegistryAction) -> anyhow::Result<()> {
@@ -42,6 +94,11 @@ pub async fn execute(action: RegistryAction) -> anyhow::Result<()> {
         RegistryAction::List { category } => cmd_list(category.as_deref()).await,
         RegistryAction::Add { agent, force } => cmd_add(&agent, force).await,
         RegistryAction::Info { agent } => cmd_info(&agent).await,
+        RegistryAction::Sources { action } => match action {
+            SourcesAction::List => sources_list().await,
+            SourcesAction::Add { kind, url } => sources_add(kind, &url).await,
+            SourcesAction::Remove { kind, url } => sources_remove(kind, &url).await,
+        },
     }
 }
 
@@ -255,6 +312,134 @@ fn check_staleness() {
     }
 }
 
+/// List all registry sources with their origins (default/user/project).
+async fn sources_list() -> anyhow::Result<()> {
+    let user = load_user_registries();
+    let project = find_project_config()
+        .map(|(_, cfg)| cfg)
+        .and_then(|cfg| cfg.registries);
+
+    // Agents
+    println!("Agents:");
+    println!("  [default] {}", sync::DEFAULT_REGISTRY_URL);
+    for source in &user.agents {
+        println!("  [user]    {}", source.url);
+    }
+    if let Some(ref proj) = project {
+        for source in &proj.agents {
+            println!("  [project] {}", source.url);
+        }
+    }
+
+    // Skills
+    println!("\nSkills:");
+    for default_url in crate::skills_registry::sync::default_sources() {
+        println!("  [default] {}", default_url);
+    }
+    for source in &user.skills {
+        println!("  [user]    {}", source.url);
+    }
+    if let Some(ref proj) = project {
+        for source in &proj.skills {
+            println!("  [project] {}", source.url);
+        }
+    }
+
+    // Models
+    println!("\nModels:");
+    println!(
+        "  [default] {}",
+        crate::model_registry::fetch::MODELS_DEV_URL
+    );
+    for source in &user.models {
+        println!("  [user]    {}", source.url);
+    }
+    if let Some(ref proj) = project {
+        for source in &proj.models {
+            println!("  [project] {}", source.url);
+        }
+    }
+
+    Ok(())
+}
+
+/// Add a custom registry source to user config (idempotent).
+async fn sources_add(kind: SourceKind, url: &str) -> anyhow::Result<()> {
+    let mut config = load_user_registries();
+    let registry_kind: RegistryKind = kind.into();
+
+    let sources = match registry_kind {
+        RegistryKind::Agents => &mut config.agents,
+        RegistryKind::Skills => &mut config.skills,
+        RegistryKind::Models => &mut config.models,
+    };
+
+    // Check if already present (idempotent)
+    if sources.iter().any(|s| s.url == url) {
+        println!("Source already registered: {url}");
+        return Ok(());
+    }
+
+    sources.push(RegistrySource {
+        url: url.to_string(),
+    });
+
+    save_registries_config(&config)?;
+    println!("Added {} registry source: {url}", kind_name(registry_kind));
+    println!("  Saved to {}", registries_config_path().display());
+
+    Ok(())
+}
+
+/// Remove a custom registry source from user config.
+async fn sources_remove(kind: SourceKind, url: &str) -> anyhow::Result<()> {
+    let mut config = load_user_registries();
+    let registry_kind: RegistryKind = kind.into();
+
+    let sources = match registry_kind {
+        RegistryKind::Agents => &mut config.agents,
+        RegistryKind::Skills => &mut config.skills,
+        RegistryKind::Models => &mut config.models,
+    };
+
+    let before = sources.len();
+    sources.retain(|s| s.url != url);
+
+    if sources.len() == before {
+        println!("Source not found in config: {url}");
+        return Ok(());
+    }
+
+    save_registries_config(&config)?;
+    println!(
+        "Removed {} registry source: {url}",
+        kind_name(registry_kind)
+    );
+    println!("  Saved to {}", registries_config_path().display());
+
+    Ok(())
+}
+
+/// Save the registries config to disk, creating parent directory if needed.
+fn save_registries_config(config: &RegistriesConfig) -> anyhow::Result<()> {
+    let path = registries_config_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let yaml = serde_yaml_ng::to_string(config)?;
+    std::fs::write(&path, yaml)?;
+    Ok(())
+}
+
+/// Human-readable name for a registry kind.
+fn kind_name(kind: RegistryKind) -> &'static str {
+    match kind {
+        RegistryKind::Agents => "agents",
+        RegistryKind::Skills => "skills",
+        RegistryKind::Models => "models",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +474,86 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("missing-agent"));
         assert!(msg.contains("registry search"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn sources_add_and_load() {
+        use tempfile::tempdir;
+
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+
+        let temp = tempdir().unwrap();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", temp.path());
+        }
+
+        let url = "https://custom.example.com/agents.git";
+        sources_add(SourceKind::Agents, url).await.unwrap();
+
+        let loaded = load_user_registries();
+        assert_eq!(loaded.agents.len(), 1);
+        assert_eq!(loaded.agents[0].url, url);
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn sources_remove_existing() {
+        use tempfile::tempdir;
+
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+
+        let temp = tempdir().unwrap();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", temp.path());
+        }
+
+        let url = "https://custom.example.com/agents.git";
+        sources_add(SourceKind::Agents, url).await.unwrap();
+        sources_remove(SourceKind::Agents, url).await.unwrap();
+
+        let loaded = load_user_registries();
+        assert!(loaded.agents.is_empty());
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn sources_add_is_idempotent() {
+        use tempfile::tempdir;
+
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+
+        let temp = tempdir().unwrap();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", temp.path());
+        }
+
+        let url = "https://custom.example.com/agents.git";
+        sources_add(SourceKind::Agents, url).await.unwrap();
+        sources_add(SourceKind::Agents, url).await.unwrap();
+
+        let loaded = load_user_registries();
+        assert_eq!(loaded.agents.len(), 1, "duplicate add should be idempotent");
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -76,6 +76,12 @@ pub fn providers_file_path() -> PathBuf {
     config_dir().join("providers.yaml")
 }
 
+/// Path to the user-level custom registries config
+/// (`~/.config/armadai/registries.yaml`). See `crate::core::registries`.
+pub fn registries_config_path() -> PathBuf {
+    config_dir().join("registries.yaml")
+}
+
 /// Create the full directory tree under the config root.
 pub fn ensure_config_dirs() -> anyhow::Result<()> {
     let dirs = [

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,8 @@ pub mod pack_validation;
 pub mod project;
 pub mod project_registry;
 pub mod prompt;
+#[allow(dead_code)]
+pub mod registries;
 pub mod routing;
 pub mod skill;
 pub mod starter;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,7 +11,6 @@ pub mod pack_validation;
 pub mod project;
 pub mod project_registry;
 pub mod prompt;
-#[allow(dead_code)]
 pub mod registries;
 pub mod routing;
 pub mod skill;

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -69,10 +69,9 @@ pub struct ProjectConfig {
     pub routing: Option<crate::core::routing::RoutingRules>,
     /// Project-level custom registry sources (agents/skills/models), merged
     /// with the user-level `~/.config/armadai/registries.yaml` and built-in
-    /// defaults. See `crate::core::registries`.
-    ///
-    /// Not yet consumed: registry wiring lands in B2 Lot A Task 2.
-    #[allow(dead_code)]
+    /// defaults. See `crate::core::registries`. Consumed by
+    /// `registry::sync::effective_sources`, `skills_registry::cache::effective_sources`
+    /// and `model_registry::fetch`'s source resolution (B2 Lot A Task 2).
     #[serde(default)]
     pub registries: Option<crate::core::registries::RegistriesConfig>,
 }

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -67,6 +67,14 @@ pub struct ProjectConfig {
     /// Consumed in `cli::run::execute` to build the `RoutingRules` passed to
     /// `run_single_agent` for `latest:auto` model resolution.
     pub routing: Option<crate::core::routing::RoutingRules>,
+    /// Project-level custom registry sources (agents/skills/models), merged
+    /// with the user-level `~/.config/armadai/registries.yaml` and built-in
+    /// defaults. See `crate::core::registries`.
+    ///
+    /// Not yet consumed: registry wiring lands in B2 Lot A Task 2.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub registries: Option<crate::core::registries::RegistriesConfig>,
 }
 
 /// Reference to an agent — resolved at runtime.
@@ -599,6 +607,32 @@ routing:
         let yaml = "agents: []\n";
         let cfg: ProjectConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(cfg.routing.is_none());
+    }
+
+    #[test]
+    fn parses_registries_section() {
+        let yaml = r#"
+agents: []
+registries:
+  agents:
+    - url: https://example.com/agents.git
+  skills:
+    - url: https://example.com/skills.git
+"#;
+        let cfg: ProjectConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        let r = cfg.registries.expect("registries present");
+        assert_eq!(r.agents.len(), 1);
+        assert_eq!(r.agents[0].url, "https://example.com/agents.git");
+        assert_eq!(r.skills.len(), 1);
+        assert_eq!(r.skills[0].url, "https://example.com/skills.git");
+        assert!(r.models.is_empty());
+    }
+
+    #[test]
+    fn registries_absent_gives_none() {
+        let yaml = "agents: []\n";
+        let cfg: ProjectConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(cfg.registries.is_none());
     }
 
     #[test]

--- a/src/core/registries.rs
+++ b/src/core/registries.rs
@@ -1,0 +1,268 @@
+//! Custom registry sources configuration and resolution.
+//!
+//! ArmadAI ships with default registry URLs baked into `registry::sync`
+//! (`DEFAULT_REGISTRY_URL`), `skills_registry::sync` (`default_skill_sources`),
+//! and `model_registry::fetch` (`MODELS_DEV_URL`). This module is the socle
+//! (B2 Lot A / Task 1) that lets users and projects declare *additional*
+//! registry sources via a `registries:` section in
+//! `~/.config/armadai/registries.yaml` (user) and/or `armadai.yaml`
+//! (project). Wiring this into the actual registries (Task 2) and exposing
+//! it via the CLI (Task 3) are handled separately.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::config::registries_config_path;
+
+/// A single custom registry source.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct RegistrySource {
+    pub url: String,
+}
+
+/// Custom registry sources declared by the user or a project, grouped by
+/// registry kind. Absent keys deserialize to empty vecs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct RegistriesConfig {
+    #[serde(default)]
+    pub agents: Vec<RegistrySource>,
+    #[serde(default)]
+    pub skills: Vec<RegistrySource>,
+    #[serde(default)]
+    pub models: Vec<RegistrySource>,
+    #[serde(default)]
+    pub starters: Vec<RegistrySource>,
+}
+
+/// Which registry kind is being resolved.
+///
+/// `starters` intentionally has no variant here yet: starter registry
+/// resolution is Lot B and out of scope for this task, even though the
+/// `starters` field already exists on [`RegistriesConfig`] for forward
+/// compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistryKind {
+    Agents,
+    Skills,
+    Models,
+}
+
+impl RegistryKind {
+    fn sources(self, config: &RegistriesConfig) -> &[RegistrySource] {
+        match self {
+            RegistryKind::Agents => &config.agents,
+            RegistryKind::Skills => &config.skills,
+            RegistryKind::Models => &config.models,
+        }
+    }
+}
+
+/// Load the user-level registries config from
+/// `~/.config/armadai/registries.yaml`. Returns [`RegistriesConfig::default`]
+/// when the file is absent, unreadable, or fails to parse.
+pub fn load_user_registries() -> RegistriesConfig {
+    let path: PathBuf = registries_config_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_yaml_ng::from_str(&content).unwrap_or_default(),
+        Err(_) => RegistriesConfig::default(),
+    }
+}
+
+/// Resolve the final ordered list of registry source URLs for `kind`.
+///
+/// Order: built-in `defaults` first, then user-level custom sources, then
+/// project-level custom sources (if any). The result is deduplicated while
+/// preserving the position of each URL's first occurrence, so defaults
+/// always win the front of the list.
+pub fn resolved_sources(
+    kind: RegistryKind,
+    defaults: &[&str],
+    user: &RegistriesConfig,
+    project: Option<&RegistriesConfig>,
+) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out = Vec::new();
+
+    let mut extend = |urls: &mut dyn Iterator<Item = String>| {
+        for url in urls {
+            if seen.insert(url.clone()) {
+                out.push(url);
+            }
+        }
+    };
+
+    extend(&mut defaults.iter().map(|s| (*s).to_string()));
+    extend(&mut kind.sources(user).iter().map(|s| s.url.clone()));
+    if let Some(project) = project {
+        extend(&mut kind.sources(project).iter().map(|s| s.url.clone()));
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Wrapper {
+        registries: RegistriesConfig,
+    }
+
+    #[test]
+    fn deserializes_full_registries_yaml() {
+        let yaml = r#"
+registries:
+  agents:
+    - url: https://example.com/agents.git
+  skills:
+    - url: https://example.com/skills.git
+  models:
+    - url: https://example.com/models.json
+"#;
+        let wrapper: Wrapper = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(
+            wrapper.registries.agents,
+            vec![RegistrySource {
+                url: "https://example.com/agents.git".to_string()
+            }]
+        );
+        assert_eq!(
+            wrapper.registries.skills,
+            vec![RegistrySource {
+                url: "https://example.com/skills.git".to_string()
+            }]
+        );
+        assert_eq!(
+            wrapper.registries.models,
+            vec![RegistrySource {
+                url: "https://example.com/models.json".to_string()
+            }]
+        );
+        assert!(wrapper.registries.starters.is_empty());
+    }
+
+    #[test]
+    fn missing_keys_default_to_empty_vecs() {
+        let yaml = r#"
+registries:
+  agents:
+    - url: https://example.com/agents.git
+"#;
+        let wrapper: Wrapper = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(wrapper.registries.agents.len(), 1);
+        assert!(wrapper.registries.skills.is_empty());
+        assert!(wrapper.registries.models.is_empty());
+        assert!(wrapper.registries.starters.is_empty());
+    }
+
+    #[test]
+    fn default_is_all_empty() {
+        let cfg = RegistriesConfig::default();
+        assert!(cfg.agents.is_empty());
+        assert!(cfg.skills.is_empty());
+        assert!(cfg.models.is_empty());
+        assert!(cfg.starters.is_empty());
+    }
+
+    #[test]
+    fn resolved_sources_defaults_only_when_user_and_project_empty() {
+        let user = RegistriesConfig::default();
+        let result = resolved_sources(
+            RegistryKind::Agents,
+            &["https://default.example/a"],
+            &user,
+            None,
+        );
+        assert_eq!(result, vec!["https://default.example/a".to_string()]);
+    }
+
+    #[test]
+    fn resolved_sources_merges_and_dedupes_preserving_order() {
+        let user = RegistriesConfig {
+            agents: vec![
+                RegistrySource {
+                    url: "https://default.example/a".to_string(),
+                }, // duplicate of a default
+                RegistrySource {
+                    url: "https://user.example/b".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let project = RegistriesConfig {
+            agents: vec![
+                RegistrySource {
+                    url: "https://user.example/b".to_string(),
+                }, // duplicate of a user source
+                RegistrySource {
+                    url: "https://project.example/c".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = resolved_sources(
+            RegistryKind::Agents,
+            &["https://default.example/a"],
+            &user,
+            Some(&project),
+        );
+
+        assert_eq!(
+            result,
+            vec![
+                "https://default.example/a".to_string(),
+                "https://user.example/b".to_string(),
+                "https://project.example/c".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolved_sources_does_not_cross_contaminate_kinds() {
+        let user = RegistriesConfig {
+            skills: vec![RegistrySource {
+                url: "https://user.example/skills".to_string(),
+            }],
+            ..Default::default()
+        };
+        let result = resolved_sources(
+            RegistryKind::Agents,
+            &["https://default.example/a"],
+            &user,
+            None,
+        );
+        assert_eq!(result, vec!["https://default.example/a".to_string()]);
+    }
+
+    #[test]
+    fn load_user_registries_missing_file_returns_default() {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var(
+                "ARMADAI_CONFIG_DIR",
+                "/tmp/armadai-registries-test-nonexistent-dir-xyz",
+            );
+        }
+
+        let cfg = load_user_registries();
+        assert!(cfg.agents.is_empty());
+        assert!(cfg.skills.is_empty());
+        assert!(cfg.models.is_empty());
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+}

--- a/src/core/registries.rs
+++ b/src/core/registries.rs
@@ -47,6 +47,12 @@ pub struct RegistriesConfig {
 pub enum RegistryKind {
     Agents,
     Skills,
+    /// Only constructed when the `providers-api` feature is enabled:
+    /// `model_registry::fetch` is the sole consumer, since resolving model
+    /// catalog sources is only useful alongside the HTTP fetch that reads
+    /// them. Harmless to keep visible in `tui`-only builds, where model
+    /// registry fetching is unavailable anyway.
+    #[allow(dead_code)]
     Models,
 }
 

--- a/src/core/registries.rs
+++ b/src/core/registries.rs
@@ -10,6 +10,7 @@
 //! it via the CLI (Task 3) are handled separately.
 
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -107,6 +108,51 @@ pub fn resolved_sources(
     }
 
     out
+}
+
+/// Derive a filesystem-safe, collision-resistant cache key for a registry
+/// source URL.
+///
+/// This is the single sanitization scheme shared by every consumer that
+/// needs to turn an arbitrary registry source URL into a directory or file
+/// name: `registry::sync::source_key` (per-source clone directories) and
+/// `model_registry::fetch::source_cache_path` (per-source model catalog
+/// cache files) both delegate here. Before this, each maintained its own ad
+/// hoc sanitization, neither of which was collision-resistant (see B2 Task 2
+/// review, minor finding).
+///
+/// The key is `<readable-prefix>-<8 hex chars of a hash of the full URL>`.
+/// The prefix (a sanitized, truncated version of the URL) exists only for
+/// human readability in cache directory listings; the hash suffix — derived
+/// from the *whole*, un-sanitized URL — is what actually guarantees
+/// uniqueness:
+/// - two different URLs that happen to sanitize to the same prefix (e.g.
+///   differing only in characters that both get replaced) still get
+///   distinct keys;
+/// - a URL that sanitizes to a bare `.` or `..` (which would otherwise be an
+///   unsafe, path-traversal-shaped directory name) can never produce a key
+///   equal to `.`/`..`, since the hash suffix is always appended.
+pub fn cache_key(url: &str) -> String {
+    let sanitized: String = url
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(60)
+        .collect();
+
+    let prefix = sanitized.trim_matches(|c| c == '.' || c == '_');
+    let prefix = if prefix.is_empty() { "src" } else { prefix };
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    url.hash(&mut hasher);
+    let hash = hasher.finish() as u32;
+
+    format!("{prefix}-{hash:08x}")
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +293,43 @@ registries:
             None,
         );
         assert_eq!(result, vec!["https://default.example/a".to_string()]);
+    }
+
+    #[test]
+    fn cache_key_is_deterministic() {
+        let url = "https://github.com/github/awesome-copilot.git";
+        assert_eq!(cache_key(url), cache_key(url));
+    }
+
+    #[test]
+    fn cache_key_has_no_path_separators() {
+        let key = cache_key("https://github.com/github/awesome-copilot.git");
+        assert!(!key.contains('/'));
+        assert!(!key.contains('\\'));
+    }
+
+    #[test]
+    fn cache_key_distinguishes_similar_urls() {
+        let a = cache_key("https://github.com/acme/registry");
+        let b = cache_key("https://github.com/acme/registry-fork");
+        let c = cache_key("http://github.com/acme/registry"); // http vs https
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn cache_key_guards_against_dot_dot_traversal() {
+        assert_ne!(cache_key(".."), "..");
+        assert_ne!(cache_key("."), ".");
+        assert_ne!(cache_key("...."), "..");
+    }
+
+    #[test]
+    fn cache_key_readable_prefix_preserved_for_normal_urls() {
+        let key = cache_key("https://github.com/github/awesome-copilot.git");
+        assert!(key.contains("github"));
+        assert!(key.contains("awesome-copilot"));
     }
 
     #[test]

--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -45,10 +45,119 @@ pub async fn load_models_online(provider: &str) -> Option<Vec<ModelEntry>> {
     None
 }
 
+/// Resolve the effective list of model registry sources: the built-in
+/// `models.dev` catalog, plus any user-level
+/// (`~/.config/armadai/registries.yaml`) and project-level (`armadai.yaml` /
+/// `.armadai/config.yaml`) custom sources.
+///
+/// Project config is looked up via `core::project::find_project_config`,
+/// which walks up from the current working directory. Without a
+/// `registries:` section anywhere, this returns exactly `[MODELS_DEV_URL]`.
+#[cfg(feature = "providers-api")]
+fn resolved_model_sources() -> Vec<String> {
+    let user = crate::core::registries::load_user_registries();
+    let project = crate::core::project::find_project_config().map(|(_, cfg)| cfg);
+    let project_registries = project.as_ref().and_then(|cfg| cfg.registries.as_ref());
+    crate::core::registries::resolved_sources(
+        crate::core::registries::RegistryKind::Models,
+        &[MODELS_DEV_URL],
+        &user,
+        project_registries,
+    )
+}
+
+/// Directory holding one cache file per model registry source, keyed by a
+/// sanitized version of the source URL. Kept separate from the merged
+/// `models-cache.json` (see `cache_path`) so a fetch failure on one source
+/// doesn't lose previously-fetched data for the others.
+#[cfg(feature = "providers-api")]
+fn source_cache_dir() -> PathBuf {
+    config_dir().join("models-sources")
+}
+
+/// Derive a filesystem-safe cache file path for a given source URL.
+#[cfg(feature = "providers-api")]
+fn source_cache_path(url: &str) -> PathBuf {
+    let key: String = url
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    source_cache_dir().join(format!("{key}.json"))
+}
+
+/// Fetch and parse a single source's catalog (models.dev format).
+#[cfg(feature = "providers-api")]
+async fn fetch_source(url: &str) -> anyhow::Result<HashMap<String, Vec<ModelEntry>>> {
+    let body: serde_json::Value = reqwest::get(url).await?.json().await?;
+    Ok(parse_registry(&body))
+}
+
+/// Fetch every configured model registry source and merge them into a
+/// single provider → models map.
+///
+/// Merge semantics: **union by provider, last source wins** — sources are
+/// processed in `resolved_model_sources()` order (built-in default first,
+/// then user, then project custom sources), and for a given provider id the
+/// last source that supplied it overwrites earlier ones.
+///
+/// Each source is cached independently (see `source_cache_path`). If a
+/// source's fetch fails, we fall back to that source's last successful
+/// cache (regardless of its TTL) so one flaky/unreachable custom registry
+/// doesn't wipe out previously known data — only if a source has *never*
+/// succeeded does it contribute nothing. If every source fails, the first
+/// error encountered is returned (preserving the pre-multi-source behavior
+/// of propagating a fetch error when there is only the single default
+/// source).
 #[cfg(feature = "providers-api")]
 async fn fetch_and_cache() -> anyhow::Result<CachedRegistry> {
-    let body: serde_json::Value = reqwest::get(MODELS_DEV_URL).await?.json().await?;
-    let providers = parse_registry(&body);
+    let sources = resolved_model_sources();
+    let mut merged: HashMap<String, Vec<ModelEntry>> = HashMap::new();
+    let mut first_err: Option<anyhow::Error> = None;
+    let mut any_data = false;
+
+    for source in &sources {
+        let source_path = source_cache_path(source);
+        match fetch_source(source).await {
+            Ok(providers) => {
+                any_data = true;
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                save_cache_to(
+                    &source_path,
+                    &CachedRegistry {
+                        fetched_at: now,
+                        providers: providers.clone(),
+                    },
+                );
+                for (provider, entries) in providers {
+                    merged.insert(provider, entries);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to fetch model registry source '{source}': {e:?}");
+                // Fall back to whatever this source last produced, however
+                // stale, rather than losing it entirely.
+                if let Ok(content) = std::fs::read_to_string(&source_path)
+                    && let Ok(cached) = serde_json::from_str::<CachedRegistry>(&content)
+                {
+                    any_data = true;
+                    for (provider, entries) in cached.providers {
+                        merged.insert(provider, entries);
+                    }
+                } else if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+    }
+
+    if !any_data {
+        return Err(
+            first_err.unwrap_or_else(|| anyhow::anyhow!("no model registry source available"))
+        );
+    }
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -57,7 +166,7 @@ async fn fetch_and_cache() -> anyhow::Result<CachedRegistry> {
 
     let registry = CachedRegistry {
         fetched_at: now,
-        providers,
+        providers: merged,
     };
     save_cache_to(&cache_path(), &registry);
     Ok(registry)
@@ -262,6 +371,50 @@ mod tests {
         let json = serde_json::json!({});
         let providers = parse_registry(&json);
         assert!(providers.is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "providers-api")]
+    fn resolved_sources_defaults_only_without_custom_config() {
+        use crate::core::registries::{RegistriesConfig, RegistryKind, resolved_sources};
+
+        let user = RegistriesConfig::default();
+        let result = resolved_sources(RegistryKind::Models, &[MODELS_DEV_URL], &user, None);
+        assert_eq!(result, vec![MODELS_DEV_URL.to_string()]);
+    }
+
+    #[test]
+    #[cfg(feature = "providers-api")]
+    fn resolved_sources_includes_default_and_custom_model_source() {
+        use crate::core::registries::{
+            RegistriesConfig, RegistryKind, RegistrySource, resolved_sources,
+        };
+
+        let user = RegistriesConfig {
+            models: vec![RegistrySource {
+                url: "https://example.com/custom-models.json".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let result = resolved_sources(RegistryKind::Models, &[MODELS_DEV_URL], &user, None);
+        assert_eq!(
+            result,
+            vec![
+                MODELS_DEV_URL.to_string(),
+                "https://example.com/custom-models.json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "providers-api")]
+    fn source_cache_path_is_stable_and_distinct_per_source() {
+        let a = source_cache_path("https://models.dev/api.json");
+        let b = source_cache_path("https://example.com/custom-models.json");
+        assert_ne!(a, b);
+        // Deterministic: same URL always maps to the same path.
+        assert_eq!(a, source_cache_path("https://models.dev/api.json"));
     }
 
     #[test]

--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -7,8 +7,7 @@ use super::ModelEntry;
 
 const CACHE_FILE: &str = "models-cache.json";
 const CACHE_TTL_SECS: u64 = 86400; // 24h
-#[cfg(feature = "providers-api")]
-const MODELS_DEV_URL: &str = "https://models.dev/api.json";
+pub(crate) const MODELS_DEV_URL: &str = "https://models.dev/api.json";
 
 /// Cached registry: provider_id → Vec<ModelEntry>
 #[derive(serde::Serialize, serde::Deserialize, Default)]

--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -76,12 +76,14 @@ fn source_cache_dir() -> PathBuf {
 }
 
 /// Derive a filesystem-safe cache file path for a given source URL.
+///
+/// Delegates to `core::registries::cache_key`, the sanitization scheme
+/// shared with `registry::sync::source_key` (previously each had its own,
+/// independently-maintained and collision-prone sanitization — see B2 Task 2
+/// review).
 #[cfg(feature = "providers-api")]
 fn source_cache_path(url: &str) -> PathBuf {
-    let key: String = url
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
+    let key = crate::core::registries::cache_key(url);
     source_cache_dir().join(format!("{key}.json"))
 }
 
@@ -108,22 +110,32 @@ async fn fetch_source(url: &str) -> anyhow::Result<HashMap<String, Vec<ModelEntr
 /// error encountered is returned (preserving the pre-multi-source behavior
 /// of propagating a fetch error when there is only the single default
 /// source).
+///
+/// The aggregate cache's `fetched_at` is the oldest timestamp among the
+/// sources that actually contributed data this run (see
+/// [`aggregate_fetched_at`]) rather than unconditionally `now()`: if any
+/// source had to fall back to its own stale cache, stamping the merged
+/// result as freshly-fetched would hide up to 24h (the per-source TTL) of
+/// degradation from consumers that only check the aggregate's freshness.
 #[cfg(feature = "providers-api")]
 async fn fetch_and_cache() -> anyhow::Result<CachedRegistry> {
     let sources = resolved_model_sources();
     let mut merged: HashMap<String, Vec<ModelEntry>> = HashMap::new();
     let mut first_err: Option<anyhow::Error> = None;
     let mut any_data = false;
+    let mut contributing_timestamps: Vec<u64> = Vec::new();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
 
     for source in &sources {
         let source_path = source_cache_path(source);
         match fetch_source(source).await {
             Ok(providers) => {
                 any_data = true;
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
+                contributing_timestamps.push(now);
                 save_cache_to(
                     &source_path,
                     &CachedRegistry {
@@ -143,6 +155,7 @@ async fn fetch_and_cache() -> anyhow::Result<CachedRegistry> {
                     && let Ok(cached) = serde_json::from_str::<CachedRegistry>(&content)
                 {
                     any_data = true;
+                    contributing_timestamps.push(cached.fetched_at);
                     for (provider, entries) in cached.providers {
                         merged.insert(provider, entries);
                     }
@@ -159,17 +172,31 @@ async fn fetch_and_cache() -> anyhow::Result<CachedRegistry> {
         );
     }
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let fetched_at = aggregate_fetched_at(&contributing_timestamps, now);
+    if fetched_at < now {
+        tracing::warn!(
+            "Model registry cache freshness degraded: at least one source fell back to a stale cache (aggregate fetched_at={fetched_at}, now={now})"
+        );
+    }
 
     let registry = CachedRegistry {
-        fetched_at: now,
+        fetched_at,
         providers: merged,
     };
     save_cache_to(&cache_path(), &registry);
     Ok(registry)
+}
+
+/// Compute the aggregate cache's `fetched_at` from the per-source
+/// timestamps that contributed data this run. Any source that fell back to
+/// a stale cache pulls the aggregate down to that source's own `fetched_at`,
+/// so a merged cache that includes stale fallback data never claims to be
+/// fresher than its stalest ingredient. Pure function, kept separate from
+/// [`fetch_and_cache`] so this logic is unit-testable without a network
+/// call.
+#[cfg(any(feature = "providers-api", test))]
+fn aggregate_fetched_at(contributing_timestamps: &[u64], now: u64) -> u64 {
+    contributing_timestamps.iter().copied().min().unwrap_or(now)
 }
 
 /// Parse the models.dev JSON structure into a provider → models map.
@@ -415,6 +442,58 @@ mod tests {
         assert_ne!(a, b);
         // Deterministic: same URL always maps to the same path.
         assert_eq!(a, source_cache_path("https://models.dev/api.json"));
+    }
+
+    #[test]
+    #[cfg(feature = "providers-api")]
+    fn resolved_model_sources_glue_includes_user_level_custom_source() {
+        // Exercises the real `resolved_model_sources()` glue (not just the
+        // pure `resolved_sources` helper) with a `RegistriesConfig` loaded
+        // from disk, per the B2 Task 2 review follow-up.
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+        }
+
+        std::fs::write(
+            dir.path().join("registries.yaml"),
+            "models:\n  - url: https://example.com/custom-glue-models.json\n",
+        )
+        .unwrap();
+
+        let sources = resolved_model_sources();
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+
+        assert!(sources.contains(&MODELS_DEV_URL.to_string()));
+        assert!(sources.contains(&"https://example.com/custom-glue-models.json".to_string()));
+    }
+
+    #[test]
+    fn aggregate_fetched_at_is_now_when_all_sources_fresh() {
+        let now = 1_700_000_000;
+        assert_eq!(aggregate_fetched_at(&[now, now], now), now);
+    }
+
+    #[test]
+    fn aggregate_fetched_at_uses_oldest_when_a_source_fell_back_to_stale_cache() {
+        let now = 1_700_000_000;
+        let stale = now - 3600; // one source fell back to a 1h-old cache
+        assert_eq!(aggregate_fetched_at(&[now, stale], now), stale);
+    }
+
+    #[test]
+    fn aggregate_fetched_at_defaults_to_now_when_no_contributions() {
+        // Defensive default; `fetch_and_cache` never actually reaches this
+        // with an empty slice (it bails out via `any_data` first), but the
+        // pure function should still behave sanely.
+        assert_eq!(aggregate_fetched_at(&[], 42), 42);
     }
 
     #[test]

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -62,12 +62,25 @@ pub fn build_index(sources: &[String]) -> anyhow::Result<Index> {
 
 /// Load the cached index, or build it from whatever sources are already
 /// synced.
+///
+/// A cached index built before multi-source support (B2 Lot A Task 2, entries
+/// with `source == ""`) is treated as invalid rather than served: its
+/// `path`s are relative to the old single `repo/` clone, which no longer
+/// exists at the new per-source `sources_dir()/<key>/` layout, so serving it
+/// would either point `list`/`search`/`info` at stale data silently or make
+/// `registry add` fail with a cryptic "source ''" error (see
+/// `sync::legacy_repo_dir`, `has_legacy_cache`). When a legacy index is
+/// detected, we fall through and rebuild from whatever *new*-layout sources
+/// are already synced (typically none yet, so this resolves to an empty
+/// index — same as a fresh install — until the user runs `registry sync`).
 pub fn load_or_build_index(sources: &[String]) -> anyhow::Result<Index> {
     let index_path = index_file_path();
     if index_path.is_file() {
         let content = std::fs::read_to_string(&index_path)?;
         let index: Index = serde_json::from_str(&content)?;
-        return Ok(index);
+        if !is_legacy(&index) {
+            return Ok(index);
+        }
     }
 
     if sources_dir().is_dir() {
@@ -75,6 +88,33 @@ pub fn load_or_build_index(sources: &[String]) -> anyhow::Result<Index> {
     }
 
     Ok(Index::default())
+}
+
+/// True when `index` was built before multi-source support (B2 Lot A Task
+/// 2): any entry with an empty `source` came from the single pre-Task-2
+/// default registry, whose on-disk paths no longer resolve under the
+/// current per-source layout.
+fn is_legacy(index: &Index) -> bool {
+    index.entries.iter().any(|e| e.source.is_empty())
+}
+
+/// True when a pre-multi-source registry cache is present on disk: either
+/// the old single-repo clone (`registry/repo/`) or a cached index with
+/// legacy (empty `source`) entries. Used to show the user a clear
+/// "run `armadai registry sync`" hint instead of silently serving stale
+/// data, or erroring cryptically on `registry add`/convert.
+pub fn has_legacy_cache() -> bool {
+    if super::sync::legacy_repo_dir().is_dir() {
+        return true;
+    }
+
+    let index_path = index_file_path();
+    match std::fs::read_to_string(&index_path) {
+        Ok(content) => serde_json::from_str::<Index>(&content)
+            .map(|index| is_legacy(&index))
+            .unwrap_or(false),
+        Err(_) => false,
+    }
 }
 
 fn index_file_path() -> PathBuf {
@@ -272,5 +312,107 @@ mod tests {
         let json = r#"{"entries":[{"path":"a.md","name":"a","description":null,"tags":[],"category":null}]}"#;
         let index: Index = serde_json::from_str(json).unwrap();
         assert_eq!(index.entries[0].source, "");
+    }
+
+    #[test]
+    fn is_legacy_true_for_index_with_empty_source_entry() {
+        let index = Index {
+            entries: vec![IndexEntry {
+                path: "a.md".to_string(),
+                name: "a".to_string(),
+                description: None,
+                tags: vec![],
+                category: None,
+                source: String::new(),
+            }],
+        };
+        assert!(is_legacy(&index));
+    }
+
+    #[test]
+    fn is_legacy_false_for_current_format_index() {
+        let index = Index {
+            entries: vec![IndexEntry {
+                path: "a.md".to_string(),
+                name: "a".to_string(),
+                description: None,
+                tags: vec![],
+                category: None,
+                source: "github/awesome-copilot-abc12345".to_string(),
+            }],
+        };
+        assert!(!is_legacy(&index));
+    }
+
+    #[test]
+    fn is_legacy_false_for_empty_index() {
+        assert!(!is_legacy(&Index::default()));
+    }
+
+    fn with_config_dir<F: FnOnce(&std::path::Path)>(f: F) {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of scope.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+        }
+
+        f(dir.path());
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+
+    #[test]
+    fn has_legacy_cache_false_when_nothing_on_disk() {
+        with_config_dir(|_| {
+            assert!(!has_legacy_cache());
+        });
+    }
+
+    #[test]
+    fn has_legacy_cache_true_for_old_repo_dir() {
+        with_config_dir(|config_dir| {
+            let legacy_repo = config_dir.join("registry").join("repo");
+            std::fs::create_dir_all(&legacy_repo).unwrap();
+            assert!(has_legacy_cache());
+        });
+    }
+
+    #[test]
+    fn has_legacy_cache_true_for_legacy_index_json() {
+        with_config_dir(|config_dir| {
+            let registry_dir = config_dir.join("registry");
+            std::fs::create_dir_all(&registry_dir).unwrap();
+            std::fs::write(
+                registry_dir.join("index.json"),
+                r#"{"entries":[{"path":"a.md","name":"a","description":null,"tags":[],"category":null,"source":""}]}"#,
+            )
+            .unwrap();
+            assert!(has_legacy_cache());
+        });
+    }
+
+    #[test]
+    fn load_or_build_index_ignores_legacy_index_instead_of_serving_it() {
+        with_config_dir(|config_dir| {
+            let registry_dir = config_dir.join("registry");
+            std::fs::create_dir_all(&registry_dir).unwrap();
+            std::fs::write(
+                registry_dir.join("index.json"),
+                r#"{"entries":[{"path":"agents/x.md","name":"x","description":null,"tags":[],"category":null,"source":""}]}"#,
+            )
+            .unwrap();
+
+            // No new-layout `sources/` dir exists, so with the legacy index
+            // ignored this must resolve to an empty index rather than the
+            // stale legacy entry (which would otherwise point `registry add`
+            // at a nonexistent `sources_dir()/agents/x.md`).
+            let index = load_or_build_index(&[]).expect("should not error");
+            assert!(index.entries.is_empty());
+        });
     }
 }

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::sync::repo_dir;
+use super::sync::{source_dir, source_key, sources_dir};
 use crate::core::config::registry_cache_dir;
 
 // ---------------------------------------------------------------------------
@@ -11,7 +11,7 @@ use crate::core::config::registry_cache_dir;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexEntry {
-    /// Relative path inside the registry repo (e.g. "agents/official/security.agent.md")
+    /// Relative path inside the source repo (e.g. "agents/official/security.agent.md")
     pub path: String,
     /// Agent name derived from the file
     pub name: String,
@@ -22,6 +22,12 @@ pub struct IndexEntry {
     pub tags: Vec<String>,
     /// Category from the directory structure (e.g. "official", "community")
     pub category: Option<String>,
+    /// Source key this entry was scanned from (see `sync::source_key`), used
+    /// to relocate the file across multiple registry sources. Defaults to
+    /// the empty string for indexes built before multi-source support (B2
+    /// Lot A Task 2) — those all came from the single default source.
+    #[serde(default)]
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -33,32 +39,42 @@ pub struct Index {
 // Index building
 // ---------------------------------------------------------------------------
 
-/// Build a search index from the registry repo.
+/// Build a search index by scanning every synced source repo in `sources`.
 ///
-/// Scans for `.agent.md` and `.md` files in the repo and extracts metadata.
-pub fn build_index() -> anyhow::Result<Index> {
-    let repo = repo_dir();
-    if !repo.is_dir() {
-        anyhow::bail!("Registry not synced. Run `armadai registry sync` first.");
-    }
-
+/// Sources that haven't been cloned yet (e.g. sync failed or wasn't run) are
+/// silently skipped so a single broken/unreachable source doesn't prevent
+/// indexing the others.
+pub fn build_index(sources: &[String]) -> anyhow::Result<Index> {
     let mut entries = Vec::new();
-    scan_dir(&repo, &repo, &mut entries)?;
+
+    for url in sources {
+        let key = source_key(url);
+        let dir = source_dir(url);
+        if dir.is_dir() {
+            scan_dir(&dir, &dir, &key, &mut entries)?;
+        }
+    }
 
     let index = Index { entries };
     save_index(&index)?;
     Ok(index)
 }
 
-/// Load the cached index, or build it if missing.
-pub fn load_or_build_index() -> anyhow::Result<Index> {
+/// Load the cached index, or build it from whatever sources are already
+/// synced.
+pub fn load_or_build_index(sources: &[String]) -> anyhow::Result<Index> {
     let index_path = index_file_path();
     if index_path.is_file() {
         let content = std::fs::read_to_string(&index_path)?;
         let index: Index = serde_json::from_str(&content)?;
         return Ok(index);
     }
-    build_index()
+
+    if sources_dir().is_dir() {
+        return build_index(sources);
+    }
+
+    Ok(Index::default())
 }
 
 fn index_file_path() -> PathBuf {
@@ -73,7 +89,12 @@ fn save_index(index: &Index) -> anyhow::Result<()> {
 }
 
 /// Recursively scan a directory for agent markdown files.
-fn scan_dir(dir: &Path, repo_root: &Path, entries: &mut Vec<IndexEntry>) -> anyhow::Result<()> {
+fn scan_dir(
+    dir: &Path,
+    repo_root: &Path,
+    source: &str,
+    entries: &mut Vec<IndexEntry>,
+) -> anyhow::Result<()> {
     let read = match std::fs::read_dir(dir) {
         Ok(r) => r,
         Err(_) => return Ok(()),
@@ -88,9 +109,9 @@ fn scan_dir(dir: &Path, repo_root: &Path, entries: &mut Vec<IndexEntry>) -> anyh
         }
 
         if path.is_dir() {
-            scan_dir(&path, repo_root, entries)?;
+            scan_dir(&path, repo_root, source, entries)?;
         } else if is_agent_file(&path)
-            && let Ok(entry) = extract_entry(&path, repo_root)
+            && let Ok(entry) = extract_entry(&path, repo_root, source)
         {
             entries.push(entry);
         }
@@ -106,7 +127,7 @@ fn is_agent_file(path: &Path) -> bool {
 }
 
 /// Extract an index entry from a file by reading its first lines.
-fn extract_entry(path: &Path, repo_root: &Path) -> anyhow::Result<IndexEntry> {
+fn extract_entry(path: &Path, repo_root: &Path, source: &str) -> anyhow::Result<IndexEntry> {
     let content = std::fs::read_to_string(path)?;
     let rel_path = path
         .strip_prefix(repo_root)
@@ -144,6 +165,7 @@ fn extract_entry(path: &Path, repo_root: &Path) -> anyhow::Result<IndexEntry> {
         description,
         tags,
         category,
+        source: source.to_string(),
     })
 }
 
@@ -204,7 +226,7 @@ mod tests {
         )
         .unwrap();
 
-        let entry = extract_entry(&file, dir.path()).unwrap();
+        let entry = extract_entry(&file, dir.path(), "github/awesome-copilot").unwrap();
         assert_eq!(entry.name, "security");
         assert_eq!(
             entry.description.as_deref(),
@@ -212,6 +234,7 @@ mod tests {
         );
         assert_eq!(entry.category.as_deref(), Some("agents"));
         assert_eq!(entry.tags, vec!["security", "review"]);
+        assert_eq!(entry.source, "github/awesome-copilot");
     }
 
     #[test]
@@ -232,6 +255,7 @@ mod tests {
                 description: Some("A test agent".to_string()),
                 tags: vec!["test".to_string()],
                 category: Some("agents".to_string()),
+                source: "github/awesome-copilot".to_string(),
             }],
         };
 
@@ -239,5 +263,14 @@ mod tests {
         let deserialized: Index = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.entries.len(), 1);
         assert_eq!(deserialized.entries[0].name, "test");
+    }
+
+    #[test]
+    fn test_index_deserializes_without_source_field() {
+        // Back-compat: indexes cached before multi-source support (B2 Lot A
+        // Task 2) have no `source` field.
+        let json = r#"{"entries":[{"path":"a.md","name":"a","description":null,"tags":[],"category":null}]}"#;
+        let index: Index = serde_json::from_str(json).unwrap();
+        assert_eq!(index.entries[0].source, "");
     }
 }

--- a/src/registry/convert.rs
+++ b/src/registry/convert.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use super::cache::converted_dir;
-use super::sync::repo_dir;
+use super::sync::dir_for_key;
 use crate::core::config::user_agents_dir;
 
 /// Convert a Copilot `.agent.md` file to ArmadAI Markdown format.
@@ -83,13 +83,18 @@ pub fn convert_to_armadai(content: &str, fallback_name: &str) -> String {
 
 /// Convert a registry agent and cache the result.
 ///
-/// `registry_path` is relative to the repo root (e.g. "agents/official/security.agent.md").
-pub fn convert_cached(registry_path: &str) -> anyhow::Result<PathBuf> {
-    let repo = repo_dir();
+/// `source` is the source key (see `sync::source_key`) the agent came from,
+/// and `registry_path` is relative to that source's repo root (e.g.
+/// "agents/official/security.agent.md").
+pub fn convert_cached(source: &str, registry_path: &str) -> anyhow::Result<PathBuf> {
+    let repo = dir_for_key(source);
     let src = repo.join(registry_path);
 
     if !src.is_file() {
-        anyhow::bail!("Registry file not found: {}", src.display());
+        anyhow::bail!(
+            "Registry file not found: {} (source '{source}')",
+            src.display()
+        );
     }
 
     let cache_dir = converted_dir();
@@ -111,8 +116,12 @@ pub fn convert_cached(registry_path: &str) -> anyhow::Result<PathBuf> {
 }
 
 /// Import a registry agent into the user library (~/.config/armadai/agents/).
-pub fn import_to_library(registry_path: &str, force: bool) -> anyhow::Result<PathBuf> {
-    let cached = convert_cached(registry_path)?;
+pub fn import_to_library(
+    source: &str,
+    registry_path: &str,
+    force: bool,
+) -> anyhow::Result<PathBuf> {
+    let cached = convert_cached(source, registry_path)?;
 
     let agents_dir = user_agents_dir();
     std::fs::create_dir_all(&agents_dir)?;

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -101,6 +101,7 @@ mod tests {
             description: desc.map(String::from),
             tags: tags.iter().map(|s| s.to_string()).collect(),
             category: category.map(String::from),
+            source: "test-source".to_string(),
         }
     }
 

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -35,27 +35,18 @@ pub fn sources_dir() -> PathBuf {
     registry_cache_dir().join("sources")
 }
 
-/// Derive a filesystem-safe, stable key for a registry source URL.
+/// Derive a filesystem-safe, collision-resistant key for a registry source
+/// URL.
 ///
-/// GitHub URLs (`https://github.com/owner/repo[.git]`) are keyed as
-/// `owner/repo`, mirroring `skills_registry::sync::repo_dir`'s layout so the
-/// two registries stay consistent. Any other URL (e.g. a self-hosted git
-/// remote) falls back to a sanitized version of the whole URL so every
-/// source still gets its own directory.
+/// Delegates to `core::registries::cache_key`, the single sanitization
+/// scheme shared with `model_registry::fetch::source_cache_path` (previously
+/// each had its own ad hoc, collision-prone sanitization — see B2 Task 2
+/// review). The key always carries a hash suffix derived from the full URL,
+/// so two sources that happen to sanitize to the same readable prefix (or a
+/// prefix that would otherwise be a bare `.`/`..`, which is unsafe as a path
+/// segment) still get distinct, safe directory names.
 pub fn source_key(url: &str) -> String {
-    match crate::skills_registry::sync::parse_source(url) {
-        Some((owner, repo)) => format!("{owner}/{repo}"),
-        None => url
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '-' || c == '.' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect(),
-    }
+    crate::core::registries::cache_key(url)
 }
 
 /// Directory for a source already identified by its [`source_key`]. Used to
@@ -87,6 +78,10 @@ pub fn sync_source(url: &str) -> anyhow::Result<PathBuf> {
 /// sources are logged and skipped rather than aborting the whole sync, so a
 /// single unreachable custom registry doesn't block the default one (same
 /// approach as `skills_registry::sync::sync_all`).
+///
+/// Records a sync-completed marker (see [`mark_synced`]) when at least one
+/// source synced successfully, so [`is_stale`] can report accurate freshness
+/// afterwards.
 pub fn registry_sync(sources: &[String]) -> anyhow::Result<Vec<PathBuf>> {
     let mut dirs = Vec::new();
     for url in sources {
@@ -94,6 +89,11 @@ pub fn registry_sync(sources: &[String]) -> anyhow::Result<Vec<PathBuf>> {
             Ok(dir) => dirs.push(dir),
             Err(e) => eprintln!("  warn: failed to sync {url}: {e}"),
         }
+    }
+    if !dirs.is_empty()
+        && let Err(e) = mark_synced()
+    {
+        eprintln!("  warn: failed to record sync timestamp: {e}");
     }
     Ok(dirs)
 }
@@ -138,17 +138,47 @@ fn pull(repo: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check if the registry cache was last synced more than `days` ago.
-/// Returns `true` if a re-sync is recommended (mirrors
-/// `skills_registry::sync::is_stale`, checking the shared sources root
-/// rather than a single repo since there may be several sources now).
-pub fn is_stale(days: u64) -> bool {
-    let dir = sources_dir();
-    if !dir.is_dir() {
-        return true;
-    }
+/// Marker file touched at the end of a successful [`registry_sync`] run, and
+/// read by [`is_stale`] to determine freshness.
+///
+/// A plain directory mtime (the previous approach — see git history) is
+/// *not* a reliable freshness signal here: `sources_dir()` is the parent of
+/// every source's own clone, and pulling into a subdirectory that already
+/// exists does not bump the parent directory's mtime on most filesystems.
+/// That made `is_stale` report "outdated" forever after the very first sync,
+/// even immediately after a successful `armadai registry sync`. A dedicated
+/// marker file, rewritten on every successful sync, sidesteps that.
+fn last_sync_marker() -> PathBuf {
+    sources_dir().join(".last_sync")
+}
 
-    match std::fs::metadata(&dir).and_then(|m| m.modified()) {
+/// Record that the registry was just synced successfully.
+///
+/// Called automatically by [`registry_sync`]; exposed so callers (and
+/// tests) can record a sync without needing to actually shell out to `git`.
+pub fn mark_synced() -> anyhow::Result<()> {
+    let marker = last_sync_marker();
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&marker, b"")?;
+    Ok(())
+}
+
+/// The pre-multi-source registry clone directory (a single `repo/` folder,
+/// used before B2 Lot A Task 2 introduced per-source `sources/<key>/`
+/// directories). Kept around only so a cache from an older ArmadAI version
+/// can be *detected* (see `cache::has_legacy_cache`) rather than silently
+/// served or mistaken for an empty registry.
+pub fn legacy_repo_dir() -> PathBuf {
+    registry_cache_dir().join("repo")
+}
+
+/// Check if the registry cache was last synced more than `days` ago.
+/// Returns `true` if a re-sync is recommended. Based on [`mark_synced`]'s
+/// marker file rather than any directory's mtime (see [`last_sync_marker`]).
+pub fn is_stale(days: u64) -> bool {
+    match std::fs::metadata(last_sync_marker()).and_then(|m| m.modified()) {
         Ok(modified) => {
             let age = std::time::SystemTime::now()
                 .duration_since(modified)
@@ -165,10 +195,14 @@ mod tests {
     use crate::core::registries::{RegistriesConfig, RegistrySource};
 
     #[test]
-    fn source_key_github_url_uses_owner_repo() {
+    fn source_key_github_url_is_readable_and_stable() {
+        let key = source_key("https://github.com/github/awesome-copilot.git");
+        assert!(key.contains("github"));
+        assert!(key.contains("awesome-copilot"));
+        // Deterministic: same URL always maps to the same key.
         assert_eq!(
-            source_key("https://github.com/github/awesome-copilot.git"),
-            "github/awesome-copilot"
+            key,
+            source_key("https://github.com/github/awesome-copilot.git")
         );
     }
 
@@ -183,6 +217,122 @@ mod tests {
         // No path separators or other characters that would escape the
         // "sources" cache directory.
         assert!(!key.contains('/'));
+    }
+
+    #[test]
+    fn source_key_distinguishes_urls_with_same_readable_prefix() {
+        // Two distinct URLs (different owners) whose naive sanitization
+        // could plausibly collide must still yield distinct keys — this is
+        // what the hash suffix in `core::registries::cache_key` guarantees.
+        let a = source_key("https://github.com/acme/registry");
+        let b = source_key("https://github.com/acme/registry-fork");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn source_key_traversal_like_input_is_not_dot_dot() {
+        // A URL that sanitizes to a bare ".." would be a path-traversal-
+        // shaped directory name; the hash suffix rules that out.
+        let key = source_key("..");
+        assert_ne!(key, "..");
+        assert_ne!(key, ".");
+    }
+
+    #[test]
+    fn is_stale_true_when_never_synced() {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+        }
+
+        assert!(is_stale(7));
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+
+    #[test]
+    fn is_stale_false_right_after_mark_synced() {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+        }
+
+        mark_synced().expect("mark_synced should succeed");
+        assert!(!is_stale(7), "should be fresh immediately after a sync");
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+
+    #[test]
+    fn is_stale_true_when_marker_older_than_ttl() {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+        }
+
+        mark_synced().expect("mark_synced should succeed");
+        let marker = last_sync_marker();
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(8 * 86400);
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&marker)
+            .expect("marker should be openable");
+        file.set_modified(old).expect("should backdate mtime");
+
+        assert!(
+            is_stale(7),
+            "8-day-old marker should be stale with a 7-day TTL"
+        );
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+    }
+
+    #[test]
+    fn effective_sources_glue_includes_user_level_custom_source() {
+        // Exercises the real `effective_sources()` glue (not just the pure
+        // `resolved_sources` helper) with a `RegistriesConfig` loaded from
+        // disk, per the B2 Task 2 review follow-up.
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+        }
+
+        std::fs::write(
+            dir.path().join("registries.yaml"),
+            "agents:\n  - url: https://example.com/custom-glue-agents.git\n",
+        )
+        .unwrap();
+
+        let sources = effective_sources();
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+
+        assert!(sources.contains(&DEFAULT_REGISTRY_URL.to_string()));
+        assert!(sources.contains(&"https://example.com/custom-glue-agents.git".to_string()));
     }
 
     #[test]

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -1,33 +1,107 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::core::config::registry_cache_dir;
+use crate::core::project::find_project_config;
+use crate::core::registries::{RegistryKind, load_user_registries, resolved_sources};
 
-const DEFAULT_REGISTRY_URL: &str = "https://github.com/github/awesome-copilot.git";
+/// Built-in default community registry (awesome-copilot).
+pub const DEFAULT_REGISTRY_URL: &str = "https://github.com/github/awesome-copilot.git";
 
-/// Return the path to the cloned registry repository.
-pub fn repo_dir() -> std::path::PathBuf {
-    registry_cache_dir().join("repo")
+/// Resolve the effective list of agent registry sources for this run: the
+/// built-in default, plus any user-level (`~/.config/armadai/registries.yaml`)
+/// and project-level (`armadai.yaml` / `.armadai/config.yaml`) custom sources.
+///
+/// Project config is looked up via `core::project::find_project_config`,
+/// which walks up from the current working directory — this matches how the
+/// `armadai registry` CLI commands are invoked. When no project config is
+/// found (or it has no `registries:` section), only defaults + user sources
+/// apply.
+pub fn effective_sources() -> Vec<String> {
+    let user = load_user_registries();
+    let project = find_project_config().map(|(_, cfg)| cfg);
+    let project_registries = project.as_ref().and_then(|cfg| cfg.registries.as_ref());
+    resolved_sources(
+        RegistryKind::Agents,
+        &[DEFAULT_REGISTRY_URL],
+        &user,
+        project_registries,
+    )
 }
 
-/// Clone or pull the registry repository.
-///
-/// Uses system `git` — no libgit2 dependency.
-pub fn registry_sync(url: Option<&str>) -> anyhow::Result<()> {
-    let url = url.unwrap_or(DEFAULT_REGISTRY_URL);
-    let repo = repo_dir();
+/// Root directory holding all cloned registry sources, one subdirectory per
+/// source (see [`source_dir`]).
+pub fn sources_dir() -> PathBuf {
+    registry_cache_dir().join("sources")
+}
 
-    if repo.join(".git").is_dir() {
-        pull(&repo)?;
+/// Derive a filesystem-safe, stable key for a registry source URL.
+///
+/// GitHub URLs (`https://github.com/owner/repo[.git]`) are keyed as
+/// `owner/repo`, mirroring `skills_registry::sync::repo_dir`'s layout so the
+/// two registries stay consistent. Any other URL (e.g. a self-hosted git
+/// remote) falls back to a sanitized version of the whole URL so every
+/// source still gets its own directory.
+pub fn source_key(url: &str) -> String {
+    match crate::skills_registry::sync::parse_source(url) {
+        Some((owner, repo)) => format!("{owner}/{repo}"),
+        None => url
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '.' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect(),
+    }
+}
+
+/// Directory for a source already identified by its [`source_key`]. Used to
+/// relocate a source's clone without needing its original URL again (e.g.
+/// from a cached [`super::cache::IndexEntry`]).
+pub fn dir_for_key(key: &str) -> PathBuf {
+    sources_dir().join(key)
+}
+
+/// Directory where a given source URL is cloned.
+pub fn source_dir(url: &str) -> PathBuf {
+    dir_for_key(&source_key(url))
+}
+
+/// Clone or pull a single registry source by URL.
+pub fn sync_source(url: &str) -> anyhow::Result<PathBuf> {
+    let dest = source_dir(url);
+
+    if dest.join(".git").is_dir() {
+        pull(&dest)?;
     } else {
-        clone(url, &repo)?;
+        clone(url, &dest)?;
     }
 
-    Ok(())
+    Ok(dest)
+}
+
+/// Sync (clone or pull) every source in `sources`. Failures on individual
+/// sources are logged and skipped rather than aborting the whole sync, so a
+/// single unreachable custom registry doesn't block the default one (same
+/// approach as `skills_registry::sync::sync_all`).
+pub fn registry_sync(sources: &[String]) -> anyhow::Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+    for url in sources {
+        match sync_source(url) {
+            Ok(dir) => dirs.push(dir),
+            Err(e) => eprintln!("  warn: failed to sync {url}: {e}"),
+        }
+    }
+    Ok(dirs)
 }
 
 fn clone(url: &str, dest: &Path) -> anyhow::Result<()> {
-    std::fs::create_dir_all(dest)?;
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
 
     let output = Command::new("git")
         .args(["clone", "--depth", "1", url])
@@ -36,10 +110,10 @@ fn clone(url: &str, dest: &Path) -> anyhow::Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git clone failed: {stderr}");
+        anyhow::bail!("git clone failed for {url}: {stderr}");
     }
 
-    println!("Cloned registry from {url}");
+    println!("Cloned {url}");
     Ok(())
 }
 
@@ -51,36 +125,30 @@ fn pull(repo: &Path) -> anyhow::Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git pull failed: {stderr}");
+        anyhow::bail!("git pull failed for {}: {stderr}", repo.display());
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     if stdout.contains("Already up to date") {
-        println!("Registry already up to date.");
+        println!("  {} already up to date.", repo.display());
     } else {
-        println!("Registry updated.");
+        println!("  {} updated.", repo.display());
     }
 
     Ok(())
 }
 
-/// Check if the registry was last synced more than `days` ago.
-/// Returns `true` if a re-sync is recommended.
+/// Check if the registry cache was last synced more than `days` ago.
+/// Returns `true` if a re-sync is recommended (mirrors
+/// `skills_registry::sync::is_stale`, checking the shared sources root
+/// rather than a single repo since there may be several sources now).
 pub fn is_stale(days: u64) -> bool {
-    let repo = repo_dir();
-    let git_dir = repo.join(".git");
-    if !git_dir.is_dir() {
+    let dir = sources_dir();
+    if !dir.is_dir() {
         return true;
     }
 
-    let fetch_head = git_dir.join("FETCH_HEAD");
-    let check_path = if fetch_head.exists() {
-        fetch_head
-    } else {
-        git_dir.join("HEAD")
-    };
-
-    match std::fs::metadata(&check_path).and_then(|m| m.modified()) {
+    match std::fs::metadata(&dir).and_then(|m| m.modified()) {
         Ok(modified) => {
             let age = std::time::SystemTime::now()
                 .duration_since(modified)
@@ -88,5 +156,59 @@ pub fn is_stale(days: u64) -> bool {
             age.as_secs() > days * 86400
         }
         Err(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::registries::{RegistriesConfig, RegistrySource};
+
+    #[test]
+    fn source_key_github_url_uses_owner_repo() {
+        assert_eq!(
+            source_key("https://github.com/github/awesome-copilot.git"),
+            "github/awesome-copilot"
+        );
+    }
+
+    #[test]
+    fn source_key_non_github_url_is_sanitized() {
+        let key = source_key("https://example.com/my-registry.git");
+        assert!(!key.is_empty());
+        assert!(
+            key.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_')
+        );
+        // No path separators or other characters that would escape the
+        // "sources" cache directory.
+        assert!(!key.contains('/'));
+    }
+
+    #[test]
+    fn effective_sources_defaults_only_without_config() {
+        // No project config in scope here (None passed directly rather than
+        // via `find_project_config`, to keep this test independent of cwd).
+        let user = RegistriesConfig::default();
+        let result = resolved_sources(RegistryKind::Agents, &[DEFAULT_REGISTRY_URL], &user, None);
+        assert_eq!(result, vec![DEFAULT_REGISTRY_URL.to_string()]);
+    }
+
+    #[test]
+    fn effective_sources_includes_default_and_custom() {
+        let user = RegistriesConfig {
+            agents: vec![RegistrySource {
+                url: "https://example.com/custom-agents.git".to_string(),
+            }],
+            ..Default::default()
+        };
+        let result = resolved_sources(RegistryKind::Agents, &[DEFAULT_REGISTRY_URL], &user, None);
+        assert_eq!(
+            result,
+            vec![
+                DEFAULT_REGISTRY_URL.to_string(),
+                "https://example.com/custom-agents.git".to_string(),
+            ]
+        );
     }
 }

--- a/src/skills_registry/cache.rs
+++ b/src/skills_registry/cache.rs
@@ -161,9 +161,28 @@ fn extract_skill_entry(
     })
 }
 
-/// Get the effective sources list (from defaults).
+/// Get the effective sources list: the built-in defaults, plus any
+/// user-level (`~/.config/armadai/registries.yaml`) and project-level
+/// (`armadai.yaml` / `.armadai/config.yaml`) custom skill sources.
+///
+/// Project config is looked up via `core::project::find_project_config`,
+/// which walks up from the current working directory — this matches how
+/// the `armadai skills` CLI commands are invoked. Without a `registries:`
+/// section anywhere, this returns exactly `default_sources()`, unchanged.
 pub fn effective_sources() -> Vec<String> {
-    default_sources()
+    let defaults = default_sources();
+    let default_refs: Vec<&str> = defaults.iter().map(String::as_str).collect();
+
+    let user = crate::core::registries::load_user_registries();
+    let project = crate::core::project::find_project_config().map(|(_, cfg)| cfg);
+    let project_registries = project.as_ref().and_then(|cfg| cfg.registries.as_ref());
+
+    crate::core::registries::resolved_sources(
+        crate::core::registries::RegistryKind::Skills,
+        &default_refs,
+        &user,
+        project_registries,
+    )
 }
 
 #[cfg(test)]

--- a/src/skills_registry/sync.rs
+++ b/src/skills_registry/sync.rs
@@ -168,4 +168,37 @@ mod tests {
         let dir = repo_dir("anthropics", "skills");
         assert!(dir.ends_with("anthropics/skills"));
     }
+
+    #[test]
+    fn resolved_sources_defaults_only_without_custom_config() {
+        use crate::core::registries::{RegistriesConfig, RegistryKind, resolved_sources};
+
+        let defaults = default_sources();
+        let default_refs: Vec<&str> = defaults.iter().map(String::as_str).collect();
+        let user = RegistriesConfig::default();
+
+        let result = resolved_sources(RegistryKind::Skills, &default_refs, &user, None);
+        assert_eq!(result, defaults);
+    }
+
+    #[test]
+    fn resolved_sources_includes_default_and_custom_skill_source() {
+        use crate::core::registries::{
+            RegistriesConfig, RegistryKind, RegistrySource, resolved_sources,
+        };
+
+        let defaults = default_sources();
+        let default_refs: Vec<&str> = defaults.iter().map(String::as_str).collect();
+        let user = RegistriesConfig {
+            skills: vec![RegistrySource {
+                url: "https://github.com/custom-org/custom-skills".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let result = resolved_sources(RegistryKind::Skills, &default_refs, &user, None);
+        let mut expected = defaults;
+        expected.push("https://github.com/custom-org/custom-skills".to_string());
+        assert_eq!(result, expected);
+    }
 }


### PR DESCRIPTION
B2 Lot A (axe 2 features) — registres personnalisés pour agents/skills/models. Spec : `docs/superpowers/specs/2026-07-20-b2-custom-registries-design.md`. (Lot B = starters distants, séparé.)

## Ce que ça apporte
- **Config `registries:`** unifiée : user (`~/.config/armadai/registries.yaml`) + `armadai.yaml` projet, mergées. Module `core/registries.rs` (`RegistriesConfig`, `resolved_sources`).
- **Défauts conservés** (awesome-copilot / anthropics+openai skills / models.dev) → sans config, comportement **inchangé**. Les sources custom s'ajoutent (union, dédup).
- **3 registres branchés** : agents (cache per-source `sources/<key>/`), skills, models (fetch multi-sources + merge union par provider, dernière source gagne).
- **CLI** : `armadai registry sources list/add/remove <agents|skills|models> <url>` (sous-groupe, sans collision avec `registry add <agent>`).

## Qualité
- 4 commits, revues par tâche (Task 2 revue → 3 findings Important corrigés) + **revue finale de branche : READY TO MERGE** (re-vérifiée).
- Clippy **2 modes** `-D warnings` + `cargo fmt --check` + `cargo build --all-features` + **778 tests**.
- Round de fix : staleness fiable (`.last_sync`), gestion cache legacy (upgrade propre + message actionnable), `fetched_at` honnête sur fallback réseau, clé de cache unifiée+hash (anti-collision + garde `..`).

## Rétro-compat
Sans `registries:`, chaque registre = sa source par défaut historique. `MODELS_DEV_URL` rendu `pub(crate)` + un-gated (pour `sources list` en build tui-only).

## Minors (defer)
`skills_registry::is_stale` même bug mtime-dossier (pré-existant, hors périmètre) ; ancien `registry/repo/` orphelin (détecté/ignoré) ; `cache_key` via `DefaultHasher` (re-sync trivial si bump toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)