### PR TITLE
feat(starters): B2 Lot B Lot 1 — remote starter registries (git core)

### DIFF
--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -372,6 +372,12 @@ async fn sources_add(kind: SourceKind, url: &str) -> anyhow::Result<()> {
         RegistryKind::Agents => &mut config.agents,
         RegistryKind::Skills => &mut config.skills,
         RegistryKind::Models => &mut config.models,
+        // Starters are not yet exposed through this CLI (B2 Lot B, Lot 2);
+        // `SourceKind` (the CLI-facing arg enum above) has no `Starters`
+        // variant, so `kind.into()` can never actually produce this arm.
+        RegistryKind::Starters => {
+            unreachable!("starters not exposed via `registry sources` CLI yet")
+        }
     };
 
     // Check if already present (idempotent)
@@ -382,6 +388,7 @@ async fn sources_add(kind: SourceKind, url: &str) -> anyhow::Result<()> {
 
     sources.push(RegistrySource {
         url: url.to_string(),
+        kind: None,
     });
 
     save_registries_config(&config)?;
@@ -400,6 +407,10 @@ async fn sources_remove(kind: SourceKind, url: &str) -> anyhow::Result<()> {
         RegistryKind::Agents => &mut config.agents,
         RegistryKind::Skills => &mut config.skills,
         RegistryKind::Models => &mut config.models,
+        // See the matching comment in `sources_add`.
+        RegistryKind::Starters => {
+            unreachable!("starters not exposed via `registry sources` CLI yet")
+        }
     };
 
     let before = sources.len();
@@ -437,6 +448,7 @@ fn kind_name(kind: RegistryKind) -> &'static str {
         RegistryKind::Agents => "agents",
         RegistryKind::Skills => "skills",
         RegistryKind::Models => "models",
+        RegistryKind::Starters => "starters",
     }
 }
 

--- a/src/core/registries.rs
+++ b/src/core/registries.rs
@@ -17,10 +17,40 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::config::registries_config_path;
 
+/// Delivery kind of a registry source (transport-agnostic fetch).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceKind {
+    Git,
+    Archive,
+}
+
 /// A single custom registry source.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct RegistrySource {
     pub url: String,
+    /// Delivery kind. Absent = inferred from the URL (see `resolved_kind`).
+    #[serde(default)]
+    pub kind: Option<SourceKind>,
+}
+
+impl RegistrySource {
+    /// The effective delivery kind: explicit `kind`, else inferred from the URL.
+    ///
+    /// Not yet called outside tests: the `starters_registry` fetcher that
+    /// dispatches on this (B2 Lot B, Task 2) lands in a follow-up task.
+    #[allow(dead_code)]
+    pub fn resolved_kind(&self) -> SourceKind {
+        if let Some(k) = self.kind {
+            return k;
+        }
+        let u = self.url.to_lowercase();
+        if u.ends_with(".tar.gz") || u.ends_with(".tgz") || u.ends_with(".zip") {
+            SourceKind::Archive
+        } else {
+            SourceKind::Git
+        }
+    }
 }
 
 /// Custom registry sources declared by the user or a project, grouped by
@@ -39,11 +69,6 @@ pub struct RegistriesConfig {
 }
 
 /// Which registry kind is being resolved.
-///
-/// `starters` intentionally has no variant here yet: starter registry
-/// resolution is Lot B and out of scope for this task, even though the
-/// `starters` field already exists on [`RegistriesConfig`] for forward
-/// compatibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegistryKind {
     Agents,
@@ -55,6 +80,11 @@ pub enum RegistryKind {
     /// registry fetching is unavailable anyway.
     #[allow(dead_code)]
     Models,
+    /// Not yet constructed outside tests: the starter-registry sync path
+    /// that resolves starter sources (B2 Lot B, Task 2) lands in a
+    /// follow-up task.
+    #[allow(dead_code)]
+    Starters,
 }
 
 impl RegistryKind {
@@ -63,6 +93,7 @@ impl RegistryKind {
             RegistryKind::Agents => &config.agents,
             RegistryKind::Skills => &config.skills,
             RegistryKind::Models => &config.models,
+            RegistryKind::Starters => &config.starters,
         }
     }
 }
@@ -183,19 +214,22 @@ registries:
         assert_eq!(
             wrapper.registries.agents,
             vec![RegistrySource {
-                url: "https://example.com/agents.git".to_string()
+                url: "https://example.com/agents.git".to_string(),
+                kind: None
             }]
         );
         assert_eq!(
             wrapper.registries.skills,
             vec![RegistrySource {
-                url: "https://example.com/skills.git".to_string()
+                url: "https://example.com/skills.git".to_string(),
+                kind: None
             }]
         );
         assert_eq!(
             wrapper.registries.models,
             vec![RegistrySource {
-                url: "https://example.com/models.json".to_string()
+                url: "https://example.com/models.json".to_string(),
+                kind: None
             }]
         );
         assert!(wrapper.registries.starters.is_empty());
@@ -242,9 +276,11 @@ registries:
             agents: vec![
                 RegistrySource {
                     url: "https://default.example/a".to_string(),
+                    kind: None,
                 }, // duplicate of a default
                 RegistrySource {
                     url: "https://user.example/b".to_string(),
+                    kind: None,
                 },
             ],
             ..Default::default()
@@ -253,9 +289,11 @@ registries:
             agents: vec![
                 RegistrySource {
                     url: "https://user.example/b".to_string(),
+                    kind: None,
                 }, // duplicate of a user source
                 RegistrySource {
                     url: "https://project.example/c".to_string(),
+                    kind: None,
                 },
             ],
             ..Default::default()
@@ -283,6 +321,7 @@ registries:
         let user = RegistriesConfig {
             skills: vec![RegistrySource {
                 url: "https://user.example/skills".to_string(),
+                kind: None,
             }],
             ..Default::default()
         };
@@ -353,5 +392,50 @@ registries:
             Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
             None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
         }
+    }
+
+    #[test]
+    fn test_source_kind_deserialize_and_infer() {
+        let yaml = r#"
+starters:
+  - url: "https://github.com/me/starters.git"
+  - url: "https://x.com/p.tar.gz"
+  - url: "https://interne/p"
+    kind: archive
+"#;
+        let c: RegistriesConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(c.starters[0].resolved_kind(), SourceKind::Git); // .git → git
+        assert_eq!(c.starters[1].resolved_kind(), SourceKind::Archive); // .tar.gz → archive
+        assert_eq!(c.starters[2].resolved_kind(), SourceKind::Archive); // explicit override
+        assert_eq!(c.starters[2].kind, Some(SourceKind::Archive));
+    }
+
+    #[test]
+    fn test_infer_defaults_to_git() {
+        let s = RegistrySource {
+            url: "https://host/repo".to_string(),
+            kind: None,
+        };
+        assert_eq!(s.resolved_kind(), SourceKind::Git);
+    }
+
+    #[test]
+    fn test_resolved_sources_starters_union() {
+        let user = RegistriesConfig {
+            starters: vec![RegistrySource {
+                url: "u".into(),
+                kind: None,
+            }],
+            ..Default::default()
+        };
+        let proj = RegistriesConfig {
+            starters: vec![RegistrySource {
+                url: "p".into(),
+                kind: None,
+            }],
+            ..Default::default()
+        };
+        let out = resolved_sources(RegistryKind::Starters, &[], &user, Some(&proj));
+        assert_eq!(out, vec!["u".to_string(), "p".to_string()]);
     }
 }

--- a/src/core/starter.rs
+++ b/src/core/starter.rs
@@ -291,9 +291,31 @@ pub fn all_starters_dirs() -> Vec<PathBuf> {
     dirs
 }
 
+/// Pack directories discovered under the remote starters cache (each
+/// synced source is a subdir; packs are found by `discover_packs`).
+pub fn remote_starter_pack_dirs() -> Vec<PathBuf> {
+    remote_starter_pack_dirs_in(&crate::starters_registry::starters_cache_dir())
+}
+
+/// Testable core: scan a cache root's per-source subdirs for packs.
+fn remote_starter_pack_dirs_in(cache_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(sources) = std::fs::read_dir(cache_root) else {
+        return out;
+    };
+    for src in sources.flatten() {
+        if src.path().is_dir() {
+            out.extend(crate::starters_registry::discover_packs(&src.path()));
+        }
+    }
+    out
+}
+
 /// Find a starter pack directory by name across all source directories.
 ///
 /// User and custom directories take priority over built-in (last match wins).
+/// If no local match is found, falls back to the remote starters cache
+/// (local always wins over remote).
 pub fn find_pack_dir(name: &str) -> Option<PathBuf> {
     let mut found: Option<PathBuf> = None;
     for dir in all_starters_dirs() {
@@ -301,6 +323,11 @@ pub fn find_pack_dir(name: &str) -> Option<PathBuf> {
         if candidate.is_dir() && candidate.join("pack.yaml").is_file() {
             found = Some(candidate);
         }
+    }
+    if found.is_none() {
+        found = remote_starter_pack_dirs()
+            .into_iter()
+            .find(|d| d.file_name().is_some_and(|n| n == name));
     }
     found
 }
@@ -325,6 +352,14 @@ pub fn load_all_packs() -> Vec<StarterPack> {
             {
                 packs_map.insert(pack.name.clone(), pack);
             }
+        }
+    }
+
+    // Remote (synced registry cache) packs: never override a local pack of
+    // the same name (local always wins over remote).
+    for dir in remote_starter_pack_dirs() {
+        if let Ok(pack) = StarterPack::load(&dir) {
+            packs_map.entry(pack.name.clone()).or_insert(pack);
         }
     }
 
@@ -365,6 +400,27 @@ pub fn list_available_packs() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_cache_packs_are_discovered() {
+        // A pack under the starters cache dir should be found by find_pack_dir.
+        // Isolate the cache via a temp registry_cache_dir if overridable; else
+        // assert discover_packs surfaces the cache packs through
+        // remote_starter_pack_dirs().
+        use std::fs;
+        let tmp = std::env::temp_dir().join(format!("armadai-remote-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let pack = tmp.join("src1/remote-demo/pack.yaml");
+        fs::create_dir_all(pack.parent().unwrap()).unwrap();
+        fs::write(&pack, "name: remote-demo\n").unwrap();
+        // remote_starter_pack_dirs scans a given cache root for packs:
+        let dirs = remote_starter_pack_dirs_in(&tmp);
+        assert!(
+            dirs.iter()
+                .any(|d| d.file_name().unwrap().to_string_lossy() == "remote-demo")
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
 
     #[test]
     fn test_load_pack() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,6 @@ mod secrets;
 #[allow(dead_code)]
 mod shell;
 mod skills_registry;
-// Not yet wired outside tests: `core/starter.rs` integration (B2 Lot B,
-// Task 3) is a follow-up task that consumes this module's public API.
-#[allow(dead_code)]
 mod starters_registry;
 #[cfg(feature = "storage")]
 mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,10 @@ mod secrets;
 #[allow(dead_code)]
 mod shell;
 mod skills_registry;
+// Not yet wired outside tests: `core/starter.rs` integration (B2 Lot B,
+// Task 3) is a follow-up task that consumes this module's public API.
+#[allow(dead_code)]
+mod starters_registry;
 #[cfg(feature = "storage")]
 mod storage;
 #[cfg(feature = "tui")]

--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -419,6 +419,7 @@ mod tests {
         let user = RegistriesConfig {
             models: vec![RegistrySource {
                 url: "https://example.com/custom-models.json".to_string(),
+                kind: None,
             }],
             ..Default::default()
         };

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -349,6 +349,7 @@ mod tests {
         let user = RegistriesConfig {
             agents: vec![RegistrySource {
                 url: "https://example.com/custom-agents.git".to_string(),
+                kind: None,
             }],
             ..Default::default()
         };

--- a/src/skills_registry/sync.rs
+++ b/src/skills_registry/sync.rs
@@ -192,6 +192,7 @@ mod tests {
         let user = RegistriesConfig {
             skills: vec![RegistrySource {
                 url: "https://github.com/custom-org/custom-skills".to_string(),
+                kind: None,
             }],
             ..Default::default()
         };

--- a/src/starters_registry/mod.rs
+++ b/src/starters_registry/mod.rs
@@ -1,0 +1,247 @@
+//! Remote starter registries (B2 Lot B): fetch starter packs from git (Lot 1)
+//! or archive (Lot 2) sources into a cache, discovered by the existing
+//! `StarterPack` convention (+ an optional `armadai-starters.yaml` manifest).
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::core::registries::{RegistrySource, SourceKind, cache_key};
+
+/// Root cache dir for synced starter registries.
+pub fn starters_cache_dir() -> PathBuf {
+    crate::core::config::registry_cache_dir().join("starters")
+}
+
+/// Cache dir for one source URL.
+pub fn source_cache_dir(url: &str) -> PathBuf {
+    starters_cache_dir().join(cache_key(url))
+}
+
+/// Optional registry manifest that enriches/restricts discovery.
+#[derive(Debug, Deserialize, Default)]
+struct StartersManifest {
+    #[serde(default)]
+    packs: Vec<ManifestPack>,
+}
+#[derive(Debug, Deserialize)]
+struct ManifestPack {
+    path: String,
+}
+
+pub trait StarterFetcher {
+    fn fetch(&self, url: &str, dest: &Path) -> anyhow::Result<()>;
+}
+
+/// Git-backed fetcher: clone if absent, else pull. Shells out to `git`.
+pub struct GitFetcher;
+
+impl StarterFetcher for GitFetcher {
+    fn fetch(&self, url: &str, dest: &Path) -> anyhow::Result<()> {
+        if dest.join(".git").is_dir() {
+            run_git(&[
+                "-C",
+                dest.to_str().unwrap_or("."),
+                "pull",
+                "--ff-only",
+                "-q",
+            ])?;
+        } else {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            run_git(&[
+                "clone",
+                "--depth",
+                "1",
+                "-q",
+                url,
+                dest.to_str().unwrap_or("."),
+            ])?;
+        }
+        Ok(())
+    }
+}
+
+fn run_git(args: &[&str]) -> anyhow::Result<()> {
+    let out = std::process::Command::new("git").args(args).output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Fetch one source into its cache dir. Git only in Lot 1; archive is Lot 2.
+pub fn fetch_starter_source(source: &RegistrySource) -> anyhow::Result<PathBuf> {
+    let dest = source_cache_dir(&source.url);
+    match source.resolved_kind() {
+        SourceKind::Git => {
+            GitFetcher.fetch(&source.url, &dest)?;
+            Ok(dest)
+        }
+        SourceKind::Archive => {
+            anyhow::bail!(
+                "archive starter source '{}' requires the `providers-api` feature (B2 Lot B Lot 2)",
+                source.url
+            )
+        }
+    }
+}
+
+/// Sync all sources; warn+continue on failure. Returns the dirs that synced OK.
+pub fn sync_starters(sources: &[RegistrySource]) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    for s in sources {
+        match fetch_starter_source(s) {
+            Ok(d) => dirs.push(d),
+            Err(e) => eprintln!("  warn: failed to sync starter source {}: {e}", s.url),
+        }
+    }
+    dirs
+}
+
+/// Discover pack directories under a fetched registry dir.
+///
+/// Hybrid: an `armadai-starters.yaml` at the root RESTRICTS to its listed
+/// `path:`s; otherwise every directory containing a `pack.yaml` is a pack.
+pub fn discover_packs(registry_dir: &Path) -> Vec<PathBuf> {
+    let manifest_path = registry_dir.join("armadai-starters.yaml");
+    if manifest_path.is_file()
+        && let Ok(content) = std::fs::read_to_string(&manifest_path)
+        && let Ok(manifest) = serde_yaml_ng::from_str::<StartersManifest>(&content)
+        && !manifest.packs.is_empty()
+    {
+        return manifest
+            .packs
+            .iter()
+            .map(|p| registry_dir.join(&p.path))
+            .filter(|d| d.join("pack.yaml").is_file())
+            .collect();
+    }
+    let mut out = Vec::new();
+    scan_for_packs(registry_dir, 0, &mut out);
+    out
+}
+
+fn scan_for_packs(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth > 4 {
+        return;
+    }
+    if dir.join("pack.yaml").is_file() {
+        out.push(dir.to_path_buf());
+        return; // a pack dir isn't itself scanned deeper
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.is_dir() && !p.file_name().is_some_and(|n| n == ".git") {
+            scan_for_packs(&p, depth + 1, out);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(p: &Path, s: &str) {
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, s).unwrap();
+    }
+
+    #[test]
+    fn discover_by_convention_scans_pack_yaml() {
+        let tmp = std::env::temp_dir().join(format!("armadai-st-conv-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        write(&tmp.join("rust-qa/pack.yaml"), "name: rust-qa\n");
+        write(&tmp.join("nested/web/pack.yaml"), "name: web\n");
+        write(&tmp.join("not-a-pack/readme.md"), "x");
+        let packs = discover_packs(&tmp);
+        let names: Vec<_> = packs
+            .iter()
+            .filter_map(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"rust-qa".to_string()));
+        assert!(names.contains(&"web".to_string()));
+        assert!(!names.iter().any(|n| n == "not-a-pack"));
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn discover_with_manifest_restricts_to_listed() {
+        let tmp = std::env::temp_dir().join(format!("armadai-st-man-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        write(&tmp.join("rust-qa/pack.yaml"), "name: rust-qa\n");
+        write(&tmp.join("hidden/pack.yaml"), "name: hidden\n");
+        write(
+            &tmp.join("armadai-starters.yaml"),
+            "packs:\n  - path: rust-qa\n",
+        );
+        let packs = discover_packs(&tmp);
+        assert_eq!(packs.len(), 1);
+        assert_eq!(packs[0].file_name().unwrap().to_string_lossy(), "rust-qa");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn fetch_archive_kind_errors_in_lot1() {
+        let src = RegistrySource {
+            url: "https://x/p.tar.gz".to_string(),
+            kind: None,
+        };
+        assert!(fetch_starter_source(&src).is_err());
+    }
+
+    #[tokio::test]
+    async fn git_fetcher_clones_local_repo() {
+        // Build a local git repo containing a pack, fetch it, discover the pack.
+        // (Skip gracefully if `git` is unavailable.)
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        let tmp = std::env::temp_dir().join(format!("armadai-st-git-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let repo = tmp.join("origin");
+        write(&repo.join("demo/pack.yaml"), "name: demo\n");
+        for args in [
+            vec!["init", "-q"],
+            vec!["add", "-A"],
+            vec![
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-qm",
+                "x",
+            ],
+        ] {
+            std::process::Command::new("git")
+                .current_dir(&repo)
+                .args(&args)
+                .output()
+                .unwrap();
+        }
+        let dest = tmp.join("dest");
+        GitFetcher.fetch(repo.to_str().unwrap(), &dest).unwrap();
+        let packs = discover_packs(&dest);
+        assert!(
+            packs
+                .iter()
+                .any(|p| p.file_name().unwrap().to_string_lossy() == "demo")
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/src/starters_registry/mod.rs
+++ b/src/starters_registry/mod.rs
@@ -14,6 +14,9 @@ pub fn starters_cache_dir() -> PathBuf {
 }
 
 /// Cache dir for one source URL.
+// Not yet wired outside tests: consumed by `fetch_starter_source` /
+// `sync_starters`, which are themselves Lot 2 (CLI `registry sync`) callers.
+#[allow(dead_code)]
 pub fn source_cache_dir(url: &str) -> PathBuf {
     starters_cache_dir().join(cache_key(url))
 }
@@ -29,11 +32,15 @@ struct ManifestPack {
     path: String,
 }
 
+// Not yet wired outside tests: real callers land in Lot 2 (`registry sync`
+// CLI + archive fetcher).
+#[allow(dead_code)]
 pub trait StarterFetcher {
     fn fetch(&self, url: &str, dest: &Path) -> anyhow::Result<()>;
 }
 
 /// Git-backed fetcher: clone if absent, else pull. Shells out to `git`.
+#[allow(dead_code)]
 pub struct GitFetcher;
 
 impl StarterFetcher for GitFetcher {
@@ -63,6 +70,7 @@ impl StarterFetcher for GitFetcher {
     }
 }
 
+#[allow(dead_code)]
 fn run_git(args: &[&str]) -> anyhow::Result<()> {
     let out = std::process::Command::new("git").args(args).output()?;
     if !out.status.success() {
@@ -76,6 +84,9 @@ fn run_git(args: &[&str]) -> anyhow::Result<()> {
 }
 
 /// Fetch one source into its cache dir. Git only in Lot 1; archive is Lot 2.
+// Not yet wired outside tests: real caller is `sync_starters`, itself a
+// Lot 2 (CLI `registry sync`) entry point.
+#[allow(dead_code)]
 pub fn fetch_starter_source(source: &RegistrySource) -> anyhow::Result<PathBuf> {
     let dest = source_cache_dir(&source.url);
     match source.resolved_kind() {
@@ -93,6 +104,9 @@ pub fn fetch_starter_source(source: &RegistrySource) -> anyhow::Result<PathBuf> 
 }
 
 /// Sync all sources; warn+continue on failure. Returns the dirs that synced OK.
+// Not yet wired outside tests: real caller is the Lot 2 `registry sync` CLI
+// command.
+#[allow(dead_code)]
 pub fn sync_starters(sources: &[RegistrySource]) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     for s in sources {


### PR DESCRIPTION
## B2 Lot B — Lot 1 : starters distants (cœur + git)

Première tranche des **starters distants** (suite de B2 Lot A #182). Fetch/découverte de starter packs depuis des registres **git**, derrière une abstraction agnostique du livrable.

### Contenu
- **`SourceKind { Git, Archive }`** + `RegistrySource.kind` (inféré de l'URL — `.git`→git, `.tar.gz`/`.zip`→archive — ou explicite). `RegistryKind::Starters` + `resolved_sources(Starters)`.
- **Module `starters_registry`** : cache par source (`registry_cache_dir()/starters/<clé>`), trait `StarterFetcher` + **`GitFetcher`** (clone --depth 1 / pull --ff-only), `fetch_starter_source` (git ; archive → erreur « requires providers-api », Lot 2), `sync_starters`, **découverte hybride** `discover_packs` (scan `pack.yaml` + `armadai-starters.yaml` optionnel qui restreint).
- **Intégration** `core/starter.rs` : `find_pack_dir`/`load_all_packs` incluent le cache distant, **priorité local > distant**.

### Hors périmètre (Lot 2)
Archive fetcher (providers-api), CLI (`registry sources … starters`, `registry sync`), auto-on-miss `init --pack`. + follow-ups revue (lookup par `name:`, rejet `..` dans manifest).

### Qualité
Subagent-driven + revue finale indépendante (backward-compat `kind`, découverte hybride bornée, GitFetcher sans injection, précédence local>distant confirmés). Clippy 2 modes (`-D warnings`), fmt, 853 tests (dont GitFetcher via dépôt git local). Compilé sans `providers-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)