### PR TITLE
feat: useful History/Costs — absolute DB, per-run project, real CLI cost

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -184,6 +184,10 @@ async fn run_inner(
         AgentResolution::Project { config, .. } => config.routing.clone().unwrap_or_default(),
         _ => crate::core::routing::RoutingRules::default(),
     };
+    // Which project (if any) these runs are attributed to in storage: the
+    // resolved project root, or the CWD as a best-effort fallback when no
+    // `armadai.yaml` was found (still useful to distinguish ad-hoc runs).
+    let project = project_display_string(&resolution);
 
     sink.emit(&RunEvent::RunStart {
         v: 1,
@@ -212,6 +216,7 @@ async fn run_inner(
             quiet,
             max_content,
             &routing_rules,
+            project.as_deref(),
         )
         .await?;
         agg_tin += metrics.tokens_in as u32;
@@ -245,6 +250,19 @@ enum AgentResolution {
     },
     /// No project config found — use default paths
     Default(PathBuf),
+}
+
+/// Best-effort project identifier for storage attribution: the resolved
+/// project root's display string when an `armadai.yaml` was found, else the
+/// current working directory (still useful to group ad-hoc runs), else
+/// `None` if even `current_dir()` fails.
+fn project_display_string(resolution: &AgentResolution) -> Option<String> {
+    match resolution {
+        AgentResolution::Project { root, .. } => Some(root.display().to_string()),
+        AgentResolution::Default(_) => std::env::current_dir()
+            .ok()
+            .map(|p| p.display().to_string()),
+    }
 }
 
 /// Resolve a single agent name to a file path using the resolution context.
@@ -286,7 +304,13 @@ async fn run_single_agent(
     quiet: bool,
     max_content: Option<usize>,
     routing_rules: &crate::core::routing::RoutingRules,
+    project: Option<&str>,
 ) -> anyhow::Result<(String, RunMetrics)> {
+    // `project` is only read by `record_run` under `#[cfg(feature = "storage")]`
+    // below; this keeps the parameter used (and its name meaningful at every
+    // call site) regardless of which features are enabled.
+    #[cfg(not(feature = "storage"))]
+    let _ = project;
     // 1. Load agent
     let mut agent = crate::parser::parse_agent_file(agent_path)?;
 
@@ -437,7 +461,7 @@ async fn run_single_agent(
 
     // 8. Record in storage (if available)
     #[cfg(feature = "storage")]
-    record_run(&metrics, input, &response.content);
+    record_run(&metrics, input, &response.content, project);
 
     Ok((response.content, metrics))
 }
@@ -454,7 +478,7 @@ struct RunMetrics {
 }
 
 #[cfg(feature = "storage")]
-fn record_run(metrics: &RunMetrics, input: &str, output: &str) {
+fn record_run(metrics: &RunMetrics, input: &str, output: &str, project: Option<&str>) {
     use crate::storage::{init_db, queries};
 
     let db = match init_db() {
@@ -476,6 +500,7 @@ fn record_run(metrics: &RunMetrics, input: &str, output: &str) {
         cost: metrics.cost,
         duration_ms: metrics.duration_ms,
         status: "success".to_string(),
+        project: project.map(|s| s.to_string()),
     };
 
     if let Err(e) = queries::insert_run(&db, record) {
@@ -674,6 +699,10 @@ async fn run_orchestrated(
         _ => crate::core::routing::RoutingRules::default(),
     };
 
+    // Project attribution for storage (mirrors the sequential path).
+    #[cfg(feature = "storage")]
+    let project = project_display_string(resolution);
+
     sink.emit(&RunEvent::RunStart {
         v: 1,
         agents: agent_names.to_vec(),
@@ -816,7 +845,7 @@ async fn run_orchestrated(
             eprintln!("[blackboard] Halted: {:?}", board.state());
 
             #[cfg(feature = "storage")]
-            record_orchestration_blackboard(&board, &config, input);
+            record_orchestration_blackboard(&board, &config, input, project.as_deref());
 
             let outcome_text = board
                 .entries()
@@ -869,7 +898,7 @@ async fn run_orchestrated(
             run_ring(&mut token, &ring_agents, &providers, &config, sink).await?;
 
             #[cfg(feature = "storage")]
-            record_orchestration_ring(&token, &config, input);
+            record_orchestration_ring(&token, &config, input, project.as_deref());
 
             let outcome_text = match token.status() {
                 TokenStatus::Done { outcome } => match outcome {
@@ -1012,7 +1041,12 @@ async fn run_orchestrated(
             );
 
             #[cfg(feature = "storage")]
-            record_orchestration_hierarchical(&result, &orch_config_for_storage, input);
+            record_orchestration_hierarchical(
+                &result,
+                &orch_config_for_storage,
+                input,
+                project.as_deref(),
+            );
 
             if !json {
                 println!("{}", result.content);
@@ -1117,12 +1151,14 @@ fn apply_ring_overrides(
 /// hierarchical team (C9). Returns the generated `run_id` so callers can
 /// link children to it.
 #[cfg(feature = "storage")]
+#[allow(clippy::too_many_arguments)]
 fn record_orchestration_blackboard_into(
     db: &crate::storage::Database,
     board: &crate::core::orchestration::blackboard::Board,
     config: &crate::core::orchestration::blackboard::BlackboardConfig,
     input: &str,
     parent_run_id: Option<&str>,
+    project: Option<&str>,
 ) -> String {
     use crate::core::orchestration::blackboard::BoardState;
     use crate::storage::queries;
@@ -1146,6 +1182,7 @@ fn record_orchestration_blackboard_into(
             "success"
         }
         .to_string(),
+        project: project.map(|s| s.to_string()),
     };
     if let Err(e) = queries::insert_run_with_id(db, &run_id, parent) {
         tracing::warn!("Failed to record orchestration parent run: {e}");
@@ -1210,6 +1247,7 @@ fn record_orchestration_blackboard(
     board: &crate::core::orchestration::blackboard::Board,
     config: &crate::core::orchestration::blackboard::BlackboardConfig,
     input: &str,
+    project: Option<&str>,
 ) {
     let db = match crate::storage::init_db() {
         Ok(db) => db,
@@ -1218,7 +1256,7 @@ fn record_orchestration_blackboard(
             return;
         }
     };
-    let _ = record_orchestration_blackboard_into(&db, board, config, input, None);
+    let _ = record_orchestration_blackboard_into(&db, board, config, input, None, project);
 }
 
 /// Persist a ring orchestration run (and its contributions/votes) into `db`,
@@ -1226,12 +1264,14 @@ fn record_orchestration_blackboard(
 /// hierarchical team (C9). Returns the generated `run_id` so callers can
 /// link children to it.
 #[cfg(feature = "storage")]
+#[allow(clippy::too_many_arguments)]
 fn record_orchestration_ring_into(
     db: &crate::storage::Database,
     token: &crate::core::orchestration::ring::RingToken,
     config: &crate::core::orchestration::ring::RingConfig,
     input: &str,
     parent_run_id: Option<&str>,
+    project: Option<&str>,
 ) -> String {
     use crate::core::orchestration::ring::TokenStatus;
     use crate::storage::queries;
@@ -1258,6 +1298,7 @@ fn record_orchestration_ring_into(
             _ => "incomplete",
         }
         .to_string(),
+        project: project.map(|s| s.to_string()),
     };
     if let Err(e) = queries::insert_run_with_id(db, &run_id, parent) {
         tracing::warn!("Failed to record orchestration parent run: {e}");
@@ -1331,6 +1372,7 @@ fn record_orchestration_ring(
     token: &crate::core::orchestration::ring::RingToken,
     config: &crate::core::orchestration::ring::RingConfig,
     input: &str,
+    project: Option<&str>,
 ) {
     let db = match crate::storage::init_db() {
         Ok(db) => db,
@@ -1339,7 +1381,7 @@ fn record_orchestration_ring(
             return;
         }
     };
-    let _ = record_orchestration_ring_into(&db, token, config, input, None);
+    let _ = record_orchestration_ring_into(&db, token, config, input, None, project);
 }
 
 /// Persist a hierarchical orchestration run: the parent run row, its
@@ -1351,6 +1393,7 @@ fn record_hierarchical_into(
     result: &crate::core::orchestration::hierarchical::OrchestrationResult,
     config: &crate::core::orchestration::OrchestrationConfig,
     input: &str,
+    project: Option<&str>,
 ) -> anyhow::Result<String> {
     use crate::core::orchestration::hierarchical::NestedRun;
     use crate::storage::queries;
@@ -1369,6 +1412,7 @@ fn record_hierarchical_into(
         cost: result.total_cost,
         duration_ms: 0,
         status: "success".to_string(),
+        project: project.map(|s| s.to_string()),
     };
     queries::insert_run_with_id(db, &run_id, parent)?;
 
@@ -1410,8 +1454,14 @@ fn record_hierarchical_into(
                 config,
                 ..
             } => {
-                let _ =
-                    record_orchestration_blackboard_into(db, board, config, task, Some(&run_id));
+                let _ = record_orchestration_blackboard_into(
+                    db,
+                    board,
+                    config,
+                    task,
+                    Some(&run_id),
+                    project,
+                );
             }
             NestedRun::Ring {
                 task,
@@ -1419,7 +1469,8 @@ fn record_hierarchical_into(
                 config,
                 ..
             } => {
-                let _ = record_orchestration_ring_into(db, token, config, task, Some(&run_id));
+                let _ =
+                    record_orchestration_ring_into(db, token, config, task, Some(&run_id), project);
             }
         }
     }
@@ -1435,6 +1486,7 @@ fn record_orchestration_hierarchical(
     result: &crate::core::orchestration::hierarchical::OrchestrationResult,
     config: &crate::core::orchestration::OrchestrationConfig,
     input: &str,
+    project: Option<&str>,
 ) {
     let db = match crate::storage::init_db() {
         Ok(db) => db,
@@ -1443,7 +1495,7 @@ fn record_orchestration_hierarchical(
             return;
         }
     };
-    if let Err(e) = record_hierarchical_into(&db, result, config, input) {
+    if let Err(e) = record_hierarchical_into(&db, result, config, input, project) {
         tracing::warn!("Failed to record hierarchical run: {e}");
     }
 }
@@ -1766,7 +1818,8 @@ mod storage_tests {
         };
         let config = OrchestrationConfig::default();
 
-        let parent_id = record_hierarchical_into(&db, &result, &config, "do research").unwrap();
+        let parent_id =
+            record_hierarchical_into(&db, &result, &config, "do research", None).unwrap();
 
         // Parent persisted as hierarchical with no parent.
         let parent = queries::get_orchestration_run(&db, &parent_id)
@@ -1786,5 +1839,51 @@ mod storage_tests {
             children[0].parent_run_id.as_deref(),
             Some(parent_id.as_str())
         );
+    }
+
+    #[test]
+    fn hierarchical_run_records_project_on_parent_and_nested_children() {
+        let db = init_embedded().unwrap();
+
+        let board = Board::new("subtask".to_string(), 50_000);
+        let result = OrchestrationResult {
+            content: "final".to_string(),
+            trace: vec![],
+            total_tokens_in: 0,
+            total_tokens_out: 0,
+            total_cost: 0.0,
+            invocation_count: 1,
+            nested_runs: vec![NestedRun::Blackboard {
+                team_lead: "research-lead".to_string(),
+                task: "subtask".to_string(),
+                board,
+                config: BlackboardConfig::default(),
+            }],
+        };
+        let config = OrchestrationConfig::default();
+
+        let parent_id = record_hierarchical_into(
+            &db,
+            &result,
+            &config,
+            "do research",
+            Some("/home/user/my-project"),
+        )
+        .unwrap();
+
+        let history = queries::get_history(&db, None, 10).unwrap();
+        assert_eq!(history.len(), 2, "parent + one nested blackboard run");
+        for run in &history {
+            assert_eq!(
+                run.project.as_deref(),
+                Some("/home/user/my-project"),
+                "every persisted run (parent and nested) should carry the project"
+            );
+        }
+        // Sanity: parent_id itself resolved to a hierarchical run.
+        let parent = queries::get_orchestration_run(&db, &parent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parent.pattern, "hierarchical");
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -44,6 +44,24 @@ pub fn config_dir() -> PathBuf {
     config_base.join("armadai")
 }
 
+/// Return the ArmadAI data root directory (for persistent storage, e.g. SQLite).
+///
+/// Resolution order:
+/// 1. `$XDG_DATA_HOME/armadai`
+/// 2. `$HOME/.local/share/armadai`
+///
+/// Unlike `config_dir()`, this is NOT overridable via `$ARMADAI_CONFIG_DIR` —
+/// config and data are separate XDG concerns.
+pub fn data_dir() -> PathBuf {
+    let data_base = std::env::var("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".local").join("share")
+        });
+    data_base.join("armadai")
+}
+
 pub fn user_agents_dir() -> PathBuf {
     config_dir().join("agents")
 }
@@ -166,7 +184,15 @@ impl Default for StorageConfig {
     fn default() -> Self {
         Self {
             mode: "embedded".to_string(),
-            path: "data/armadai.sqlite".to_string(),
+            // Absolute path so History/Costs are shared across CWDs (was
+            // "data/armadai.sqlite", relative to the CWD — a different DB per
+            // directory, meaning `armadai run` and `armadai tui` only saw the
+            // same data when launched from the same directory). Explicit
+            // `storage.path` in an existing config.yaml is unaffected.
+            path: data_dir()
+                .join("armadai.sqlite")
+                .to_string_lossy()
+                .into_owned(),
         }
     }
 }
@@ -362,7 +388,10 @@ defaults:
 
 storage:
   mode: embedded
-  path: data/armadai.sqlite
+  # `path` intentionally omitted: defaults to an absolute, shared location
+  # (~/.local/share/armadai/armadai.sqlite, or $XDG_DATA_HOME/armadai if set)
+  # so History/Costs are consistent regardless of CWD. Set explicitly here to
+  # override.
 
 rate_limits:
   anthropic: 50

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -29,6 +29,63 @@ impl CliProvider {
         cmd.stderr(std::process::Stdio::piped());
         cmd
     }
+
+    /// Same shape as [`Self::build_command`] but with the canonical
+    /// stream-json args for this CLI (see
+    /// `crate::shell::json_runner::json_mode_args`) instead of `self.args`,
+    /// so we get structured JSONL events (cost/tokens) on stdout instead of
+    /// free-form text. Only meaningful when
+    /// `crate::shell::json_runner::supports_json(&self.command)` is true.
+    fn build_json_command(&self, input: &str) -> Command {
+        let mut cmd = Command::new(&self.command);
+        for arg in crate::shell::json_runner::json_mode_args(&self.command) {
+            cmd.arg(arg);
+        }
+        cmd.arg(input);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd
+    }
+
+    /// Parse a JSON-mode CLI's raw stdout (one JSONL event per line) into a
+    /// [`CompletionResponse`]: accumulate the visible text from
+    /// `Delta`/`Message` events, and pull cost/tokens/model from the
+    /// terminal `Result` event.
+    ///
+    /// If no `Result` event appears (e.g. the CLI errored out mid-stream
+    /// after producing partial JSONL, or its stdout wasn't JSON at all),
+    /// falls back to the raw stdout as `content` with zeroed cost/tokens —
+    /// the same shape `complete()` has always returned for non-JSON CLIs.
+    fn parse_json_stdout(&self, raw: &str) -> CompletionResponse {
+        use crate::shell::json_runner::{StreamEvent, parse_stream_event};
+
+        let mut content = String::new();
+        let mut result = None;
+        for line in raw.lines() {
+            match parse_stream_event(&self.command, line) {
+                StreamEvent::Delta(t) | StreamEvent::Message(t) => content.push_str(&t),
+                StreamEvent::Result(resp) => result = Some(resp),
+                _ => {}
+            }
+        }
+
+        match result {
+            Some(resp) => CompletionResponse {
+                content,
+                model: resp.model.unwrap_or_else(|| self.command.clone()),
+                tokens_in: resp.tokens_in.unwrap_or(0) as u32,
+                tokens_out: resp.tokens_out.unwrap_or(0) as u32,
+                cost: resp.cost_usd.unwrap_or(0.0),
+            },
+            None => CompletionResponse {
+                content: raw.to_string(),
+                model: self.command.clone(),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -40,7 +97,12 @@ impl Provider for CliProvider {
             .map(|m| m.content.as_str())
             .unwrap_or("");
 
-        let mut cmd = self.build_command(input);
+        let use_json = crate::shell::json_runner::supports_json(&self.command);
+        let mut cmd = if use_json {
+            self.build_json_command(input)
+        } else {
+            self.build_command(input)
+        };
         let timeout = std::time::Duration::from_secs(self.timeout_secs);
 
         let output = match tokio::time::timeout(timeout, cmd.output()).await {
@@ -55,15 +117,19 @@ impl Provider for CliProvider {
             anyhow::bail!("CLI command failed ({}): {stderr}", output.status);
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout);
 
-        Ok(CompletionResponse {
-            content: stdout,
-            model: self.command.clone(),
-            tokens_in: 0,
-            tokens_out: 0,
-            cost: 0.0,
-        })
+        if use_json {
+            Ok(self.parse_json_stdout(&stdout))
+        } else {
+            Ok(CompletionResponse {
+                content: stdout.to_string(),
+                model: self.command.clone(),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+            })
+        }
     }
 
     async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
@@ -185,5 +251,45 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("timed out"), "Error was: {err}");
+    }
+
+    // ── JSON-mode stdout parsing (Part C: real cost/tokens from `claude`) ──
+
+    #[test]
+    fn parse_json_stdout_claude_extracts_cost_and_tokens() {
+        let provider = CliProvider::new("claude".to_string(), vec![], 10);
+        // A representative claude --output-format stream-json session: an
+        // init event, one assistant turn (the visible answer), then the
+        // terminal result event carrying usage/cost.
+        let jsonl = concat!(
+            r#"{"type":"system","subtype":"init","session_id":"s1","model":"claude-opus-4-6","agents":[]}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello there!"}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1200,"num_turns":1,"result":"Hello there!","session_id":"s1","total_cost_usd":0.0123,"usage":{"input_tokens":42,"output_tokens":17},"modelUsage":{"claude-opus-4-6":{"outputTokens":17}}}"#,
+        );
+
+        let response = provider.parse_json_stdout(jsonl);
+
+        assert_eq!(response.content, "Hello there!");
+        assert_eq!(response.tokens_in, 42);
+        assert_eq!(response.tokens_out, 17);
+        assert!((response.cost - 0.0123).abs() < 1e-9);
+        assert_eq!(response.model, "claude-opus-4-6");
+    }
+
+    #[test]
+    fn parse_json_stdout_falls_back_to_raw_when_no_result_event() {
+        // Partial/interrupted stream: no terminal "result" event at all.
+        let provider = CliProvider::new("claude".to_string(), vec![], 10);
+        let jsonl = r#"{"type":"system","subtype":"init","session_id":"s1","tools":[]}"#;
+
+        let response = provider.parse_json_stdout(jsonl);
+
+        // Falls back to the current behavior: raw stdout as content, zeroed metrics.
+        assert_eq!(response.content, jsonl);
+        assert_eq!(response.tokens_in, 0);
+        assert_eq!(response.tokens_out, 0);
+        assert_eq!(response.cost, 0.0);
     }
 }

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -30,32 +30,6 @@ impl CliProvider {
         cmd
     }
 
-    /// Same shape as [`Self::build_command`] but with the canonical
-    /// stream-json args for this CLI (see
-    /// `crate::shell::json_runner::json_mode_args`) instead of `self.args`,
-    /// so we get structured JSONL events (cost/tokens) on stdout instead of
-    /// free-form text. Only meaningful when
-    /// `crate::shell::json_runner::supports_json(&self.command)` is true.
-    fn build_json_command(&self, input: &str) -> Command {
-        let mut cmd = Command::new(&self.command);
-        for arg in crate::shell::json_runner::json_mode_args(&self.command) {
-            cmd.arg(arg);
-        }
-        cmd.arg(input);
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-        cmd
-    }
-
-    /// Parse a JSON-mode CLI's raw stdout (one JSONL event per line) into a
-    /// [`CompletionResponse`]: accumulate the visible text from
-    /// `Delta`/`Message` events, and pull cost/tokens/model from the
-    /// terminal `Result` event.
-    ///
-    /// If no `Result` event appears (e.g. the CLI errored out mid-stream
-    /// after producing partial JSONL, or its stdout wasn't JSON at all),
-    /// falls back to the raw stdout as `content` with zeroed cost/tokens —
-    /// the same shape `complete()` has always returned for non-JSON CLIs.
     fn parse_json_stdout(&self, raw: &str) -> CompletionResponse {
         use crate::shell::json_runner::{StreamEvent, parse_stream_event};
 
@@ -97,12 +71,12 @@ impl Provider for CliProvider {
             .map(|m| m.content.as_str())
             .unwrap_or("");
 
-        let use_json = crate::shell::json_runner::supports_json(&self.command);
-        let mut cmd = if use_json {
-            self.build_json_command(input)
-        } else {
-            self.build_command(input)
-        };
+        // Run with `self.args` verbatim (the factory already selected the right
+        // args: canonical stream-json args for a default JSON-capable CLI, or
+        // the agent's explicit args). Then parse stdout opportunistically:
+        // `parse_json_stdout` extracts content + cost/tokens from JSONL events
+        // when present, and falls back to raw stdout (zeroed metrics) otherwise.
+        let mut cmd = self.build_command(input);
         let timeout = std::time::Duration::from_secs(self.timeout_secs);
 
         let output = match tokio::time::timeout(timeout, cmd.output()).await {
@@ -118,18 +92,7 @@ impl Provider for CliProvider {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-
-        if use_json {
-            Ok(self.parse_json_stdout(&stdout))
-        } else {
-            Ok(CompletionResponse {
-                content: stdout.to_string(),
-                model: self.command.clone(),
-                tokens_in: 0,
-                tokens_out: 0,
-                cost: 0.0,
-            })
-        }
+        Ok(self.parse_json_stdout(&stdout))
     }
 
     async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -132,7 +132,13 @@ fn create_unified_provider(
 
     if cli_available(command) {
         let args = if has_custom_args {
+            // Respect the agent's explicit args verbatim (never override them).
             agent.metadata.args.clone().unwrap_or_default()
+        } else if crate::shell::json_runner::supports_json(command) {
+            // Default (no custom args) on a JSON-capable CLI: use the canonical
+            // stream-json args so the provider captures real cost/tokens
+            // instead of $0.00. The provider parses stdout opportunistically.
+            crate::shell::json_runner::json_mode_args(command)
         } else {
             tool.cli_args.iter().map(|s| (*s).to_string()).collect()
         };

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -15,6 +15,9 @@ pub struct RunRecord {
     pub cost: f64,
     pub duration_ms: i64,
     pub status: String,
+    /// Project root path the run was executed from (display string), or
+    /// `None` when there was no project config (default/global agent run).
+    pub project: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,10 +42,10 @@ pub fn insert_run_with_id(db: &Database, id: &str, run: RunRecord) -> anyhow::Re
         .lock()
         .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
     conn.execute(
-        "INSERT INTO runs (id, agent, input, output, provider, model, tokens_in, tokens_out, cost, duration_ms, status)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        "INSERT INTO runs (id, agent, input, output, provider, model, tokens_in, tokens_out, cost, duration_ms, status, project)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         params![id, run.agent, run.input, run.output, run.provider, run.model,
-                run.tokens_in, run.tokens_out, run.cost, run.duration_ms, run.status],
+                run.tokens_in, run.tokens_out, run.cost, run.duration_ms, run.status, run.project],
     )?;
     Ok(())
 }
@@ -61,7 +64,7 @@ pub fn get_history(
     match agent {
         Some(name) => {
             let mut stmt = conn.prepare(
-                "SELECT agent, input, output, provider, model, tokens_in, tokens_out, cost, duration_ms, status
+                "SELECT agent, input, output, provider, model, tokens_in, tokens_out, cost, duration_ms, status, project
                  FROM runs WHERE agent = ?1 ORDER BY created_at DESC LIMIT ?2",
             )?;
             let rows = stmt.query_map(params![name, limit], |row| {
@@ -76,6 +79,7 @@ pub fn get_history(
                     cost: row.get(7)?,
                     duration_ms: row.get(8)?,
                     status: row.get(9)?,
+                    project: row.get(10)?,
                 })
             })?;
             for row in rows {
@@ -84,7 +88,7 @@ pub fn get_history(
         }
         None => {
             let mut stmt = conn.prepare(
-                "SELECT agent, input, output, provider, model, tokens_in, tokens_out, cost, duration_ms, status
+                "SELECT agent, input, output, provider, model, tokens_in, tokens_out, cost, duration_ms, status, project
                  FROM runs ORDER BY created_at DESC LIMIT ?1",
             )?;
             let rows = stmt.query_map(params![limit], |row| {
@@ -99,6 +103,7 @@ pub fn get_history(
                     cost: row.get(7)?,
                     duration_ms: row.get(8)?,
                     status: row.get(9)?,
+                    project: row.get(10)?,
                 })
             })?;
             for row in rows {
@@ -570,6 +575,7 @@ mod tests {
             cost,
             duration_ms: 500,
             status: "success".to_string(),
+            project: None,
         }
     }
 
@@ -585,6 +591,22 @@ mod tests {
         let filtered = get_history(&db, Some("agent-a"), 10).unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].agent, "agent-a");
+    }
+
+    #[test]
+    fn test_run_project_roundtrips_through_history() {
+        let db = init_embedded().unwrap();
+        let mut with_project = sample_run("agent-a", 0.01);
+        with_project.project = Some("/home/user/my-project".to_string());
+        insert_run(&db, with_project).unwrap();
+        insert_run(&db, sample_run("agent-b", 0.02)).unwrap(); // no project
+
+        let all = get_history(&db, None, 10).unwrap();
+        assert_eq!(all.len(), 2);
+        let a = all.iter().find(|r| r.agent == "agent-a").unwrap();
+        let b = all.iter().find(|r| r.agent == "agent-b").unwrap();
+        assert_eq!(a.project.as_deref(), Some("/home/user/my-project"));
+        assert_eq!(b.project, None);
     }
 
     #[test]

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -2,7 +2,7 @@ use rusqlite::Connection;
 
 /// Current schema version. Bumped whenever a migration is added.
 #[allow(dead_code)] // not yet consumed outside tests; will back future migration tooling (Lot 2+)
-pub const SCHEMA_VERSION: i64 = 1;
+pub const SCHEMA_VERSION: i64 = 2;
 
 /// Apply the database schema: create base tables (target schema) then run migrations.
 pub fn apply(conn: &Connection) -> anyhow::Result<()> {
@@ -30,7 +30,8 @@ pub fn apply(conn: &Connection) -> anyhow::Result<()> {
             cost REAL NOT NULL DEFAULT 0.0,
             duration_ms INTEGER NOT NULL DEFAULT 0,
             status TEXT NOT NULL DEFAULT 'success',
-            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            project TEXT
         );
 
         CREATE INDEX IF NOT EXISTS idx_runs_agent ON runs(agent);
@@ -128,6 +129,10 @@ fn migrate(conn: &Connection) -> anyhow::Result<()> {
         migrate_to_v1(conn)?;
         conn.execute_batch("PRAGMA user_version = 1;")?;
     }
+    if version < 2 {
+        migrate_to_v2(conn)?;
+        conn.execute_batch("PRAGMA user_version = 2;")?;
+    }
     Ok(())
 }
 
@@ -177,6 +182,24 @@ fn migrate_to_v1(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// v1 → v2: add `runs.project` (the project root path a run was executed
+/// from), so History/Costs can attribute runs to a project. A plain `ALTER
+/// TABLE ADD COLUMN` suffices (unlike v1, no CHECK constraint is involved),
+/// so no table rebuild is needed. A fresh database already has the column
+/// from `apply`'s base `CREATE TABLE IF NOT EXISTS runs` above, so this is a
+/// no-op there.
+fn migrate_to_v2(conn: &Connection) -> anyhow::Result<()> {
+    let has_project: bool = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('runs') WHERE name = 'project'",
+        [],
+        |r| r.get::<_, i64>(0),
+    )? > 0;
+    if !has_project {
+        conn.execute_batch("ALTER TABLE runs ADD COLUMN project TEXT;")?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,6 +225,7 @@ mod tests {
         apply(&conn).unwrap();
         assert_eq!(user_version(&conn), SCHEMA_VERSION);
         assert!(has_column(&conn, "orchestration_runs", "parent_run_id"));
+        assert!(has_column(&conn, "runs", "project"));
         // delegation_events table exists
         let n: i64 = conn
             .query_row(
@@ -342,5 +366,53 @@ mod tests {
         apply(&conn).unwrap();
         apply(&conn).unwrap(); // must not error or duplicate
         assert_eq!(user_version(&conn), SCHEMA_VERSION);
+    }
+
+    /// A v1 database (already migrated past the CHECK-relaxation, i.e. it has
+    /// `parent_run_id`, but predates `runs.project`) migrates to v2 by adding
+    /// the column in place — no table rebuild, no data loss.
+    #[test]
+    fn v1_db_migrates_to_v2_adding_project_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE runs (id TEXT PRIMARY KEY, agent TEXT NOT NULL, input TEXT NOT NULL,
+                output TEXT NOT NULL, provider TEXT NOT NULL, model TEXT NOT NULL,
+                tokens_in INTEGER NOT NULL DEFAULT 0, tokens_out INTEGER NOT NULL DEFAULT 0,
+                cost REAL NOT NULL DEFAULT 0.0, duration_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'success', created_at TEXT NOT NULL DEFAULT (datetime('now')));
+            CREATE TABLE orchestration_runs (
+                run_id        TEXT PRIMARY KEY REFERENCES runs(id),
+                pattern       TEXT NOT NULL CHECK (pattern IN ('direct', 'blackboard', 'ring', 'hierarchical')),
+                config_json   TEXT NOT NULL,
+                outcome_json  TEXT,
+                rounds        INTEGER NOT NULL DEFAULT 0,
+                halt_reason   TEXT,
+                parent_run_id TEXT,
+                created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                finished_at   TEXT
+            );
+            INSERT INTO runs (id, agent, input, output, provider, model) VALUES ('r1','a','i','o','p','m');
+            ",
+        )
+        .unwrap();
+        conn.execute_batch("PRAGMA user_version = 1;").unwrap();
+
+        assert_eq!(user_version(&conn), 1);
+        assert!(has_column(&conn, "orchestration_runs", "parent_run_id"));
+        assert!(!has_column(&conn, "runs", "project"));
+
+        apply(&conn).unwrap();
+
+        assert_eq!(user_version(&conn), SCHEMA_VERSION);
+        assert!(has_column(&conn, "runs", "project"));
+        // Existing row preserved (ALTER TABLE ADD COLUMN, not a rebuild).
+        let (agent, project): (String, Option<String>) = conn
+            .query_row("SELECT agent, project FROM runs WHERE id='r1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(agent, "a");
+        assert_eq!(project, None);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -74,6 +74,7 @@ pub struct RunEntry {
     pub status: String,
     pub input_preview: String,
     pub output_preview: String,
+    pub project: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -378,6 +378,7 @@ fn load_storage_data(app: &mut app::App) {
                 cost: r.cost,
                 duration_ms: r.duration_ms,
                 status: r.status,
+                project: r.project,
             })
             .collect();
     }

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -11,6 +11,17 @@ use crate::tui::filter;
 use crate::tui::format::format_cost;
 use crate::tui::widgets::search_bar;
 
+/// Display value for the History table's PROJECT column: the basename of the
+/// project root path (the full path is long; the last component is enough
+/// to tell projects apart), or `—` when the run has no associated project
+/// (ad-hoc runs outside any `armadai.yaml`, or pre-migration rows).
+fn project_display(project: Option<&str>) -> String {
+    project
+        .and_then(|p| std::path::Path::new(p).file_name())
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "—".to_string())
+}
+
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.history.is_empty() {
         let msg =
@@ -32,7 +43,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     let header = Row::new(vec![
-        "", "AGENT", "PROVIDER", "MODEL", "IN", "OUT", "COST", "MS", "STATUS",
+        "", "AGENT", "PROJECT", "PROVIDER", "MODEL", "IN", "OUT", "COST", "MS", "STATUS",
     ])
     .style(Style::default().add_modifier(Modifier::BOLD))
     .bottom_margin(1);
@@ -52,6 +63,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 r.model.clone()
             };
+            let project_short = project_display(r.project.as_deref());
             let style = if display_i == app.selected_history {
                 theme::selection()
             } else {
@@ -60,6 +72,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             Row::new(vec![
                 marker.to_string(),
                 r.agent.clone(),
+                project_short,
                 r.provider.clone(),
                 model_short,
                 r.tokens_in.to_string(),
@@ -76,9 +89,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         rows,
         [
             Constraint::Length(2),
-            Constraint::Min(12),
+            Constraint::Min(10),
+            Constraint::Length(14),
             Constraint::Length(10),
-            Constraint::Length(20),
+            Constraint::Length(16),
             Constraint::Length(6),
             Constraint::Length(6),
             Constraint::Length(8),
@@ -99,5 +113,32 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     // Render search bar if in search mode
     if app.search_mode {
         search_bar(frame, &app.search_query, area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_display_basename_of_a_path() {
+        assert_eq!(
+            project_display(Some("/home/user/projects/my-app")),
+            "my-app"
+        );
+    }
+
+    #[test]
+    fn project_display_none_shows_placeholder() {
+        assert_eq!(project_display(None), "—");
+    }
+
+    #[test]
+    fn project_display_trailing_slash_still_resolves_basename() {
+        // Path::file_name ignores a trailing separator.
+        assert_eq!(
+            project_display(Some("/home/user/projects/my-app/")),
+            "my-app"
+        );
     }
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -965,6 +965,7 @@ mod tests {
                 cost: 0.01,
                 duration_ms: 500,
                 status: "success".to_string(),
+                project: None,
             },
         )
         .unwrap();
@@ -1072,6 +1073,7 @@ mod tests {
                 cost: 0.0,
                 duration_ms: 0,
                 status: "success".to_string(),
+                project: None,
             },
         )
         .unwrap();
@@ -1116,6 +1118,7 @@ mod tests {
                 cost: 0.0,
                 duration_ms: 0,
                 status: "success".to_string(),
+                project: None,
             },
         )
         .unwrap();


### PR DESCRIPTION
## History/Costs enfin utiles (3 parties + fix revue)

- **A — DB path absolu** : défaut `~/.local/share/armadai/armadai.sqlite` (XDG) au lieu de `data/armadai.sqlite` relatif au CWD. Fini le « History/Costs vides selon le dossier ». `armadai init` ne réinjecte plus le path relatif. Configs avec `storage.path` explicite inchangées.
- **B — `project` par run** : migration schema **v2** (`ALTER TABLE runs ADD COLUMN project`, via user_version), chaque run (séquentiel + orchestration) tagué avec son projet (`AgentResolution::root`, sinon CWD).
- **C — coût/tokens réels du provider CLI** : le provider CLI parse la sortie stream-json (via `json_runner`) → `total_cost_usd` + `usage` au lieu de `$0.00`. Fix revue : les args json sont choisis **dans la factory** (les `args:` custom d'un agent sont respectés, jamais écrasés) ; le provider est format-agnostique (parse le json opportunément, fallback texte brut).
- **D — TUI** : colonne **PROJECT** (basename) dans History.

### Vérifs
Clippy 3 modes (`-D warnings`), fmt, build release, tests schema/queries/cli (v2 migration testée, parsing coût testé). Revue finale opus (a validé l'extraction de contenu partie C, la migration, et fait corriger le drop d'args custom).
⚠️ Flake `llm_agents`/`model_resolution` `latest:auto` pré-existant, non lié.
Note : les users ayant déjà `armadai init` gardent leur `storage.path` relatif jusqu'à re-init/édition (Part A n'aide que fresh inits + configs sans path).

⚠️ **Visuel/comportement → validation avant merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)