### PR TITLE
feat(orchestration): C8 Lot A — deterministic agent routing core

### DIFF
--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -67,6 +67,11 @@ pub enum RunEvent {
     NestedEnd {
         team_lead: String,
     },
+    #[allow(dead_code)] // constructed by the CLI wiring in C8 Lot B (--route/--tags)
+    AgentSelect {
+        selected: Vec<String>,
+        reason: String,
+    },
 }
 
 /// Sink for run events. `NullSink` is a zero-cost no-op; `JsonlSink` writes JSONL to a writer.
@@ -287,6 +292,19 @@ mod tests {
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert_eq!(s, r#"{"t":"nested_end","team_lead":"research-lead"}"#);
+    }
+
+    #[test]
+    fn agent_select_serializes_with_short_keys() {
+        let ev = RunEvent::AgentSelect {
+            selected: vec!["rust-security".to_string(), "qa-specialist".to_string()],
+            reason: "route 'security-audit' → 2 agents".to_string(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            s,
+            r#"{"t":"agent_select","selected":["rust-security","qa-specialist"],"reason":"route 'security-audit' → 2 agents"}"#
+        );
     }
 
     // Test helper: a Write that appends to a shared buffer.

--- a/src/core/orchestration/agent_selection.rs
+++ b/src/core/orchestration/agent_selection.rs
@@ -1,0 +1,224 @@
+//! C8 — deterministic declarative agent selection (named routes + capability tags).
+
+use std::collections::{BTreeMap, HashMap};
+
+/// Result of an agent selection.
+#[derive(Debug, Clone)]
+pub struct AgentSelection {
+    pub agents: Vec<String>,
+    pub reason: String,
+}
+
+/// Error selecting agents.
+#[derive(Debug, thiserror::Error)]
+pub enum SelectionError {
+    #[error("unknown route '{name}' (known routes: {})", known.join(", "))]
+    UnknownRoute { name: String, known: Vec<String> },
+    #[error("no agent matches tags [{}] in roster [{}]", tags.join(", "), roster.join(", "))]
+    NoMatch {
+        tags: Vec<String>,
+        roster: Vec<String>,
+    },
+}
+
+/// True if `agent_tags` (already lowercased-comparable) intersects `wanted`,
+/// case-insensitively.
+fn tags_intersect(agent_tags: &[String], wanted: &[String]) -> bool {
+    wanted.iter().any(|w| {
+        let wl = w.to_lowercase();
+        agent_tags.iter().any(|t| t.to_lowercase() == wl)
+    })
+}
+
+/// Select the participating agents deterministically.
+///
+/// - neither `route` nor `tags` → full `roster`.
+/// - `route` only → the route's agent list (`UnknownRoute` if absent).
+/// - `tags` only → `roster` filtered by tag intersection (`NoMatch` if empty).
+/// - `route` + `tags` → the route's list is the candidate pool, filtered by
+///   tags (`NoMatch` if empty).
+///
+/// `agent_tags` maps an agent name to its (tags ∪ stacks). Deterministic:
+/// order follows the input (`roster` order for tag filtering, route order for
+/// route selection). No I/O.
+pub fn select_agents(
+    roster: &[String],
+    route: Option<&str>,
+    tags: &[String],
+    routes: &BTreeMap<String, Vec<String>>,
+    agent_tags: &HashMap<String, Vec<String>>,
+) -> Result<AgentSelection, SelectionError> {
+    let empty: Vec<String> = Vec::new();
+
+    // Resolve the candidate pool (route list, or the roster).
+    let (pool, via_route): (Vec<String>, Option<String>) = match route {
+        Some(name) => match routes.get(name) {
+            Some(list) => (list.clone(), Some(name.to_string())),
+            None => {
+                return Err(SelectionError::UnknownRoute {
+                    name: name.to_string(),
+                    known: routes.keys().cloned().collect(),
+                });
+            }
+        },
+        None => (roster.to_vec(), None),
+    };
+
+    // Filter the pool by tags if any were requested.
+    if tags.is_empty() {
+        let reason = match &via_route {
+            Some(r) => format!("route '{r}' → {} agent(s)", pool.len()),
+            None => format!("no routing (full roster, {} agent(s))", pool.len()),
+        };
+        return Ok(AgentSelection {
+            agents: pool,
+            reason,
+        });
+    }
+
+    let filtered: Vec<String> = pool
+        .iter()
+        .filter(|name| {
+            let t = agent_tags.get(*name).unwrap_or(&empty);
+            tags_intersect(t, tags)
+        })
+        .cloned()
+        .collect();
+
+    if filtered.is_empty() {
+        return Err(SelectionError::NoMatch {
+            tags: tags.to_vec(),
+            roster: pool,
+        });
+    }
+
+    let reason = match &via_route {
+        Some(r) => format!(
+            "route '{r}' + tags [{}] → {}/{} agent(s)",
+            tags.join(", "),
+            filtered.len(),
+            pool.len()
+        ),
+        None => format!(
+            "tags [{}] matched {}/{} roster agent(s)",
+            tags.join(", "),
+            filtered.len(),
+            pool.len()
+        ),
+    };
+    Ok(AgentSelection {
+        agents: filtered,
+        reason,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{BTreeMap, HashMap};
+
+    fn routes() -> BTreeMap<String, Vec<String>> {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "security-audit".to_string(),
+            vec!["rust-security".to_string(), "qa".to_string()],
+        );
+        m
+    }
+    fn tags_map() -> HashMap<String, Vec<String>> {
+        let mut m = HashMap::new();
+        m.insert(
+            "rust-security".to_string(),
+            vec!["security".to_string(), "rust".to_string()],
+        );
+        m.insert("ui".to_string(), vec!["frontend".to_string()]);
+        m.insert("qa".to_string(), vec!["testing".to_string()]);
+        m
+    }
+
+    #[test]
+    fn no_selectors_returns_full_roster() {
+        let roster = vec!["rust-security".to_string(), "ui".to_string()];
+        let sel = select_agents(&roster, None, &[], &routes(), &tags_map()).unwrap();
+        assert_eq!(sel.agents, roster);
+    }
+
+    #[test]
+    fn route_only_returns_route_agents() {
+        let roster = vec!["ui".to_string()];
+        let sel =
+            select_agents(&roster, Some("security-audit"), &[], &routes(), &tags_map()).unwrap();
+        assert_eq!(
+            sel.agents,
+            vec!["rust-security".to_string(), "qa".to_string()]
+        );
+    }
+
+    #[test]
+    fn unknown_route_errors() {
+        let roster = vec!["ui".to_string()];
+        let err = select_agents(&roster, Some("nope"), &[], &routes(), &tags_map()).unwrap_err();
+        assert!(matches!(err, SelectionError::UnknownRoute { .. }));
+    }
+
+    #[test]
+    fn tags_only_filters_roster_case_insensitive() {
+        let roster = vec![
+            "rust-security".to_string(),
+            "ui".to_string(),
+            "qa".to_string(),
+        ];
+        let sel = select_agents(
+            &roster,
+            None,
+            &["Security".to_string()],
+            &routes(),
+            &tags_map(),
+        )
+        .unwrap();
+        assert_eq!(sel.agents, vec!["rust-security".to_string()]); // only rust-security has "security"
+    }
+
+    #[test]
+    fn tags_no_match_errors() {
+        let roster = vec!["ui".to_string()];
+        let err = select_agents(
+            &roster,
+            None,
+            &["security".to_string()],
+            &routes(),
+            &tags_map(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, SelectionError::NoMatch { .. }));
+    }
+
+    #[test]
+    fn route_then_tags_refines_within_pool() {
+        // pool = [rust-security, qa]; tags [security] keeps only rust-security.
+        let roster = vec!["ui".to_string()];
+        let sel = select_agents(
+            &roster,
+            Some("security-audit"),
+            &["security".to_string()],
+            &routes(),
+            &tags_map(),
+        )
+        .unwrap();
+        assert_eq!(sel.agents, vec!["rust-security".to_string()]);
+    }
+
+    #[test]
+    fn deterministic_same_input_same_output() {
+        let roster = vec![
+            "rust-security".to_string(),
+            "qa".to_string(),
+            "ui".to_string(),
+        ];
+        let a =
+            select_agents(&roster, None, &["rust".to_string()], &routes(), &tags_map()).unwrap();
+        let b =
+            select_agents(&roster, None, &["rust".to_string()], &routes(), &tags_map()).unwrap();
+        assert_eq!(a.agents, b.agents);
+    }
+}

--- a/src/core/orchestration/mod.rs
+++ b/src/core/orchestration/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! The `Auto` variant uses a classifier to pick the best pattern.
 
+pub mod agent_selection;
 pub mod blackboard;
 pub mod classifier;
 pub mod context_injection;

--- a/src/core/orchestration/mod.rs
+++ b/src/core/orchestration/mod.rs
@@ -167,6 +167,11 @@ pub struct OrchestrationConfig {
     /// Team topology (hierarchical only).
     pub teams: Vec<TeamConfig>,
 
+    /// C8: named agent routes (route name → agent names). Selected via
+    /// `--route <name>`. Empty = no routes configured.
+    #[serde(default)]
+    pub routes: std::collections::BTreeMap<String, Vec<String>>,
+
     // ── Shared limits (all patterns) ───────────────────────────
     /// Max delegation depth (default: 5).
     pub max_depth: Option<u32>,
@@ -637,6 +642,30 @@ consensus_threshold: 0.85
         assert_eq!(config.max_depth(), 5);
         assert_eq!(config.max_iterations(), 50);
         assert_eq!(config.timeout_secs(), 300);
+    }
+
+    #[test]
+    fn test_orchestration_config_deserializes_routes() {
+        let yaml = r#"
+enabled: true
+pattern: blackboard
+routes:
+  security-audit: [rust-security, rust-reviewer]
+  frontend: [ui-specialist]
+"#;
+        let config: OrchestrationConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(
+            config.routes.get("security-audit").unwrap(),
+            &vec!["rust-security".to_string(), "rust-reviewer".to_string()]
+        );
+        assert_eq!(config.routes.get("frontend").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_orchestration_config_routes_default_empty() {
+        let yaml = "enabled: true\npattern: blackboard\n";
+        let config: OrchestrationConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(config.routes.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## C8 Lot A — Cœur du routage déclaratif d'agents

Première tranche de **C8** : sélectionner de façon **déterministe et auditable** quels agents du roster participent à un run orchestré. Pas d'inférence floue depuis la prose — la clé est explicite (route nommée ou tags).

### Contenu
- **Config** : `orchestration.routes` (table `nom → [agents]`, `#[serde(default)]`).
- **`select_agents`** (pur, déterministe, `core/orchestration/agent_selection.rs`) : routes nommées + tags de capacité + précédence (route = vivier, tags = raffinement) + erreurs actionnables (`UnknownRoute`, `NoMatch`). Intersection de tags insensible à la casse.
- **Événement** `RunEvent::AgentSelect { selected, reason }` (JSONL `t:"agent_select"`) pour la transparence.

### Hors périmètre (Lot B)
Flags CLI `--route`/`--tags`/`--dry-run`, câblage dans `run_orchestrated`, garde-fou « blackboard/ring ≥2 agents », warning hierarchical.

### Qualité
Subagent-driven (revue de tâche + revue finale de branche indépendante : sémantique/déterminisme/pureté confirmés). Clippy 2 modes (`-D warnings`), fmt, 7 tests de sélection + non-régression orchestration/events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)