### PR TITLE
feat(starters): B2 Lot B Lot 2 — archive fetcher + CLI + auto-sync-on-miss

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -64,11 +64,27 @@ fn init_global(force: bool) -> anyhow::Result<()> {
 
 /// Resolve a pack reference: a local directory containing `pack.yaml`
 /// takes precedence, otherwise fall back to the named starter pack lookup.
+///
+/// If both miss, auto-sync-on-miss kicks in: known starter registry sources
+/// (user ∪ project, see `crate::cli::registry::effective_starter_sources`)
+/// are synced once, then the lookup is retried. Network is only touched on
+/// a miss — a plain `armadai init --pack <known-local-name>` never syncs.
 pub(crate) fn resolve_pack_dir(name: &str) -> Option<std::path::PathBuf> {
     let candidate = std::path::Path::new(name);
     if candidate.join("pack.yaml").is_file() {
         return Some(candidate.to_path_buf());
     }
+    if let Some(dir) = find_pack_dir(name) {
+        return Some(dir);
+    }
+
+    // Auto-sync-on-miss: fetch remote starter sources, then retry once.
+    let sources = crate::cli::registry::effective_starter_sources();
+    if sources.is_empty() {
+        return None;
+    }
+    eprintln!("Pack '{name}' not found locally — syncing remote starter registries...");
+    let _ = crate::starters_registry::sync_starters(&sources);
     find_pack_dir(name)
 }
 
@@ -388,5 +404,28 @@ mod tests {
         .unwrap();
         let resolved = resolve_pack_dir(dir.path().to_str().unwrap()).unwrap();
         assert_eq!(resolved, dir.path());
+    }
+
+    #[test]
+    fn resolve_pack_dir_miss_without_starter_sources_touches_no_network() {
+        // Backward compat: with no starter registry sources configured (the
+        // default — no `registries.yaml`), a miss on an unknown pack name
+        // must return None without attempting any sync/network call.
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        let config_dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", config_dir.path());
+        }
+
+        let resolved = resolve_pack_dir("definitely-nonexistent-pack-xyz");
+        assert!(resolved.is_none());
+
+        // SAFETY: restoring original env state at end of test scope.
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
     }
 }

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -75,6 +75,8 @@ pub enum SourceKind {
     Skills,
     /// Model catalog sources
     Models,
+    /// Starter pack registry sources
+    Starters,
 }
 
 impl From<SourceKind> for RegistryKind {
@@ -83,6 +85,7 @@ impl From<SourceKind> for RegistryKind {
             SourceKind::Agents => RegistryKind::Agents,
             SourceKind::Skills => RegistryKind::Skills,
             SourceKind::Models => RegistryKind::Models,
+            SourceKind::Starters => RegistryKind::Starters,
         }
     }
 }
@@ -109,7 +112,36 @@ async fn cmd_sync() -> anyhow::Result<()> {
     println!("Building search index...");
     let index = cache::build_index(&sources)?;
     println!("Indexed {} agent(s).", index.entries.len());
+
+    let starter_sources = effective_starter_sources();
+    println!("Syncing {} starter source(s)...", starter_sources.len());
+    if !starter_sources.is_empty() {
+        crate::starters_registry::sync_starters(&starter_sources);
+    }
+
     Ok(())
+}
+
+/// Gather typed starter registry sources (user ∪ project), deduplicated by
+/// URL. Unlike `resolved_sources` (which flattens to bare URL strings and
+/// loses the explicit `kind` override), this keeps the full [`RegistrySource`]
+/// so `sync_starters` can dispatch via `resolved_kind()` with an explicit
+/// `kind:` honored when set.
+fn effective_starter_sources() -> Vec<RegistrySource> {
+    let user = load_user_registries();
+    let project = find_project_config()
+        .map(|(_, cfg)| cfg)
+        .and_then(|cfg| cfg.registries);
+
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    let project_starters = project.map(|cfg| cfg.starters).unwrap_or_default();
+    for source in user.starters.into_iter().chain(project_starters) {
+        if seen.insert(source.url.clone()) {
+            out.push(source);
+        }
+    }
+    out
 }
 
 async fn cmd_search(query: &str, category: Option<&str>) -> anyhow::Result<()> {
@@ -360,6 +392,17 @@ async fn sources_list() -> anyhow::Result<()> {
         }
     }
 
+    // Starters (no built-in default registry — user/project sources only)
+    println!("\nStarters:");
+    for source in &user.starters {
+        println!("  [user]    {}", source.url);
+    }
+    if let Some(ref proj) = project {
+        for source in &proj.starters {
+            println!("  [project] {}", source.url);
+        }
+    }
+
     Ok(())
 }
 
@@ -372,12 +415,7 @@ async fn sources_add(kind: SourceKind, url: &str) -> anyhow::Result<()> {
         RegistryKind::Agents => &mut config.agents,
         RegistryKind::Skills => &mut config.skills,
         RegistryKind::Models => &mut config.models,
-        // Starters are not yet exposed through this CLI (B2 Lot B, Lot 2);
-        // `SourceKind` (the CLI-facing arg enum above) has no `Starters`
-        // variant, so `kind.into()` can never actually produce this arm.
-        RegistryKind::Starters => {
-            unreachable!("starters not exposed via `registry sources` CLI yet")
-        }
+        RegistryKind::Starters => &mut config.starters,
     };
 
     // Check if already present (idempotent)
@@ -407,10 +445,7 @@ async fn sources_remove(kind: SourceKind, url: &str) -> anyhow::Result<()> {
         RegistryKind::Agents => &mut config.agents,
         RegistryKind::Skills => &mut config.skills,
         RegistryKind::Models => &mut config.models,
-        // See the matching comment in `sources_add`.
-        RegistryKind::Starters => {
-            unreachable!("starters not exposed via `registry sources` CLI yet")
-        }
+        RegistryKind::Starters => &mut config.starters,
     };
 
     let before = sources.len();
@@ -455,6 +490,14 @@ fn kind_name(kind: RegistryKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cli_source_kind_starters_maps_to_registry_kind() {
+        assert_eq!(
+            RegistryKind::from(SourceKind::Starters),
+            crate::core::registries::RegistryKind::Starters
+        );
+    }
 
     #[test]
     fn not_found_error_on_empty_index_points_to_sync_not_search() {

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -127,7 +127,7 @@ async fn cmd_sync() -> anyhow::Result<()> {
 /// loses the explicit `kind` override), this keeps the full [`RegistrySource`]
 /// so `sync_starters` can dispatch via `resolved_kind()` with an explicit
 /// `kind:` honored when set.
-fn effective_starter_sources() -> Vec<RegistrySource> {
+pub(crate) fn effective_starter_sources() -> Vec<RegistrySource> {
     let user = load_user_registries();
     let project = find_project_config()
         .map(|(_, cfg)| cfg)

--- a/src/core/registries.rs
+++ b/src/core/registries.rs
@@ -36,10 +36,6 @@ pub struct RegistrySource {
 
 impl RegistrySource {
     /// The effective delivery kind: explicit `kind`, else inferred from the URL.
-    ///
-    /// Not yet called outside tests: the `starters_registry` fetcher that
-    /// dispatches on this (B2 Lot B, Task 2) lands in a follow-up task.
-    #[allow(dead_code)]
     pub fn resolved_kind(&self) -> SourceKind {
         if let Some(k) = self.kind {
             return k;
@@ -73,17 +69,7 @@ pub struct RegistriesConfig {
 pub enum RegistryKind {
     Agents,
     Skills,
-    /// Only constructed when the `providers-api` feature is enabled:
-    /// `model_registry::fetch` is the sole consumer, since resolving model
-    /// catalog sources is only useful alongside the HTTP fetch that reads
-    /// them. Harmless to keep visible in `tui`-only builds, where model
-    /// registry fetching is unavailable anyway.
-    #[allow(dead_code)]
     Models,
-    /// Not yet constructed outside tests: the starter-registry sync path
-    /// that resolves starter sources (B2 Lot B, Task 2) lands in a
-    /// follow-up task.
-    #[allow(dead_code)]
     Starters,
 }
 

--- a/src/core/starter.rs
+++ b/src/core/starter.rs
@@ -314,8 +314,10 @@ fn remote_starter_pack_dirs_in(cache_root: &Path) -> Vec<PathBuf> {
 /// Find a starter pack directory by name across all source directories.
 ///
 /// User and custom directories take priority over built-in (last match wins).
-/// If no local match is found, falls back to the remote starters cache
-/// (local always wins over remote).
+/// If no local match is found, falls back to the remote starters cache: first
+/// by directory basename, then — for single-pack repos whose dir differs from
+/// the pack's declared `name:` — by reading each remote pack's `pack.yaml`
+/// (local always wins over remote either way).
 pub fn find_pack_dir(name: &str) -> Option<PathBuf> {
     let mut found: Option<PathBuf> = None;
     for dir in all_starters_dirs() {
@@ -329,7 +331,29 @@ pub fn find_pack_dir(name: &str) -> Option<PathBuf> {
             .into_iter()
             .find(|d| d.file_name().is_some_and(|n| n == name));
     }
+    if found.is_none() {
+        found = find_remote_pack_by_name(name);
+    }
     found
+}
+
+/// Find a remote pack by its `pack.yaml` `name:` (not just its dir basename),
+/// so single-pack repos whose dir != name still resolve. Testable core.
+fn find_remote_pack_by_name_in(cache_root: &Path, name: &str) -> Option<PathBuf> {
+    for dir in remote_starter_pack_dirs_in(cache_root) {
+        if let Ok(pack) = StarterPack::load(&dir)
+            && pack.name == name
+        {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// Find a remote pack by its declared `name:` across the synced starters
+/// cache. See [`find_remote_pack_by_name_in`] for the testable core.
+pub fn find_remote_pack_by_name(name: &str) -> Option<PathBuf> {
+    find_remote_pack_by_name_in(&crate::starters_registry::starters_cache_dir(), name)
 }
 
 /// Load all starter packs from all source directories.
@@ -634,6 +658,25 @@ agents:
     #[test]
     fn test_find_pack_dir_not_found() {
         assert!(find_pack_dir("nonexistent-pack-xyz").is_none());
+    }
+
+    #[test]
+    fn find_remote_pack_by_name_by_manifest_name_not_dir() {
+        // A remote pack whose dir differs from its `name:` should still
+        // resolve by name, not just by directory basename.
+        use std::fs;
+        let tmp = std::env::temp_dir().join(format!("armadai-nm-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let d = tmp.join("some-hash-dir/inner");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(
+            d.join("pack.yaml"),
+            "name: cool-pack\ndescription: A cool pack\n",
+        )
+        .unwrap();
+        let found = find_remote_pack_by_name_in(&tmp, "cool-pack");
+        assert!(found.is_some());
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/starters_registry/mod.rs
+++ b/src/starters_registry/mod.rs
@@ -14,9 +14,6 @@ pub fn starters_cache_dir() -> PathBuf {
 }
 
 /// Cache dir for one source URL.
-// Not yet wired outside tests: consumed by `fetch_starter_source` /
-// `sync_starters`, which are themselves Lot 2 (CLI `registry sync`) callers.
-#[allow(dead_code)]
 pub fn source_cache_dir(url: &str) -> PathBuf {
     starters_cache_dir().join(cache_key(url))
 }
@@ -83,6 +80,98 @@ fn run_git(args: &[&str]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Extract a downloaded archive (.tar.gz/.tgz or .zip) into `dest` by shelling
+/// out to system `tar`/`unzip` (no extra crate). `dest` is created.
+// Only called by `ArchiveFetcher`, which is gated `providers-api`; without
+// that feature this helper is unused (still exercised directly by tests).
+#[cfg_attr(not(feature = "providers-api"), allow(dead_code))]
+fn extract_archive(archive: &Path, dest: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dest)?;
+    let name = archive.to_string_lossy().to_lowercase();
+    let status = if name.ends_with(".zip") {
+        std::process::Command::new("unzip")
+            .args([
+                "-q",
+                "-o",
+                archive.to_str().unwrap_or(""),
+                "-d",
+                dest.to_str().unwrap_or(""),
+            ])
+            .status()?
+    } else {
+        // .tar.gz / .tgz
+        std::process::Command::new("tar")
+            .args([
+                "-xzf",
+                archive.to_str().unwrap_or(""),
+                "-C",
+                dest.to_str().unwrap_or(""),
+            ])
+            .status()?
+    };
+    if !status.success() {
+        anyhow::bail!("failed to extract archive {}", archive.display());
+    }
+    Ok(())
+}
+
+/// Archive-backed fetcher: download via reqwest, then extract via `tar`/`unzip`.
+#[cfg(feature = "providers-api")]
+pub struct ArchiveFetcher;
+
+#[cfg(feature = "providers-api")]
+impl StarterFetcher for ArchiveFetcher {
+    fn fetch(&self, url: &str, dest: &Path) -> anyhow::Result<()> {
+        // Download to a temp file, then extract into `dest`.
+        let bytes = download_bytes(url)?;
+        let tmp = std::env::temp_dir().join(format!("armadai-dl-{}", cache_key(url)));
+        std::fs::write(&tmp, &bytes)?;
+        // Preserve the extension so extract_archive picks tar vs unzip.
+        let ext_tmp = tmp.with_extension(archive_ext(url));
+        std::fs::rename(&tmp, &ext_tmp).ok();
+        let src = if ext_tmp.exists() { ext_tmp } else { tmp };
+        let _ = std::fs::remove_dir_all(dest); // fresh extract
+        extract_archive(&src, dest)?;
+        let _ = std::fs::remove_file(&src);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "providers-api")]
+fn archive_ext(url: &str) -> &'static str {
+    let u = url.to_lowercase();
+    if u.ends_with(".zip") {
+        "zip"
+    } else if u.ends_with(".tgz") {
+        "tgz"
+    } else {
+        "tar.gz"
+    }
+}
+
+#[cfg(feature = "providers-api")]
+fn download_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
+    // `fetch` is a sync trait method but is called from WITHIN an async runtime
+    // (`registry sync`, `init`). Creating a tokio runtime inline would panic
+    // ("cannot start a runtime from within a runtime"). Run the async reqwest
+    // download on a dedicated OS thread with its own current-thread runtime.
+    let url = url.to_string();
+    std::thread::spawn(move || -> anyhow::Result<Vec<u8>> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        rt.block_on(async {
+            let resp = reqwest::get(&url).await?;
+            if !resp.status().is_success() {
+                anyhow::bail!("download {url} failed: HTTP {}", resp.status());
+            }
+            Ok(resp.bytes().await?.to_vec())
+        })
+    })
+    .join()
+    .map_err(|_| anyhow::anyhow!("download thread panicked"))?
+}
+
 /// Fetch one source into its cache dir. Git only in Lot 1; archive is Lot 2.
 // Not yet wired outside tests: real caller is `sync_starters`, itself a
 // Lot 2 (CLI `registry sync`) entry point.
@@ -95,10 +184,18 @@ pub fn fetch_starter_source(source: &RegistrySource) -> anyhow::Result<PathBuf> 
             Ok(dest)
         }
         SourceKind::Archive => {
-            anyhow::bail!(
-                "archive starter source '{}' requires the `providers-api` feature (B2 Lot B Lot 2)",
-                source.url
-            )
+            #[cfg(feature = "providers-api")]
+            {
+                ArchiveFetcher.fetch(&source.url, &dest)?;
+                Ok(dest)
+            }
+            #[cfg(not(feature = "providers-api"))]
+            {
+                anyhow::bail!(
+                    "archive starter source '{}' requires the `providers-api` feature (B2 Lot B Lot 2)",
+                    source.url
+                )
+            }
         }
     }
 }
@@ -132,6 +229,15 @@ pub fn discover_packs(registry_dir: &Path) -> Vec<PathBuf> {
         return manifest
             .packs
             .iter()
+            .filter(|p| {
+                let path = std::path::Path::new(&p.path);
+                !path.components().any(|c| {
+                    matches!(
+                        c,
+                        std::path::Component::ParentDir | std::path::Component::RootDir
+                    )
+                })
+            })
             .map(|p| registry_dir.join(&p.path))
             .filter(|d| d.join("pack.yaml").is_file())
             .collect();
@@ -206,12 +312,33 @@ mod tests {
     }
 
     #[test]
-    fn fetch_archive_kind_errors_in_lot1() {
+    #[cfg(not(feature = "providers-api"))]
+    fn fetch_archive_kind_errors_without_providers_api() {
+        // Without `providers-api`, archive sources have no fetcher wired and
+        // must fail fast with a clear error (no network attempted).
         let src = RegistrySource {
             url: "https://x/p.tar.gz".to_string(),
             kind: None,
         };
         assert!(fetch_starter_source(&src).is_err());
+    }
+
+    #[test]
+    fn discover_rejects_parent_traversal_in_manifest() {
+        let tmp = std::env::temp_dir().join(format!("armadai-trav-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("ok")).unwrap();
+        fs::write(tmp.join("ok/pack.yaml"), "name: ok\n").unwrap();
+        fs::write(
+            tmp.join("armadai-starters.yaml"),
+            "packs:\n  - path: ../escape\n  - path: ok\n",
+        )
+        .unwrap();
+        let packs = discover_packs(&tmp);
+        // The `../escape` entry is rejected; only `ok` survives.
+        assert_eq!(packs.len(), 1);
+        assert!(packs[0].ends_with("ok"));
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[tokio::test]
@@ -255,6 +382,55 @@ mod tests {
             packs
                 .iter()
                 .any(|p| p.file_name().unwrap().to_string_lossy() == "demo")
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}
+
+#[cfg(all(test, feature = "providers-api"))]
+mod archive_tests {
+    use super::*;
+    use std::fs;
+
+    fn write(p: &std::path::Path, s: &str) {
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, s).unwrap();
+    }
+
+    // Extract a local .tar.gz built with system `tar` and confirm packs discovered.
+    #[test]
+    fn archive_fetcher_extracts_local_targz() {
+        if std::process::Command::new("tar")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        let tmp = std::env::temp_dir().join(format!("armadai-arc-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        // Build a source tree with a pack, tar it.
+        let srcroot = tmp.join("srcroot");
+        write(&srcroot.join("rust-qa/pack.yaml"), "name: rust-qa\n");
+        let archive = tmp.join("packs.tar.gz");
+        std::process::Command::new("tar")
+            .args([
+                "-czf",
+                archive.to_str().unwrap(),
+                "-C",
+                srcroot.to_str().unwrap(),
+                ".",
+            ])
+            .output()
+            .unwrap();
+        // Extract via the fetcher's extract helper (file:// or local path).
+        let dest = tmp.join("dest");
+        extract_archive(&archive, &dest).unwrap();
+        let packs = discover_packs(&dest);
+        assert!(
+            packs
+                .iter()
+                .any(|p| p.file_name().unwrap().to_string_lossy() == "rust-qa")
         );
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/src/starters_registry/mod.rs
+++ b/src/starters_registry/mod.rs
@@ -29,15 +29,11 @@ struct ManifestPack {
     path: String,
 }
 
-// Not yet wired outside tests: real callers land in Lot 2 (`registry sync`
-// CLI + archive fetcher).
-#[allow(dead_code)]
 pub trait StarterFetcher {
     fn fetch(&self, url: &str, dest: &Path) -> anyhow::Result<()>;
 }
 
 /// Git-backed fetcher: clone if absent, else pull. Shells out to `git`.
-#[allow(dead_code)]
 pub struct GitFetcher;
 
 impl StarterFetcher for GitFetcher {
@@ -67,7 +63,6 @@ impl StarterFetcher for GitFetcher {
     }
 }
 
-#[allow(dead_code)]
 fn run_git(args: &[&str]) -> anyhow::Result<()> {
     let out = std::process::Command::new("git").args(args).output()?;
     if !out.status.success() {
@@ -173,9 +168,6 @@ fn download_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
 }
 
 /// Fetch one source into its cache dir. Git only in Lot 1; archive is Lot 2.
-// Not yet wired outside tests: real caller is `sync_starters`, itself a
-// Lot 2 (CLI `registry sync`) entry point.
-#[allow(dead_code)]
 pub fn fetch_starter_source(source: &RegistrySource) -> anyhow::Result<PathBuf> {
     let dest = source_cache_dir(&source.url);
     match source.resolved_kind() {
@@ -201,9 +193,6 @@ pub fn fetch_starter_source(source: &RegistrySource) -> anyhow::Result<PathBuf> 
 }
 
 /// Sync all sources; warn+continue on failure. Returns the dirs that synced OK.
-// Not yet wired outside tests: real caller is the Lot 2 `registry sync` CLI
-// command.
-#[allow(dead_code)]
 pub fn sync_starters(sources: &[RegistrySource]) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     for s in sources {


### PR DESCRIPTION
## B2 Lot B — Lot 2 : archive + CLI + auto-on-miss (complète les starters distants)

Deuxième et dernière tranche des starters distants (suite Lot 1 #211).

### Contenu
- **`ArchiveFetcher`** (gated `providers-api`) : download reqwest (**sur thread dédié + runtime**, pas de panic « runtime within runtime » depuis les contextes async) + extraction par **shell-out `tar`/`unzip`** (zéro nouvelle dep). Sans `providers-api`, source archive → erreur claire (inchangé).
- **CLI** : `armadai registry sources add|remove|list starters <url>` (variant `Starters` ajouté) ; `armadai registry sync` synchronise aussi les sources starters (user ∪ projet, dédup) en plus des agents.
- **Auto-sync-on-miss** : `init --pack <nom>` — si le pack est introuvable en local/cache, sync des sources starters puis retry (réseau **uniquement sur miss** ; zéro réseau si aucune source configurée).
- **Follow-ups revue Lot 1** : rejet des `..`/absolus dans les `path:` du manifest ; résolution d'un pack distant par son `name:` (repos single-pack dont le dossier ≠ nom).

### Qualité
Subagent-driven + revue finale indépendante (runtime-safety du download confirmée, pas d'injection shell, rétro-compat auto-on-miss, dead_code nettoyé). Clippy 3 modes (`tui`, `tui,providers-api`, `tui,web,storage`, `-D warnings`), fmt, 857 tests, `cargo build --release`. Zéro nouvelle dépendance.

Follow-up LOW noté : valider les chemins extraits d'archive (zip-slip) dans `dest` (defense-in-depth ; frontière de confiance = `git clone` d'une source configurée).

**B2 Lot B complet** avec le Lot 1 (#211).

🤖 Generated with [Claude Code](https://claude.com/claude-code)