### PR TITLE
fix(shell): reset workroom at turn start (keep final states visible between turns)

### DIFF
--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -430,6 +430,11 @@ async fn event_loop(
 
         app.add_user_message(&input);
 
+        // Reset the workroom at the START of a new turn (not the end), so the
+        // previous turn's final agent states (Done / who participated) stay
+        // visible between turns instead of snapping back to idle immediately.
+        app.workroom.reset();
+
         // PTY mode execution
         if app.is_pty_mode() {
             execute_pty_turn(
@@ -738,8 +743,9 @@ async fn event_loop(
                 break;
             }
         }
-        // Reset workroom for next turn
-        app.workroom.reset();
+        // NOTE: the workroom is reset at the START of the next turn (see
+        // `add_user_message` above), so the final Done states remain visible
+        // between turns rather than being wiped here.
     }
     Ok(())
 }


### PR DESCRIPTION
## Workroom : garder la trace entre les tours

**Bug (test manuel)** : après un tour de délégation, la Workroom retombait **toute en `idle`** — on perdait qui avait travaillé/fini. Cause : `reset()` était appelé en **fin de tour**, juste après `on_complete()` (qui pose `Done`) → les états `Done` étaient effacés immédiatement.

**Fix** : `reset()` déplacé au **début du tour suivant** (après `add_user_message`, avant tout branchement pty/tandem/pipeline/normal). Les états finaux (`Done` / qui a participé) restent donc visibles jusqu'à ce que l'utilisateur envoie un nouveau message.

Changement minimal (2 lignes déplacées), non-visuel en logique mais **effet visuel** → à valider en `armadai shell`.

Clippy 2 modes (`-D warnings`), fmt, build release OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)