### PR TITLE
feat(web): C9 Lot 3 — expose hierarchical traces (delegation tree + nested sub-runs)

### DIFF
--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -627,6 +627,7 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
         {
             let traces: Vec<serde_json::Value> = runs
                 .iter()
+                .filter(|r| r.parent_run_id.is_none())
                 .map(|r| {
                     serde_json::json!({
                         "id": r.run_id,
@@ -671,8 +672,71 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
     }))
 }
 
-/// Get orchestration run detail (board entries, ring contributions, ring votes)
-/// for a single run identified by `run_id`.
+/// Fetch the board entries, ring contributions, and ring votes for a single
+/// run, serialized to JSON. Shared between the main run and each of its
+/// nested children so their entries render identically.
+#[cfg(feature = "storage")]
+fn fetch_run_entries(
+    db: &crate::storage::Database,
+    run_id: &str,
+) -> (
+    Vec<serde_json::Value>,
+    Vec<serde_json::Value>,
+    Vec<serde_json::Value>,
+) {
+    use crate::storage::queries;
+
+    let board_entries = queries::get_board_entries(db, run_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|e| {
+            serde_json::json!({
+                "agent": e.agent,
+                "round": e.round,
+                "kind": e.kind,
+                "content": e.content,
+                "refs": e.refs_json,
+                "confidence": e.confidence,
+                "tokens_in": e.tokens_in,
+                "tokens_out": e.tokens_out,
+            })
+        })
+        .collect();
+    let ring_contributions = queries::get_ring_contributions(db, run_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| {
+            serde_json::json!({
+                "agent": c.agent,
+                "lap": c.lap,
+                "position_in_lap": c.position_in_lap,
+                "action": c.action,
+                "content": c.content,
+                "reactions": c.reactions_json,
+                "tokens_in": c.tokens_in,
+                "tokens_out": c.tokens_out,
+            })
+        })
+        .collect();
+    let ring_votes = queries::get_ring_votes(db, run_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|v| {
+            serde_json::json!({
+                "agent": v.agent,
+                "position": v.position,
+                "confidence": v.confidence,
+                "supports": v.supports,
+                "concerns": v.concerns,
+            })
+        })
+        .collect();
+    (board_entries, ring_contributions, ring_votes)
+}
+
+/// Get orchestration run detail (board entries, ring contributions, ring votes,
+/// delegation events, and nested children) for a single run identified by
+/// `run_id`.
 #[cfg(feature = "storage")]
 pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<serde_json::Value> {
     use crate::storage::{init_db, queries};
@@ -683,6 +747,8 @@ pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<
             "board_entries": [],
             "ring_contributions": [],
             "ring_votes": [],
+            "delegation_events": [],
+            "children": [],
         })
     };
 
@@ -702,53 +768,44 @@ pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<
                 "outcome": r.outcome_json,
                 "rounds": r.rounds,
                 "halt_reason": r.halt_reason,
+                "parent_run_id": r.parent_run_id,
             })
         });
 
-    let board_entries: Vec<serde_json::Value> = queries::get_board_entries(&db, &run_id)
+    let (board_entries, ring_contributions, ring_votes) = fetch_run_entries(&db, &run_id);
+
+    let delegation_events: Vec<serde_json::Value> = queries::get_delegation_events(&db, &run_id)
         .unwrap_or_default()
         .into_iter()
         .map(|e| {
             serde_json::json!({
-                "agent": e.agent,
-                "round": e.round,
-                "kind": e.kind,
-                "content": e.content,
-                "refs": e.refs_json,
-                "confidence": e.confidence,
-                "tokens_in": e.tokens_in,
-                "tokens_out": e.tokens_out,
+                "seq": e.seq,
+                "from": e.from_agent,
+                "to": e.to_agent,
+                "message": e.message,
+                "depth": e.depth,
             })
         })
         .collect();
 
-    let ring_contributions: Vec<serde_json::Value> = queries::get_ring_contributions(&db, &run_id)
+    let children: Vec<serde_json::Value> = queries::get_child_orchestration_runs(&db, &run_id)
         .unwrap_or_default()
         .into_iter()
         .map(|c| {
+            let (cb, cc, cv) = fetch_run_entries(&db, &c.run_id);
             serde_json::json!({
-                "agent": c.agent,
-                "lap": c.lap,
-                "position_in_lap": c.position_in_lap,
-                "action": c.action,
-                "content": c.content,
-                "reactions": c.reactions_json,
-                "tokens_in": c.tokens_in,
-                "tokens_out": c.tokens_out,
-            })
-        })
-        .collect();
-
-    let ring_votes: Vec<serde_json::Value> = queries::get_ring_votes(&db, &run_id)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|v| {
-            serde_json::json!({
-                "agent": v.agent,
-                "position": v.position,
-                "confidence": v.confidence,
-                "supports": v.supports,
-                "concerns": v.concerns,
+                "run": {
+                    "id": c.run_id,
+                    "pattern": c.pattern,
+                    "config": c.config_json,
+                    "outcome": c.outcome_json,
+                    "rounds": c.rounds,
+                    "halt_reason": c.halt_reason,
+                    "parent_run_id": c.parent_run_id,
+                },
+                "board_entries": cb,
+                "ring_contributions": cc,
+                "ring_votes": cv,
             })
         })
         .collect();
@@ -758,6 +815,8 @@ pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<
         "board_entries": board_entries,
         "ring_contributions": ring_contributions,
         "ring_votes": ring_votes,
+        "delegation_events": delegation_events,
+        "children": children,
     }))
 }
 
@@ -771,6 +830,8 @@ pub async fn get_orchestration_trace_detail(
         "board_entries": [],
         "ring_contributions": [],
         "ring_votes": [],
+        "delegation_events": [],
+        "children": [],
     }))
 }
 
@@ -831,8 +892,9 @@ mod tests {
     use super::*;
     use crate::core::config::ENV_MUTEX;
     use crate::storage::queries::{
-        BoardEntryRecord, OrchestrationRunRecord, RingVoteRecord, RunRecord, insert_board_entry,
-        insert_orchestration_run, insert_ring_vote, insert_run_with_id,
+        BoardEntryRecord, DelegationEventRecord, OrchestrationRunRecord, RingVoteRecord, RunRecord,
+        insert_board_entry, insert_delegation_event, insert_orchestration_run, insert_ring_vote,
+        insert_run_with_id,
     };
 
     /// Guard that points `ARMADAI_CONFIG_DIR` at a fresh temp dir with a
@@ -988,5 +1050,125 @@ mod tests {
         assert!(value["board_entries"].as_array().unwrap().is_empty());
         assert!(value["ring_contributions"].as_array().unwrap().is_empty());
         assert!(value["ring_votes"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trace_detail_hierarchical_has_delegation_events_and_children() {
+        let _guard = TempStorageGuard::new();
+        let db = crate::storage::init_db().unwrap();
+
+        // Parent hierarchical run.
+        insert_run_with_id(
+            &db,
+            "h-1",
+            RunRecord {
+                agent: "coordinator".to_string(),
+                input: "go".to_string(),
+                output: "done".to_string(),
+                provider: "orchestration".to_string(),
+                model: String::new(),
+                tokens_in: 10,
+                tokens_out: 20,
+                cost: 0.0,
+                duration_ms: 0,
+                status: "success".to_string(),
+            },
+        )
+        .unwrap();
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: "h-1".to_string(),
+                pattern: "hierarchical".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 2,
+                halt_reason: None,
+                parent_run_id: None,
+            },
+        )
+        .unwrap();
+        insert_delegation_event(
+            &db,
+            DelegationEventRecord {
+                run_id: "h-1".to_string(),
+                seq: 0,
+                from_agent: "coordinator".to_string(),
+                to_agent: "research-lead".to_string(),
+                message: "analyze".to_string(),
+                depth: 1,
+            },
+        )
+        .unwrap();
+
+        // Nested child blackboard run linked to the parent.
+        insert_run_with_id(
+            &db,
+            "c-1",
+            RunRecord {
+                agent: "orchestration:blackboard".to_string(),
+                input: "analyze".to_string(),
+                output: "x".to_string(),
+                provider: "orchestration".to_string(),
+                model: String::new(),
+                tokens_in: 5,
+                tokens_out: 5,
+                cost: 0.0,
+                duration_ms: 0,
+                status: "success".to_string(),
+            },
+        )
+        .unwrap();
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: "c-1".to_string(),
+                pattern: "blackboard".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 1,
+                halt_reason: None,
+                parent_run_id: Some("h-1".to_string()),
+            },
+        )
+        .unwrap();
+        insert_board_entry(
+            &db,
+            BoardEntryRecord {
+                run_id: "c-1".to_string(),
+                agent: "searcher".to_string(),
+                round: 1,
+                kind: "finding".to_string(),
+                content: "a finding".to_string(),
+                refs_json: "[]".to_string(),
+                confidence: 0.9,
+                tokens_in: 5,
+                tokens_out: 5,
+            },
+        )
+        .unwrap();
+
+        drop(db);
+
+        // Detail of the hierarchical run.
+        let response = get_orchestration_trace_detail(Path("h-1".to_string())).await;
+        let v = response.0;
+        assert_eq!(v["run"]["pattern"], "hierarchical");
+        let events = v["delegation_events"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["to"], "research-lead");
+        let children = v["children"].as_array().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0]["run"]["pattern"], "blackboard");
+        assert_eq!(children[0]["board_entries"].as_array().unwrap().len(), 1);
+
+        // The list shows only the root (the nested child is hidden).
+        let list = get_orchestration_trace().await.0;
+        let traces = list["traces"].as_array().unwrap();
+        assert!(traces.iter().any(|t| t["id"] == "h-1"));
+        assert!(
+            !traces.iter().any(|t| t["id"] == "c-1"),
+            "nested child must not appear in the list"
+        );
     }
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1006,6 +1006,28 @@ function generateTraceTimeline(boardEntries, ringContributions, ringVotes) {
     </table>`;
 }
 
+// Build a mermaid flowchart of the hierarchical delegation tree from events.
+function generateDelegationDiagram(delegationEvents) {
+  const lines = ['flowchart TD'];
+  const seenNode = new Set();
+  const node = (name) => {
+    const id = mermaidSanitizeId(name);
+    if (!seenNode.has(id)) {
+      seenNode.add(id);
+      const label = mermaidEscapeLabel(String(name == null ? 'unknown' : name), 30) || id;
+      lines.push(`${id}["${label}"]`);
+    }
+    return id;
+  };
+  (delegationEvents || []).forEach(ev => {
+    const from = node(ev.from);
+    const to = node(ev.to);
+    const label = mermaidEscapeLabel(ev.message || '', 40);
+    lines.push(label ? `${from}-->|${label}| ${to}` : `${from}--> ${to}`);
+  });
+  return lines.join('\n');
+}
+
 async function viewTraceRun(id) {
   const res = await fetch(`/api/orchestration/trace/${encodeURIComponent(id)}`);
   const d = await res.json();
@@ -1030,8 +1052,37 @@ async function viewTraceRun(id) {
   const hasEntries = boardEntries.length > 0 || ringContributions.length > 0;
   const outcomeObj = parseJsonSafe(run.outcome);
 
+  const delegationEvents = d.delegation_events || [];
+  const children = d.children || [];
+  const isHierarchical = (run.pattern === 'hierarchical') || delegationEvents.length > 0 || children.length > 0;
+
   let bodyHtml;
-  if (!hasEntries) {
+  if (isHierarchical) {
+    if (!delegationEvents.length && !children.length) {
+      bodyHtml = '<div class="empty">This hierarchical run recorded no delegations or nested sub-runs.</div>';
+    } else {
+      const tree = generateDelegationDiagram(delegationEvents);
+      const childSections = children.map((c, i) => {
+        const cRun = c.run || {};
+        const cBoard = c.board_entries || [];
+        const cContribs = c.ring_contributions || [];
+        const cVotes = c.ring_votes || [];
+        const cHasEntries = cBoard.length > 0 || cContribs.length > 0;
+        const inner = cHasEntries
+          ? `<div class="list-section"><h4>Sequence</h4><div class="mermaid">${escapeHtml(generateTraceSequenceDiagram(cBoard, cContribs, cVotes))}</div></div>
+             <div class="list-section"><h4>Timeline</h4>${generateTraceTimeline(cBoard, cContribs, cVotes)}</div>`
+          : '<div class="empty">No entries for this sub-run.</div>';
+        const lead = cRun.pattern || 'sub-run';
+        return `<details${i === 0 ? ' open' : ''}>
+          <summary>Nested ${escapeHtmlContent(lead)} — ${escapeHtmlContent(String(cRun.id || ''))}</summary>
+          ${inner}
+        </details>`;
+      }).join('');
+      bodyHtml = `
+        <div class="list-section"><h3>Delegation Tree</h3><div class="mermaid">${escapeHtml(tree)}</div></div>
+        <div class="list-section"><h3>Nested Sub-runs (${children.length})</h3>${childSections || '<div class="empty">None.</div>'}</div>`;
+    }
+  } else if (!hasEntries) {
     bodyHtml = '<div class="empty">This run has no recorded board/ring entries (direct pattern, or an empty trace).</div>';
   } else {
     const diagram = generateTraceSequenceDiagram(boardEntries, ringContributions, ringVotes);
@@ -1054,7 +1105,7 @@ async function viewTraceRun(id) {
       ${bodyHtml}
     </div>`;
 
-  if (hasEntries) mermaid.run();
+  if (hasEntries || isHierarchical) mermaid.run();
 }
 
 // Initial load

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -863,14 +863,15 @@ function mermaidSanitizeId(name) {
   return id;
 }
 
-// Escape a label so it can't break Mermaid sequenceDiagram syntax
-// (colons, semicolons, newlines, arrows, quotes) and truncate it.
+// Escape a label so it can't break Mermaid sequenceDiagram or flowchart
+// syntax (colons, semicolons, newlines, arrows, quotes, and the `|` that
+// delimits flowchart edge labels) and truncate it.
 function mermaidEscapeLabel(text, maxLen) {
   if (text == null) return '';
   let s = String(text)
     .replace(/\r?\n/g, ' ')
     .replace(/-{1,2}>{1,2}/g, '-')
-    .replace(/[:;"<>]/g, ',')
+    .replace(/[:;"<>|]/g, ',')
     .trim();
   if (maxLen && s.length > maxLen) s = s.slice(0, maxLen - 1) + '…';
   return s;


### PR DESCRIPTION
## C9 Lot 3 — Exposition (C6 web)

Dernière tranche de **C9** : les runs hierarchical persistés (Lot 2) sont affichés dans le trace UI web.

### Contenu
- **Backend** (`web/api.rs`) : `get_orchestration_trace_detail` enrichi de `parent_run_id`, `delegation_events` et `children` (sous-runs avec leurs board/ring entries, via un helper `fetch_run_entries` factorisé). La liste ne montre plus que les **runs racines** (`parent_run_id IS NULL`) — les sous-runs apparaissent dans le détail du parent.
- **Frontend** (`index.html`) : un run hierarchical affiche un **arbre de délégation** (mermaid) + ses **sous-runs dépliables** (`<details>`), chacun réutilisant le rendu séquence/timeline existant. Le rendu blackboard/ring existant est inchangé (byte-identique).
- Robustesse : `mermaidEscapeLabel` filtre désormais aussi le `|` (un message de délégation avec `|` ne peut plus casser un edge de flowchart).

### JSONL headless (§7)
Aucun code : les événements `NestedStart`/`NestedEnd` traversent déjà le sink partagé (Lot 1) et sont couverts par les tests moteur.

### C9 complet
Lot 1 (moteur #183) + Lot 2 (storage #184) + Lot 3 (exposition, cette PR) = pattern mixing de bout en bout : config → exécution imbriquée + arbitrage → persistance → visualisation web + JSONL.

### Qualité
- Subagent-driven : revue de tâche + revue finale de branche indépendante (a confirmé l'absence de régression du rendu existant et l'échappement anti-injection).
- CI locale : clippy (`tui`, `tui,providers-api`, `tui,web,storage`, `-D warnings`), `fmt`, tests `api::`, `cargo build --release`.

### Limitation connue (différée)
`get_orchestration_trace` applique `LIMIT 50` avant le filtre racines → à fort volume la liste peut montrer <50 racines. Dette C6 de pagination, à corriger ultérieurement (filtre racines poussé en SQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)