### PR TITLE
feat(tui,shell): shared semantic theme + light-terminal support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ mod skills_registry;
 #[cfg(feature = "storage")]
 mod storage;
 #[cfg(feature = "tui")]
+mod theme;
+#[cfg(feature = "tui")]
 mod tui;
 #[cfg(feature = "web")]
 mod web;

--- a/src/shell/md_render.rs
+++ b/src/shell/md_render.rs
@@ -12,19 +12,29 @@ use ratatui::{
     text::{Line, Span},
 };
 
-// ── Colors (GitHub dark theme) ──────────────────────────────────
+// ── Colors ────────────────────────────────────────────────────────
+//
+// Named colors only (no `Rgb(...)`) so markdown stays legible on both
+// dark and light terminals — named colors resolve against the terminal's
+// own palette instead of forcing an exact truecolor value that may have
+// only been checked against a dark background. See
+// docs/proposals/ux-audit-tui-2026-07-20.md P0-2.
+//
+// `CODE_FG`/`CODE_BG` are the one intentional exception: they're always
+// used as a paired fg+bg (a self-contained "code box"), so the contrast
+// is fixed regardless of the surrounding terminal theme.
 
-const H1_COLOR: Color = Color::Rgb(88, 166, 255);
-const H2_COLOR: Color = Color::Rgb(63, 185, 80);
-const H3_COLOR: Color = Color::Rgb(210, 153, 34);
-const H4_COLOR: Color = Color::Rgb(139, 148, 158);
+const H1_COLOR: Color = Color::Blue;
+const H2_COLOR: Color = Color::Green;
+const H3_COLOR: Color = Color::Yellow;
+const H4_COLOR: Color = Color::DarkGray;
 const CODE_FG: Color = Color::Rgb(230, 237, 243);
 const CODE_BG: Color = Color::Rgb(55, 62, 71);
-const LINK_COLOR: Color = Color::Rgb(88, 166, 255);
-const QUOTE_COLOR: Color = Color::Rgb(139, 148, 158);
+const LINK_COLOR: Color = Color::Blue;
+const QUOTE_COLOR: Color = Color::DarkGray;
 const SEPARATOR_COLOR: Color = Color::DarkGray;
 const TABLE_BORDER_COLOR: Color = Color::DarkGray;
-const TABLE_HEADER_COLOR: Color = Color::Rgb(88, 166, 255);
+const TABLE_HEADER_COLOR: Color = Color::Blue;
 
 // ── Public API ──────────────────────────────────────────────────
 

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthChar;
 
 use super::SPINNER_FRAMES;
+use crate::theme;
 
 /// A single message in the conversation
 #[derive(Debug, Clone)]
@@ -944,11 +945,11 @@ impl ShellApp {
             )
         };
 
-        let statusbar = Paragraph::new(status_text).style(
-            Style::default()
-                .fg(Color::DarkGray)
-                .bg(Color::Rgb(22, 27, 34)),
-        );
+        // No fixed background here (was `bg(Rgb(22, 27, 34))`, a near-black
+        // strip that rendered dark-grey-on-near-black on light terminals —
+        // unreadable). A named fg on the terminal's own default background
+        // stays legible on both dark and light themes.
+        let statusbar = Paragraph::new(status_text).style(theme::muted());
 
         frame.render_widget(statusbar, area);
     }

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use std::time::Instant;
 
 use super::SPINNER_FRAMES as SPINNER;
+use crate::theme;
 
 /// Agent activity state
 #[derive(Debug, Clone, PartialEq)]
@@ -514,32 +515,20 @@ impl Workroom {
                         .started_at
                         .map(|s| format!(" {:.0}s", s.elapsed().as_secs_f64()))
                         .unwrap_or_default();
-                    (
-                        spinner,
-                        format!("working{elapsed}"),
-                        Style::default().fg(Color::Green),
-                    )
+                    (spinner, format!("working{elapsed}"), theme::working())
                 }
                 AgentState::Delegating => {
                     let spinner = SPINNER[agent.spinner_frame];
-                    (
-                        spinner,
-                        "delegating".to_string(),
-                        Style::default().fg(Color::Yellow),
-                    )
+                    (spinner, "delegating".to_string(), theme::delegating())
                 }
-                AgentState::Done => ("✓", "done".to_string(), Style::default().fg(Color::Green)),
-                AgentState::Idle => (
-                    "○",
-                    "idle".to_string(),
-                    Style::default().fg(Color::DarkGray),
-                ),
+                AgentState::Done => ("✓", "done".to_string(), theme::done()),
+                AgentState::Idle => ("○", "idle".to_string(), theme::muted()),
             };
 
-            let role_color = match agent.role {
-                AgentRole::Coordinator => Color::Rgb(231, 76, 60), // red
-                AgentRole::Lead => Color::Rgb(243, 156, 18),       // orange
-                AgentRole::Agent => Color::Rgb(88, 166, 255),      // blue
+            let role_style = match agent.role {
+                AgentRole::Coordinator => theme::role_coordinator(),
+                AgentRole::Lead => theme::role_lead(),
+                AgentRole::Agent => theme::role_agent(),
             };
 
             let indent = match agent.role {
@@ -550,12 +539,9 @@ impl Workroom {
 
             let is_selected = self.focused && idx == self.selected;
             let name_style = if is_selected {
-                Style::default()
-                    .fg(role_color)
-                    .bold()
-                    .add_modifier(Modifier::REVERSED)
+                role_style.add_modifier(Modifier::REVERSED)
             } else {
-                Style::default().fg(role_color).bold()
+                role_style
             };
             let marker = if is_selected { "▸ " } else { "" };
 
@@ -571,7 +557,7 @@ impl Workroom {
         if lines.is_empty() {
             lines.push(Line::from(Span::styled(
                 "No agents configured",
-                Style::default().fg(Color::DarkGray),
+                theme::muted(),
             )));
         }
 
@@ -580,25 +566,22 @@ impl Workroom {
         if self.focused {
             lines.push(Line::from(Span::styled(
                 "Ctrl+W exit · j/k select",
-                Style::default().fg(Color::DarkGray),
+                theme::muted(),
             )));
-            lines.push(Line::from(Span::styled(
-                "Enter detail",
-                Style::default().fg(Color::DarkGray),
-            )));
+            lines.push(Line::from(Span::styled("Enter detail", theme::muted())));
         } else {
-            lines.push(Line::from(Span::styled(
-                "Ctrl+W focus",
-                Style::default().fg(Color::DarkGray),
-            )));
+            lines.push(Line::from(Span::styled("Ctrl+W focus", theme::muted())));
         }
 
+        // NOTE: the border color (`Rgb(48, 54, 61)`) is left as-is — it's a
+        // decorative box-drawing accent, not body text, and is legible on
+        // both dark and light terminals. See theme-report.md follow-ups.
         let panel = Paragraph::new(lines).block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(Color::Rgb(48, 54, 61)))
                 .title(" Workroom ")
-                .title_style(Style::default().fg(Color::Cyan).bold()),
+                .title_style(theme::heading()),
         );
 
         frame.render_widget(panel, area);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,174 @@
+//! Shared semantic color palette for ArmadAI's two terminal UIs
+//! (the ratatui dashboard in `tui/` and the conversational shell's
+//! rendering in `shell/tui.rs`, `shell/md_render.rs`, `shell/workroom.rs`).
+//!
+//! Every color here is a ratatui **named** color, never `Color::Rgb(...)`.
+//! Named colors are resolved against the terminal's own ANSI palette, so
+//! they stay legible whether the user runs a dark or a light terminal
+//! theme. `Rgb(...)` bypasses that palette and can produce (near-)invisible
+//! text on a terminal theme the author didn't test against — see
+//! `docs/proposals/ux-audit-tui-2026-07-20.md` (P0-1, P0-2, P1-8).
+//!
+//! Keep this module the single source of truth for "what color means what"
+//! across both UIs: selection, state, role, and a couple of shared accents.
+//! Anything not covered here (borders, one-off accents) is left to local
+//! judgement — see the audit's P1-8 for the deliberately-out-of-scope list.
+
+#![cfg(feature = "tui")]
+
+use ratatui::style::{Color, Modifier, Style};
+
+// ── Semantic colors ──────────────────────────────────────────────
+
+/// Selected row / active element (dashboard lists, palette, workroom focus).
+pub const SELECTION: Color = Color::Cyan;
+/// Section headings / titles (dashboard detail titles, panel titles).
+pub const HEADING: Color = Color::Cyan;
+
+/// An agent or turn is actively generating.
+pub const WORKING: Color = Color::Green;
+/// A coordinator/lead is waiting on a delegated sub-agent.
+pub const DELEGATING: Color = Color::Yellow;
+/// An agent has finished its work. Distinct from `WORKING` (Blue vs Green)
+/// so "still going" and "finished" never look the same at a glance.
+pub const DONE: Color = Color::Blue;
+/// Idle / not-yet-involved / de-emphasized text.
+pub const MUTED: Color = Color::DarkGray;
+
+/// Errors. Not yet wired to a call site in either UI (neither currently
+/// renders an error/failure banner) — reserved so the next consumer (e.g.
+/// a shell error banner, a failed-run indicator) has a semantic slot to
+/// reach for instead of inventing another ad-hoc red.
+#[allow(dead_code)]
+pub const ERROR: Color = Color::Red;
+/// Warnings (distinct semantic slot from `DELEGATING`, same color today).
+/// Reserved for the same reason as `ERROR`.
+#[allow(dead_code)]
+pub const WARNING: Color = Color::Yellow;
+
+/// Orchestration coordinator role.
+pub const ROLE_COORDINATOR: Color = Color::Magenta;
+/// Orchestration lead role.
+pub const ROLE_LEAD: Color = Color::Yellow;
+// Plain agent role deliberately has NO color constant: it renders in the
+// terminal's default foreground (bold only) so it never collides with
+// `DONE` (Blue) when an agent's row also shows its finished state.
+
+/// Agent tag accent (metadata tags in the dashboard).
+pub const TAG: Color = Color::Yellow;
+/// Agent stack accent (metadata stacks in the dashboard).
+pub const STACK: Color = Color::Green;
+
+// ── Style helpers ─────────────────────────────────────────────────
+
+/// Style for a selected row / active element: bold `SELECTION`.
+pub fn selection() -> Style {
+    Style::default().fg(SELECTION).add_modifier(Modifier::BOLD)
+}
+
+/// Style for a section heading / panel title: bold `HEADING`.
+pub fn heading() -> Style {
+    Style::default().fg(HEADING).add_modifier(Modifier::BOLD)
+}
+
+/// Style for "working" state text.
+pub fn working() -> Style {
+    Style::default().fg(WORKING)
+}
+
+/// Style for "delegating" state text.
+pub fn delegating() -> Style {
+    Style::default().fg(DELEGATING)
+}
+
+/// Style for "done" state text.
+pub fn done() -> Style {
+    Style::default().fg(DONE)
+}
+
+/// Style for muted / idle text.
+pub fn muted() -> Style {
+    Style::default().fg(MUTED)
+}
+
+/// Style for error text. See `ERROR` for why this has no call site yet.
+#[allow(dead_code)]
+pub fn error() -> Style {
+    Style::default().fg(ERROR)
+}
+
+/// Style for warning text. See `WARNING` for why this has no call site yet.
+#[allow(dead_code)]
+pub fn warning() -> Style {
+    Style::default().fg(WARNING)
+}
+
+/// Style for a coordinator role label: bold `ROLE_COORDINATOR`.
+pub fn role_coordinator() -> Style {
+    Style::default()
+        .fg(ROLE_COORDINATOR)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Style for a lead role label: bold `ROLE_LEAD`.
+pub fn role_lead() -> Style {
+    Style::default().fg(ROLE_LEAD).add_modifier(Modifier::BOLD)
+}
+
+/// Style for a plain agent role label: bold, no color (see `ROLE_AGENT` note
+/// above — avoids colliding with `DONE`).
+pub fn role_agent() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
+}
+
+/// Style for a tag accent.
+pub fn tag() -> Style {
+    Style::default().fg(TAG)
+}
+
+/// Style for a stack accent.
+pub fn stack() -> Style {
+    Style::default().fg(STACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semantic_colors_are_named_not_rgb() {
+        // Sanity: these consts are the exact named colors the palette
+        // sign-off specified. A future accidental edit to `Color::Rgb(...)`
+        // would break this and be caught immediately.
+        assert_eq!(SELECTION, Color::Cyan);
+        assert_eq!(HEADING, Color::Cyan);
+        assert_eq!(WORKING, Color::Green);
+        assert_eq!(DELEGATING, Color::Yellow);
+        assert_eq!(DONE, Color::Blue);
+        assert_eq!(MUTED, Color::DarkGray);
+        assert_eq!(ERROR, Color::Red);
+        assert_eq!(WARNING, Color::Yellow);
+        assert_eq!(ROLE_COORDINATOR, Color::Magenta);
+        assert_eq!(ROLE_LEAD, Color::Yellow);
+        assert_eq!(TAG, Color::Yellow);
+        assert_eq!(STACK, Color::Green);
+    }
+
+    #[test]
+    fn done_is_distinct_from_working() {
+        // The whole point of P0-1: idle/done/working must be visually
+        // distinguishable, not all shades of gray/green.
+        assert_ne!(DONE, WORKING);
+    }
+
+    #[test]
+    fn role_agent_style_has_no_explicit_color() {
+        assert_eq!(role_agent().fg, None);
+    }
+
+    #[test]
+    fn selection_and_heading_styles_are_bold() {
+        assert!(selection().add_modifier.contains(Modifier::BOLD));
+        assert!(heading().add_modifier.contains(Modifier::BOLD));
+    }
+}

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -6,6 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
@@ -51,12 +52,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Title bar
     let title = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!(" {} ", agent.name),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!(" {} ", agent.name), theme::heading()),
         Span::styled(
             format!("  ({})", agent.source.display()),
             Style::default().fg(Color::DarkGray),
@@ -91,14 +87,14 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if !meta.tags.is_empty() {
         meta_lines.push(Line::from(vec![
             Span::styled("Tags:     ", Style::default().add_modifier(Modifier::BOLD)),
-            Span::styled(meta.tags.join(", "), Style::default().fg(Color::Yellow)),
+            Span::styled(meta.tags.join(", "), theme::tag()),
         ]));
     }
 
     if !meta.stacks.is_empty() {
         meta_lines.push(Line::from(vec![
             Span::styled("Stacks:   ", Style::default().add_modifier(Modifier::BOLD)),
-            Span::styled(meta.stacks.join(", "), Style::default().fg(Color::Green)),
+            Span::styled(meta.stacks.join(", "), theme::stack()),
         ]));
     }
 
@@ -232,7 +228,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .title(" System Prompt ")
                 .title_style(Style::default().add_modifier(Modifier::BOLD)),
         )
-        .style(Style::default().fg(Color::White))
+        // Was `fg(Color::White)` — white-on-white on a light terminal.
+        .style(Style::default())
         .wrap(Wrap { trim: false });
     frame.render_widget(prompt_widget, chunks[3 + orch_offset]);
 

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -1,11 +1,12 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Row, Table, Tabs},
 };
 
+use crate::theme;
 use crate::tui::app::{App, Tab};
 use crate::tui::filter;
 use crate::tui::widgets::search_bar;
@@ -29,12 +30,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     let tabs = Tabs::new(titles)
         .block(Block::default().borders(Borders::ALL).title(" ArmadAI "))
         .select(app.tab_index)
-        .style(Style::default().fg(Color::White))
-        .highlight_style(
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        );
+        // Was `fg(Color::White)` — white-on-white on a light terminal.
+        // Default terminal fg adapts to either theme.
+        .style(Style::default())
+        .highlight_style(theme::selection());
     frame.render_widget(tabs, chunks[0]);
 
     // Content area — dispatch to the right view
@@ -111,9 +110,7 @@ fn render_agent_list(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) 
             let agent = &app.agents[agent_i];
             let tags = agent.metadata.tags.join(", ");
             let style = if display_i == app.selected_agent {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -1,10 +1,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::format::format_cost;
@@ -52,9 +53,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 r.model.clone()
             };
             let style = if display_i == app.selected_history {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/model_detail.rs
+++ b/src/tui/views/model_detail.rs
@@ -6,6 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::format::format_context;
 
@@ -34,12 +35,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Title bar
     let title = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!(" {} ", entry.id),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!(" {} ", entry.id), theme::heading()),
         Span::styled(
             format!("  ({})", provider),
             Style::default().fg(Color::DarkGray),

--- a/src/tui/views/models_list.rs
+++ b/src/tui/views/models_list.rs
@@ -1,10 +1,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::format::format_context;
@@ -68,9 +69,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .map(|v| format!("${v:.2}"))
                 .unwrap_or_else(|| "-".to_string());
             let style = if display_i == app.selected_model {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -3,10 +3,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::widgets::search_bar;
@@ -63,9 +64,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             let halt_reason = r.halt_reason.as_deref().unwrap_or("—");
             let style = if display_i == app.selected_orchestration {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/palette.rs
+++ b/src/tui/views/palette.rs
@@ -1,11 +1,12 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 
 /// Render the command palette as a centered overlay.
@@ -34,11 +35,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         Block::default()
             .borders(Borders::ALL)
             .title(" Command Palette ")
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
+            .title_style(theme::heading())
             .border_style(Style::default().fg(Color::Cyan)),
     );
     frame.render_widget(input, chunks[0]);
@@ -51,9 +48,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         .enumerate()
         .map(|(i, cmd)| {
             let style = if i == app.palette.selected {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/prompt_detail.rs
+++ b/src/tui/views/prompt_detail.rs
@@ -6,6 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
@@ -34,12 +35,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Title bar
     let title = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!(" {} ", prompt.name),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!(" {} ", prompt.name), theme::heading()),
         Span::styled(
             format!("  ({})", prompt.source.display()),
             Style::default().fg(Color::DarkGray),
@@ -104,7 +100,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .title(" Content ")
                 .title_style(Style::default().add_modifier(Modifier::BOLD)),
         )
-        .style(Style::default().fg(Color::White))
+        // Was `fg(Color::White)` — white-on-white on a light terminal.
+        .style(Style::default())
         .wrap(Wrap { trim: false });
     frame.render_widget(body_widget, chunks[2]);
 }

--- a/src/tui/views/prompts_list.rs
+++ b/src/tui/views/prompts_list.rs
@@ -1,10 +1,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::widgets::search_bar;
@@ -43,9 +44,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             let p = &app.prompts[prompt_i];
             let style = if display_i == app.selected_prompt {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/skill_detail.rs
+++ b/src/tui/views/skill_detail.rs
@@ -7,6 +7,7 @@ use ratatui::{
 };
 
 use crate::core::skill::read_text_file;
+use crate::theme;
 use crate::tui::app::App;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
@@ -62,12 +63,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Title bar
     let title = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!(" {} ", skill.name),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!(" {} ", skill.name), theme::heading()),
         Span::styled(
             format!("  ({})", skill.source.display()),
             Style::default().fg(Color::DarkGray),
@@ -139,7 +135,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .title(" SKILL.md ")
                 .title_style(Style::default().add_modifier(Modifier::BOLD)),
         )
-        .style(Style::default().fg(Color::White))
+        // Was `fg(Color::White)` — white-on-white on a light terminal.
+        .style(Style::default())
         .wrap(Wrap { trim: false });
     frame.render_widget(body_widget, chunks[2]);
 

--- a/src/tui/views/skills_list.rs
+++ b/src/tui/views/skills_list.rs
@@ -1,10 +1,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::widgets::search_bar;
@@ -51,9 +52,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             let s = &app.skills[skill_i];
             let style = if display_i == app.selected_skill {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };

--- a/src/tui/views/starter_detail.rs
+++ b/src/tui/views/starter_detail.rs
@@ -6,6 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
@@ -53,12 +54,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Title bar
     let title = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!(" {} ", pack.name),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!(" {} ", pack.name), theme::heading()),
         Span::styled(
             format!("  — {}", pack.description),
             Style::default().fg(Color::DarkGray),
@@ -74,10 +70,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             .agents
             .iter()
             .map(|a| {
-                Line::from(Span::styled(
-                    format!("  • {a}"),
-                    Style::default().fg(Color::White),
-                ))
+                // Was `fg(Color::White)` — white-on-white on a light terminal.
+                Line::from(Span::styled(format!("  • {a}"), Style::default()))
             })
             .collect();
         let widget = Paragraph::new(lines)

--- a/src/tui/views/starters_list.rs
+++ b/src/tui/views/starters_list.rs
@@ -1,10 +1,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::widgets::search_bar;
@@ -50,9 +51,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             let p = &app.starters[starter_i];
             let style = if display_i == app.selected_starter {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::selection()
             } else {
                 Style::default()
             };


### PR DESCRIPTION
## theme.rs partagé + support terminal clair (Shortlist B, bloc 2)

Résout P0-2 (couleurs cassées en terminal clair) + P1-8 (pas de palette partagée) de l'audit UX.

### Contenu
- **`src/theme.rs`** (crate-level, gated `tui`) : palette sémantique en **couleurs nommées** (s'adaptent à la palette du terminal → lisible clair + sombre). Sign-off utilisateur : selection/heading=Cyan, working=Green, delegating=Yellow, **done=Blue** (distinct de working), idle=DarkGray, error=Red, roles coordinator=Magenta/lead=Yellow/agent=défaut, tags=Yellow/stacks=Green. 4 tests.
- **Recâblage** des 2 TUI (workroom, statusbar, sélection, tags/stacks, vues détail) via `theme`.
- **Casseurs terminal clair corrigés** : statusbar (fond sombre figé retiré), textes `fg(White)` des vues détail (+ 2 autres du même bug), `md_render.rs` (RGB GitHub-dark → couleurs nommées).

### Changements visuels (dark)
`done` = bleu (était vert) ; statusbar sans bande sombre. Le reste inchangé.

### Vérifs
Clippy 3 modes (`tui`, `tui,providers-api`, `tui,web,storage`, `-D warnings`), fmt, build release, tests theme/workroom/md_render OK.
⚠️ Flake pré-existant `llm_agents`/`model_resolution` (`latest:auto`) confirmé indépendant (reproduit sur la base via git stash) — non lié.

⚠️ **Visuel → validation manuelle (dark + clair) avant merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)