### PR TITLE
feat(shell): Workroom drill-down (Ctrl+W focus + agent detail popup)

### DIFF
--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -257,6 +257,12 @@ async fn event_loop(
             break;
         }
 
+        // While the workroom has drill-down focus, Enter is consumed by
+        // handle_key to open the agent detail popup — never submit input.
+        if app.workroom.is_focused() {
+            continue;
+        }
+
         // Check if user submitted input
         if key.code != KeyCode::Enter || app.should_quit() {
             continue;

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -17,13 +17,6 @@ use super::runner::ShellRunner;
 use super::session::{SessionMessage, ShellSession};
 use super::tui::ShellApp;
 
-/// Check if a key event is a cancel key (Esc or Ctrl+C).
-fn is_cancel_key(key: &event::KeyEvent) -> bool {
-    key.code == KeyCode::Esc
-        || (key.code == KeyCode::Char('c')
-            && key.modifiers == crossterm::event::KeyModifiers::CONTROL)
-}
-
 /// Fold one pipeline step's exact metrics into the running aggregate.
 ///
 /// Pipeline steps run in **series**, each on a different input (step *n*'s
@@ -598,7 +591,7 @@ async fn event_loop(
             if event::poll(Duration::from_millis(30))?
                 && let Event::Key(key) = event::read()?
                 && key.kind == KeyEventKind::Press
-                && is_cancel_key(&key)
+                && app.handle_streaming_key(&key)
             {
                 if let Err(e) = child.kill().await {
                     tracing::debug!("Failed to kill cancelled command: {:?}", e);
@@ -917,7 +910,7 @@ async fn execute_tandem(
         if event::poll(Duration::from_millis(30))?
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
-            && is_cancel_key(&key)
+            && app.handle_streaming_key(&key)
         {
             for stream in &mut streams {
                 let _ = stream.child.kill().await;
@@ -1307,7 +1300,7 @@ async fn execute_pipeline_steps(
             if event::poll(Duration::from_millis(30))?
                 && let Event::Key(key) = event::read()?
                 && key.kind == KeyEventKind::Press
-                && is_cancel_key(&key)
+                && app.handle_streaming_key(&key)
             {
                 let _ = child.kill().await;
                 app.append_to_streaming("\n\n[Pipeline cancelled]");
@@ -1535,7 +1528,7 @@ async fn execute_pty_turn(
         if event::poll(Duration::from_millis(50))?
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
-            && is_cancel_key(&key)
+            && app.handle_streaming_key(&key)
         {
             pty.kill();
             app.append_to_streaming("\n\n[Cancelled]");

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -433,6 +433,77 @@ impl ShellApp {
         self.manual_scroll = true;
     }
 
+    /// Handle a key pressed WHILE a turn is streaming. Returns true if the
+    /// turn should be cancelled; the caller is responsible for killing the
+    /// child process / PTY and appending a "[Cancelled]" marker. Otherwise
+    /// this applies workroom focus / popup / navigation as a side effect and
+    /// returns false, so drill-down (Ctrl+W + j/k/Enter) works mid-stream,
+    /// not just between turns.
+    ///
+    /// Esc is disambiguated: dismiss popup > exit workroom focus > cancel.
+    pub fn handle_streaming_key(&mut self, key: &KeyEvent) -> bool {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        // Ctrl+C always cancels, regardless of focus/popup state.
+        if key.code == KeyCode::Char('c') && key.modifiers == KeyModifiers::CONTROL {
+            return true;
+        }
+
+        // Ctrl+W toggles workroom focus mode (drill-down), same as handle_key.
+        if key.code == KeyCode::Char('w') && key.modifiers == KeyModifiers::CONTROL {
+            if self.workroom.is_focused() {
+                self.workroom.set_focused(false);
+            } else {
+                if !self.workroom.is_visible() {
+                    self.workroom.set_visible(true);
+                    self.workroom.toggle_pin();
+                }
+                self.workroom.set_focused(true);
+            }
+            return false;
+        }
+
+        // Popup open: Esc/q/Enter dismiss; j/k/arrows/PageUp/PageDown scroll.
+        if self.has_popup() {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => self.dismiss_popup(),
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.popup_scroll = self.popup_scroll.saturating_sub(2);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.popup_scroll = self.popup_scroll.saturating_add(2);
+                }
+                KeyCode::PageUp => {
+                    self.popup_scroll = self.popup_scroll.saturating_sub(10);
+                }
+                KeyCode::PageDown => {
+                    self.popup_scroll = self.popup_scroll.saturating_add(10);
+                }
+                _ => {}
+            }
+            return false;
+        }
+
+        // Workroom focused: navigate / open detail / exit focus.
+        if self.workroom.is_focused() {
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => self.workroom.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') => self.workroom.select_next(),
+                KeyCode::Enter => {
+                    if let Some(md) = self.workroom.selected_detail_markdown() {
+                        self.show_popup(md);
+                    }
+                }
+                KeyCode::Esc => self.workroom.set_focused(false),
+                _ => {}
+            }
+            return false;
+        }
+
+        // Otherwise: Esc cancels the turn (legacy behavior preserved).
+        key.code == KeyCode::Esc
+    }
+
     /// Handle a key event, returns true if should quit
     pub fn handle_key(&mut self, key: KeyEvent) -> bool {
         use crossterm::event::{KeyCode, KeyModifiers};

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -458,6 +458,42 @@ impl ShellApp {
             return false;
         }
 
+        // Ctrl+W toggles workroom focus mode (drill-down). If hidden, show +
+        // pin it and enter focus; if focused, exit focus; if visible but
+        // unfocused, enter focus.
+        if key.code == KeyCode::Char('w') && key.modifiers == KeyModifiers::CONTROL {
+            if self.workroom.is_focused() {
+                self.workroom.set_focused(false);
+            } else {
+                if !self.workroom.is_visible() {
+                    self.workroom.set_visible(true);
+                    self.workroom.toggle_pin();
+                }
+                self.workroom.set_focused(true);
+            }
+            return false;
+        }
+
+        // Gate focus-mode navigation BEFORE the text-input branch below, so
+        // that j/k/Enter/Esc are consumed here instead of being inserted into
+        // the input buffer or triggering submit/quit.
+        if self.workroom.is_focused() {
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => self.workroom.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') => self.workroom.select_next(),
+                KeyCode::Enter => {
+                    if let Some(md) = self.workroom.selected_detail_markdown() {
+                        self.show_popup(md);
+                    }
+                }
+                KeyCode::Esc => {
+                    self.workroom.set_focused(false);
+                }
+                _ => {}
+            }
+            return false;
+        }
+
         match key.code {
             // Handle Ctrl+C and Esc for quit
             KeyCode::Esc => {
@@ -716,7 +752,7 @@ impl ShellApp {
 
     fn render_messages_area(&self, frame: &mut Frame, area: Rect) {
         if self.messages.is_empty() {
-            let placeholder = Paragraph::new("Welcome to ArmadAI Shell!\n\nType your message and press Enter to get started. Press Ctrl+L to clear conversation, Ctrl+C or Esc to quit.")
+            let placeholder = Paragraph::new("Welcome to ArmadAI Shell!\n\nType your message and press Enter to get started. Press Ctrl+L to clear conversation, Ctrl+W to focus the workroom panel, Ctrl+C or Esc to quit.")
                 .block(Block::default().borders(Borders::ALL))
                 .wrap(Wrap { trim: false });
             frame.render_widget(placeholder, area);

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -60,6 +60,10 @@ pub struct Workroom {
     marker_buf: String,
     /// Name of the agent currently holding the token (for END → Done).
     current_agent: Option<String>,
+    /// Index of the selected agent row (drill-down focus mode).
+    selected: usize,
+    /// Whether the workroom currently has keyboard focus (drill-down mode).
+    focused: bool,
 }
 
 impl Workroom {
@@ -70,7 +74,93 @@ impl Workroom {
             pinned: false,
             marker_buf: String::new(),
             current_agent: None,
+            selected: 0,
+            focused: false,
         }
+    }
+
+    /// Set whether the workroom has keyboard focus (drill-down mode).
+    pub fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+
+    /// Whether the workroom currently has keyboard focus.
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Move the selection to the next agent (wraps around). No-op if empty.
+    pub fn select_next(&mut self) {
+        if self.agents.is_empty() {
+            return;
+        }
+        self.selected = (self.selected + 1) % self.agents.len();
+    }
+
+    /// Move the selection to the previous agent (wraps around). No-op if empty.
+    pub fn select_prev(&mut self) {
+        if self.agents.is_empty() {
+            return;
+        }
+        self.selected = if self.selected == 0 {
+            self.agents.len() - 1
+        } else {
+            self.selected - 1
+        };
+    }
+
+    /// Build a markdown detail view for the currently selected agent
+    /// (name, role, state, elapsed time, last action, and a transition timeline).
+    pub fn selected_detail_markdown(&self) -> Option<String> {
+        let agent = self.agents.get(self.selected)?;
+
+        let role = match agent.role {
+            AgentRole::Coordinator => "coordinator",
+            AgentRole::Lead => "lead",
+            AgentRole::Agent => "agent",
+        };
+        let state = match agent.state {
+            AgentState::Working => "working",
+            AgentState::Delegating => "delegating",
+            AgentState::Done => "done",
+            AgentState::Idle => "idle",
+        };
+
+        let elapsed = match (agent.started_at, agent.finished_at) {
+            (Some(start), Some(finish)) => {
+                format!(
+                    "{:.1}s",
+                    finish.saturating_duration_since(start).as_secs_f64()
+                )
+            }
+            (Some(start), None) => format!("{:.1}s", start.elapsed().as_secs_f64()),
+            (None, _) => "—".to_string(),
+        };
+
+        let last_action = agent.last_action.as_deref().unwrap_or("—");
+
+        let mut md = format!(
+            "# {name}  ({role})\n**State:** {state} · **Elapsed:** {elapsed}\n**Last action:** {last_action}\n\n## Timeline\n",
+            name = agent.name,
+        );
+
+        if agent.transitions.is_empty() {
+            md.push_str("- (no transitions recorded yet)\n");
+        } else {
+            let first = agent.transitions[0].1;
+            for (state, at) in &agent.transitions {
+                let offset = at.saturating_duration_since(first).as_secs_f64();
+                let label = match state {
+                    AgentState::Working => "working",
+                    AgentState::Delegating => "delegating",
+                    AgentState::Done => "done",
+                    AgentState::Idle => "idle",
+                };
+                md.push_str(&format!("- {label}      +{offset:.1}s\n"));
+            }
+        }
+
+        Some(md)
     }
 
     /// Initialize from orchestration config (coordinator + teams)
@@ -416,7 +506,7 @@ impl Workroom {
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         let mut lines: Vec<Line> = Vec::new();
 
-        for agent in &self.agents {
+        for (idx, agent) in self.agents.iter().enumerate() {
             let (icon, state_str, style) = match agent.state {
                 AgentState::Working => {
                     let spinner = SPINNER[agent.spinner_frame];
@@ -458,10 +548,22 @@ impl Workroom {
                 AgentRole::Agent => "    ",
             };
 
+            let is_selected = self.focused && idx == self.selected;
+            let name_style = if is_selected {
+                Style::default()
+                    .fg(role_color)
+                    .bold()
+                    .add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default().fg(role_color).bold()
+            };
+            let marker = if is_selected { "▸ " } else { "" };
+
             lines.push(Line::from(vec![
                 Span::raw(indent),
+                Span::raw(marker),
                 Span::styled(format!("{icon} "), style),
-                Span::styled(&agent.name, Style::default().fg(role_color).bold()),
+                Span::styled(&agent.name, name_style),
                 Span::styled(format!("  {state_str}"), style),
             ]));
         }
@@ -469,6 +571,24 @@ impl Workroom {
         if lines.is_empty() {
             lines.push(Line::from(Span::styled(
                 "No agents configured",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+
+        // Footer hint — compact, panel is only 35 cols wide.
+        lines.push(Line::from(""));
+        if self.focused {
+            lines.push(Line::from(Span::styled(
+                "Ctrl+W exit · j/k select",
+                Style::default().fg(Color::DarkGray),
+            )));
+            lines.push(Line::from(Span::styled(
+                "Enter detail",
+                Style::default().fg(Color::DarkGray),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "Ctrl+W focus",
                 Style::default().fg(Color::DarkGray),
             )));
         }
@@ -769,5 +889,63 @@ orchestration:
             wr.marker_buf_len_for_test() <= 8192,
             "unterminated marker buffer must be capped"
         );
+    }
+
+    #[test]
+    fn test_select_next_prev_wrap() {
+        let mut wr = wr_dev_lead_core(); // 2 agents: dev-lead, core-specialist
+        assert_eq!(wr.selected, 0);
+        wr.select_next();
+        assert_eq!(wr.selected, 1);
+        wr.select_next(); // wraps back to 0
+        assert_eq!(wr.selected, 0);
+        wr.select_prev(); // wraps to last
+        assert_eq!(wr.selected, 1);
+        wr.select_prev();
+        assert_eq!(wr.selected, 0);
+    }
+
+    #[test]
+    fn test_select_next_prev_empty_roster_no_panic() {
+        let mut wr = Workroom::new();
+        assert!(wr.agents_for_test().is_empty());
+        wr.select_next();
+        wr.select_prev();
+        assert_eq!(wr.selected, 0);
+    }
+
+    #[test]
+    fn test_focused_toggle() {
+        let mut wr = Workroom::new();
+        assert!(!wr.is_focused());
+        wr.set_focused(true);
+        assert!(wr.is_focused());
+        wr.set_focused(false);
+        assert!(!wr.is_focused());
+    }
+
+    #[test]
+    fn test_selected_detail_markdown_none_when_empty() {
+        let wr = Workroom::new();
+        assert!(wr.selected_detail_markdown().is_none());
+    }
+
+    #[test]
+    fn test_selected_detail_markdown_has_name_and_timeline() {
+        let mut wr = wr_dev_lead_core();
+        wr.apply_stream_text("<!--ARMADAI_DELEGATE:core-specialist-->");
+        wr.apply_stream_text("<!--ARMADAI_META:status=complete-->");
+        wr.apply_stream_text("<!--ARMADAI_END-->");
+
+        // Select core-specialist explicitly (index depends on config order —
+        // wr_dev_lead_core() yields [dev-lead, core-specialist]).
+        wr.selected = 1;
+        let md = wr.selected_detail_markdown().expect("agent selected");
+        assert!(md.contains("core-specialist"));
+        assert!(md.contains("(agent)"));
+        assert!(md.contains("## Timeline"));
+        assert!(md.contains("working"));
+        assert!(md.contains("done"));
+        assert!(md.contains("Last action:** complete"));
     }
 }


### PR DESCRIPTION
## Workroom drill-down (Shortlist B)

Expose les données par-agent déjà collectées (durée, dernière action, transitions) via un mode focus clavier + popup détail — sans alourdir le panneau par défaut.

### Interaction
- **`Ctrl+W`** : entre/sort du mode focus (affiche+épingle la Workroom si cachée).
- En focus : **`j`/`k` ou `↑`/`↓`** sélectionnent un agent (surligné), **`Entrée`** ouvre un popup markdown (état, durée, dernière action, timeline des transitions), **`Esc`/`Ctrl+W`** sortent du focus.
- Hors focus : `j`/`k`/`Entrée`/`Esc` gardent leur comportement normal (saisie / submit / quit). Gate placé avant la branche de saisie ; submit gardé dans le loop.

### Réutilise
`show_popup` (overlay markdown existant) pour le détail. Footer d'aide dans le panneau.

### Vérifs
Clippy 2 modes (`-D warnings`), fmt, build release, 20 tests workroom (dont `select_next`/`prev` wrapping + `selected_detail_markdown`). Invariants clavier vérifiés (bare j/k = saisie hors focus ; Esc en focus ≠ quit).

⚠️ **Visuel/interactif → à valider en `armadai shell` avant merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)