### PR TITLE
chore: address post-rc.3 debts (hermetic tests, cache tokens, root-only trace list)

### DIFF
--- a/src/core/orchestration/llm_agents.rs
+++ b/src/core/orchestration/llm_agents.rs
@@ -1314,12 +1314,62 @@ mod tests {
         agent
     }
 
+    /// RAII guard that points `ARMADAI_CONFIG_DIR` at a private, empty
+    /// tempdir for the lifetime of the guard, so `resolve_model_for_tier`
+    /// (called both by the production code path under test and by the
+    /// test's own expected-value computation) can never observe the
+    /// ambient/machine-local models.dev cache.
+    ///
+    /// Without this, two calls to `resolve_model_for_tier` in the same test
+    /// could race against a *different* test (in another thread) that is
+    /// concurrently fetching/writing the real shared cache file, or could
+    /// simply see different content across machines/CI — exactly the
+    /// "present/absent/partial depending on machine + parallel runs"
+    /// flakiness this guard eliminates. Serialised via `ENV_MUTEX` since
+    /// mutating `ARMADAI_CONFIG_DIR` is process-global state.
+    struct IsolatedModelCache {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        _tmp: tempfile::TempDir,
+        orig: Option<String>,
+    }
+
+    impl IsolatedModelCache {
+        fn new() -> Self {
+            let guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+            let tmp = tempfile::tempdir().expect("tempdir");
+            // SAFETY: env mutation is serialised via ENV_MUTEX for the
+            // lifetime of this guard, and the original value is restored on
+            // drop.
+            unsafe {
+                std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path());
+            }
+            Self {
+                _guard: guard,
+                _tmp: tmp,
+                orig,
+            }
+        }
+    }
+
+    impl Drop for IsolatedModelCache {
+        fn drop(&mut self) {
+            // SAFETY: still holding `_guard` (ENV_MUTEX) at this point.
+            match self.orig.take() {
+                Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+                None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_board_agent_latest_auto_downgrades_on_low_budget() {
         // The "critical" tag maps to Max under default RoutingRules, but the
         // board's remaining budget is far below `budget_downgrade_ratio`
         // (default 0.2) — the router must downgrade to Fast and report
         // RouteReason::Budget, exactly as it would for run_single_agent.
+        let _isolated = IsolatedModelCache::new();
+
         let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
         let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
         let sink = Arc::new(CaptureSink::new());
@@ -1363,6 +1413,8 @@ mod tests {
     async fn test_board_agent_latest_auto_no_downgrade_when_budget_healthy() {
         // Same "critical" tag (→ Max) but a healthy budget: no downgrade,
         // reason stays Tag — proves the budget check is not unconditional.
+        let _isolated = IsolatedModelCache::new();
+
         let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
         let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
         let sink = Arc::new(CaptureSink::new());
@@ -1401,6 +1453,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_ring_agent_latest_auto_downgrades_on_low_budget() {
+        let _isolated = IsolatedModelCache::new();
+
         let agent = make_agent_latest_auto("agent-a", vec!["critical".to_string()]);
         let routing = RoutingCtx::new(RoutingRules::default(), 1_000);
         let sink = Arc::new(CaptureSink::new());
@@ -1467,6 +1521,7 @@ mod tests {
         // A `RoutingCtx::default()` (used by `LlmBoardAgent::new`/`LlmRingAgent::new`
         // when no explicit routing context is supplied) must carry no budget,
         // so `route()` never downgrades regardless of remaining tokens.
+        let _isolated = IsolatedModelCache::new();
         let routing = RoutingCtx::default();
         let sink: Arc<dyn EventSink> = Arc::new(NullSink);
 

--- a/src/linker/model_resolution.rs
+++ b/src/linker/model_resolution.rs
@@ -145,15 +145,29 @@ pub fn fallback_model(provider: &str) -> &'static str {
 ///
 /// Strategy:
 /// 1. Filter cached models by tier (using `classify_model_tier`).
-/// 2. Exclude dated variants (IDs containing `-20` date suffixes).
-/// 3. Exclude preview models.
+/// 2. Exclude `latest`-alias IDs (e.g. `claude-3-5-sonnet-latest`) — real
+///    provider catalogs (models.dev) can list these alongside dated/bare
+///    variants, and since `"latest"` sorts alphabetically after any digit,
+///    an unfiltered `max()` would prefer them over a concrete pinned
+///    version. Callers (e.g. `latest:*` placeholder resolution) require a
+///    genuinely concrete model id — never one containing the literal
+///    substring `latest` — so these are excluded at every stage below, not
+///    just from the "clean" preference pass.
+/// 3. Exclude dated variants (IDs containing `-20` date suffixes) and
+///    preview models from the preferred ("clean") candidate set.
 /// 4. Among remaining, pick the one that sorts last alphabetically (highest version).
-/// 5. If no candidate survives filtering, fall back to hardcoded defaults.
+/// 5. If no "clean" candidate survives, fall back to any non-`latest` candidate.
+/// 6. If no candidate survives filtering at all, fall back to hardcoded defaults.
+///
+/// This guarantees `resolve_model_for_tier` never returns a string
+/// containing `"latest"`, regardless of what the ambient model registry
+/// cache does or doesn't contain.
 pub fn resolve_model_for_tier(provider: &str, tier: ModelTier) -> String {
     if let Some(entries) = crate::model_registry::fetch::load_models_cached(provider) {
         let candidates: Vec<&str> = entries
             .iter()
             .filter(|e| classify_model_tier(&e.id, provider) == Some(tier))
+            .filter(|e| !e.id.contains("latest"))
             .map(|e| e.id.as_str())
             .collect();
 
@@ -167,7 +181,7 @@ pub fn resolve_model_for_tier(provider: &str, tier: ModelTier) -> String {
             return (**best).to_string();
         }
 
-        // Fallback: any candidate, pick highest
+        // Fallback: any candidate (already excludes `latest`-alias ids), pick highest
         if let Some(best) = candidates.iter().max() {
             return best.to_string();
         }
@@ -685,7 +699,28 @@ mod tests {
 
     #[test]
     fn test_preview_resolution_with_latest() {
+        // Hermetic: force an empty, private `ARMADAI_CONFIG_DIR` so this test
+        // never sees the ambient/machine-local models.dev cache (which may
+        // be present, absent, or contain `-latest` alias ids depending on
+        // machine + parallel test runs — see resolve_model_for_tier's
+        // doc-comment). With no cache reachable, resolution always takes the
+        // hardcoded-fallback path, making the assertion deterministic.
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: env mutation is serialised via ENV_MUTEX for the duration
+        // of this test, and the original value is restored before returning.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path());
+        }
+
         let result = preview_model_resolution(Some("latest:fast"));
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+
         for (_target, model) in &result {
             // All targets should resolve to a concrete model, not "latest:fast"
             assert!(!model.contains("latest"));

--- a/src/shell/json_runner.rs
+++ b/src/shell/json_runner.rs
@@ -395,11 +395,26 @@ fn parse_claude_json(json: &Value) -> CliResponse {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    // Extract tokens from usage
+    // Extract tokens from usage.
+    //
+    // Claude Code reports most of the prompt via the prompt-cache fields
+    // (`cache_read_input_tokens` for a cache hit, `cache_creation_input_tokens`
+    // when writing a new cache entry) rather than `input_tokens`, which is
+    // often just a handful of uncached tokens. Summing all three gives the
+    // true total prompt size — otherwise History/Costs show a misleading
+    // near-zero "IN" count for a run that actually sent a full prompt.
     let usage = json.get("usage");
-    let tokens_in = usage
-        .and_then(|u| u.get("input_tokens"))
-        .and_then(|v| v.as_u64());
+    let usage_u64 = |field: &str| {
+        usage
+            .and_then(|u| u.get(field))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+    };
+    let tokens_in = usage.map(|_| {
+        usage_u64("input_tokens")
+            + usage_u64("cache_read_input_tokens")
+            + usage_u64("cache_creation_input_tokens")
+    });
     let tokens_out = usage
         .and_then(|u| u.get("output_tokens"))
         .and_then(|v| v.as_u64());
@@ -661,6 +676,38 @@ mod tests {
         assert_eq!(resp.session_id, Some("abc-123".to_string()));
         assert_eq!(resp.model, Some("claude-opus-4-6".to_string()));
         assert!(resp.from_json);
+    }
+
+    #[test]
+    fn test_parse_claude_json_sums_cache_tokens_into_tokens_in() {
+        // Claude Code reports most of the real prompt via cache_read/
+        // cache_creation, not input_tokens — tokens_in must be the sum of
+        // all three so History/Costs don't show a misleading near-zero "IN"
+        // for a run that actually sent a full (cached) prompt.
+        let json = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":5100,"num_turns":1,"result":"Hello!","session_id":"abc-123","total_cost_usd":0.076,"usage":{"input_tokens":2,"cache_read_input_tokens":15000,"cache_creation_input_tokens":300,"output_tokens":10},"modelUsage":{"claude-opus-4-6":{"outputTokens":10}}}"#;
+        let resp = parse_json_response("claude", json);
+        assert_eq!(resp.tokens_in, Some(2 + 15000 + 300));
+        assert_eq!(resp.tokens_out, Some(10));
+    }
+
+    #[test]
+    fn test_parse_claude_json_tokens_in_without_cache_fields_unchanged() {
+        // No cache fields present: tokens_in falls back to input_tokens alone
+        // (each missing field defaults to 0), matching pre-fix behavior.
+        let json =
+            r#"{"type":"result","result":"Hi","usage":{"input_tokens":100,"output_tokens":10}}"#;
+        let resp = parse_json_response("claude", json);
+        assert_eq!(resp.tokens_in, Some(100));
+    }
+
+    #[test]
+    fn test_parse_claude_json_no_usage_object_yields_none() {
+        // No `usage` key at all: tokens_in/tokens_out stay None rather than
+        // becoming Some(0), matching pre-fix behavior for malformed output.
+        let json = r#"{"type":"result","result":"Hi"}"#;
+        let resp = parse_json_response("claude", json);
+        assert_eq!(resp.tokens_in, None);
+        assert_eq!(resp.tokens_out, None);
     }
 
     #[test]

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -387,6 +387,43 @@ pub fn get_orchestration_runs(
     Ok(records)
 }
 
+/// Get root orchestration runs list (most recent first), excluding nested
+/// children (`parent_run_id IS NOT NULL`).
+///
+/// Filters at the SQL level rather than in Rust so `limit` bounds the number
+/// of *roots* returned — filtering a `get_orchestration_runs` result in Rust
+/// after the fact would let nested children consume slots in the initial
+/// `LIMIT`, silently returning fewer than `limit` roots whenever a run in the
+/// window has children (see C6 trace list pagination).
+pub fn get_root_orchestration_runs(
+    db: &Database,
+    limit: u32,
+) -> anyhow::Result<Vec<OrchestrationRunRecord>> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+    let mut stmt = conn.prepare(
+        "SELECT run_id, pattern, config_json, outcome_json, rounds, halt_reason, parent_run_id
+         FROM orchestration_runs WHERE parent_run_id IS NULL ORDER BY created_at DESC LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(params![limit], |row| {
+        Ok(OrchestrationRunRecord {
+            run_id: row.get(0)?,
+            pattern: row.get(1)?,
+            config_json: row.get(2)?,
+            outcome_json: row.get(3)?,
+            rounds: row.get(4)?,
+            halt_reason: row.get(5)?,
+            parent_run_id: row.get(6)?,
+        })
+    })?;
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row?);
+    }
+    Ok(records)
+}
+
 /// Get board entries for a run.
 #[allow(dead_code)] // API reserved for future `armadai history` / web UI
 pub fn get_board_entries(db: &Database, run_id: &str) -> anyhow::Result<Vec<BoardEntryRecord>> {
@@ -653,6 +690,75 @@ mod tests {
         let r = result.unwrap();
         assert_eq!(r.pattern, "blackboard");
         assert_eq!(r.rounds, 3);
+    }
+
+    #[test]
+    fn test_get_root_orchestration_runs_excludes_children() {
+        // C6 regression: pagination must filter parent_run_id at the SQL
+        // level (WHERE parent_run_id IS NULL ... LIMIT), not by fetching
+        // `limit` rows and filtering roots out in Rust afterwards — the
+        // latter lets children consume slots in the LIMIT window and can
+        // silently return fewer than `limit` roots.
+        let db = init_embedded().unwrap();
+
+        insert_run_with_id(&db, "root-1", sample_run("agent-a", 0.01)).unwrap();
+        insert_run_with_id(&db, "root-2", sample_run("agent-a", 0.02)).unwrap();
+        insert_run_with_id(&db, "child-1", sample_run("agent-a", 0.03)).unwrap();
+
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: "root-1".to_string(),
+                pattern: "blackboard".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 1,
+                halt_reason: None,
+                parent_run_id: None,
+            },
+        )
+        .unwrap();
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: "root-2".to_string(),
+                pattern: "ring".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 1,
+                halt_reason: None,
+                parent_run_id: None,
+            },
+        )
+        .unwrap();
+        insert_orchestration_run(
+            &db,
+            OrchestrationRunRecord {
+                run_id: "child-1".to_string(),
+                pattern: "hierarchical".to_string(),
+                config_json: "{}".to_string(),
+                outcome_json: None,
+                rounds: 1,
+                halt_reason: None,
+                parent_run_id: Some("root-1".to_string()),
+            },
+        )
+        .unwrap();
+
+        let roots = get_root_orchestration_runs(&db, 50).unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots.iter().all(|r| r.parent_run_id.is_none()));
+        let ids: Vec<&str> = roots.iter().map(|r| r.run_id.as_str()).collect();
+        assert!(ids.contains(&"root-1"));
+        assert!(ids.contains(&"root-2"));
+        assert!(!ids.contains(&"child-1"));
+
+        // Also verify the LIMIT-window-loss scenario the SQL-level filter
+        // fixes: a limit of 1 must still return exactly a root (not a
+        // truncated set that happened to include the child).
+        let limited = get_root_orchestration_runs(&db, 1).unwrap();
+        assert_eq!(limited.len(), 1);
+        assert!(limited[0].parent_run_id.is_none());
     }
 
     #[test]

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -395,6 +395,7 @@ pub fn get_orchestration_runs(
 /// after the fact would let nested children consume slots in the initial
 /// `LIMIT`, silently returning fewer than `limit` roots whenever a run in the
 /// window has children (see C6 trace list pagination).
+#[allow(dead_code)] // sole caller (get_orchestration_trace) is gated behind `web`
 pub fn get_root_orchestration_runs(
     db: &Database,
     limit: u32,

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -623,11 +623,10 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
     {
         use crate::storage::{init_db, queries};
         if let Ok(db) = init_db()
-            && let Ok(runs) = queries::get_orchestration_runs(&db, 50)
+            && let Ok(runs) = queries::get_root_orchestration_runs(&db, 50)
         {
             let traces: Vec<serde_json::Value> = runs
                 .iter()
-                .filter(|r| r.parent_run_id.is_none())
                 .map(|r| {
                     serde_json::json!({
                         "id": r.run_id,


### PR DESCRIPTION
## Assainissement post-rc.3 (3 dettes)

- **Tests hermétiques** : `resolve_model_for_tier` exclut désormais les candidats `-latest` (alias flottants de models.dev qui triaient au-dessus des versions pinnées) → renvoie toujours un modèle **pinné concret** ; les 5 tests `latest:auto`/`preview` isolés via `ENV_MUTEX`+`ARMADAI_CONFIG_DIR` tempdir. **Loop 30/30 stable** (fini le flaky).
- **Tokens IN CLI** : `parse_claude_json` somme `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` → History/Costs n'affichent plus un « IN 2 » trompeur pour les prompts cachés de claude.
- **Liste trace C6** : nouvelle query `get_root_orchestration_runs` (filtre `parent_run_id IS NULL` **au niveau SQL, avant LIMIT**) → la liste ne perd plus des racines quand des sous-runs consomment des slots.

### Vérifs
Clippy 4 modes (`tui`, `tui,providers-api`, `tui,storage`, `tui,web,storage`, `-D warnings`), fmt, build release, 848 tests. Revue finale (a capté + fait corriger un dead_code dans le combo `tui,storage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)