### PR TITLE
fix(cli,shell): --dry-run without selectors + filter pseudo-agents from workroom

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -722,6 +722,7 @@ async fn run_orchestrated(
     // to before this change (AgentStart and AgentEnd/Result stay on the same
     // roster keys).
     let mut effective_names: Vec<String> = agent_names.to_vec();
+    let mut selection_reason: Option<String> = None;
     if routing_active && pattern == "hierarchical" {
         sink.emit(&RunEvent::Warning {
             code: "routing_ignored_hierarchical".to_string(),
@@ -742,6 +743,7 @@ async fn run_orchestrated(
         agents = sel_agents;
         providers = sel_providers;
         effective_names = sel_keys;
+        selection_reason = Some(selection.reason.clone());
 
         sink.emit(&RunEvent::AgentSelect {
             selected: selection.agents.clone(),
@@ -758,19 +760,24 @@ async fn run_orchestrated(
                 selection.reason
             );
         }
+    }
 
-        if dry_run {
-            eprintln!(
-                "[dry-run] pattern '{pattern}' — {} ({} agent(s)): {}",
-                selection.reason,
-                effective_names.len(),
-                effective_names.join(", ")
-            );
-            if !json {
-                println!("{}", effective_names.join("\n"));
-            }
-            return Ok(());
+    // --dry-run: resolve + print the selection WITHOUT executing. Works with
+    // OR without --route/--tags — a plain dry-run previews the full roster
+    // (this check lives OUTSIDE the routing block so it fires unconditionally).
+    if dry_run {
+        let reason = selection_reason
+            .as_deref()
+            .unwrap_or("no routing (full roster)");
+        eprintln!(
+            "[dry-run] pattern '{pattern}' — {reason} ({} agent(s)): {}",
+            effective_names.len(),
+            effective_names.join(", ")
+        );
+        if !json {
+            println!("{}", effective_names.join("\n"));
         }
+        return Ok(());
     }
 
     // Reflect the (possibly narrowed/reordered) selection in downstream events

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -174,16 +174,31 @@ impl Workroom {
     /// Set agents from the stream-json init event.
     /// Filters out Claude Code internal agents and deduplicates.
     pub fn set_agents_from_init(&mut self, agent_names: &[String]) {
+        // Claude Code built-in agents AND the underlying CLI/provider names
+        // (which leak into the init event's agent list) — none of these are
+        // real fleet members and must not appear in the Workroom.
         const INTERNAL_AGENTS: &[&str] = &[
             "general-purpose",
             "statusline-setup",
             "Explore",
             "Plan",
             "claude-code-guide",
+            // Provider CLI names that surface as a pseudo-agent in the stream.
+            "claude",
+            "gemini",
+            "copilot",
+            "cursor",
+            "aider",
+            "codex",
+            "windsurf",
+            "cline",
+            "opencode",
         ];
 
         for name in agent_names {
-            if INTERNAL_AGENTS.contains(&name.as_str()) {
+            // Case-insensitive so "Claude"/"claude" are both filtered.
+            let name_lc = name.to_lowercase();
+            if INTERNAL_AGENTS.iter().any(|i| i.to_lowercase() == name_lc) {
                 continue;
             }
             // Skip if already present — case-insensitive match
@@ -612,6 +627,32 @@ orchestration:
             "coordinator: dev-lead\nteams:\n  - agents:\n      - core-specialist\n",
         );
         wr
+    }
+
+    #[test]
+    fn test_set_agents_from_init_filters_cli_provider_names() {
+        let mut wr = Workroom::new();
+        wr.set_agents_from_init(&[
+            "core-specialist".to_string(),
+            "claude".to_string(), // CLI/provider pseudo-agent — must be filtered
+            "Claude".to_string(), // case-insensitive
+            "gemini".to_string(),
+            "general-purpose".to_string(), // built-in — filtered
+            "qa-specialist".to_string(),
+        ]);
+        let names: Vec<String> = wr
+            .agents_for_test()
+            .iter()
+            .map(|a| a.name.clone())
+            .collect();
+        assert!(names.contains(&"core-specialist".to_string()));
+        assert!(names.contains(&"qa-specialist".to_string()));
+        assert!(
+            !names.iter().any(|n| n.eq_ignore_ascii_case("claude")),
+            "claude leaked: {names:?}"
+        );
+        assert!(!names.contains(&"gemini".to_string()));
+        assert!(!names.contains(&"general-purpose".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Deux bugs trouvés au test manuel (rc.2 install locale)

### 1. `--dry-run` ne court-circuitait pas sans `--route`/`--tags`
Le bloc `if dry_run { … return }` était imbriqué sous `else if routing_active` → un `armadai run … --orchestrate blackboard --dry-run` **sans** sélecteur sautait le bloc et **exécutait** l'orchestration (`[blackboard] Starting …`). Fix : le `--dry-run` est sorti du bloc routing → il court-circuite **toujours** (aperçu du roster complet, ou de la sélection si `--route`/`--tags`). La raison de sélection est conservée quand un routage s'applique.

### 2. Agent parasite `claude` dans la Workroom
`set_agents_from_init` filtrait les agents internes Claude Code mais pas le **nom de la CLI/provider** → `claude` (et pairs) apparaissait comme faux agent. Fix : filtre étendu (claude/gemini/copilot/cursor/aider/codex/windsurf/cline/opencode), insensible à la casse. + test `test_set_agents_from_init_filters_cli_provider_names`.

### Vérifs
Clippy 2 modes (`-D warnings`), fmt, tests workroom (15). 

⚠️ **Note (pré-existant, non lié à cette PR)** : `linker::model_resolution::tests::test_preview_resolution_with_latest` et les tests `llm_agents` `latest:auto` sont **non-hermétiques** (dépendent du cache models.dev partagé) → flaky en local. À rendre hermétiques dans un suivi (dette notée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)