### PR TITLE
fix(tui,shell): UX audit — Shortlist A (safe consistency fixes)

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -31,6 +31,12 @@ pub mod pty_runner;
 #[cfg(feature = "tui")]
 pub mod workroom;
 
+/// Braille spinner frames shared by the shell TUI (`tui.rs`) and the
+/// workroom panel (`workroom.rs`) so the two animations stay in sync and
+/// the frame set is defined exactly once.
+#[cfg(feature = "tui")]
+pub const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 // Re-exported for external use when shell command is implemented
 #[allow(unused_imports)]
 pub use parser::{ParsedResponse, parse_response};

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthChar;
 
-const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+use super::SPINNER_FRAMES;
 
 /// A single message in the conversation
 #[derive(Debug, Clone)]

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -453,7 +453,7 @@ impl ShellApp {
                 KeyCode::PageDown => {
                     self.popup_scroll = self.popup_scroll.saturating_add(10);
                 }
-                _ => self.dismiss_popup(),
+                _ => {}
             }
             return false;
         }

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -316,7 +316,7 @@ impl ShellApp {
         self.pipeline_providers.take()
     }
 
-    /// Show a popup overlay (dismissed with Esc or any key)
+    /// Show a popup overlay (dismissed with Esc / q / Enter; other keys are ignored)
     pub fn show_popup(&mut self, content: String) {
         self.popup = Some(content);
         self.popup_scroll = 0;

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -423,11 +423,7 @@ impl Workroom {
                         Style::default().fg(Color::Yellow),
                     )
                 }
-                AgentState::Done => (
-                    "✓",
-                    "done".to_string(),
-                    Style::default().fg(Color::Green),
-                ),
+                AgentState::Done => ("✓", "done".to_string(), Style::default().fg(Color::Green)),
                 AgentState::Idle => (
                     "○",
                     "idle".to_string(),

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -12,6 +12,8 @@ use ratatui::{
 };
 use std::time::Instant;
 
+use super::SPINNER_FRAMES as SPINNER;
+
 /// Agent activity state
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentState {
@@ -48,8 +50,6 @@ pub enum AgentRole {
     Lead,
     Agent,
 }
-
-const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 /// The workroom tracks all agents and their states
 pub struct Workroom {

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -426,12 +426,12 @@ impl Workroom {
                 AgentState::Done => (
                     "✓",
                     "done".to_string(),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(Color::Green),
                 ),
                 AgentState::Idle => (
                     "○",
                     "idle".to_string(),
-                    Style::default().fg(Color::Rgb(60, 60, 60)),
+                    Style::default().fg(Color::DarkGray),
                 ),
             };
 

--- a/src/tui/format.rs
+++ b/src/tui/format.rs
@@ -1,0 +1,84 @@
+//! Shared numeric formatting helpers for the dashboard TUI.
+//!
+//! Centralizes cost and context-window formatting so every view (Costs,
+//! History, Models list, Model detail, ...) displays the same precision and
+//! unit conventions instead of ad-hoc `{:.N}` calls scattered across files.
+
+/// Format a cost value in USD with a fixed 4-decimal precision, e.g. `$0.0000`.
+pub fn format_cost(cost: f64) -> String {
+    format!("${cost:.4}")
+}
+
+/// Format a token-count / context-window size with a `K`/`M` suffix.
+///
+/// - Values under 1,000 are shown as-is (e.g. `999`).
+/// - Values under 1,000,000 are shown in thousands (e.g. `200000` -> `200K`).
+/// - Values at or above 1,000,000 are shown in millions (e.g. `1500000` -> `1.5M`).
+///
+/// Fractional K/M values keep a single decimal place; whole values drop it.
+pub fn format_context(value: u64) -> String {
+    const THOUSAND: u64 = 1_000;
+    const MILLION: u64 = 1_000_000;
+
+    if value < THOUSAND {
+        value.to_string()
+    } else if value < MILLION {
+        format_unit(value, THOUSAND, "K")
+    } else {
+        format_unit(value, MILLION, "M")
+    }
+}
+
+fn format_unit(value: u64, divisor: u64, suffix: &str) -> String {
+    let scaled = value as f64 / divisor as f64;
+    if scaled.fract() == 0.0 {
+        format!("{scaled:.0}{suffix}")
+    } else {
+        format!("{scaled:.1}{suffix}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_cost_zero() {
+        assert_eq!(format_cost(0.0), "$0.0000");
+    }
+
+    #[test]
+    fn format_cost_rounds_to_four_decimals() {
+        assert_eq!(format_cost(0.00005), "$0.0001");
+    }
+
+    #[test]
+    fn format_cost_typical_value() {
+        assert_eq!(format_cost(1.5), "$1.5000");
+    }
+
+    #[test]
+    fn format_context_below_thousand_is_raw() {
+        assert_eq!(format_context(999), "999");
+    }
+
+    #[test]
+    fn format_context_at_thousand_boundary() {
+        assert_eq!(format_context(1000), "1K");
+    }
+
+    #[test]
+    fn format_context_typical_k_value() {
+        assert_eq!(format_context(200_000), "200K");
+    }
+
+    #[test]
+    fn format_context_at_million_boundary() {
+        assert_eq!(format_context(1_500_000), "1.5M");
+    }
+
+    #[test]
+    fn format_context_fractional_million() {
+        assert_eq!(format_context(1_000_000), "1M");
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,6 @@
 mod app;
 pub mod filter;
+pub mod format;
 pub mod views;
 pub mod widgets;
 

--- a/src/tui/views/costs.rs
+++ b/src/tui/views/costs.rs
@@ -6,6 +6,7 @@ use ratatui::{
 };
 
 use crate::tui::app::App;
+use crate::tui::format::format_cost;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.costs.is_empty() {
@@ -35,7 +36,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             Row::new(vec![
                 c.agent.clone(),
                 c.total_runs.to_string(),
-                format!("${:.6}", c.total_cost),
+                format_cost(c.total_cost),
                 c.total_tokens_in.to_string(),
                 c.total_tokens_out.to_string(),
             ])
@@ -56,7 +57,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     .block(
         Block::default()
             .borders(Borders::ALL)
-            .title(format!(" Costs — total: ${total_cost:.4} ")),
+            .title(format!(" Costs — total: {} ", format_cost(total_cost))),
     );
 
     frame.render_widget(table, area);

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::tui::app::{App, Tab};
 use crate::tui::filter;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App) {
     let chunks = Layout::default()
@@ -149,21 +150,6 @@ fn render_agent_list(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) 
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: ratatui::layout::Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -8,6 +8,7 @@ use ratatui::{
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::format::format_cost;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.history.is_empty() {
@@ -98,21 +99,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -7,6 +7,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
+use crate::tui::format::format_cost;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.history.is_empty() {
@@ -63,7 +64,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 model_short,
                 r.tokens_in.to_string(),
                 r.tokens_out.to_string(),
-                format!("{:.4}", r.cost),
+                format_cost(r.cost),
                 r.duration_ms.to_string(),
                 r.status.clone(),
             ])

--- a/src/tui/views/model_detail.rs
+++ b/src/tui/views/model_detail.rs
@@ -7,6 +7,7 @@ use ratatui::{
 };
 
 use crate::tui::app::App;
+use crate::tui::format::format_context;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let (provider, entry) = match app.selected_model_entry() {
@@ -53,7 +54,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         .limit
         .as_ref()
         .and_then(|l| l.context)
-        .map(|c| format!("{}", c))
+        .map(format_context)
         .unwrap_or_else(|| "(unknown)".to_string());
     let max_output = entry
         .limit

--- a/src/tui/views/models_list.rs
+++ b/src/tui/views/models_list.rs
@@ -7,6 +7,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
+use crate::tui::format::{format_context, format_cost};
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.models_flat.is_empty() {
@@ -48,19 +49,19 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .limit
                 .as_ref()
                 .and_then(|l| l.context)
-                .map(|c| format!("{}K", c / 1000))
+                .map(format_context)
                 .unwrap_or_else(|| "-".to_string());
             let cost_in = entry
                 .cost
                 .as_ref()
                 .and_then(|c| c.input)
-                .map(|v| format!("${:.2}", v))
+                .map(format_cost)
                 .unwrap_or_else(|| "-".to_string());
             let cost_out = entry
                 .cost
                 .as_ref()
                 .and_then(|c| c.output)
-                .map(|v| format!("${:.2}", v))
+                .map(format_cost)
                 .unwrap_or_else(|| "-".to_string());
             let style = if display_i == app.selected_model {
                 Style::default()

--- a/src/tui/views/models_list.rs
+++ b/src/tui/views/models_list.rs
@@ -8,6 +8,7 @@ use ratatui::{
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::format::{format_context, format_cost};
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.models_flat.is_empty() {
@@ -115,21 +116,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }

--- a/src/tui/views/models_list.rs
+++ b/src/tui/views/models_list.rs
@@ -7,7 +7,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
-use crate::tui::format::{format_context, format_cost};
+use crate::tui::format::format_context;
 use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
@@ -52,17 +52,20 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .and_then(|l| l.context)
                 .map(format_context)
                 .unwrap_or_else(|| "-".to_string());
+            // Catalog prices are per-million-token rates (convention: 2dp,
+            // matching model_detail + model_registry::display_label). `format_cost`
+            // is for per-run costs only, not catalog pricing.
             let cost_in = entry
                 .cost
                 .as_ref()
                 .and_then(|c| c.input)
-                .map(format_cost)
+                .map(|v| format!("${v:.2}"))
                 .unwrap_or_else(|| "-".to_string());
             let cost_out = entry
                 .cost
                 .as_ref()
                 .and_then(|c| c.output)
-                .map(format_cost)
+                .map(|v| format!("${v:.2}"))
                 .unwrap_or_else(|| "-".to_string());
             let style = if display_i == app.selected_model {
                 Style::default()

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -9,6 +9,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.orchestration_runs.is_empty() {
@@ -101,23 +102,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }
 
 pub fn render_detail(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/tui/views/prompts_list.rs
+++ b/src/tui/views/prompts_list.rs
@@ -7,6 +7,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.prompts.is_empty() {
@@ -84,21 +85,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }

--- a/src/tui/views/skills_list.rs
+++ b/src/tui/views/skills_list.rs
@@ -7,6 +7,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.skills.is_empty() {
@@ -94,21 +95,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }

--- a/src/tui/views/starters_list.rs
+++ b/src/tui/views/starters_list.rs
@@ -7,6 +7,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 use crate::tui::filter;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.starters.is_empty() {
@@ -90,21 +91,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        render_search_bar(frame, app, area);
+        search_bar(frame, &app.search_query, area);
     }
-}
-
-fn render_search_bar(frame: &mut Frame, app: &App, list_area: Rect) {
-    let search_area = ratatui::layout::Rect {
-        x: list_area.x,
-        y: list_area.bottom() - 1,
-        width: list_area.width,
-        height: 1,
-    };
-
-    let query_display = format!("/ {}\u{2588}", app.search_query);
-    let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
-        .block(Block::default());
-    frame.render_widget(search, search_area);
 }

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -1,3 +1,6 @@
 pub mod agent_list;
 pub mod cost_chart;
 pub mod log_viewer;
+pub mod search_bar;
+
+pub use search_bar::search_bar;

--- a/src/tui/widgets/search_bar.rs
+++ b/src/tui/widgets/search_bar.rs
@@ -1,0 +1,29 @@
+//! Shared search-bar widget for list views (Agents, Prompts, Skills, Starters,
+//! History, Models, Orchestration).
+//!
+//! Renders the one-line `/ query█` filter indicator pinned to the bottom of a
+//! list panel. Extracted from the identical `render_search_bar` copy-pasted
+//! across every list view so appearance stays in sync by construction.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Paragraph},
+};
+
+/// Render the search/filter bar as the last line of `list_area`.
+pub fn search_bar(frame: &mut Frame, query: &str, list_area: Rect) {
+    let search_area = Rect {
+        x: list_area.x,
+        y: list_area.bottom() - 1,
+        width: list_area.width,
+        height: 1,
+    };
+
+    let query_display = format!("/ {query}\u{2588}");
+    let search = Paragraph::new(query_display)
+        .style(Style::default().fg(Color::Yellow))
+        .block(Block::default());
+    frame.render_widget(search, search_area);
+}


### PR DESCRIPTION
## UX audit — Shortlist A (fixes sûrs)

Fixes objectifs/à faible risque issus de l'audit UX transverse (`docs/proposals/ux-audit-tui-2026-07-20.md`).

### Contenu
- **P1-2** — la popup shell ignore désormais les touches inconnues (`_ => {}`) ; seules Esc/q/Enter la ferment (+ scroll). Fini la fermeture accidentelle.
- **P0-1** — couleurs Workroom lisibles : `idle` near-black `Rgb(60,60,60)` → `DarkGray` ; `done` `DarkGray` → `Green`. Icônes `○`/`✓` conservées.
- **P1-6** — helpers `format_cost`/`format_context` centralisés (`src/tui/format.rs`, 8 tests) : coûts de **run** uniformisés en `$0.0000`, fenêtre de contexte en `K`/`M`. Les **prix catalogue** (models_list/detail) restent en `$X.XX` (convention distincte — revue).
- **P2-1 / P2-2** — dédup : un seul widget `search_bar` (remplace 7 copies), une seule constante `SPINNER_FRAMES` partagée shell.

### ⚠️ Contient des changements VISUELS
Couleurs Workroom + formatage coût/contexte. **À valider en `armadai shell` / dashboard avant merge** (ne pas merger sans ton feu vert visuel).

### Hors périmètre (Shortlist B, à suivre)
theme.rs partagé + terminal clair, Esc sécurisé, drill-down Workroom, scroll vues détail, Costs aux conventions, barre raccourcis shell.

### Qualité
Revue indépendante (a corrigé l'application erronée de `format_cost` aux prix catalogue). Clippy 3 modes (`tui`, `tui,providers-api`, `tui,storage`, `-D warnings`), fmt, 819 tests, `cargo build --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)