### PR TITLE
feat(tui): dashboard polish — scrollable details, Costs conventions, Ctrl+C quit

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -269,6 +269,7 @@ pub struct App {
     pub selected_history: usize,
     // Costs
     pub costs: Vec<CostEntry>,
+    pub selected_cost: usize,
     // Models (from model registry cache)
     pub models_flat: Vec<(String, ModelEntry)>,
     pub selected_model: usize,
@@ -285,6 +286,8 @@ pub struct App {
     pub search_mode: bool,
     pub search_query: String,
     pub sort_mode: SortMode,
+    // Detail view scroll offset (reset on tab switch / selection change).
+    pub detail_scroll: u16,
 }
 
 impl App {
@@ -303,6 +306,7 @@ impl App {
             history: Vec::new(),
             selected_history: 0,
             costs: Vec::new(),
+            selected_cost: 0,
             models_flat: Vec::new(),
             selected_model: 0,
             #[cfg(feature = "storage")]
@@ -314,12 +318,14 @@ impl App {
             search_mode: false,
             search_query: String::new(),
             sort_mode: SortMode::Default,
+            detail_scroll: 0,
         }
     }
 
     pub fn next_tab(&mut self) {
         self.tab_index = (self.tab_index + 1) % Tab::ALL.len();
         self.current_tab = Tab::ALL[self.tab_index];
+        self.detail_scroll = 0;
     }
 
     pub fn prev_tab(&mut self) {
@@ -329,11 +335,25 @@ impl App {
             self.tab_index - 1
         };
         self.current_tab = Tab::ALL[self.tab_index];
+        self.detail_scroll = 0;
     }
 
     pub fn switch_tab(&mut self, tab: Tab) {
         self.current_tab = tab;
         self.tab_index = tab.index();
+        self.detail_scroll = 0;
+    }
+
+    /// Scroll a detail view down by one line (saturating at the content's end
+    /// is handled by ratatui simply rendering nothing past it — no need to
+    /// track content length here).
+    pub fn scroll_detail_down(&mut self) {
+        self.detail_scroll = self.detail_scroll.saturating_add(1);
+    }
+
+    /// Scroll a detail view up by one line.
+    pub fn scroll_detail_up(&mut self) {
+        self.detail_scroll = self.detail_scroll.saturating_sub(1);
     }
 
     pub fn load_agents(&mut self) {
@@ -493,6 +513,7 @@ impl App {
         self.selected_skill = 0;
         self.selected_starter = 0;
         self.selected_history = 0;
+        self.selected_cost = 0;
         self.selected_model = 0;
         #[cfg(feature = "storage")]
         {
@@ -509,6 +530,7 @@ impl App {
         self.selected_skill = 0;
         self.selected_starter = 0;
         self.selected_history = 0;
+        self.selected_cost = 0;
         self.selected_model = 0;
         #[cfg(feature = "storage")]
         {
@@ -616,6 +638,16 @@ impl App {
                     self.selected_history = (self.selected_history + 1) % display_indices.len();
                 }
             }
+            Tab::Costs => {
+                let display_indices = filter::apply_filter_and_sort_costs(
+                    &self.costs,
+                    &self.search_query,
+                    self.sort_mode,
+                );
+                if !display_indices.is_empty() {
+                    self.selected_cost = (self.selected_cost + 1) % display_indices.len();
+                }
+            }
             Tab::Models => {
                 let display_indices = filter::apply_filter_and_sort_models(
                     &self.models_flat,
@@ -712,6 +744,20 @@ impl App {
                         display_indices.len() - 1
                     } else {
                         self.selected_history - 1
+                    };
+                }
+            }
+            Tab::Costs => {
+                let display_indices = filter::apply_filter_and_sort_costs(
+                    &self.costs,
+                    &self.search_query,
+                    self.sort_mode,
+                );
+                if !display_indices.is_empty() {
+                    self.selected_cost = if self.selected_cost == 0 {
+                        display_indices.len() - 1
+                    } else {
+                        self.selected_cost - 1
                     };
                 }
             }

--- a/src/tui/filter.rs
+++ b/src/tui/filter.rs
@@ -5,7 +5,7 @@ use crate::core::starter::StarterPack;
 use crate::model_registry::ModelEntry;
 #[cfg(feature = "storage")]
 use crate::tui::app::OrchestrationEntry;
-use crate::tui::app::{RunEntry, SortMode};
+use crate::tui::app::{CostEntry, RunEntry, SortMode};
 
 /// Filter items by search query (case-insensitive substring match on name + metadata).
 pub fn filter_agents(agents: &[Agent], query: &str) -> Vec<usize> {
@@ -96,6 +96,19 @@ pub fn filter_history(history: &[RunEntry], query: &str) -> Vec<usize> {
                 || r.provider.to_lowercase().contains(&query)
                 || r.model.to_lowercase().contains(&query)
         })
+        .map(|(i, _)| i)
+        .collect()
+}
+
+pub fn filter_costs(costs: &[CostEntry], query: &str) -> Vec<usize> {
+    if query.is_empty() {
+        return (0..costs.len()).collect();
+    }
+    let query = query.to_lowercase();
+    costs
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.agent.to_lowercase().contains(&query))
         .map(|(i, _)| i)
         .collect()
 }
@@ -194,6 +207,36 @@ pub fn apply_filter_and_sort_history(
     sort_by_name(filtered, &names, sort_mode)
 }
 
+/// Apply filtering and sorting to get display indices for costs.
+///
+/// Unlike the other list views, `SortMode::Default` here means **cost
+/// descending** (the most useful ordering for a cost summary) rather than
+/// load order — costs have no inherent "natural" order to fall back to.
+/// `NameAsc`/`NameDesc` still sort by agent name, same as everywhere else.
+pub fn apply_filter_and_sort_costs(
+    costs: &[CostEntry],
+    query: &str,
+    sort_mode: SortMode,
+) -> Vec<usize> {
+    let filtered = filter_costs(costs, query);
+    match sort_mode {
+        SortMode::Default => {
+            let mut sorted = filtered;
+            sorted.sort_by(|&a, &b| {
+                costs[b]
+                    .total_cost
+                    .partial_cmp(&costs[a].total_cost)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            sorted
+        }
+        SortMode::NameAsc | SortMode::NameDesc => {
+            let names: Vec<_> = filtered.iter().map(|&i| &costs[i].agent).collect();
+            sort_by_name(filtered, &names, sort_mode)
+        }
+    }
+}
+
 /// Apply filtering and sorting to get display indices for models.
 pub fn apply_filter_and_sort_models(
     models: &[(String, ModelEntry)],
@@ -236,4 +279,42 @@ pub fn apply_filter_and_sort_orchestration(
     let filtered = filter_orchestration(orchestration, query);
     let names: Vec<_> = filtered.iter().map(|&i| &orchestration[i].run_id).collect();
     sort_by_name(filtered, &names, sort_mode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cost(agent: &str, total_cost: f64) -> CostEntry {
+        CostEntry {
+            agent: agent.to_string(),
+            total_runs: 1,
+            total_cost,
+            total_tokens_in: 0,
+            total_tokens_out: 0,
+        }
+    }
+
+    #[test]
+    fn costs_default_sort_is_cost_descending() {
+        let costs = vec![cost("alpha", 0.5), cost("beta", 2.0), cost("gamma", 1.0)];
+        let indices = apply_filter_and_sort_costs(&costs, "", SortMode::Default);
+        let ordered: Vec<&str> = indices.iter().map(|&i| costs[i].agent.as_str()).collect();
+        assert_eq!(ordered, vec!["beta", "gamma", "alpha"]);
+    }
+
+    #[test]
+    fn costs_name_asc_sorts_alphabetically() {
+        let costs = vec![cost("gamma", 1.0), cost("alpha", 0.5), cost("beta", 2.0)];
+        let indices = apply_filter_and_sort_costs(&costs, "", SortMode::NameAsc);
+        let ordered: Vec<&str> = indices.iter().map(|&i| costs[i].agent.as_str()).collect();
+        assert_eq!(ordered, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn costs_filter_by_agent_name() {
+        let costs = vec![cost("alpha", 0.5), cost("beta", 2.0)];
+        let indices = apply_filter_and_sort_costs(&costs, "alp", SortMode::Default);
+        assert_eq!(indices, vec![0]);
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -44,6 +44,12 @@ pub async fn run() -> Result<()> {
                 continue;
             }
 
+            // Ctrl+C quits unconditionally (aligns with the shell TUI's quit
+            // key), regardless of palette/search mode or the current tab.
+            if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                break;
+            }
+
             // Command palette mode
             if app.palette.visible {
                 match key.code {
@@ -155,6 +161,7 @@ pub async fn run() -> Result<()> {
                             | app::Tab::Skills
                             | app::Tab::Starters
                             | app::Tab::History
+                            | app::Tab::Costs
                             | app::Tab::Models
                     ) || {
                         #[cfg(feature = "storage")]
@@ -180,6 +187,7 @@ pub async fn run() -> Result<()> {
                             | app::Tab::Skills
                             | app::Tab::Starters
                             | app::Tab::History
+                            | app::Tab::Costs
                             | app::Tab::Models
                     ) || {
                         #[cfg(feature = "storage")]
@@ -197,8 +205,22 @@ pub async fn run() -> Result<()> {
                 }
                 KeyCode::Tab => app.next_tab(),
                 KeyCode::BackTab => app.prev_tab(),
-                KeyCode::Char('j') | KeyCode::Down => app.select_next(),
-                KeyCode::Char('k') | KeyCode::Up => app.select_prev(),
+                KeyCode::Char('j') | KeyCode::Down => {
+                    // In a scrollable detail view, j/Down scrolls the body
+                    // instead of moving a (non-existent) list selection.
+                    if is_scrollable_detail(app.current_tab) {
+                        app.scroll_detail_down();
+                    } else {
+                        app.select_next();
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    if is_scrollable_detail(app.current_tab) {
+                        app.scroll_detail_up();
+                    } else {
+                        app.select_prev();
+                    }
+                }
                 KeyCode::Char('R')
                     if matches!(app.current_tab, app::Tab::Models | app::Tab::ModelDetail) =>
                 {
@@ -313,6 +335,23 @@ pub async fn run() -> Result<()> {
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
     Ok(())
+}
+
+/// Detail tabs whose body panel honors `App::detail_scroll` (see
+/// `agent_detail`, `prompt_detail`, `skill_detail`, `orchestration::render_detail`).
+/// While one of these is active, j/k and the arrow keys scroll the body
+/// instead of moving a list selection (there is no list to navigate).
+fn is_scrollable_detail(tab: app::Tab) -> bool {
+    // `Tab::OrchestrationDetail` exists regardless of the `storage` feature
+    // (only the underlying data is gated), so no extra `#[cfg]` is needed
+    // here — without `storage` the tab is simply never reached.
+    matches!(
+        tab,
+        app::Tab::AgentDetail
+            | app::Tab::PromptDetail
+            | app::Tab::SkillDetail
+            | app::Tab::OrchestrationDetail
+    )
 }
 
 #[cfg(feature = "storage")]

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -36,7 +36,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Constraint::Length(8), // Metadata
                 Constraint::Length(5), // Orchestration
                 Constraint::Length(8), // Model Resolution
-                Constraint::Min(6),    // System Prompt
+                Constraint::Min(0),    // System Prompt (scrollable — j/k)
                 Constraint::Length(6), // Instructions
             ]
         } else {
@@ -44,7 +44,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Constraint::Length(3), // Title
                 Constraint::Length(8), // Metadata
                 Constraint::Length(8), // Model Resolution
-                Constraint::Min(6),    // System Prompt
+                Constraint::Min(0),    // System Prompt (scrollable — j/k)
                 Constraint::Length(6), // Instructions
             ]
         })
@@ -230,7 +230,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         )
         // Was `fg(Color::White)` — white-on-white on a light terminal.
         .style(Style::default())
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.detail_scroll, 0));
     frame.render_widget(prompt_widget, chunks[3 + orch_offset]);
 
     // Instructions section

--- a/src/tui/views/costs.rs
+++ b/src/tui/views/costs.rs
@@ -5,8 +5,11 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
+use crate::theme;
 use crate::tui::app::App;
+use crate::tui::filter;
 use crate::tui::format::format_cost;
+use crate::tui::widgets::search_bar;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.costs.is_empty() {
@@ -16,7 +19,20 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
+    // Apply filtering and sorting (default: cost descending — see
+    // `filter::apply_filter_and_sort_costs`).
+    let display_indices =
+        filter::apply_filter_and_sort_costs(&app.costs, &app.search_query, app.sort_mode);
+
+    if display_indices.is_empty() {
+        let msg = Paragraph::new("No cost entries match your search.")
+            .block(Block::default().borders(Borders::ALL).title(" Costs "));
+        frame.render_widget(msg, area);
+        return;
+    }
+
     let header = Row::new(vec![
+        "",
         "AGENT",
         "RUNS",
         "COST (USD)",
@@ -26,26 +42,54 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     .style(Style::default().add_modifier(Modifier::BOLD))
     .bottom_margin(1);
 
-    let mut total_cost = 0.0;
-
-    let rows: Vec<Row> = app
-        .costs
+    let mut rows: Vec<Row> = display_indices
         .iter()
-        .map(|c| {
-            total_cost += c.total_cost;
+        .enumerate()
+        .map(|(display_i, &cost_i)| {
+            let marker = if display_i == app.selected_cost {
+                ">"
+            } else {
+                " "
+            };
+            let c = &app.costs[cost_i];
+            let style = if display_i == app.selected_cost {
+                theme::selection()
+            } else {
+                Style::default()
+            };
             Row::new(vec![
+                marker.to_string(),
                 c.agent.clone(),
                 c.total_runs.to_string(),
                 format_cost(c.total_cost),
                 c.total_tokens_in.to_string(),
                 c.total_tokens_out.to_string(),
             ])
+            .style(style)
         })
         .collect();
+
+    // Grand total row over the *full* cost set (not just the filtered/shown
+    // rows), visually set apart with a blank separator margin + bold text so
+    // it never looks like just another (unselectable) agent row.
+    let total_cost: f64 = app.costs.iter().map(|c| c.total_cost).sum();
+    rows.push(
+        Row::new(vec![
+            String::new(),
+            "TOTAL".to_string(),
+            String::new(),
+            format_cost(total_cost),
+            String::new(),
+            String::new(),
+        ])
+        .style(Style::default().add_modifier(Modifier::BOLD))
+        .top_margin(1),
+    );
 
     let table = Table::new(
         rows,
         [
+            Constraint::Length(2),
             Constraint::Min(15),
             Constraint::Length(8),
             Constraint::Length(14),
@@ -54,11 +98,17 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         ],
     )
     .header(header)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(format!(" Costs — total: {} ", format_cost(total_cost))),
-    );
+    .block(Block::default().borders(Borders::ALL).title(format!(
+        " Costs — {} loaded, {} shown{} ",
+        app.costs.len(),
+        display_indices.len(),
+        app.sort_indicator()
+    )));
 
     frame.render_widget(table, area);
+
+    // Render search bar if in search mode
+    if app.search_mode {
+        search_bar(frame, &app.search_query, area);
+    }
 }

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -163,7 +163,7 @@ pub fn render_detail(frame: &mut Frame, app: &App, area: Rect) {
                     .borders(Borders::ALL)
                     .title(format!(" Run {} ", entry.run_id)),
             )
-            .scroll((0, 0));
+            .scroll((app.detail_scroll, 0));
 
         frame.render_widget(paragraph, area);
     } else {

--- a/src/tui/views/prompt_detail.rs
+++ b/src/tui/views/prompt_detail.rs
@@ -29,7 +29,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         .constraints([
             Constraint::Length(3), // Title
             Constraint::Length(5), // Metadata
-            Constraint::Min(6),    // Body
+            Constraint::Min(0),    // Body (scrollable — j/k)
         ])
         .split(area);
 
@@ -102,6 +102,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         )
         // Was `fg(Color::White)` — white-on-white on a light terminal.
         .style(Style::default())
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.detail_scroll, 0));
     frame.render_widget(body_widget, chunks[2]);
 }

--- a/src/tui/views/shortcuts.rs
+++ b/src/tui/views/shortcuts.rs
@@ -10,6 +10,11 @@ use crate::tui::app::{App, Tab};
 
 /// Render the keyboard shortcuts bar at the bottom of the screen.
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    // Quit and tab-jump are available from every tab (P1-4 / P2-5): document
+    // them once here instead of repeating the pair in each arm below.
+    const QUIT: (&str, &str) = ("q / ^C", "Quit");
+    const JUMP: (&str, &str) = ("1-8", "Jump tab");
+
     let shortcuts = match app.current_tab {
         Tab::Dashboard => vec![
             ("j/k", "Navigate"),
@@ -17,22 +22,33 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("/", "Search"),
             ("s", "Sort"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
-        Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail | Tab::ModelDetail => vec![
+        Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail => vec![
+            ("j/k", "Scroll"),
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
-            ("q", "Quit"),
+            QUIT,
+        ],
+        Tab::ModelDetail => vec![
+            ("Esc", "Back to list"),
+            ("Tab", "Next tab"),
+            JUMP,
+            (":", "Commands"),
+            QUIT,
         ],
         Tab::StarterDetail => vec![
             ("Esc", "Back to list"),
             ("i", "Init project"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
-            ("q", "Quit"),
+            QUIT,
         ],
         Tab::Prompts | Tab::Skills => vec![
             ("j/k", "Navigate"),
@@ -40,9 +56,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("/", "Search"),
             ("s", "Sort"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
         Tab::Starters => vec![
             ("j/k", "Navigate"),
@@ -51,24 +68,30 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("s", "Sort"),
             ("i", "Init project"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
         Tab::History => vec![
             ("j/k", "Navigate"),
             ("/", "Search"),
             ("s", "Sort"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
         Tab::Costs => vec![
+            ("j/k", "Navigate"),
+            ("/", "Search"),
+            ("s", "Sort"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
         Tab::Models => vec![
             ("j/k", "Navigate"),
@@ -77,9 +100,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("s", "Sort"),
             ("R", "Sync models.dev"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
         #[cfg(feature = "storage")]
         Tab::Orchestration => vec![
@@ -88,20 +112,23 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("/", "Search"),
             ("s", "Sort"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            ("q", "Quit"),
+            QUIT,
         ],
         #[cfg(feature = "storage")]
         Tab::OrchestrationDetail => vec![
+            ("j/k", "Scroll"),
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
+            JUMP,
             (":", "Commands"),
-            ("q", "Quit"),
+            QUIT,
         ],
         #[cfg(not(feature = "storage"))]
         Tab::Orchestration | Tab::OrchestrationDetail => {
-            vec![("Tab", "Next tab"), (":", "Commands"), ("q", "Quit")]
+            vec![("Tab", "Next tab"), JUMP, (":", "Commands"), QUIT]
         }
     };
 

--- a/src/tui/views/skill_detail.rs
+++ b/src/tui/views/skill_detail.rs
@@ -43,7 +43,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let mut constraints = vec![
         Constraint::Length(3), // Title
         Constraint::Length(6), // Metadata
-        Constraint::Min(6),    // Body
+        Constraint::Min(0),    // Body (scrollable — j/k)
     ];
 
     // One block per reference file
@@ -137,7 +137,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         )
         // Was `fg(Color::White)` — white-on-white on a light terminal.
         .style(Style::default())
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.detail_scroll, 0));
     frame.render_widget(body_widget, chunks[2]);
 
     // Reference file content blocks


### PR DESCRIPTION
## Dashboard polish (Shortlist B — restants)

Derniers items de l'audit UX côté dashboard.

- **P1-7 — Scroll des vues détail** : agent/prompt/skill/orchestration detail scrollables (`detail_scroll`, `↑↓`/`j`/`k`), fini le contenu tronqué.
- **P1-5 — Costs aux conventions** : marqueur `>` + ligne sélectionnée, `/` filtre, `s` tri (coût décroissant par défaut), ligne TOTAL distincte, légende à jour. Utilise `format_cost`.
- **P1-4 — Quit-keys** : `Ctrl+C` quitte le dashboard (en plus de `q`), aligné avec le shell (non-clashant). Légendes documentent quit + `1-8` jump (P2-5) + scroll.

### Vérifs
Clippy 3 modes (`tui`, `tui,providers-api`, `tui,web,storage`, `-D warnings`), fmt, build release, 836 tests. Dashboard-only (shell/workroom/theme/C8 non touchés).
⚠️ Flake `llm_agents`/`model_resolution` pré-existant confirmé indépendant (git stash).

⚠️ **Visuel → validation `armadai tui` avant merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)