### PR TITLE
feat(orchestration): C9 Lot 1 — pattern mixing (hierarchical → nested blackboard/ring)

### DIFF
--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -60,6 +60,13 @@ pub enum RunEvent {
         agent: String,
         kind: String,
     },
+    NestedStart {
+        team_lead: String,
+        pattern: String,
+    },
+    NestedEnd {
+        team_lead: String,
+    },
 }
 
 /// Sink for run events. `NullSink` is a zero-cost no-op; `JsonlSink` writes JSONL to a writer.
@@ -258,6 +265,28 @@ mod tests {
             s,
             r#"{"t":"board","agent":"qa-specialist","kind":"passed"}"#
         );
+    }
+
+    #[test]
+    fn nested_start_serializes_with_short_keys() {
+        let ev = RunEvent::NestedStart {
+            team_lead: "research-lead".to_string(),
+            pattern: "blackboard".to_string(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            s,
+            r#"{"t":"nested_start","team_lead":"research-lead","pattern":"blackboard"}"#
+        );
+    }
+
+    #[test]
+    fn nested_end_serializes_with_short_keys() {
+        let ev = RunEvent::NestedEnd {
+            team_lead: "research-lead".to_string(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(s, r#"{"t":"nested_end","team_lead":"research-lead"}"#);
     }
 
     // Test helper: a Write that appends to a shared buffer.

--- a/src/core/orchestration/classifier.rs
+++ b/src/core/orchestration/classifier.rs
@@ -535,6 +535,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: Some("lead-a".to_string()),
                 agents: vec!["worker-1".to_string(), "worker-2".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         }
@@ -583,6 +584,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-x".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };

--- a/src/core/orchestration/context_injection.rs
+++ b/src/core/orchestration/context_injection.rs
@@ -307,10 +307,12 @@ mod tests {
                 TeamConfig {
                     lead: Some("java-lead".to_string()),
                     agents: vec!["java-arch".to_string(), "java-sec".to_string()],
+                    ..Default::default()
                 },
                 TeamConfig {
                     lead: None,
                     agents: vec!["cloud-expert".to_string(), "ops-expert".to_string()],
+                    ..Default::default()
                 },
             ],
             ..Default::default()

--- a/src/core/orchestration/e2e_tests.rs
+++ b/src/core/orchestration/e2e_tests.rs
@@ -250,6 +250,7 @@ timeout: 120
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["worker".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -294,6 +295,7 @@ timeout: 120
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["worker".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -419,6 +421,7 @@ teams:
             teams: vec![TeamConfig {
                 lead: Some("lead".to_string()),
                 agents: vec!["worker".to_string()],
+                ..Default::default()
             }],
             max_depth: Some(5),
             ..Default::default()
@@ -486,6 +489,7 @@ teams:
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["a".to_string(), "b".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -547,6 +551,7 @@ teams:
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["worker".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -585,6 +590,7 @@ teams:
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["worker".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -629,6 +635,7 @@ teams:
                     "performance".to_string(),
                     "ux".to_string(),
                 ],
+                ..Default::default()
             }],
             ..Default::default()
         };

--- a/src/core/orchestration/gemini_integration_tests.rs
+++ b/src/core/orchestration/gemini_integration_tests.rs
@@ -197,6 +197,7 @@ async fn test_hierarchical_delegation_works() {
         teams: vec![TeamConfig {
             lead: None,
             agents: vec!["analyst".to_string(), "reviewer".to_string()],
+            ..Default::default()
         }],
         max_depth: Some(3),
         max_iterations: Some(10),
@@ -284,6 +285,7 @@ async fn test_budget_halts_gracefully() {
         teams: vec![TeamConfig {
             lead: None,
             agents: vec!["analyst".to_string()],
+            ..Default::default()
         }],
         max_depth: Some(2),
         max_iterations: Some(5),
@@ -375,6 +377,7 @@ async fn test_agents_follow_roles() {
         teams: vec![TeamConfig {
             lead: None,
             agents: vec!["translator".to_string(), "summarizer".to_string()],
+            ..Default::default()
         }],
         max_depth: Some(3),
         max_iterations: Some(10),

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -701,6 +701,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-a".to_string(), "agent-b".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         }
@@ -1057,6 +1058,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: Some("lead".to_string()),
                 agents: vec!["worker".to_string()],
+                ..Default::default()
             }],
             max_depth: Some(2),
             ..Default::default()
@@ -1098,6 +1100,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-a".to_string()],
+                ..Default::default()
             }],
             max_iterations: Some(1),
             ..Default::default()
@@ -1191,6 +1194,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-a".to_string(), "agent-b".to_string()],
+                ..Default::default()
             }],
             token_budget: Some(55),
             ..Default::default()
@@ -1248,6 +1252,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-a".to_string(), "agent-b".to_string()],
+                ..Default::default()
             }],
             cost_limit: Some(0.0015),
             ..Default::default()
@@ -1300,6 +1305,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-a".to_string()],
+                ..Default::default()
             }],
             token_budget: None,
             cost_limit: None,
@@ -1343,6 +1349,7 @@ mod tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["agent-a".to_string(), "agent-b".to_string()],
+                ..Default::default()
             }],
             token_budget: Some(50),
             ..Default::default()
@@ -1398,6 +1405,7 @@ mod tests {
                     "agent-b".to_string(),
                     "agent-c".to_string(),
                 ],
+                ..Default::default()
             }],
             ..Default::default()
         };

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -511,7 +511,7 @@ async fn run_nested_team(
 
     let routing_ctx = RoutingCtx::new(ctx.routing_rules.clone(), remaining_budget);
 
-    let (outcome_text, folded_in, folded_out, folded_cost) = match nested {
+    let sub_run_result: anyhow::Result<(String, u32, u32, f64)> = match nested {
         NestedPattern::Blackboard => {
             let config = BlackboardConfig {
                 token_budget: remaining_budget,
@@ -529,28 +529,34 @@ async fn run_nested_team(
                 })
                 .collect();
             let mut board = Board::new(task.to_string(), config.token_budget);
-            run_blackboard(
+            match run_blackboard(
                 &mut board,
                 &board_agents,
                 &member_providers,
                 &config,
                 &ctx.sink,
             )
-            .await?;
-            let (ti, to, cost) = board.entries().iter().fold((0u32, 0u32, 0f64), |acc, e| {
-                (
-                    acc.0 + e.tokens_used.input,
-                    acc.1 + e.tokens_used.output,
-                    acc.2 + e.tokens_used.cost,
-                )
-            });
-            let text = board
-                .entries()
-                .iter()
-                .map(|e| format!("[{}] {}", e.agent, e.content))
-                .collect::<Vec<_>>()
-                .join("\n");
-            (text, ti, to, cost)
+            .await
+            {
+                Ok(()) => {
+                    let (ti, to, cost) =
+                        board.entries().iter().fold((0u32, 0u32, 0f64), |acc, e| {
+                            (
+                                acc.0 + e.tokens_used.input,
+                                acc.1 + e.tokens_used.output,
+                                acc.2 + e.tokens_used.cost,
+                            )
+                        });
+                    let text = board
+                        .entries()
+                        .iter()
+                        .map(|e| format!("[{}] {}", e.agent, e.content))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    Ok((text, ti, to, cost))
+                }
+                Err(e) => Err(e),
+            }
         }
         NestedPattern::Ring => {
             let config = RingConfig {
@@ -570,40 +576,53 @@ async fn run_nested_team(
                 .collect();
             let order: Vec<String> = ring_agents.iter().map(|a| a.name().to_string()).collect();
             let mut token = RingToken::new(task.to_string(), order, config.token_budget);
-            run_ring(
+            match run_ring(
                 &mut token,
                 &ring_agents,
                 &member_providers,
                 &config,
                 &ctx.sink,
             )
-            .await?;
-            let (ti, to, cost) = token
-                .contributions
-                .iter()
-                .fold((0u32, 0u32, 0f64), |acc, c| {
-                    (
-                        acc.0 + c.tokens_used.input,
-                        acc.1 + c.tokens_used.output,
-                        acc.2 + c.tokens_used.cost,
-                    )
-                });
-            let text = match token.status() {
-                TokenStatus::Done { outcome } => match outcome {
-                    RingOutcome::Consensus { resolution, .. }
-                    | RingOutcome::Majority { resolution, .. } => resolution.clone(),
-                    RingOutcome::NoConsensus { summary, .. } => summary.clone(),
-                    RingOutcome::BudgetExhausted { partial_summary }
-                    | RingOutcome::CostLimitExceeded {
-                        partial_summary, ..
-                    } => partial_summary.clone(),
-                    RingOutcome::Cancelled => String::new(),
-                },
-                _ => String::new(),
-            };
-            (text, ti, to, cost)
+            .await
+            {
+                Ok(()) => {
+                    let (ti, to, cost) =
+                        token
+                            .contributions
+                            .iter()
+                            .fold((0u32, 0u32, 0f64), |acc, c| {
+                                (
+                                    acc.0 + c.tokens_used.input,
+                                    acc.1 + c.tokens_used.output,
+                                    acc.2 + c.tokens_used.cost,
+                                )
+                            });
+                    let text = match token.status() {
+                        TokenStatus::Done { outcome } => match outcome {
+                            RingOutcome::Consensus { resolution, .. }
+                            | RingOutcome::Majority { resolution, .. } => resolution.clone(),
+                            RingOutcome::NoConsensus { summary, .. } => summary.clone(),
+                            RingOutcome::BudgetExhausted { partial_summary }
+                            | RingOutcome::CostLimitExceeded {
+                                partial_summary, ..
+                            } => partial_summary.clone(),
+                            RingOutcome::Cancelled => String::new(),
+                        },
+                        _ => String::new(),
+                    };
+                    Ok((text, ti, to, cost))
+                }
+                Err(e) => Err(e),
+            }
         }
     };
+
+    // Emit `NestedEnd` regardless of outcome so it always balances
+    // `NestedStart`, then propagate a sub-run error if there was one.
+    ctx.sink.emit(&RunEvent::NestedEnd {
+        team_lead: team_lead.to_string(),
+    });
+    let (outcome_text, folded_in, folded_out, folded_cost) = sub_run_result?;
 
     // Fold the sub-run's metrics into the shared hierarchical state.
     {
@@ -616,10 +635,6 @@ async fn run_nested_team(
         s.total_cost += folded_cost;
         s.invocation_count += agent_names.len() as u32;
     }
-
-    ctx.sink.emit(&RunEvent::NestedEnd {
-        team_lead: team_lead.to_string(),
-    });
 
     // Lead arbitrates the aggregated outcome (may accept/refine/override).
     let arbitrated = arbitrate_nested_outcome(ctx, state, team_lead, task, &outcome_text).await?;
@@ -2072,6 +2087,89 @@ mod tests {
         assert!(
             result.total_tokens_in > 0 && result.total_tokens_out > 0,
             "nested board tokens should fold into run metrics, got in={} out={}",
+            result.total_tokens_in,
+            result.total_tokens_out
+        );
+    }
+
+    /// Config: coordinator → one nested-ring team (lead + 2 agents).
+    fn nested_ring_config() -> OrchestrationConfig {
+        OrchestrationConfig {
+            enabled: true,
+            pattern: super::super::OrchestrationPattern::Hierarchical,
+            coordinator: Some("coordinator".to_string()),
+            teams: vec![TeamConfig {
+                lead: Some("research-lead".to_string()),
+                agents: vec!["searcher".to_string(), "analyst".to_string()],
+                pattern: Some(super::super::NestedPattern::Ring),
+                max_laps: Some(1),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nested_ring_runs_and_folds_metrics() {
+        let config = nested_ring_config();
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "Coordinate."),
+        );
+        agents.insert(
+            "research-lead".to_string(),
+            make_agent("research-lead", "Lead."),
+        );
+        agents.insert("searcher".to_string(), make_agent("searcher", "Search."));
+        agents.insert("analyst".to_string(), make_agent("analyst", "Analyze."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        // Coordinator delegates the whole task to the nested-pattern lead.
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(FixedProvider::new("@research-lead: analyze the topic")),
+        );
+        // Lead arbitrates the ring outcome afterwards.
+        providers.insert(
+            "research-lead".to_string(),
+            Arc::new(FixedProvider::new("lead verdict")),
+        );
+        // Team agents produce ring contributions (parse_ring_action format, see
+        // `RING_ACTION_INSTRUCTIONS` / `parse_ring_action` in llm_agents.rs —
+        // unlike blackboard there is no CONFIDENCE header on a contribution).
+        let ring_action = "ACTION: PROPOSE\nCONTENT: a concrete proposal";
+        providers.insert(
+            "searcher".to_string(),
+            Arc::new(FixedProvider::new(ring_action)),
+        );
+        providers.insert(
+            "analyst".to_string(),
+            Arc::new(FixedProvider::new(ring_action)),
+        );
+
+        let capture = Arc::new(CaptureSink::new());
+        let sink: Arc<dyn EventSink> = capture.clone();
+        let mut engine = HierarchicalEngine::new(config, agents, providers, sink);
+        let result = engine.run("Do research").await.unwrap();
+
+        let events = capture.events();
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"nested_start""#)
+                && e.contains(r#""pattern":"ring""#)
+                && e.contains(r#""team_lead":"research-lead""#)),
+            "expected nested_start, got: {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"nested_end""#)),
+            "expected nested_end, got: {events:?}"
+        );
+        // Ring agents consumed tokens (circulation + voting) → folded into the
+        // hierarchical run metrics.
+        assert!(
+            result.total_tokens_in > 0 && result.total_tokens_out > 0,
+            "nested ring tokens should fold into run metrics, got in={} out={}",
             result.total_tokens_in,
             result.total_tokens_out
         );

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -621,7 +621,56 @@ async fn run_nested_team(
         team_lead: team_lead.to_string(),
     });
 
-    Ok(outcome_text)
+    // Lead arbitrates the aggregated outcome (may accept/refine/override).
+    let arbitrated = arbitrate_nested_outcome(ctx, state, team_lead, task, &outcome_text).await?;
+    Ok(arbitrated)
+}
+
+/// Have the lead arbitrate a nested sub-run's aggregated outcome (C9).
+///
+/// The lead receives the sub-run outcome as a user turn and produces the
+/// team's final answer — it may accept, refine, or override. Reuses the
+/// standard `call_llm` path so budget/metrics accounting stays consistent.
+async fn arbitrate_nested_outcome(
+    ctx: &Arc<EngineContext>,
+    state: &Arc<Mutex<EngineState>>,
+    lead: &str,
+    task: &str,
+    outcome: &str,
+) -> anyhow::Result<String> {
+    let arb_prompt = format!(
+        "You lead a team that produced the following outcome for the task.\n\n\
+         Task:\n{task}\n\n\
+         Team outcome:\n{outcome}\n\n\
+         As the team lead, give the final answer for this task. You may accept \
+         the team's outcome, refine it, or override it with your own judgment."
+    );
+    {
+        let mut s = state.lock().unwrap_or_else(|e| {
+            tracing::warn!("Mutex poisoned queuing arbitration: {:?}", e);
+            e.into_inner()
+        });
+        s.iteration_count += 1;
+        let conv = s.conversations.entry(lead.to_string()).or_default();
+        conv.push(ChatMessage {
+            role: "user".to_string(),
+            content: arb_prompt,
+        });
+    }
+    let system_prompt = build_enriched_prompt(ctx, lead);
+    let verdict = call_llm(ctx, state, lead, &system_prompt).await?;
+    {
+        let mut s = state.lock().unwrap_or_else(|e| {
+            tracing::warn!("Mutex poisoned recording arbitration: {:?}", e);
+            e.into_inner()
+        });
+        let conv = s.conversations.entry(lead.to_string()).or_default();
+        conv.push(ChatMessage {
+            role: "assistant".to_string(),
+            content: verdict.clone(),
+        });
+    }
+    Ok(verdict)
 }
 
 /// Resolve the effective BlackboardConfig for a team (team overrides > global).
@@ -2061,5 +2110,128 @@ mod tests {
             "flat delegation must not emit nested events"
         );
         assert!(!result.content.is_empty());
+    }
+
+    /// Provider for `coordinator` in the arbitration test: delegates once,
+    /// then echoes back the last message it receives (the re-injected team
+    /// result, produced by `format_results` from whatever `run_nested_team`
+    /// returned) as its final answer.
+    ///
+    /// A `FixedProvider` can't model this — it ignores its input, so its
+    /// second (synthesis) call would just repeat the delegation directive
+    /// verbatim and get stripped by `extract_narrative`, making the test pass
+    /// or fail independently of what the nested team/lead actually produced.
+    /// Echoing the injected conversation instead makes the assertion below
+    /// genuinely depend on `run_nested_team`'s return value (raw board text
+    /// pre-arbitration vs. the lead's verdict post-arbitration). The
+    /// coordinator is never invoked concurrently with itself, so a plain
+    /// call counter is safe (no shared state races).
+    struct DelegateThenEchoProvider {
+        delegate_to: String,
+        task: String,
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl DelegateThenEchoProvider {
+        fn new(delegate_to: &str, task: &str) -> Self {
+            Self {
+                delegate_to: delegate_to.to_string(),
+                task: task.to_string(),
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for DelegateThenEchoProvider {
+        async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+            let call_index = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let content = if call_index == 0 {
+                format!("@{}: {}", self.delegate_to, self.task)
+            } else {
+                let last = request
+                    .messages
+                    .last()
+                    .map(|m| m.content.clone())
+                    .unwrap_or_default();
+                format!("Final answer based on team result:\n{last}")
+            };
+            Ok(CompletionResponse {
+                content,
+                model: "mock".to_string(),
+                tokens_in: 10,
+                tokens_out: 20,
+                cost: 0.001,
+            })
+        }
+
+        async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+            anyhow::bail!("streaming not supported in mock")
+        }
+
+        fn metadata(&self) -> ProviderMetadata {
+            ProviderMetadata {
+                name: "mock".to_string(),
+                models: vec!["mock".to_string()],
+                supports_streaming: false,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_lead_arbitrates_and_can_override_consensus() {
+        let config = nested_blackboard_config();
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "Coordinate."),
+        );
+        agents.insert(
+            "research-lead".to_string(),
+            make_agent("research-lead", "Lead."),
+        );
+        agents.insert("searcher".to_string(), make_agent("searcher", "Search."));
+        agents.insert("analyst".to_string(), make_agent("analyst", "Analyze."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(DelegateThenEchoProvider::new(
+                "research-lead",
+                "analyze the topic",
+            )),
+        );
+        // The lead OVERRIDES the team consensus with its own verdict.
+        providers.insert(
+            "research-lead".to_string(),
+            Arc::new(FixedProvider::new("ARBITER VERDICT: proceed with option B")),
+        );
+        // Team agents produce a board finding suggesting a DIFFERENT option —
+        // if the raw board text ever surfaced instead of the lead's verdict,
+        // this is what would leak into the final result.
+        let board_action = "ACTION: FINDING\nCONFIDENCE: 0.9\nCONTENT: team suggests option A";
+        providers.insert(
+            "searcher".to_string(),
+            Arc::new(FixedProvider::new(board_action)),
+        );
+        providers.insert(
+            "analyst".to_string(),
+            Arc::new(FixedProvider::new(board_action)),
+        );
+
+        let mut engine = HierarchicalEngine::new(config, agents, providers, Arc::new(NullSink));
+        let result = engine.run("Do research").await.unwrap();
+
+        // The lead's arbitration is what surfaces (not the raw board text).
+        assert!(
+            result
+                .content
+                .contains("ARBITER VERDICT: proceed with option B"),
+            "expected lead arbitration to surface, got: {}",
+            result.content
+        );
     }
 }

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -17,9 +17,13 @@ use crate::core::events::{EventSink, RunEvent};
 use crate::core::routing::{BudgetState, RoutingRules, route};
 use crate::providers::traits::{ChatMessage, CompletionRequest, CompletionResponse, Provider};
 
+use super::NestedPattern;
 use super::OrchestrationConfig;
+use super::blackboard::{BlackboardConfig, Board, BoardAgent, run_blackboard};
 use super::context_injection::{AgentInfo, build_orchestration_prompt};
+use super::llm_agents::{LlmBoardAgent, LlmRingAgent, RoutingCtx};
 use super::protocol::{DelegationAction, extract_narrative, parse_delegations};
+use super::ring::{RingAgent, RingConfig, RingOutcome, RingToken, TokenStatus, run_ring};
 
 // ── Result types ─────────────────────────────────────────────────
 
@@ -281,6 +285,22 @@ fn invoke_agent(
             });
         } // unlock
 
+        // ── C9: nested team sub-pattern short-circuit ───────────
+        // If this agent is the lead of a team that declares a nested
+        // pattern, run that sub-pattern over the team's agents instead of
+        // the normal LLM+delegation loop, then return the aggregated result.
+        if let Some(team) = ctx
+            .config
+            .teams
+            .iter()
+            .find(|t| t.lead.as_deref() == Some(agent_name.as_str()) && t.pattern.is_some())
+        {
+            let nested = team.pattern.expect("checked is_some above");
+            let members = team.agents.clone();
+            return run_nested_team(&ctx, &state, &agent_name, nested, &members, &input, depth)
+                .await;
+        }
+
         // ── Build enriched system prompt (read-only) ────────────
         let system_prompt = build_enriched_prompt(&ctx, &agent_name);
 
@@ -421,6 +441,231 @@ fn invoke_agent(
         // For safety, just return the synthesis text to avoid infinite loops
         Ok(extract_narrative(&synthesis))
     })
+}
+
+// ── Nested team sub-patterns (C9) ────────────────────────────────
+
+/// Run a hierarchical team as a nested blackboard/ring sub-run (C9).
+///
+/// The team's agents run the declared sub-pattern on `task`, sharing the
+/// hierarchical run's remaining token budget. Consumed tokens/cost are folded
+/// back into `EngineState`. Returns the aggregated outcome text (arbitration
+/// by the lead is layered on in a later task). Depth of the sub-run is
+/// `depth + 1` (counted against `max_depth` before launching).
+async fn run_nested_team(
+    ctx: &Arc<EngineContext>,
+    state: &Arc<Mutex<EngineState>>,
+    team_lead: &str,
+    nested: NestedPattern,
+    agent_names: &[String],
+    task: &str,
+    depth: u32,
+) -> anyhow::Result<String> {
+    // Depth guard: the sub-run conceptually runs at depth + 1.
+    if depth + 1 >= ctx.config.max_depth() {
+        anyhow::bail!(
+            "Max delegation depth ({}) reached launching nested team '{team_lead}'",
+            ctx.config.max_depth()
+        );
+    }
+
+    // Compute the remaining shared budget (never below zero).
+    let remaining_budget = {
+        let s = state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Mutex poisoned computing nested budget: {:?}", e))?;
+        match ctx.config.token_budget {
+            Some(total) => {
+                let used = s.total_tokens_in as u64 + s.total_tokens_out as u64;
+                total.saturating_sub(used)
+            }
+            // No global budget: fall back to the sub-pattern's own default.
+            None => match nested {
+                NestedPattern::Blackboard => BlackboardConfig::default().token_budget,
+                NestedPattern::Ring => RingConfig::default().token_budget,
+            },
+        }
+    };
+
+    // Resolve the team's agents into (Agent, provider) pairs.
+    let mut member_agents = Vec::new();
+    let mut member_providers: Vec<Arc<dyn Provider>> = Vec::new();
+    for name in agent_names {
+        let agent = ctx
+            .agents
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("nested team agent '{name}' not found"))?
+            .clone();
+        let provider = ctx
+            .providers
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("no provider for nested team agent '{name}'"))?;
+        member_agents.push(agent);
+        member_providers.push(Arc::clone(provider));
+    }
+
+    ctx.sink.emit(&RunEvent::NestedStart {
+        team_lead: team_lead.to_string(),
+        pattern: nested.to_string(),
+    });
+
+    let routing_ctx = RoutingCtx::new(ctx.routing_rules.clone(), remaining_budget);
+
+    let (outcome_text, folded_in, folded_out, folded_cost) = match nested {
+        NestedPattern::Blackboard => {
+            let config = BlackboardConfig {
+                token_budget: remaining_budget,
+                ..BlackboardConfig::default()
+            };
+            let config = apply_team_blackboard_overrides(config, ctx, team_lead);
+            let board_agents: Vec<Arc<dyn BoardAgent>> = member_agents
+                .into_iter()
+                .map(|a| {
+                    Arc::new(LlmBoardAgent::with_routing(
+                        a,
+                        routing_ctx.clone(),
+                        Arc::clone(&ctx.sink),
+                    )) as Arc<dyn BoardAgent>
+                })
+                .collect();
+            let mut board = Board::new(task.to_string(), config.token_budget);
+            run_blackboard(
+                &mut board,
+                &board_agents,
+                &member_providers,
+                &config,
+                &ctx.sink,
+            )
+            .await?;
+            let (ti, to, cost) = board.entries().iter().fold((0u32, 0u32, 0f64), |acc, e| {
+                (
+                    acc.0 + e.tokens_used.input,
+                    acc.1 + e.tokens_used.output,
+                    acc.2 + e.tokens_used.cost,
+                )
+            });
+            let text = board
+                .entries()
+                .iter()
+                .map(|e| format!("[{}] {}", e.agent, e.content))
+                .collect::<Vec<_>>()
+                .join("\n");
+            (text, ti, to, cost)
+        }
+        NestedPattern::Ring => {
+            let config = RingConfig {
+                token_budget: remaining_budget,
+                ..RingConfig::default()
+            };
+            let config = apply_team_ring_overrides(config, ctx, team_lead);
+            let ring_agents: Vec<Arc<dyn RingAgent>> = member_agents
+                .into_iter()
+                .map(|a| {
+                    Arc::new(LlmRingAgent::with_routing(
+                        a,
+                        routing_ctx.clone(),
+                        Arc::clone(&ctx.sink),
+                    )) as Arc<dyn RingAgent>
+                })
+                .collect();
+            let order: Vec<String> = ring_agents.iter().map(|a| a.name().to_string()).collect();
+            let mut token = RingToken::new(task.to_string(), order, config.token_budget);
+            run_ring(
+                &mut token,
+                &ring_agents,
+                &member_providers,
+                &config,
+                &ctx.sink,
+            )
+            .await?;
+            let (ti, to, cost) = token
+                .contributions
+                .iter()
+                .fold((0u32, 0u32, 0f64), |acc, c| {
+                    (
+                        acc.0 + c.tokens_used.input,
+                        acc.1 + c.tokens_used.output,
+                        acc.2 + c.tokens_used.cost,
+                    )
+                });
+            let text = match token.status() {
+                TokenStatus::Done { outcome } => match outcome {
+                    RingOutcome::Consensus { resolution, .. }
+                    | RingOutcome::Majority { resolution, .. } => resolution.clone(),
+                    RingOutcome::NoConsensus { summary, .. } => summary.clone(),
+                    RingOutcome::BudgetExhausted { partial_summary }
+                    | RingOutcome::CostLimitExceeded {
+                        partial_summary, ..
+                    } => partial_summary.clone(),
+                    RingOutcome::Cancelled => String::new(),
+                },
+                _ => String::new(),
+            };
+            (text, ti, to, cost)
+        }
+    };
+
+    // Fold the sub-run's metrics into the shared hierarchical state.
+    {
+        let mut s = state.lock().unwrap_or_else(|e| {
+            tracing::warn!("Mutex poisoned folding nested metrics: {:?}", e);
+            e.into_inner()
+        });
+        s.total_tokens_in += folded_in;
+        s.total_tokens_out += folded_out;
+        s.total_cost += folded_cost;
+        s.invocation_count += agent_names.len() as u32;
+    }
+
+    ctx.sink.emit(&RunEvent::NestedEnd {
+        team_lead: team_lead.to_string(),
+    });
+
+    Ok(outcome_text)
+}
+
+/// Resolve the effective BlackboardConfig for a team (team overrides > global).
+fn apply_team_blackboard_overrides(
+    mut config: BlackboardConfig,
+    ctx: &EngineContext,
+    team_lead: &str,
+) -> BlackboardConfig {
+    if let Some(team) = ctx
+        .config
+        .teams
+        .iter()
+        .find(|t| t.lead.as_deref() == Some(team_lead))
+    {
+        if let Some(v) = team.max_rounds.or(ctx.config.max_rounds) {
+            config.max_rounds = v;
+        }
+        if let Some(v) = team.consensus_threshold.or(ctx.config.consensus_threshold) {
+            config.consensus_threshold = v;
+        }
+    }
+    config
+}
+
+/// Resolve the effective RingConfig for a team (team overrides > global).
+fn apply_team_ring_overrides(
+    mut config: RingConfig,
+    ctx: &EngineContext,
+    team_lead: &str,
+) -> RingConfig {
+    if let Some(team) = ctx
+        .config
+        .teams
+        .iter()
+        .find(|t| t.lead.as_deref() == Some(team_lead))
+    {
+        if let Some(v) = team.max_laps {
+            config.max_laps = v;
+        }
+        if let Some(v) = team.consensus_threshold.or(ctx.config.consensus_threshold) {
+            config.consensus_threshold = v;
+        }
+    }
+    config
 }
 
 // ── Internal helpers ────────────────────────────────────────────
@@ -1660,5 +1905,161 @@ mod tests {
         );
         assert!(result.total_cost > 0.0, "Should have captured cost");
         assert_eq!(result.invocation_count, 1, "Should have one invocation");
+    }
+
+    // ── C9: nested team sub-pattern tests ───────────────────────
+
+    /// Provider that always returns the same content (order-independent — needed
+    /// because nested board/ring agents run concurrently).
+    struct FixedProvider {
+        text: String,
+    }
+    impl FixedProvider {
+        fn new(text: &str) -> Self {
+            Self {
+                text: text.to_string(),
+            }
+        }
+    }
+    #[async_trait]
+    impl Provider for FixedProvider {
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> anyhow::Result<CompletionResponse> {
+            Ok(CompletionResponse {
+                content: self.text.clone(),
+                model: "mock".to_string(),
+                tokens_in: 10,
+                tokens_out: 20,
+                cost: 0.001,
+            })
+        }
+        async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+            anyhow::bail!("streaming not supported in mock")
+        }
+        fn metadata(&self) -> ProviderMetadata {
+            ProviderMetadata {
+                name: "mock".to_string(),
+                models: vec!["mock".to_string()],
+                supports_streaming: false,
+            }
+        }
+    }
+
+    /// Config: coordinator → one nested-blackboard team (lead + 2 agents).
+    fn nested_blackboard_config() -> OrchestrationConfig {
+        OrchestrationConfig {
+            enabled: true,
+            pattern: super::super::OrchestrationPattern::Hierarchical,
+            coordinator: Some("coordinator".to_string()),
+            teams: vec![TeamConfig {
+                lead: Some("research-lead".to_string()),
+                agents: vec!["searcher".to_string(), "analyst".to_string()],
+                pattern: Some(super::super::NestedPattern::Blackboard),
+                max_rounds: Some(2),
+                ..Default::default()
+            }],
+            max_rounds: Some(2),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nested_blackboard_runs_and_folds_metrics() {
+        let config = nested_blackboard_config();
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "Coordinate."),
+        );
+        agents.insert(
+            "research-lead".to_string(),
+            make_agent("research-lead", "Lead."),
+        );
+        agents.insert("searcher".to_string(), make_agent("searcher", "Search."));
+        agents.insert("analyst".to_string(), make_agent("analyst", "Analyze."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        // Coordinator delegates the whole task to the nested-pattern lead.
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(FixedProvider::new("@research-lead: analyze the topic")),
+        );
+        // Lead is not LLM-called in Lot 1 (no arbitration yet).
+        providers.insert(
+            "research-lead".to_string(),
+            Arc::new(FixedProvider::new("lead")),
+        );
+        // Team agents produce board findings (parse_board_action format).
+        let board_action = "ACTION: FINDING\nCONFIDENCE: 0.9\nCONTENT: a concrete finding";
+        providers.insert(
+            "searcher".to_string(),
+            Arc::new(FixedProvider::new(board_action)),
+        );
+        providers.insert(
+            "analyst".to_string(),
+            Arc::new(FixedProvider::new(board_action)),
+        );
+
+        let capture = Arc::new(CaptureSink::new());
+        let sink: Arc<dyn EventSink> = capture.clone();
+        let mut engine = HierarchicalEngine::new(config, agents, providers, sink);
+        let result = engine.run("Do research").await.unwrap();
+
+        let events = capture.events();
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"nested_start""#)
+                && e.contains(r#""pattern":"blackboard""#)
+                && e.contains(r#""team_lead":"research-lead""#)),
+            "expected nested_start, got: {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| e.contains(r#""t":"nested_end""#)),
+            "expected nested_end, got: {events:?}"
+        );
+        // Board agents consumed tokens → folded into the hierarchical run metrics.
+        assert!(
+            result.total_tokens_in > 0 && result.total_tokens_out > 0,
+            "nested board tokens should fold into run metrics, got in={} out={}",
+            result.total_tokens_in,
+            result.total_tokens_out
+        );
+    }
+
+    #[tokio::test]
+    async fn test_flat_delegation_still_works_without_pattern() {
+        // A team WITHOUT `pattern` must behave exactly as before (regression guard).
+        let config = sample_config(); // teams have no `pattern`
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "Coordinate."),
+        );
+        agents.insert("agent-a".to_string(), make_agent("agent-a", "Do A."));
+        agents.insert("agent-b".to_string(), make_agent("agent-b", "Do B."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(MockProvider::new(vec!["@agent-a: do it", "final answer"])),
+        );
+        providers.insert(
+            "agent-a".to_string(),
+            Arc::new(MockProvider::new(vec!["A result"])),
+        );
+
+        let capture = Arc::new(CaptureSink::new());
+        let sink: Arc<dyn EventSink> = capture.clone();
+        let mut engine = HierarchicalEngine::new(config, agents, providers, sink);
+        let result = engine.run("go").await.unwrap();
+
+        let events = capture.events();
+        assert!(
+            !events.iter().any(|e| e.contains(r#""t":"nested_start""#)),
+            "flat delegation must not emit nested events"
+        );
+        assert!(!result.content.is_empty());
     }
 }

--- a/src/core/orchestration/mod.rs
+++ b/src/core/orchestration/mod.rs
@@ -77,6 +77,27 @@ impl std::fmt::Display for OrchestrationPattern {
     }
 }
 
+/// Sub-pattern a hierarchical team can run instead of flat delegation (C9).
+///
+/// A dedicated enum (not `OrchestrationPattern`) makes deeper nesting
+/// (hierarchical/direct/auto inside a team) impossible by construction:
+/// only one level of nesting can ever exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NestedPattern {
+    Blackboard,
+    Ring,
+}
+
+impl std::fmt::Display for NestedPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Blackboard => write!(f, "blackboard"),
+            Self::Ring => write!(f, "ring"),
+        }
+    }
+}
+
 /// Configuration for the selected orchestration pattern.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "pattern", rename_all = "lowercase")]
@@ -188,7 +209,7 @@ impl OrchestrationConfig {
 }
 
 /// A team definition within the hierarchical topology.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct TeamConfig {
     /// Optional sub-lead for this team. If absent, agents report
     /// directly to the coordinator.
@@ -197,6 +218,23 @@ pub struct TeamConfig {
     /// Agents in this team.
     #[serde(default)]
     pub agents: Vec<String>,
+
+    /// C9: if set, the team runs as this sub-pattern (blackboard/ring)
+    /// instead of flat delegation. Requires a `lead` (the arbiter).
+    #[serde(default)]
+    pub pattern: Option<NestedPattern>,
+
+    /// C9: per-team override for blackboard `max_rounds` (else global/default).
+    #[serde(default)]
+    pub max_rounds: Option<u32>,
+
+    /// C9: per-team override for ring `max_laps` (else global/default).
+    #[serde(default)]
+    pub max_laps: Option<u32>,
+
+    /// C9: per-team override for the sub-pattern consensus threshold.
+    #[serde(default)]
+    pub consensus_threshold: Option<f32>,
 }
 
 // ── Validation ───────────────────────────────────────────────────
@@ -221,6 +259,12 @@ pub enum OrchestrationValidationError {
 
     #[error("teams are empty — hierarchical pattern requires at least one team")]
     EmptyTeams,
+
+    #[error("team led by '{0}' declares a nested pattern but the root pattern is not hierarchical")]
+    NestedPatternRequiresHierarchical(String),
+
+    #[error("a team declaring a nested pattern must have a `lead` (the arbiter)")]
+    NestedPatternRequiresLead,
 }
 
 /// Validate the orchestration configuration for internal consistency.
@@ -232,6 +276,16 @@ pub fn validate_config(
 ) -> Result<(), Vec<OrchestrationValidationError>> {
     if !config.enabled {
         return Ok(());
+    }
+
+    // C9: a team-level nested pattern is only valid under a hierarchical root.
+    if config.pattern != OrchestrationPattern::Hierarchical
+        && let Some(team) = config.teams.iter().find(|t| t.pattern.is_some())
+    {
+        let lead = team.lead.clone().unwrap_or_default();
+        return Err(vec![
+            OrchestrationValidationError::NestedPatternRequiresHierarchical(lead),
+        ]);
     }
 
     // Only validate hierarchical-specific fields for that pattern
@@ -260,6 +314,11 @@ pub fn validate_config(
     let mut seen_leads = std::collections::HashSet::new();
 
     for team in &config.teams {
+        // C9: a nested-pattern team needs a lead to arbitrate its sub-run.
+        if team.pattern.is_some() && team.lead.is_none() {
+            errors.push(OrchestrationValidationError::NestedPatternRequiresLead);
+        }
+
         // Check lead uniqueness
         if let Some(ref lead) = team.lead {
             if !seen_leads.insert(lead.clone()) {
@@ -375,14 +434,17 @@ mod hierarchical_tests {
                         "java-sec".to_string(),
                         "java-test".to_string(),
                     ],
+                    ..Default::default()
                 },
                 TeamConfig {
                     lead: Some("node-lead".to_string()),
                     agents: vec!["node-arch".to_string(), "node-gql".to_string()],
+                    ..Default::default()
                 },
                 TeamConfig {
                     lead: None,
                     agents: vec!["cloud-expert".to_string(), "ops-expert".to_string()],
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -460,10 +522,12 @@ mod hierarchical_tests {
                 TeamConfig {
                     lead: None,
                     agents: vec!["agent-a".to_string()],
+                    ..Default::default()
                 },
                 TeamConfig {
                     lead: None,
                     agents: vec!["agent-a".to_string()],
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -485,6 +549,7 @@ mod hierarchical_tests {
             teams: vec![TeamConfig {
                 lead: None,
                 agents: vec!["coord".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -506,10 +571,12 @@ mod hierarchical_tests {
                 TeamConfig {
                     lead: Some("lead-a".to_string()),
                     agents: vec!["agent-1".to_string()],
+                    ..Default::default()
                 },
                 TeamConfig {
                     lead: Some("lead-a".to_string()),
                     agents: vec!["agent-2".to_string()],
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -652,5 +719,95 @@ consensus_threshold: 0.85
             "hierarchical"
         );
         assert_eq!(OrchestrationPattern::Auto.to_string(), "auto");
+    }
+
+    // ── C9: nested pattern tests ──
+
+    #[test]
+    fn test_team_config_deserializes_nested_pattern() {
+        let yaml = r#"
+enabled: true
+pattern: hierarchical
+coordinator: coord
+teams:
+  - lead: research-lead
+    agents: [searcher, analyst]
+    pattern: blackboard
+    max_rounds: 4
+  - lead: build-lead
+    agents: [coder]
+    pattern: ring
+    max_laps: 2
+    consensus_threshold: 0.8
+  - lead: doc-lead
+    agents: [writer]
+"#;
+        let config: OrchestrationConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.teams[0].pattern, Some(NestedPattern::Blackboard));
+        assert_eq!(config.teams[0].max_rounds, Some(4));
+        assert_eq!(config.teams[1].pattern, Some(NestedPattern::Ring));
+        assert_eq!(config.teams[1].max_laps, Some(2));
+        assert_eq!(config.teams[1].consensus_threshold, Some(0.8));
+        assert_eq!(config.teams[2].pattern, None); // flat delegation
+    }
+
+    #[test]
+    fn test_validate_nested_pattern_requires_hierarchical() {
+        let config = OrchestrationConfig {
+            enabled: true,
+            pattern: OrchestrationPattern::Blackboard,
+            coordinator: Some("coord".to_string()),
+            teams: vec![TeamConfig {
+                lead: Some("lead".to_string()),
+                agents: vec!["a".to_string()],
+                pattern: Some(NestedPattern::Ring),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let errs = validate_config(&config).unwrap_err();
+        assert!(matches!(
+            errs[0],
+            OrchestrationValidationError::NestedPatternRequiresHierarchical(_)
+        ));
+    }
+
+    #[test]
+    fn test_validate_nested_pattern_requires_lead() {
+        let config = OrchestrationConfig {
+            enabled: true,
+            pattern: OrchestrationPattern::Hierarchical,
+            coordinator: Some("coord".to_string()),
+            teams: vec![TeamConfig {
+                lead: None,
+                agents: vec!["a".to_string()],
+                pattern: Some(NestedPattern::Blackboard),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let errs = validate_config(&config).unwrap_err();
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, OrchestrationValidationError::NestedPatternRequiresLead)),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_nested_pattern_ok_under_hierarchical() {
+        let config = OrchestrationConfig {
+            enabled: true,
+            pattern: OrchestrationPattern::Hierarchical,
+            coordinator: Some("coord".to_string()),
+            teams: vec![TeamConfig {
+                lead: Some("lead".to_string()),
+                agents: vec!["a".to_string()],
+                pattern: Some(NestedPattern::Blackboard),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(validate_config(&config).is_ok());
     }
 }

--- a/src/core/orchestration/protocol.rs
+++ b/src/core/orchestration/protocol.rs
@@ -136,10 +136,12 @@ mod tests {
                         "java-sec".to_string(),
                         "java-test".to_string(),
                     ],
+                    ..Default::default()
                 },
                 TeamConfig {
                     lead: None,
                     agents: vec!["cloud-expert".to_string(), "ops-expert".to_string()],
+                    ..Default::default()
                 },
             ],
             ..Default::default()


### PR DESCRIPTION
## C9 Lot 1 — Moteur (pattern mixing)

Première tranche de **C9** : une sous-équipe d'un pattern **hierarchical** peut s'exécuter en **blackboard** ou **ring** (déclaré en config), au lieu d'une délégation plate.

### Contenu
- **`NestedPattern { Blackboard, Ring }`** + champs `TeamConfig` (`pattern`, `max_rounds`, `max_laps`, `consensus_threshold`) — un enum dédié interdit *par construction* toute imbrication récursive (une seule profondeur).
- **Validation** : un `pattern` de team n'est valide que sous une racine `hierarchical` (`NestedPatternRequiresHierarchical`) et exige un `lead` (`NestedPatternRequiresLead`).
- **`run_nested_team`** : exécute la team via les moteurs existants `run_blackboard`/`run_ring` (aucune duplication), budget **partagé** (restant du run hierarchical), métriques **repliées** dans l'`EngineState`, profondeur comptée dans `max_depth`.
- **Arbitrage du lead** : après le sous-run, le lead reçoit le résultat agrégé et **tranche** (accepte / affine / surcharge) via un appel LLM d'arbitrage.
- **Événements** : `RunEvent::NestedStart{team_lead,pattern}` / `NestedEnd{team_lead}` (clés courtes JSONL), équilibrés y compris sur chemin d'erreur.
- **Rétro-compat totale** : une team sans `pattern` = délégation plate, comportement identique.

### Hors périmètre (lots suivants)
- Lot 2 : persistance hierarchical (migration `user_version`, `parent_run_id`, `delegation_events`).
- Lot 3 : exposition C6 (web) + JSONL headless.

### Qualité
- Développé en subagent-driven : implémenteur + revue de tâche (spec + qualité) à chaque tâche, revue finale de branche indépendante.
- Chemins blackboard **et** ring couverts par des tests d'intégration ; arbitrage testé (le lead surcharge le consensus).
- CI locale : clippy `--features tui` **et** `--features tui,providers-api` (`-D warnings`), `fmt`, 236 tests d'orchestration verts (787 sur tout le crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)