### PR TITLE
fix(cli): hierarchical orchestration — key agents by roster key not H1 title

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -969,13 +969,21 @@ async fn run_orchestrated(
                 .as_deref()
                 .unwrap_or(agent_names.first().map(|s| s.as_str()).unwrap_or(""));
 
-            // Build agent map and provider map
+            // Build agent map and provider map, keyed by the ROSTER KEY (the
+            // config name / filename slug in `agent_names`), NOT `agent.name`
+            // (the H1 title). The coordinator and the delegation directives
+            // reference agents by their config key (e.g. `dev-lead`), so keying
+            // by the H1 title (`Dev Lead`) would break the coordinator lookup
+            // and every `@agent` delegation. `agents`/`providers` are in the
+            // same order as `agent_names` (built by the load loop above).
             let mut agent_map: HashMap<String, crate::core::agent::Agent> = HashMap::new();
             let mut provider_map: HashMap<String, Arc<dyn Provider>> = HashMap::new();
 
-            for (agent, provider) in agents.into_iter().zip(providers) {
-                provider_map.insert(agent.name.clone(), provider);
-                agent_map.insert(agent.name.clone(), agent);
+            for (name, (agent, provider)) in
+                agent_names.iter().zip(agents.into_iter().zip(providers))
+            {
+                provider_map.insert(name.clone(), provider);
+                agent_map.insert(name.clone(), agent);
             }
 
             eprintln!(


### PR DESCRIPTION
## Release-blocker : orchestration hierarchical cassée

**Symptôme** (trouvé au test manuel) : `armadai run <agent>` dans un projet avec `orchestration.enabled: true` (auto-détection hierarchical) → `Error: No provider found for agent 'dev-lead'`.

**Cause** : la branche hierarchical de `run_orchestrated` indexait `agent_map`/`provider_map` par **`agent.name` (titre H1, « Dev Lead »)**, alors que le coordinateur (`orchestration.coordinator`) et les directives de délégation `@agent` utilisent la **clé de config / nom de fichier (`dev-lead`)**. → lookup du coordinateur (et toute délégation) échoue dès que H1 ≠ nom de fichier (le cas courant). Même classe de bug que celui corrigé pour C8 (#188/#192), mais dans le chemin hierarchical.

**Fix** : indexer les maps par la **clé de roster** (`agent_names`, alignée avec `agents`/`providers`), pas par `agent.name`.

### Vérifs
Clippy 2 modes (`-D warnings`), fmt, build. Non-visuel (correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)