### PR TITLE
feat(storage): C9 Lot 2 — persist hierarchical runs + nested sub-runs

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -957,6 +957,7 @@ fn record_orchestration_blackboard(
         outcome_json: serde_json::to_string(board.state()).ok(),
         rounds: board.round as i64,
         halt_reason,
+        parent_run_id: None,
     };
     if let Err(e) = queries::insert_orchestration_run(&db, orch) {
         tracing::warn!("Failed to record orchestration metadata: {e}");
@@ -1045,6 +1046,7 @@ fn record_orchestration_ring(
         outcome_json: outcome_str,
         rounds: token.lap as i64,
         halt_reason: None,
+        parent_run_id: None,
     };
     if let Err(e) = queries::insert_orchestration_run(&db, orch) {
         tracing::warn!("Failed to record orchestration metadata: {e}");

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -791,6 +791,11 @@ async fn run_orchestrated(
                 agent_map.len()
             );
 
+            // Kept alive for post-run persistence (`record_orchestration_hierarchical`)
+            // since `orch_config` itself is moved into the engine below.
+            #[cfg(feature = "storage")]
+            let orch_config_for_storage = orch_config.clone();
+
             let mut engine = HierarchicalEngine::with_routing_rules(
                 orch_config,
                 agent_map,
@@ -804,6 +809,9 @@ async fn run_orchestrated(
                 "[hierarchical] Done: {} invocations, {} tokens in, {} tokens out",
                 result.invocation_count, result.total_tokens_in, result.total_tokens_out
             );
+
+            #[cfg(feature = "storage")]
+            record_orchestration_hierarchical(&result, &orch_config_for_storage, input);
 
             if !json {
                 println!("{}", result.content);
@@ -903,22 +911,20 @@ fn apply_ring_overrides(
     config
 }
 
+/// Persist a blackboard orchestration run (and its board entries) into `db`,
+/// linked to `parent_run_id` when this run is a nested sub-run of a
+/// hierarchical team (C9). Returns the generated `run_id` so callers can
+/// link children to it.
 #[cfg(feature = "storage")]
-fn record_orchestration_blackboard(
+fn record_orchestration_blackboard_into(
+    db: &crate::storage::Database,
     board: &crate::core::orchestration::blackboard::Board,
     config: &crate::core::orchestration::blackboard::BlackboardConfig,
     input: &str,
-) {
+    parent_run_id: Option<&str>,
+) -> String {
     use crate::core::orchestration::blackboard::BoardState;
-    use crate::storage::{init_db, queries};
-
-    let db = match init_db() {
-        Ok(db) => db,
-        Err(e) => {
-            tracing::warn!("Failed to init storage: {e}");
-            return;
-        }
-    };
+    use crate::storage::queries;
 
     let run_id = uuid::Uuid::new_v4().to_string();
 
@@ -940,9 +946,9 @@ fn record_orchestration_blackboard(
         }
         .to_string(),
     };
-    if let Err(e) = queries::insert_run_with_id(&db, &run_id, parent) {
+    if let Err(e) = queries::insert_run_with_id(db, &run_id, parent) {
         tracing::warn!("Failed to record orchestration parent run: {e}");
-        return;
+        return run_id;
     }
 
     // 2. Orchestration metadata
@@ -957,11 +963,11 @@ fn record_orchestration_blackboard(
         outcome_json: serde_json::to_string(board.state()).ok(),
         rounds: board.round as i64,
         halt_reason,
-        parent_run_id: None,
+        parent_run_id: parent_run_id.map(|s| s.to_string()),
     };
-    if let Err(e) = queries::insert_orchestration_run(&db, orch) {
+    if let Err(e) = queries::insert_orchestration_run(db, orch) {
         tracing::warn!("Failed to record orchestration metadata: {e}");
-        return;
+        return run_id;
     }
 
     // 3. Board entries
@@ -987,28 +993,47 @@ fn record_orchestration_blackboard(
             tokens_in: entry.tokens_used.input as i64,
             tokens_out: entry.tokens_used.output as i64,
         };
-        if let Err(e) = queries::insert_board_entry(&db, record) {
+        if let Err(e) = queries::insert_board_entry(db, record) {
             tracing::warn!("Failed to record board entry: {e}");
         }
     }
+
+    run_id
 }
 
+/// Top-level entry point for persisting a standalone blackboard run
+/// (`armadai run --orchestrate blackboard`). Initializes storage and
+/// delegates to [`record_orchestration_blackboard_into`] with no parent.
 #[cfg(feature = "storage")]
-fn record_orchestration_ring(
-    token: &crate::core::orchestration::ring::RingToken,
-    config: &crate::core::orchestration::ring::RingConfig,
+fn record_orchestration_blackboard(
+    board: &crate::core::orchestration::blackboard::Board,
+    config: &crate::core::orchestration::blackboard::BlackboardConfig,
     input: &str,
 ) {
-    use crate::core::orchestration::ring::TokenStatus;
-    use crate::storage::{init_db, queries};
-
-    let db = match init_db() {
+    let db = match crate::storage::init_db() {
         Ok(db) => db,
         Err(e) => {
             tracing::warn!("Failed to init storage: {e}");
             return;
         }
     };
+    let _ = record_orchestration_blackboard_into(&db, board, config, input, None);
+}
+
+/// Persist a ring orchestration run (and its contributions/votes) into `db`,
+/// linked to `parent_run_id` when this run is a nested sub-run of a
+/// hierarchical team (C9). Returns the generated `run_id` so callers can
+/// link children to it.
+#[cfg(feature = "storage")]
+fn record_orchestration_ring_into(
+    db: &crate::storage::Database,
+    token: &crate::core::orchestration::ring::RingToken,
+    config: &crate::core::orchestration::ring::RingConfig,
+    input: &str,
+    parent_run_id: Option<&str>,
+) -> String {
+    use crate::core::orchestration::ring::TokenStatus;
+    use crate::storage::queries;
 
     let run_id = uuid::Uuid::new_v4().to_string();
     let outcome_str = match token.status() {
@@ -1033,9 +1058,9 @@ fn record_orchestration_ring(
         }
         .to_string(),
     };
-    if let Err(e) = queries::insert_run_with_id(&db, &run_id, parent) {
+    if let Err(e) = queries::insert_run_with_id(db, &run_id, parent) {
         tracing::warn!("Failed to record orchestration parent run: {e}");
-        return;
+        return run_id;
     }
 
     // 2. Orchestration metadata
@@ -1046,11 +1071,11 @@ fn record_orchestration_ring(
         outcome_json: outcome_str,
         rounds: token.lap as i64,
         halt_reason: None,
-        parent_run_id: None,
+        parent_run_id: parent_run_id.map(|s| s.to_string()),
     };
-    if let Err(e) = queries::insert_orchestration_run(&db, orch) {
+    if let Err(e) = queries::insert_orchestration_run(db, orch) {
         tracing::warn!("Failed to record orchestration metadata: {e}");
-        return;
+        return run_id;
     }
 
     // 3. Contributions
@@ -1074,7 +1099,7 @@ fn record_orchestration_ring(
             tokens_in: c.tokens_used.input as i64,
             tokens_out: c.tokens_used.output as i64,
         };
-        if let Err(e) = queries::insert_ring_contribution(&db, record) {
+        if let Err(e) = queries::insert_ring_contribution(db, record) {
             tracing::warn!("Failed to record ring contribution: {e}");
         }
     }
@@ -1089,9 +1114,136 @@ fn record_orchestration_ring(
             supports: serde_json::to_string(&vote.supporting_contributions).unwrap_or_default(),
             concerns: serde_json::to_string(&vote.unresolved_concerns).unwrap_or_default(),
         };
-        if let Err(e) = queries::insert_ring_vote(&db, record) {
+        if let Err(e) = queries::insert_ring_vote(db, record) {
             tracing::warn!("Failed to record ring vote: {e}");
         }
+    }
+
+    run_id
+}
+
+/// Top-level entry point for persisting a standalone ring run
+/// (`armadai run --orchestrate ring`). Initializes storage and delegates to
+/// [`record_orchestration_ring_into`] with no parent.
+#[cfg(feature = "storage")]
+fn record_orchestration_ring(
+    token: &crate::core::orchestration::ring::RingToken,
+    config: &crate::core::orchestration::ring::RingConfig,
+    input: &str,
+) {
+    let db = match crate::storage::init_db() {
+        Ok(db) => db,
+        Err(e) => {
+            tracing::warn!("Failed to init storage: {e}");
+            return;
+        }
+    };
+    let _ = record_orchestration_ring_into(&db, token, config, input, None);
+}
+
+/// Persist a hierarchical orchestration run: the parent run row, its
+/// delegation trace, and every nested blackboard/ring sub-run (linked via
+/// `parent_run_id`). Returns the generated hierarchical `run_id`.
+#[cfg(feature = "storage")]
+fn record_hierarchical_into(
+    db: &crate::storage::Database,
+    result: &crate::core::orchestration::hierarchical::OrchestrationResult,
+    config: &crate::core::orchestration::OrchestrationConfig,
+    input: &str,
+) -> anyhow::Result<String> {
+    use crate::core::orchestration::hierarchical::NestedRun;
+    use crate::storage::queries;
+
+    let run_id = uuid::Uuid::new_v4().to_string();
+
+    // 1. Parent run record.
+    let parent = queries::RunRecord {
+        agent: "orchestration:hierarchical".to_string(),
+        input: input.to_string(),
+        output: result.content.clone(),
+        provider: "orchestration".to_string(),
+        model: String::new(),
+        tokens_in: result.total_tokens_in as i64,
+        tokens_out: result.total_tokens_out as i64,
+        cost: result.total_cost,
+        duration_ms: 0,
+        status: "success".to_string(),
+    };
+    queries::insert_run_with_id(db, &run_id, parent)?;
+
+    // 2. Orchestration metadata (hierarchical, no parent).
+    queries::insert_orchestration_run(
+        db,
+        queries::OrchestrationRunRecord {
+            run_id: run_id.clone(),
+            pattern: "hierarchical".to_string(),
+            config_json: serde_json::to_string(config).unwrap_or_default(),
+            outcome_json: None,
+            rounds: result.invocation_count as i64,
+            halt_reason: None,
+            parent_run_id: None,
+        },
+    )?;
+
+    // 3. Delegation events (seq = order in trace).
+    for (seq, ev) in result.trace.iter().enumerate() {
+        let rec = queries::DelegationEventRecord {
+            run_id: run_id.clone(),
+            seq: seq as i64,
+            from_agent: ev.from.clone(),
+            to_agent: ev.to.clone(),
+            message: ev.message.clone(),
+            depth: ev.depth as i64,
+        };
+        if let Err(e) = queries::insert_delegation_event(db, rec) {
+            tracing::warn!("Failed to record delegation event: {e}");
+        }
+    }
+
+    // 4. Nested sub-runs, linked to the hierarchical parent.
+    for nested in &result.nested_runs {
+        match nested {
+            NestedRun::Blackboard {
+                task,
+                board,
+                config,
+                ..
+            } => {
+                let _ =
+                    record_orchestration_blackboard_into(db, board, config, task, Some(&run_id));
+            }
+            NestedRun::Ring {
+                task,
+                token,
+                config,
+                ..
+            } => {
+                let _ = record_orchestration_ring_into(db, token, config, task, Some(&run_id));
+            }
+        }
+    }
+
+    Ok(run_id)
+}
+
+/// Top-level entry point for persisting a hierarchical run
+/// (`armadai run --orchestrate hierarchical`). Initializes storage and
+/// delegates to [`record_hierarchical_into`].
+#[cfg(feature = "storage")]
+fn record_orchestration_hierarchical(
+    result: &crate::core::orchestration::hierarchical::OrchestrationResult,
+    config: &crate::core::orchestration::OrchestrationConfig,
+    input: &str,
+) {
+    let db = match crate::storage::init_db() {
+        Ok(db) => db,
+        Err(e) => {
+            tracing::warn!("Failed to init storage: {e}");
+            return;
+        }
+    };
+    if let Err(e) = record_hierarchical_into(&db, result, config, input) {
+        tracing::warn!("Failed to record hierarchical run: {e}");
     }
 }
 
@@ -1171,5 +1323,66 @@ mod tests {
                 assert!(!dir.to_string_lossy().is_empty());
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "storage"))]
+mod storage_tests {
+    use super::*;
+    use crate::core::orchestration::OrchestrationConfig;
+    use crate::core::orchestration::blackboard::{BlackboardConfig, Board};
+    use crate::core::orchestration::hierarchical::{
+        DelegationEvent, NestedRun, OrchestrationResult,
+    };
+    use crate::storage::{init_embedded, queries};
+
+    #[test]
+    fn hierarchical_run_and_nested_children_are_persisted() {
+        let db = init_embedded().unwrap();
+
+        // A hierarchical result with one delegation event and one nested board.
+        let board = Board::new("subtask".to_string(), 50_000);
+        // (empty board is fine; we only assert the run + linkage persists)
+        let result = OrchestrationResult {
+            content: "final".to_string(),
+            trace: vec![DelegationEvent {
+                from: "coordinator".to_string(),
+                to: "research-lead".to_string(),
+                message: "analyze".to_string(),
+                depth: 1,
+            }],
+            total_tokens_in: 30,
+            total_tokens_out: 40,
+            total_cost: 0.01,
+            invocation_count: 3,
+            nested_runs: vec![NestedRun::Blackboard {
+                team_lead: "research-lead".to_string(),
+                task: "subtask".to_string(),
+                board,
+                config: BlackboardConfig::default(),
+            }],
+        };
+        let config = OrchestrationConfig::default();
+
+        let parent_id = record_hierarchical_into(&db, &result, &config, "do research").unwrap();
+
+        // Parent persisted as hierarchical with no parent.
+        let parent = queries::get_orchestration_run(&db, &parent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parent.pattern, "hierarchical");
+        assert_eq!(parent.parent_run_id, None);
+        // Delegation event persisted.
+        let events = queries::get_delegation_events(&db, &parent_id).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].to_agent, "research-lead");
+        // Nested child persisted and linked.
+        let children = queries::get_child_orchestration_runs(&db, &parent_id).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].pattern, "blackboard");
+        assert_eq!(
+            children[0].parent_run_id.as_deref(),
+            Some(parent_id.as_str())
+        );
     }
 }

--- a/src/core/orchestration/hierarchical.rs
+++ b/src/core/orchestration/hierarchical.rs
@@ -39,6 +39,8 @@ pub struct OrchestrationResult {
     pub total_tokens_out: u32,
     pub total_cost: f64,
     pub invocation_count: u32,
+    /// Nested blackboard/ring sub-runs (C9), for downstream persistence.
+    pub nested_runs: Vec<NestedRun>,
 }
 
 /// A single delegation event in the trace.
@@ -48,6 +50,24 @@ pub struct DelegationEvent {
     pub to: String,
     pub message: String,
     pub depth: u32,
+}
+
+/// A nested sub-run produced by a team running a blackboard/ring sub-pattern (C9).
+/// Held so the CLI layer can persist it (with `parent_run_id`) after the run.
+#[derive(Debug)]
+pub enum NestedRun {
+    Blackboard {
+        team_lead: String,
+        task: String,
+        board: Board,
+        config: BlackboardConfig,
+    },
+    Ring {
+        team_lead: String,
+        task: String,
+        token: RingToken,
+        config: RingConfig,
+    },
 }
 
 // ── Shared state ────────────────────────────────────────────────
@@ -76,6 +96,7 @@ struct EngineState {
     total_tokens_out: u32,
     total_cost: f64,
     invocation_count: u32,
+    nested_runs: Vec<NestedRun>,
 }
 
 // ── Engine ───────────────────────────────────────────────────────
@@ -157,6 +178,7 @@ impl HierarchicalEngine {
                 total_tokens_out: 0,
                 total_cost: 0.0,
                 invocation_count: 0,
+                nested_runs: Vec::new(),
             })),
         }
     }
@@ -194,6 +216,7 @@ impl HierarchicalEngine {
             total_tokens_out: state.total_tokens_out,
             total_cost: state.total_cost,
             invocation_count: state.invocation_count,
+            nested_runs: std::mem::take(&mut state.nested_runs),
         })
     }
 }
@@ -511,7 +534,7 @@ async fn run_nested_team(
 
     let routing_ctx = RoutingCtx::new(ctx.routing_rules.clone(), remaining_budget);
 
-    let sub_run_result: anyhow::Result<(String, u32, u32, f64)> = match nested {
+    let sub_run_result: anyhow::Result<(String, u32, u32, f64, NestedRun)> = match nested {
         NestedPattern::Blackboard => {
             let config = BlackboardConfig {
                 token_budget: remaining_budget,
@@ -553,7 +576,13 @@ async fn run_nested_team(
                         .map(|e| format!("[{}] {}", e.agent, e.content))
                         .collect::<Vec<_>>()
                         .join("\n");
-                    Ok((text, ti, to, cost))
+                    let nested_run = NestedRun::Blackboard {
+                        team_lead: team_lead.to_string(),
+                        task: task.to_string(),
+                        board,
+                        config,
+                    };
+                    Ok((text, ti, to, cost, nested_run))
                 }
                 Err(e) => Err(e),
             }
@@ -610,7 +639,13 @@ async fn run_nested_team(
                         },
                         _ => String::new(),
                     };
-                    Ok((text, ti, to, cost))
+                    let nested_run = NestedRun::Ring {
+                        team_lead: team_lead.to_string(),
+                        task: task.to_string(),
+                        token,
+                        config,
+                    };
+                    Ok((text, ti, to, cost, nested_run))
                 }
                 Err(e) => Err(e),
             }
@@ -622,9 +657,10 @@ async fn run_nested_team(
     ctx.sink.emit(&RunEvent::NestedEnd {
         team_lead: team_lead.to_string(),
     });
-    let (outcome_text, folded_in, folded_out, folded_cost) = sub_run_result?;
+    let (outcome_text, folded_in, folded_out, folded_cost, nested_run) = sub_run_result?;
 
-    // Fold the sub-run's metrics into the shared hierarchical state.
+    // Fold the sub-run's metrics into the shared hierarchical state, then
+    // surface the sub-run itself for downstream persistence.
     {
         let mut s = state.lock().unwrap_or_else(|e| {
             tracing::warn!("Mutex poisoned folding nested metrics: {:?}", e);
@@ -634,6 +670,7 @@ async fn run_nested_team(
         s.total_tokens_out += folded_out;
         s.total_cost += folded_cost;
         s.invocation_count += agent_names.len() as u32;
+        s.nested_runs.push(nested_run);
     }
 
     // Lead arbitrates the aggregated outcome (may accept/refine/override).
@@ -1912,6 +1949,7 @@ mod tests {
             total_tokens_out: 0,
             total_cost: 0.0,
             invocation_count: 0,
+            nested_runs: Vec::new(),
         }));
 
         let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
@@ -2173,6 +2211,59 @@ mod tests {
             result.total_tokens_in,
             result.total_tokens_out
         );
+    }
+
+    #[tokio::test]
+    async fn test_nested_run_is_surfaced_in_result() {
+        let config = nested_blackboard_config();
+        let mut agents = HashMap::new();
+        agents.insert(
+            "coordinator".to_string(),
+            make_agent("coordinator", "Coordinate."),
+        );
+        agents.insert(
+            "research-lead".to_string(),
+            make_agent("research-lead", "Lead."),
+        );
+        agents.insert("searcher".to_string(), make_agent("searcher", "Search."));
+        agents.insert("analyst".to_string(), make_agent("analyst", "Analyze."));
+
+        let mut providers: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        providers.insert(
+            "coordinator".to_string(),
+            Arc::new(FixedProvider::new("@research-lead: analyze the topic")),
+        );
+        providers.insert(
+            "research-lead".to_string(),
+            Arc::new(FixedProvider::new("lead verdict")),
+        );
+        let board_action = "ACTION: FINDING\nCONFIDENCE: 0.9\nCONTENT: a finding";
+        providers.insert(
+            "searcher".to_string(),
+            Arc::new(FixedProvider::new(board_action)),
+        );
+        providers.insert(
+            "analyst".to_string(),
+            Arc::new(FixedProvider::new(board_action)),
+        );
+
+        let mut engine = HierarchicalEngine::new(config, agents, providers, Arc::new(NullSink));
+        let result = engine.run("Do research").await.unwrap();
+
+        assert_eq!(
+            result.nested_runs.len(),
+            1,
+            "one nested sub-run should be surfaced"
+        );
+        match &result.nested_runs[0] {
+            NestedRun::Blackboard {
+                team_lead, board, ..
+            } => {
+                assert_eq!(team_lead, "research-lead");
+                assert!(!board.entries().is_empty(), "board should have entries");
+            }
+            NestedRun::Ring { .. } => panic!("expected a blackboard nested run"),
+        }
     }
 
     #[tokio::test]

--- a/src/core/orchestration/mod.rs
+++ b/src/core/orchestration/mod.rs
@@ -151,7 +151,7 @@ fn default_vote_weight() -> f32 {
 /// Unified orchestration configuration (top-level `orchestration:` key in armadai.yaml).
 ///
 /// Combines PR #91 Blackboard/Ring parameters with Hierarchical topology.
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct OrchestrationConfig {
     /// Whether orchestration mode is active.
@@ -209,7 +209,7 @@ impl OrchestrationConfig {
 }
 
 /// A team definition within the hierarchical topology.
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TeamConfig {
     /// Optional sub-lead for this team. If absent, agents report
     /// directly to the coordinator.

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -473,7 +473,6 @@ pub fn get_ring_votes(db: &Database, run_id: &str) -> anyhow::Result<Vec<RingVot
 }
 
 /// Insert a delegation event.
-#[allow(dead_code)] // consumed by hierarchical persistence (Lot 2 Task 4)
 pub fn insert_delegation_event(db: &Database, record: DelegationEventRecord) -> anyhow::Result<()> {
     let conn = db
         .lock()

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -175,6 +175,7 @@ pub struct OrchestrationRunRecord {
     pub outcome_json: Option<String>,
     pub rounds: i64,
     pub halt_reason: Option<String>,
+    pub parent_run_id: Option<String>,
 }
 
 /// Record for a board entry.
@@ -216,6 +217,17 @@ pub struct RingVoteRecord {
     pub concerns: String,
 }
 
+/// Record for a hierarchical delegation event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationEventRecord {
+    pub run_id: String,
+    pub seq: i64,
+    pub from_agent: String,
+    pub to_agent: String,
+    pub message: String,
+    pub depth: i64,
+}
+
 /// Insert an orchestration run record (finished_at populated automatically).
 pub fn insert_orchestration_run(
     db: &Database,
@@ -225,15 +237,16 @@ pub fn insert_orchestration_run(
         .lock()
         .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
     conn.execute(
-        "INSERT INTO orchestration_runs (run_id, pattern, config_json, outcome_json, rounds, halt_reason, finished_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))",
+        "INSERT INTO orchestration_runs (run_id, pattern, config_json, outcome_json, rounds, halt_reason, parent_run_id, finished_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))",
         params![
             record.run_id,
             record.pattern,
             record.config_json,
             record.outcome_json,
             record.rounds,
-            record.halt_reason
+            record.halt_reason,
+            record.parent_run_id
         ],
     )?;
     Ok(())
@@ -318,7 +331,7 @@ pub fn get_orchestration_run(
         .lock()
         .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
     let mut stmt = conn.prepare(
-        "SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason
+        "SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason, parent_run_id
          FROM orchestration_runs WHERE run_id = ?1",
     )?;
     let mut rows = stmt.query_map(params![run_id], |row| {
@@ -329,6 +342,7 @@ pub fn get_orchestration_run(
             outcome_json: row.get(3)?,
             rounds: row.get(4)?,
             halt_reason: row.get(5)?,
+            parent_run_id: row.get(6)?,
         })
     })?;
     match rows.next() {
@@ -347,7 +361,7 @@ pub fn get_orchestration_runs(
         .lock()
         .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
     let mut stmt = conn.prepare(
-        "SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason
+        "SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason, parent_run_id
          FROM orchestration_runs ORDER BY created_at DESC LIMIT ?1",
     )?;
     let rows = stmt.query_map(params![limit], |row| {
@@ -358,6 +372,7 @@ pub fn get_orchestration_runs(
             outcome_json: row.get(3)?,
             rounds: row.get(4)?,
             halt_reason: row.get(5)?,
+            parent_run_id: row.get(6)?,
         })
     })?;
     let mut records = Vec::new();
@@ -457,6 +472,88 @@ pub fn get_ring_votes(db: &Database, run_id: &str) -> anyhow::Result<Vec<RingVot
     Ok(records)
 }
 
+/// Insert a delegation event.
+#[allow(dead_code)] // consumed by hierarchical persistence (Lot 2 Task 4)
+pub fn insert_delegation_event(db: &Database, record: DelegationEventRecord) -> anyhow::Result<()> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+    conn.execute(
+        "INSERT INTO delegation_events (run_id, seq, from_agent, to_agent, message, depth)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            record.run_id,
+            record.seq,
+            record.from_agent,
+            record.to_agent,
+            record.message,
+            record.depth
+        ],
+    )?;
+    Ok(())
+}
+
+/// Get delegation events for a run, ordered by sequence.
+#[allow(dead_code)] // consumed by web/TUI trace UI (Lot 3)
+pub fn get_delegation_events(
+    db: &Database,
+    run_id: &str,
+) -> anyhow::Result<Vec<DelegationEventRecord>> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+    let mut stmt = conn.prepare(
+        "SELECT run_id, seq, from_agent, to_agent, message, depth
+         FROM delegation_events WHERE run_id = ?1 ORDER BY seq ASC",
+    )?;
+    let rows = stmt.query_map(params![run_id], |row| {
+        Ok(DelegationEventRecord {
+            run_id: row.get(0)?,
+            seq: row.get(1)?,
+            from_agent: row.get(2)?,
+            to_agent: row.get(3)?,
+            message: row.get(4)?,
+            depth: row.get(5)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// Get the child orchestration runs of a parent (nested sub-runs).
+#[allow(dead_code)] // consumed by web/TUI trace UI (Lot 3)
+pub fn get_child_orchestration_runs(
+    db: &Database,
+    parent_run_id: &str,
+) -> anyhow::Result<Vec<OrchestrationRunRecord>> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+    let mut stmt = conn.prepare(
+        "SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason, parent_run_id
+         FROM orchestration_runs WHERE parent_run_id = ?1 ORDER BY created_at ASC",
+    )?;
+    let rows = stmt.query_map(params![parent_run_id], |row| {
+        Ok(OrchestrationRunRecord {
+            run_id: row.get(0)?,
+            pattern: row.get(1)?,
+            config_json: row.get(2)?,
+            outcome_json: row.get(3)?,
+            rounds: row.get(4)?,
+            halt_reason: row.get(5)?,
+            parent_run_id: row.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,6 +623,7 @@ mod tests {
             outcome_json: Some(r#"{"state":"halted"}"#.to_string()),
             rounds: 3,
             halt_reason: Some("consensus".to_string()),
+            parent_run_id: None,
         };
         insert_orchestration_run(&db, orch).unwrap();
 
@@ -556,6 +654,7 @@ mod tests {
                 outcome_json: None,
                 rounds: 1,
                 halt_reason: None,
+                parent_run_id: None,
             },
         )
         .unwrap();
@@ -617,6 +716,7 @@ mod tests {
                 outcome_json: None,
                 rounds: 1,
                 halt_reason: None,
+                parent_run_id: None,
             },
         )
         .unwrap();
@@ -662,6 +762,7 @@ mod tests {
                 outcome_json: None,
                 rounds: 2,
                 halt_reason: None,
+                parent_run_id: None,
             },
         )
         .unwrap();
@@ -722,5 +823,120 @@ mod tests {
         let db = init_embedded().unwrap();
         let votes = get_ring_votes(&db, "nonexistent").unwrap();
         assert!(votes.is_empty());
+    }
+
+    #[test]
+    fn test_orchestration_run_parent_and_children() {
+        let db = init_embedded().unwrap();
+        // parent hierarchical run
+        insert_run(&db, sample_run("coord", 0.0)).unwrap();
+        let parent_id = {
+            let conn = db.lock().unwrap();
+            conn.query_row("SELECT id FROM runs LIMIT 1", [], |r| r.get::<_, String>(0))
+                .unwrap()
+        };
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: parent_id.clone(),
+                pattern: "hierarchical".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 0,
+                halt_reason: None,
+                parent_run_id: None,
+            },
+        )
+        .unwrap();
+        // child blackboard run linked to the parent
+        insert_run(&db, sample_run("searcher", 0.0)).unwrap();
+        let child_id = {
+            let conn = db.lock().unwrap();
+            conn.query_row(
+                "SELECT id FROM runs WHERE agent='searcher' LIMIT 1",
+                [],
+                |r| r.get::<_, String>(0),
+            )
+            .unwrap()
+        };
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: child_id.clone(),
+                pattern: "blackboard".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 2,
+                halt_reason: None,
+                parent_run_id: Some(parent_id.clone()),
+            },
+        )
+        .unwrap();
+
+        let got = get_orchestration_run(&db, &parent_id).unwrap().unwrap();
+        assert_eq!(got.parent_run_id, None);
+        let children = get_child_orchestration_runs(&db, &parent_id).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].run_id, child_id);
+        assert_eq!(
+            children[0].parent_run_id.as_deref(),
+            Some(parent_id.as_str())
+        );
+    }
+
+    #[test]
+    fn test_delegation_events_roundtrip() {
+        let db = init_embedded().unwrap();
+        insert_run(&db, sample_run("coord", 0.0)).unwrap();
+        let run_id = {
+            let conn = db.lock().unwrap();
+            conn.query_row("SELECT id FROM runs LIMIT 1", [], |r| r.get::<_, String>(0))
+                .unwrap()
+        };
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: run_id.clone(),
+                pattern: "hierarchical".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 0,
+                halt_reason: None,
+                parent_run_id: None,
+            },
+        )
+        .unwrap();
+        insert_delegation_event(
+            &db,
+            DelegationEventRecord {
+                run_id: run_id.clone(),
+                seq: 1,
+                from_agent: "coord".into(),
+                to_agent: "lead".into(),
+                message: "do X".into(),
+                depth: 1,
+            },
+        )
+        .unwrap();
+        insert_delegation_event(
+            &db,
+            DelegationEventRecord {
+                run_id: run_id.clone(),
+                seq: 0,
+                from_agent: "user".into(),
+                to_agent: "coord".into(),
+                message: "start".into(),
+                depth: 0,
+            },
+        )
+        .unwrap();
+
+        let events = get_delegation_events(&db, &run_id).unwrap();
+        assert_eq!(events.len(), 2);
+        // ordered by seq ascending
+        assert_eq!(events[0].seq, 0);
+        assert_eq!(events[0].to_agent, "coord");
+        assert_eq!(events[1].seq, 1);
+        assert_eq!(events[1].to_agent, "lead");
     }
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -6,10 +6,12 @@ pub const SCHEMA_VERSION: i64 = 1;
 
 /// Apply the database schema: create base tables (target schema) then run migrations.
 pub fn apply(conn: &Connection) -> anyhow::Result<()> {
-    // NOTE: PRAGMA foreign_keys is intentionally omitted here.  The FK
-    // constraints in the schema below exist for documentation and external
-    // tooling only; enforcing them globally could break existing code paths
-    // that insert into `runs` without a matching orchestration record.
+    // NOTE: SQLite foreign keys ARE enforced by default in this build
+    // (`PRAGMA foreign_keys` is ON). `migrate_to_v1` below temporarily
+    // disables enforcement around its `orchestration_runs` table rebuild
+    // (DROP + RENAME), since child rows in `board_entries`,
+    // `ring_contributions`, and `ring_votes` reference `orchestration_runs`
+    // and would otherwise trip a FOREIGN KEY constraint failure.
     //
     // Base tables. `orchestration_runs` here carries the v1 target schema
     // (relaxed CHECK + parent_run_id); an EXISTING pre-v1 database keeps its
@@ -141,6 +143,13 @@ fn migrate_to_v1(conn: &Connection) -> anyhow::Result<()> {
         |r| r.get::<_, i64>(0),
     )? > 0;
     if !has_parent {
+        // `PRAGMA foreign_keys` is a no-op inside a transaction; `apply()`
+        // runs no explicit transaction around this call, so toggling it here
+        // takes effect for the DROP/RENAME below. Without this, the DROP
+        // TABLE fails with SQLite error 787 (FOREIGN KEY constraint failed)
+        // whenever `board_entries`, `ring_contributions`, or `ring_votes`
+        // hold rows referencing `orchestration_runs`.
+        conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
         conn.execute_batch(
             "
             CREATE TABLE orchestration_runs_new (
@@ -163,6 +172,7 @@ fn migrate_to_v1(conn: &Connection) -> anyhow::Result<()> {
             CREATE INDEX IF NOT EXISTS idx_orch_parent ON orchestration_runs(parent_run_id);
             ",
         )?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
     }
     Ok(())
 }
@@ -252,6 +262,78 @@ mod tests {
         // hierarchical now accepted.
         conn.execute("INSERT INTO runs (id, agent, input, output, provider, model) VALUES ('h1','a','i','o','p','m')", []).unwrap();
         conn.execute("INSERT INTO orchestration_runs (run_id, pattern, config_json) VALUES ('h1','hierarchical','{}')", []).unwrap();
+    }
+
+    #[test]
+    fn legacy_db_with_child_rows_migrates() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Recreate the PRE-v1 schema (old CHECK, no parent_run_id), user_version 0,
+        // plus the legacy `board_entries` table (not created by the fixture above)
+        // with a row referencing `old1` via its FK on `orchestration_runs(run_id)`.
+        conn.execute_batch(
+            "
+            CREATE TABLE runs (id TEXT PRIMARY KEY, agent TEXT NOT NULL, input TEXT NOT NULL,
+                output TEXT NOT NULL, provider TEXT NOT NULL, model TEXT NOT NULL,
+                tokens_in INTEGER NOT NULL DEFAULT 0, tokens_out INTEGER NOT NULL DEFAULT 0,
+                cost REAL NOT NULL DEFAULT 0.0, duration_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'success', created_at TEXT NOT NULL DEFAULT (datetime('now')));
+            CREATE TABLE orchestration_runs (
+                run_id TEXT PRIMARY KEY REFERENCES runs(id),
+                pattern TEXT NOT NULL CHECK (pattern IN ('direct','blackboard','ring')),
+                config_json TEXT NOT NULL, outcome_json TEXT,
+                rounds INTEGER NOT NULL DEFAULT 0, halt_reason TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')), finished_at TEXT);
+            CREATE TABLE board_entries (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id      TEXT NOT NULL REFERENCES orchestration_runs(run_id),
+                agent       TEXT NOT NULL,
+                round       INTEGER NOT NULL,
+                kind        TEXT NOT NULL,
+                content     TEXT NOT NULL,
+                refs_json   TEXT NOT NULL DEFAULT '[]',
+                confidence  REAL NOT NULL DEFAULT 0.5,
+                tokens_in   INTEGER NOT NULL DEFAULT 0,
+                tokens_out  INTEGER NOT NULL DEFAULT 0,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO runs (id, agent, input, output, provider, model) VALUES ('old1','a','i','o','p','m');
+            INSERT INTO orchestration_runs (run_id, pattern, config_json, rounds) VALUES ('old1','blackboard','{}',3);
+            INSERT INTO board_entries (run_id, agent, round, kind, content) VALUES ('old1','a',1,'note','hello');
+            ",
+        )
+        .unwrap();
+        assert_eq!(user_version(&conn), 0);
+        assert!(!has_column(&conn, "orchestration_runs", "parent_run_id"));
+
+        // This is the assertion that fails without the FK-toggle fix: the
+        // table rebuild's DROP TABLE orchestration_runs trips SQLite error 787
+        // (FOREIGN KEY constraint failed) because `board_entries` still
+        // references 'old1'.
+        apply(&conn).unwrap();
+
+        assert_eq!(user_version(&conn), SCHEMA_VERSION);
+        assert!(has_column(&conn, "orchestration_runs", "parent_run_id"));
+
+        // Child row survived the rebuild (rowid-preserving INSERT...SELECT + RENAME).
+        let board_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM board_entries WHERE run_id = 'old1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(board_count, 1);
+
+        // Parent row survived too.
+        let (pat, rounds): (String, i64) = conn
+            .query_row(
+                "SELECT pattern, rounds FROM orchestration_runs WHERE run_id='old1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(pat, "blackboard");
+        assert_eq!(rounds, 3);
     }
 
     #[test]

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,11 +1,19 @@
 use rusqlite::Connection;
 
-/// Apply the database schema.
+/// Current schema version. Bumped whenever a migration is added.
+#[allow(dead_code)] // not yet consumed outside tests; will back future migration tooling (Lot 2+)
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// Apply the database schema: create base tables (target schema) then run migrations.
 pub fn apply(conn: &Connection) -> anyhow::Result<()> {
     // NOTE: PRAGMA foreign_keys is intentionally omitted here.  The FK
     // constraints in the schema below exist for documentation and external
     // tooling only; enforcing them globally could break existing code paths
     // that insert into `runs` without a matching orchestration record.
+    //
+    // Base tables. `orchestration_runs` here carries the v1 target schema
+    // (relaxed CHECK + parent_run_id); an EXISTING pre-v1 database keeps its
+    // old table (IF NOT EXISTS is a no-op) and is upgraded by `migrate`.
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS runs (
@@ -26,19 +34,18 @@ pub fn apply(conn: &Connection) -> anyhow::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_runs_agent ON runs(agent);
         CREATE INDEX IF NOT EXISTS idx_runs_created ON runs(created_at);
 
-        -- Orchestration runs (extends runs table)
         CREATE TABLE IF NOT EXISTS orchestration_runs (
-            run_id       TEXT PRIMARY KEY REFERENCES runs(id),
-            pattern      TEXT NOT NULL CHECK (pattern IN ('direct', 'blackboard', 'ring')),
-            config_json  TEXT NOT NULL,
-            outcome_json TEXT,
-            rounds       INTEGER NOT NULL DEFAULT 0,
-            halt_reason  TEXT,
-            created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-            finished_at  TEXT
+            run_id        TEXT PRIMARY KEY REFERENCES runs(id),
+            pattern       TEXT NOT NULL CHECK (pattern IN ('direct', 'blackboard', 'ring', 'hierarchical')),
+            config_json   TEXT NOT NULL,
+            outcome_json  TEXT,
+            rounds        INTEGER NOT NULL DEFAULT 0,
+            halt_reason   TEXT,
+            parent_run_id TEXT,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            finished_at   TEXT
         );
 
-        -- Blackboard entries
         CREATE TABLE IF NOT EXISTS board_entries (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id      TEXT NOT NULL REFERENCES orchestration_runs(run_id),
@@ -55,7 +62,6 @@ pub fn apply(conn: &Connection) -> anyhow::Result<()> {
 
         CREATE INDEX IF NOT EXISTS idx_board_entries_run ON board_entries(run_id, round);
 
-        -- Ring contributions
         CREATE TABLE IF NOT EXISTS ring_contributions (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id          TEXT NOT NULL REFERENCES orchestration_runs(run_id),
@@ -72,7 +78,6 @@ pub fn apply(conn: &Connection) -> anyhow::Result<()> {
 
         CREATE INDEX IF NOT EXISTS idx_ring_contributions_run ON ring_contributions(run_id, lap);
 
-        -- Ring votes
         CREATE TABLE IF NOT EXISTS ring_votes (
             run_id      TEXT NOT NULL REFERENCES orchestration_runs(run_id),
             agent       TEXT NOT NULL,
@@ -82,7 +87,178 @@ pub fn apply(conn: &Connection) -> anyhow::Result<()> {
             concerns    TEXT NOT NULL DEFAULT '[]',
             PRIMARY KEY (run_id, agent)
         );
+
+        CREATE TABLE IF NOT EXISTS delegation_events (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id     TEXT NOT NULL REFERENCES orchestration_runs(run_id),
+            seq        INTEGER NOT NULL,
+            from_agent TEXT NOT NULL,
+            to_agent   TEXT NOT NULL,
+            message    TEXT NOT NULL,
+            depth      INTEGER NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_delegation_events_run ON delegation_events(run_id, seq);
         ",
     )?;
+
+    migrate(conn)?;
+
+    // `idx_orch_parent` must be created only after the `parent_run_id` column
+    // is guaranteed to exist. For a fresh database it already does (base
+    // schema above); for a legacy database `migrate_to_v1` just added it via
+    // table rebuild. Creating it here (rather than in the base batch above)
+    // avoids referencing a column that doesn't exist yet on an un-migrated
+    // legacy `orchestration_runs` table (whose `CREATE TABLE IF NOT EXISTS`
+    // above is a no-op).
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_orch_parent ON orchestration_runs(parent_run_id);",
+    )?;
+
     Ok(())
+}
+
+/// Apply pending migrations based on `PRAGMA user_version`.
+fn migrate(conn: &Connection) -> anyhow::Result<()> {
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
+    if version < 1 {
+        migrate_to_v1(conn)?;
+        conn.execute_batch("PRAGMA user_version = 1;")?;
+    }
+    Ok(())
+}
+
+/// v0 → v1: relax the `orchestration_runs` CHECK and add `parent_run_id`.
+///
+/// SQLite cannot ALTER a CHECK constraint, so the table is rebuilt. A fresh
+/// database already has the v1 schema from `apply` (detected via the
+/// `parent_run_id` column), so the rebuild is skipped there.
+fn migrate_to_v1(conn: &Connection) -> anyhow::Result<()> {
+    let has_parent: bool = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('orchestration_runs') WHERE name = 'parent_run_id'",
+        [],
+        |r| r.get::<_, i64>(0),
+    )? > 0;
+    if !has_parent {
+        conn.execute_batch(
+            "
+            CREATE TABLE orchestration_runs_new (
+                run_id        TEXT PRIMARY KEY REFERENCES runs(id),
+                pattern       TEXT NOT NULL CHECK (pattern IN ('direct', 'blackboard', 'ring', 'hierarchical')),
+                config_json   TEXT NOT NULL,
+                outcome_json  TEXT,
+                rounds        INTEGER NOT NULL DEFAULT 0,
+                halt_reason   TEXT,
+                parent_run_id TEXT,
+                created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                finished_at   TEXT
+            );
+            INSERT INTO orchestration_runs_new
+                (run_id, pattern, config_json, outcome_json, rounds, halt_reason, created_at, finished_at)
+                SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason, created_at, finished_at
+                FROM orchestration_runs;
+            DROP TABLE orchestration_runs;
+            ALTER TABLE orchestration_runs_new RENAME TO orchestration_runs;
+            CREATE INDEX IF NOT EXISTS idx_orch_parent ON orchestration_runs(parent_run_id);
+            ",
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn user_version(conn: &Connection) -> i64 {
+        conn.query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap()
+    }
+    fn has_column(conn: &Connection, table: &str, col: &str) -> bool {
+        conn.query_row(
+            &format!("SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = ?1"),
+            [col],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+            > 0
+    }
+
+    #[test]
+    fn fresh_db_is_at_schema_version_and_has_new_columns() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply(&conn).unwrap();
+        assert_eq!(user_version(&conn), SCHEMA_VERSION);
+        assert!(has_column(&conn, "orchestration_runs", "parent_run_id"));
+        // delegation_events table exists
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='delegation_events'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1);
+        // hierarchical is now an accepted pattern (CHECK relaxed)
+        conn.execute("INSERT INTO runs (id, agent, input, output, provider, model) VALUES ('r1','a','i','o','p','m')", []).unwrap();
+        conn.execute(
+            "INSERT INTO orchestration_runs (run_id, pattern, config_json) VALUES ('r1','hierarchical','{}')",
+            [],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn legacy_db_migrates_without_data_loss() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Recreate the PRE-v1 schema (old CHECK, no parent_run_id), user_version 0.
+        conn.execute_batch(
+            "
+            CREATE TABLE runs (id TEXT PRIMARY KEY, agent TEXT NOT NULL, input TEXT NOT NULL,
+                output TEXT NOT NULL, provider TEXT NOT NULL, model TEXT NOT NULL,
+                tokens_in INTEGER NOT NULL DEFAULT 0, tokens_out INTEGER NOT NULL DEFAULT 0,
+                cost REAL NOT NULL DEFAULT 0.0, duration_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'success', created_at TEXT NOT NULL DEFAULT (datetime('now')));
+            CREATE TABLE orchestration_runs (
+                run_id TEXT PRIMARY KEY REFERENCES runs(id),
+                pattern TEXT NOT NULL CHECK (pattern IN ('direct','blackboard','ring')),
+                config_json TEXT NOT NULL, outcome_json TEXT,
+                rounds INTEGER NOT NULL DEFAULT 0, halt_reason TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')), finished_at TEXT);
+            INSERT INTO runs (id, agent, input, output, provider, model) VALUES ('old1','a','i','o','p','m');
+            INSERT INTO orchestration_runs (run_id, pattern, config_json, rounds) VALUES ('old1','blackboard','{}',3);
+            ",
+        )
+        .unwrap();
+        assert_eq!(user_version(&conn), 0);
+        assert!(!has_column(&conn, "orchestration_runs", "parent_run_id"));
+
+        apply(&conn).unwrap();
+
+        assert_eq!(user_version(&conn), SCHEMA_VERSION);
+        assert!(has_column(&conn, "orchestration_runs", "parent_run_id"));
+        // Existing row preserved.
+        let (pat, rounds): (String, i64) = conn
+            .query_row(
+                "SELECT pattern, rounds FROM orchestration_runs WHERE run_id='old1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(pat, "blackboard");
+        assert_eq!(rounds, 3);
+        // hierarchical now accepted.
+        conn.execute("INSERT INTO runs (id, agent, input, output, provider, model) VALUES ('h1','a','i','o','p','m')", []).unwrap();
+        conn.execute("INSERT INTO orchestration_runs (run_id, pattern, config_json) VALUES ('h1','hierarchical','{}')", []).unwrap();
+    }
+
+    #[test]
+    fn apply_is_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply(&conn).unwrap();
+        apply(&conn).unwrap(); // must not error or duplicate
+        assert_eq!(user_version(&conn), SCHEMA_VERSION);
+    }
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -916,6 +916,7 @@ mod tests {
                 outcome_json: Some("{\"status\":\"ok\"}".to_string()),
                 rounds: 3,
                 halt_reason: None,
+                parent_run_id: None,
             },
         )
         .unwrap();


### PR DESCRIPTION
## C9 Lot 2 — Storage (persistance hierarchical + sous-runs)

Deuxième tranche de **C9** : persistance complète des runs hierarchical et de leurs sous-runs blackboard/ring imbriqués (Lot 1), via un vrai mécanisme de migration SQLite.

### Contenu
- **Migration versionnée** (`schema.rs`) via `PRAGMA user_version` — la brique manquante (le schéma n'avait aucun versioning). Migration v1 : contrainte CHECK relâchée (`+ 'hierarchical'`), colonne `parent_run_id`, table `delegation_events`.
  - **Rétro-compat** : une base pré-v1 migre sans perte de données. FK **désactivées le temps du rebuild** (SQLite a les FK **ON** dans ce build → un `DROP TABLE` naïf cassait les lignes enfants), puis restaurées. Idempotent.
- **`queries.rs`** : `parent_run_id` sur `OrchestrationRunRecord` ; `DelegationEventRecord` + insert/get (tri `seq`) ; `get_child_orchestration_runs`.
- **Moteur** : `OrchestrationResult.nested_runs` expose les sous-runs (types core `Board`/`RingToken`), sans dépendance storage.
- **`cli/run.rs`** : `record_orchestration_hierarchical` persiste le run hierarchical + delegation events + chaque sous-run avec `parent_run_id`, en réutilisant les `record_*` existants (enrichis d'un `parent_run_id`).

### Hors périmètre
- Lot 3 : exposition C6 (web) + JSONL headless — ces sous-runs persistés seront alors affichés.

### Qualité
- Subagent-driven : revue de tâche à chaque étape + revue finale de branche indépendante.
- **La revue a capté un CRITIQUE** que la CI ratait : `PRAGMA foreign_keys = 1` dans ce build → le rebuild de migration échouait (erreur 787) sur toute base legacy avec historique → storage bloqué. Corrigé + test de non-régression vérifié en red/green.
- CI locale : clippy 4 modes (`tui`, `tui,providers-api`, `tui,storage`, `tui,storage,providers-api`, `-D warnings`), `fmt`, 788 tests (`tui,storage`) + 237 orchestration, `cargo build --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)