### PR TITLE
feat(es): OH1 Lot 3 — blackboard + ring event-sourcés + nested C9 (coexistence)

### DIFF
--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -1,0 +1,517 @@
+//! Pure helpers for the blackboard pattern (OH1 Lot 3): agent eligibility,
+//! convergence detection, and `EntryKind` ↔ `(kind, refs)` mapping.
+//!
+//! Reproduces the *decision* logic of the legacy blackboard engine —
+//! `core::orchestration::blackboard::check_convergence`/`Board::consecutive_convergence`
+//! and `core::orchestration::llm_agents::LlmBoardAgent::can_contribute` — as
+//! pure, synchronous functions over the event-sourced `ExecutionState`
+//! projection: no I/O, no clock, no randomness, no `tracing`. Strict
+//! coexistence: the legacy `blackboard.rs`/`llm_agents.rs` engines are
+//! untouched; this module only *imports* their plain, side-effect-free data
+//! types (`BlackboardConfig`, `EntryKind`, `entry_kind_name`) rather than
+//! duplicating their definitions.
+
+use std::collections::BTreeMap;
+
+use super::state::{BoardEntryRec, ExecutionState};
+use crate::core::agent::Agent;
+use crate::core::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
+
+/// Agents eligible to contribute on the board's current round, ordered by
+/// the run's roster (`state.agents`) rather than `agents`' own (`BTreeMap`,
+/// name-sorted) iteration order.
+///
+/// Reproduces `LlmBoardAgent::can_contribute`
+/// (`core::orchestration::llm_agents`): an agent with no `triggers`
+/// configured is always eligible; otherwise every one of the following must
+/// hold against `state.board`:
+/// - `state.board.round >= triggers.min_round`
+/// - `triggers.max_round.is_none()` or `state.board.round <= max_round`
+/// - every kind in `triggers.requires` is present among `state.board.entries`
+/// - no kind in `triggers.excludes` is present among `state.board.entries`
+///
+/// A name in `state.agents` with no matching entry in `agents` is skipped
+/// (only possible for a malformed/partial state — the roster is expected to
+/// be a subset of `agents`' keys in practice).
+pub(crate) fn eligible_agents(
+    state: &ExecutionState,
+    agents: &BTreeMap<String, Agent>,
+) -> Vec<String> {
+    let present_kinds: Vec<&str> = state
+        .board
+        .entries
+        .iter()
+        .map(|e| e.kind.as_str())
+        .collect();
+
+    state
+        .agents
+        .iter()
+        .filter(|name| {
+            let Some(agent) = agents.get(*name) else {
+                return false;
+            };
+            let Some(triggers) = agent.metadata.triggers.as_ref() else {
+                return true;
+            };
+
+            if state.board.round < triggers.min_round {
+                return false;
+            }
+            if let Some(max) = triggers.max_round
+                && state.board.round > max
+            {
+                return false;
+            }
+            if triggers
+                .requires
+                .iter()
+                .any(|req| !present_kinds.contains(&req.to_lowercase().as_str()))
+            {
+                return false;
+            }
+            if triggers
+                .excludes
+                .iter()
+                .any(|excl| present_kinds.contains(&excl.to_lowercase().as_str()))
+            {
+                return false;
+            }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+/// `confirmations / total` for the entries of `entries` matching `round`, or
+/// `None` if that round has no entries (division-by-zero guard, mirroring
+/// the legacy `check_convergence`'s `last_round_entries.is_empty()` early
+/// return).
+fn round_confirmation_ratio(entries: &[BoardEntryRec], round: u32) -> Option<f32> {
+    let round_entries: Vec<&BoardEntryRec> = entries.iter().filter(|e| e.round == round).collect();
+    if round_entries.is_empty() {
+        return None;
+    }
+    let confirmations = round_entries
+        .iter()
+        .filter(|e| e.kind == "confirmation")
+        .count();
+    Some(confirmations as f32 / round_entries.len() as f32)
+}
+
+/// Confirmation-based convergence signal for `state.board.round`, reproducing
+/// the "Consensus" branch of the legacy
+/// `core::orchestration::blackboard::check_convergence` purely.
+///
+/// Deliberately narrower than the legacy function: no `tracing::warn!`
+/// budget-warning side effect (irrelevant here — `ExecutionState` carries no
+/// budget-warning threshold to log against), and no `Stable`/`Divergence`
+/// branches (`ExecutionState`/`BoardEntryRec` don't model a `HaltReason`, only
+/// a bare confirmation ratio; the empty-round case that legacy reports as
+/// `Some(HaltReason::Stable)` returns `None` here instead — see module docs
+/// and the task report for this documented deviation).
+///
+/// Returns `Some(ratio)` when `confirmations / total >= config.consensus_threshold`
+/// for the current round's entries, `None` otherwise (including on an empty
+/// round).
+pub(crate) fn check_convergence(state: &ExecutionState, config: &BlackboardConfig) -> Option<f32> {
+    round_confirmation_ratio(&state.board.entries, state.board.round)
+        .filter(|&ratio| ratio >= config.consensus_threshold)
+}
+
+/// Number of rounds, counted backward from the latest round present in
+/// `state.board.entries`, whose confirmation ratio reaches
+/// `config.consensus_threshold` without interruption.
+///
+/// Pure reconstruction of the legacy `Board::consecutive_convergence` counter
+/// — which increments by one each round `check_convergence` detects
+/// consensus and resets to `0` the moment it doesn't — from the final entry
+/// log alone, since `ExecutionState` carries no running counter of its own.
+///
+/// Distinct rounds are derived from `state.board.entries` itself (sorted,
+/// deduped), not from `0..=state.board.round`, so a state folded from a
+/// partial/sparse event log (e.g. skipping straight to a later round)
+/// reconstructs correctly. Returns `0` when there are no entries at all.
+pub(crate) fn consecutive_convergence(state: &ExecutionState, config: &BlackboardConfig) -> u32 {
+    let mut rounds: Vec<u32> = state.board.entries.iter().map(|e| e.round).collect();
+    rounds.sort_unstable();
+    rounds.dedup();
+
+    let mut count = 0u32;
+    for &round in rounds.iter().rev() {
+        match round_confirmation_ratio(&state.board.entries, round) {
+            Some(ratio) if ratio >= config.consensus_threshold => count += 1,
+            _ => break,
+        }
+    }
+    count
+}
+
+/// Map a legacy `EntryKind` (`core::orchestration::blackboard`) onto the
+/// event-sourced `(kind: String, refs: Vec<usize>)` pair carried by
+/// `ExecutionEvent::BoardEntryAdded`/`BoardEntryRec`.
+///
+/// `kind` reuses `entry_kind_name` — the single source of truth for the
+/// lowercase names `eligible_agents`'s requires/excludes matching (and the
+/// legacy `can_contribute`) read back. `refs` documents the reference
+/// convention:
+/// - `Finding`, `Question` → no refs
+/// - `Challenge { target }`, `Confirmation { target }` → `refs = [target]`
+/// - `Synthesis { sources }` → `refs = sources` (in order)
+/// - `Answer { question }` → `refs = [question]`
+pub(crate) fn entry_kind_to_rec(kind: &EntryKind) -> (String, Vec<usize>) {
+    let refs = match kind {
+        EntryKind::Finding | EntryKind::Question => vec![],
+        EntryKind::Challenge { target } | EntryKind::Confirmation { target } => vec![*target],
+        EntryKind::Synthesis { sources } => sources.clone(),
+        EntryKind::Answer { question } => vec![*question],
+    };
+    (entry_kind_name(kind).to_string(), refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent::AgentMetadata;
+    use crate::core::orchestration::TriggerConfig;
+    use crate::core::orchestration::es::event::ExecutionEvent as E;
+    use crate::core::orchestration::es::state::fold;
+    use std::path::PathBuf;
+
+    fn test_agent(name: &str, triggers: Option<TriggerConfig>) -> Agent {
+        Agent {
+            name: name.to_string(),
+            source: PathBuf::from(format!("{name}.md")),
+            metadata: AgentMetadata {
+                provider: "anthropic".to_string(),
+                model: Some("concrete-model".to_string()),
+                command: None,
+                args: None,
+                temperature: 0.7,
+                max_tokens: None,
+                timeout: None,
+                tags: vec![],
+                stacks: vec![],
+                scope: vec![],
+                model_fallback: vec![],
+                cost_limit: None,
+                rate_limit: None,
+                context_window: None,
+                mode: None,
+                orchestration: None,
+                triggers,
+                ring_config: None,
+            },
+            system_prompt: "prompt".to_string(),
+            instructions: None,
+            output_format: None,
+            pipeline: None,
+            context: None,
+        }
+    }
+
+    fn run_started(agents: &[&str]) -> E {
+        E::RunStarted {
+            run_id: "r".into(),
+            pattern: "blackboard".into(),
+            agents: agents.iter().map(|a| a.to_string()).collect(),
+            input: "task".into(),
+            project: None,
+        }
+    }
+
+    fn board_entry(agent: &str, round: u32, kind: &str, refs: Vec<usize>, confidence: f32) -> E {
+        E::BoardEntryAdded {
+            agent: agent.to_string(),
+            round,
+            kind: kind.to_string(),
+            content: "c".to_string(),
+            refs,
+            confidence,
+            tokens_in: 0,
+            tokens_out: 0,
+            cost: 0.0,
+        }
+    }
+
+    // ── eligible_agents ────────────────────────────────────────────
+
+    #[test]
+    fn eligible_agents_no_triggers_always_eligible() {
+        let mut agents = BTreeMap::new();
+        agents.insert("a".to_string(), test_agent("a", None));
+        let state = fold(&[run_started(&["a"])]);
+        assert_eq!(eligible_agents(&state, &agents), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn eligible_agents_respects_min_round() {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "a".to_string(),
+            test_agent(
+                "a",
+                Some(TriggerConfig {
+                    requires: vec![],
+                    excludes: vec![],
+                    min_round: 1,
+                    max_round: None,
+                    priority: 50,
+                }),
+            ),
+        );
+        let state0 = fold(&[run_started(&["a"]), E::RoundStarted { round: 0 }]);
+        assert!(eligible_agents(&state0, &agents).is_empty());
+
+        let state1 = fold(&[run_started(&["a"]), E::RoundStarted { round: 1 }]);
+        assert_eq!(eligible_agents(&state1, &agents), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn eligible_agents_respects_max_round() {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "a".to_string(),
+            test_agent(
+                "a",
+                Some(TriggerConfig {
+                    requires: vec![],
+                    excludes: vec![],
+                    min_round: 0,
+                    max_round: Some(1),
+                    priority: 50,
+                }),
+            ),
+        );
+        let state_ok = fold(&[run_started(&["a"]), E::RoundStarted { round: 1 }]);
+        assert_eq!(eligible_agents(&state_ok, &agents), vec!["a".to_string()]);
+
+        let state_over = fold(&[run_started(&["a"]), E::RoundStarted { round: 2 }]);
+        assert!(eligible_agents(&state_over, &agents).is_empty());
+    }
+
+    #[test]
+    fn eligible_agents_requires_kind_present_on_board() {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "a".to_string(),
+            test_agent(
+                "a",
+                Some(TriggerConfig {
+                    requires: vec!["confirmation".to_string()],
+                    excludes: vec![],
+                    min_round: 0,
+                    max_round: None,
+                    priority: 50,
+                }),
+            ),
+        );
+        let no_confirmation = fold(&[
+            run_started(&["a"]),
+            board_entry("b", 0, "finding", vec![], 0.5),
+        ]);
+        assert!(eligible_agents(&no_confirmation, &agents).is_empty());
+
+        let with_confirmation = fold(&[
+            run_started(&["a"]),
+            board_entry("b", 0, "finding", vec![], 0.5),
+            board_entry("c", 0, "confirmation", vec![0], 0.9),
+        ]);
+        assert_eq!(
+            eligible_agents(&with_confirmation, &agents),
+            vec!["a".to_string()]
+        );
+    }
+
+    #[test]
+    fn eligible_agents_excludes_kind_present_on_board() {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "a".to_string(),
+            test_agent(
+                "a",
+                Some(TriggerConfig {
+                    requires: vec![],
+                    excludes: vec!["challenge".to_string()],
+                    min_round: 0,
+                    max_round: None,
+                    priority: 50,
+                }),
+            ),
+        );
+        let clean = fold(&[
+            run_started(&["a"]),
+            board_entry("b", 0, "finding", vec![], 0.5),
+        ]);
+        assert_eq!(eligible_agents(&clean, &agents), vec!["a".to_string()]);
+
+        let challenged = fold(&[
+            run_started(&["a"]),
+            board_entry("b", 0, "challenge", vec![0], 0.5),
+        ]);
+        assert!(eligible_agents(&challenged, &agents).is_empty());
+    }
+
+    #[test]
+    fn eligible_agents_ordered_by_roster_not_by_agent_map() {
+        let mut agents = BTreeMap::new();
+        // BTreeMap iteration order would be "a" then "b" (alphabetic) — the
+        // roster deliberately reverses that, and the result must follow it.
+        agents.insert("a".to_string(), test_agent("a", None));
+        agents.insert("b".to_string(), test_agent("b", None));
+        let state = fold(&[run_started(&["b", "a"])]);
+        assert_eq!(
+            eligible_agents(&state, &agents),
+            vec!["b".to_string(), "a".to_string()]
+        );
+    }
+
+    #[test]
+    fn eligible_agents_skips_names_missing_from_agents_map() {
+        let agents: BTreeMap<String, Agent> = BTreeMap::new();
+        let state = fold(&[run_started(&["ghost"])]);
+        assert!(eligible_agents(&state, &agents).is_empty());
+    }
+
+    // ── check_convergence ────────────────────────────────────────────
+
+    #[test]
+    fn check_convergence_empty_round_is_none() {
+        let state = fold(&[run_started(&["a"])]);
+        let config = BlackboardConfig::default();
+        assert_eq!(check_convergence(&state, &config), None);
+    }
+
+    #[test]
+    fn check_convergence_high_consensus_matches_legacy_case() {
+        // Mirrors `blackboard::tests::test_check_convergence_high_consensus`:
+        // round 1 has 4 confirmations + 1 new finding == 5 entries, 4/5 = 0.8
+        // >= default threshold 0.75.
+        let mut events = vec![run_started(&["a"]), E::RoundStarted { round: 1 }];
+        for i in 0..4 {
+            events.push(board_entry(
+                &format!("agent-{i}"),
+                1,
+                "confirmation",
+                vec![0],
+                0.9,
+            ));
+        }
+        events.push(board_entry("agent-4", 1, "finding", vec![], 0.7));
+        let state = fold(&events);
+        let config = BlackboardConfig::default();
+        let ratio = check_convergence(&state, &config).expect("expected consensus");
+        assert!((ratio - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn check_convergence_no_convergence_matches_legacy_case() {
+        // Mirrors `test_check_convergence_no_convergence`: all findings, no
+        // confirmations at all.
+        let mut events = vec![run_started(&["a"])];
+        for i in 0..5 {
+            events.push(board_entry(
+                &format!("agent-{i}"),
+                0,
+                "finding",
+                vec![],
+                0.5,
+            ));
+        }
+        let state = fold(&events);
+        let config = BlackboardConfig::default();
+        assert_eq!(check_convergence(&state, &config), None);
+    }
+
+    #[test]
+    fn check_convergence_below_threshold_is_none() {
+        // 1 confirmation out of 4 entries = 0.25, below default 0.75.
+        let events = vec![
+            run_started(&["a"]),
+            board_entry("a", 0, "confirmation", vec![0], 0.9),
+            board_entry("b", 0, "finding", vec![], 0.5),
+            board_entry("c", 0, "finding", vec![], 0.5),
+            board_entry("d", 0, "finding", vec![], 0.5),
+        ];
+        let state = fold(&events);
+        let config = BlackboardConfig::default();
+        assert_eq!(check_convergence(&state, &config), None);
+    }
+
+    // ── consecutive_convergence ──────────────────────────────────────
+
+    #[test]
+    fn consecutive_convergence_counts_trailing_convergent_rounds() {
+        let config = BlackboardConfig::default(); // consensus_threshold = 0.75
+        // Round 0: non-convergent (all findings).
+        // Round 1 & 2: convergent (100% confirmations).
+        // Latest round (2) counted backward hits round 1 then stops at round 0.
+        let events = vec![
+            run_started(&["a"]),
+            board_entry("a", 0, "finding", vec![], 0.5),
+            board_entry("b", 0, "finding", vec![], 0.5),
+            board_entry("a", 1, "confirmation", vec![0], 0.9),
+            board_entry("b", 1, "confirmation", vec![0], 0.9),
+            board_entry("a", 2, "confirmation", vec![0], 0.9),
+            board_entry("b", 2, "confirmation", vec![0], 0.9),
+        ];
+        let state = fold(&events);
+        assert_eq!(consecutive_convergence(&state, &config), 2);
+    }
+
+    #[test]
+    fn consecutive_convergence_resets_at_first_non_convergent_round_from_the_end() {
+        let config = BlackboardConfig::default();
+        // Round 0 convergent, round 1 NOT convergent (latest) — counting
+        // backward from round 1 stops immediately: result is 0, even though
+        // an earlier round did converge.
+        let events = vec![
+            run_started(&["a"]),
+            board_entry("a", 0, "confirmation", vec![0], 0.9),
+            board_entry("b", 0, "confirmation", vec![0], 0.9),
+            board_entry("a", 1, "finding", vec![], 0.5),
+            board_entry("b", 1, "finding", vec![], 0.5),
+        ];
+        let state = fold(&events);
+        assert_eq!(consecutive_convergence(&state, &config), 0);
+    }
+
+    #[test]
+    fn consecutive_convergence_no_entries_is_zero() {
+        let state = fold(&[run_started(&["a"])]);
+        let config = BlackboardConfig::default();
+        assert_eq!(consecutive_convergence(&state, &config), 0);
+    }
+
+    // ── entry_kind_to_rec ────────────────────────────────────────────
+
+    #[test]
+    fn entry_kind_to_rec_matches_documented_convention() {
+        assert_eq!(
+            entry_kind_to_rec(&EntryKind::Finding),
+            ("finding".to_string(), vec![])
+        );
+        assert_eq!(
+            entry_kind_to_rec(&EntryKind::Question),
+            ("question".to_string(), vec![])
+        );
+        assert_eq!(
+            entry_kind_to_rec(&EntryKind::Challenge { target: 3 }),
+            ("challenge".to_string(), vec![3])
+        );
+        assert_eq!(
+            entry_kind_to_rec(&EntryKind::Confirmation { target: 7 }),
+            ("confirmation".to_string(), vec![7])
+        );
+        assert_eq!(
+            entry_kind_to_rec(&EntryKind::Synthesis {
+                sources: vec![1, 2, 4]
+            }),
+            ("synthesis".to_string(), vec![1, 2, 4])
+        );
+        assert_eq!(
+            entry_kind_to_rec(&EntryKind::Answer { question: 5 }),
+            ("answer".to_string(), vec![5])
+        );
+    }
+}

--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -12,13 +12,21 @@
 //! duplicating their definitions.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use super::engine::{Action, Decider};
+use async_trait::async_trait;
+
+use super::engine::{Action, Decider, EffectRunner};
 use super::event::ExecutionEvent;
 use super::state::{BoardEntryRec, ExecutionState};
 use crate::core::agent::Agent;
 use crate::core::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
+use crate::core::orchestration::llm_agents::{BOARD_ACTION_INSTRUCTIONS, parse_board_action};
 use crate::core::routing::{BudgetState, RoutingRules, route};
+#[cfg(test)]
+use crate::linker::model_resolution::fallback_model_for_tier;
+use crate::linker::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
 /// Agents eligible to contribute on the board's current round, ordered by
 /// the run's roster (`state.agents`) rather than `agents`' own (`BTreeMap`,
@@ -448,6 +456,241 @@ pub(crate) fn build_board_result(state: &ExecutionState) -> String {
         .map(|entry| format!("[{}] {}", entry.agent, entry.content))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+// ── BlackboardEffectRunner (Task 4): the sole async/impure effect ────
+
+/// Parse a tier string as stored in `ExecutionState::routed_tiers` back into
+/// a `ModelTier`.
+///
+/// Identical in spirit to `es::hierarchical::parse_routed_tier` — duplicated
+/// rather than shared (same rationale as `BlackboardDecider::model_routed_event`
+/// above: the two effect runners' `agents`/model-resolution concerns live on
+/// unrelated structs with no common trait today). Unrecognized strings fall
+/// back to `Pro`, matching the hierarchical counterpart.
+fn parse_routed_tier(tier: &str) -> ModelTier {
+    match tier.to_lowercase().as_str() {
+        "fast" => ModelTier::Fast,
+        "max" => ModelTier::Max,
+        _ => ModelTier::Pro,
+    }
+}
+
+/// Executes the actual LLM call behind `Action::Invoke` for the blackboard
+/// pattern and turns the raw provider response into the `BoardEntryAdded`
+/// event the pure loop/`BlackboardDecider` expect.
+///
+/// This is the *only* impure/async piece of the event-sourced blackboard
+/// engine — every other function in this module is a pure, synchronous
+/// helper over `ExecutionState`. Coexists with the legacy
+/// `core::orchestration::llm_agents::LlmBoardAgent`/`blackboard::run_blackboard`
+/// (this struct is not wired into it, and does not import from it beyond the
+/// plain, side-effect-free `parse_board_action` parser and
+/// `BOARD_ACTION_INSTRUCTIONS` constant it explicitly reuses — strict
+/// coexistence, mirroring `HierarchicalEffectRunner`).
+pub struct BlackboardEffectRunner {
+    /// All known agents by name (system prompt, model, temperature, …).
+    pub agents: BTreeMap<String, Agent>,
+    /// Provider instance per agent name.
+    pub providers: BTreeMap<String, Arc<dyn Provider>>,
+    /// Blackboard configuration — currently read only for `token_budget`,
+    /// surfaced in the "Budget remaining" line of the assembled prompt (the
+    /// same line `LlmBoardAgent::contribute` sends), for prompt fidelity with
+    /// the legacy engine.
+    pub config: BlackboardConfig,
+}
+
+impl BlackboardEffectRunner {
+    /// Construct a new `BlackboardEffectRunner` from its immutable inputs.
+    pub fn new(
+        agents: BTreeMap<String, Agent>,
+        providers: BTreeMap<String, Arc<dyn Provider>>,
+        config: BlackboardConfig,
+    ) -> Self {
+        Self {
+            agents,
+            providers,
+            config,
+        }
+    }
+
+    /// Assemble the user-turn prompt sent to `agent_name` for the current
+    /// round, reproducing the shape of `LlmBoardAgent::contribute`'s
+    /// `user_msg` (`core::orchestration::llm_agents`) over the event-sourced
+    /// `state.board` projection instead of a live `BoardSnapshot`:
+    /// `"Task: …\nRound: …\nBudget remaining: … tokens\n"`, then (only if any
+    /// qualify) a `"Recent board entries:\n"` section listing every entry
+    /// **whose `round` is strictly less than `state.board.round`** as
+    /// `"- [{agent}#{index} {kind}] {content}\n"` — `{index}` being the
+    /// entry's position in `state.board.entries` (the same numbering
+    /// `entry_kind_to_rec`'s `refs`/the legacy `BoardEntry::index` target —
+    /// so a `TARGET: <index>` an LLM emits in its structured response points
+    /// at the same entries this snapshot exposed to it) — then
+    /// `BOARD_ACTION_INSTRUCTIONS` verbatim.
+    ///
+    /// The round filter is the deliberate, documented deviation from a plain
+    /// "last 10 entries" window: legacy fidelity requires that agents
+    /// contributing within the *same* round never see each other's
+    /// in-flight entries (they all act off the board as it stood at the
+    /// start of the round) — only entries from rounds that have already
+    /// fully completed are visible. Unlike `LlmBoardAgent::contribute`
+    /// (which caps at the 10 most recent entries), this includes every
+    /// qualifying entry — the task's snapshot-filter requirement takes
+    /// priority over reproducing that truncation, and no test scenario here
+    /// exercises more than a handful of entries.
+    fn build_prompt(&self, agent_name: &str, input: &str, state: &ExecutionState) -> String {
+        let budget_remaining = self
+            .config
+            .token_budget
+            .saturating_sub(state.budget_tokens_in + state.budget_tokens_out);
+        let mut user_msg = format!(
+            "Task: {input}\nRound: {}\nBudget remaining: {budget_remaining} tokens\n",
+            state.board.round
+        );
+
+        let snapshot: Vec<(usize, &BoardEntryRec)> = state
+            .board
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.round < state.board.round)
+            .collect();
+        if !snapshot.is_empty() {
+            user_msg.push_str("\nRecent board entries:\n");
+            for (index, entry) in snapshot {
+                user_msg.push_str(&format!(
+                    "- [{}#{index} {}] {}\n",
+                    entry.agent, entry.kind, entry.content
+                ));
+            }
+        }
+
+        // Silence the unused `agent_name` parameter warning below: kept for
+        // signature symmetry with `run_invoke`/future per-agent prompt
+        // customization, even though the current prompt shape doesn't read
+        // it directly (the legacy `contribute` prompt is agent-agnostic
+        // too — the agent's own perspective comes entirely from its system
+        // prompt, sent separately).
+        let _ = agent_name;
+
+        user_msg.push_str(BOARD_ACTION_INSTRUCTIONS);
+        user_msg
+    }
+}
+
+#[async_trait]
+impl EffectRunner for BlackboardEffectRunner {
+    async fn run_invoke(
+        &self,
+        agent: &str,
+        input: &str,
+        state: &ExecutionState,
+    ) -> anyhow::Result<ExecutionEvent> {
+        let agent_def = self
+            .agents
+            .get(agent)
+            .ok_or_else(|| anyhow::anyhow!("Unknown agent '{agent}' — no Agent definition"))?;
+        let provider = self
+            .providers
+            .get(agent)
+            .ok_or_else(|| anyhow::anyhow!("No provider configured for agent '{agent}'"))?;
+
+        let prompt = self.build_prompt(agent, input, state);
+
+        // Same `"latest:auto"` resolution as `HierarchicalEffectRunner`: see
+        // its doc comment for the full rationale. `BlackboardDecider`
+        // (Task 3) emits `ModelRouted` ahead of every `latest:auto` agent's
+        // `Invoke`, so `state.routed_tiers` should already carry its tier by
+        // the time this runs; the `None` branch is a defensive fallback for
+        // a hand-built state (tests) or a future decider regression.
+        let raw_model = agent_def
+            .metadata
+            .model
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+        let model = if raw_model == "latest:auto" {
+            let tier = match state.routed_tiers.get(agent) {
+                Some(tier_str) => parse_routed_tier(tier_str),
+                None => {
+                    tracing::warn!(
+                        agent,
+                        "no ModelRouted tier recorded for latest:auto agent; falling back to Pro tier"
+                    );
+                    ModelTier::Pro
+                }
+            };
+            resolve_model_for_tier(&agent_def.metadata.provider, tier)
+        } else {
+            raw_model
+        };
+
+        let request = CompletionRequest {
+            model,
+            system_prompt: agent_def.system_prompt.clone(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: prompt,
+            }],
+            temperature: agent_def.metadata.temperature,
+            max_tokens: agent_def.metadata.max_tokens,
+        };
+
+        let round = state.board.round;
+
+        // Graceful degradation (Task 4 brief, point 5): a provider error
+        // must NOT abort the run — legacy fidelity requires the blackboard
+        // to keep going even when one agent's LLM call fails outright (a
+        // timeout, a 5xx, an auth error, …). Instead of propagating the
+        // error through `?` (which `es::engine::run_event_sourced` would
+        // otherwise let bubble out of the whole run via its own `?` on
+        // `run_invoke`), we swallow it here and manufacture a degraded
+        // `BoardEntryAdded`: `kind = "finding"` (the neutral default,
+        // matching `parse_board_action`'s own fallback for an unparseable
+        // response), a `"[agent failed]"` marker prefix so the failure is
+        // visible in the board transcript, `confidence: 0.0` (the LLM never
+        // actually vouched for anything), and `tokens_in/out = 0, cost =
+        // 0.0` (no tokens were actually consumed/billed — the call never
+        // returned a response to meter). This keeps `BlackboardDecider`'s
+        // round-completion bookkeeping correct (`round_complete` only checks
+        // that every eligible agent posted *an* entry for the round, not
+        // that it succeeded) without corrupting the budget totals with a
+        // cost that was never incurred.
+        match provider.complete(request).await {
+            Ok(response) => {
+                let (kind, confidence, content) = parse_board_action(&response.content);
+                let (kind, refs) = entry_kind_to_rec(&kind);
+                Ok(ExecutionEvent::BoardEntryAdded {
+                    agent: agent.to_string(),
+                    round,
+                    kind,
+                    content,
+                    refs,
+                    confidence,
+                    tokens_in: response.tokens_in,
+                    tokens_out: response.tokens_out,
+                    cost: response.cost,
+                })
+            }
+            Err(err) => {
+                tracing::warn!(
+                    agent,
+                    error = %err,
+                    "blackboard agent provider call failed; recording a degraded entry instead of aborting the run"
+                );
+                Ok(ExecutionEvent::BoardEntryAdded {
+                    agent: agent.to_string(),
+                    round,
+                    kind: "finding".to_string(),
+                    content: format!("[agent failed] {err}"),
+                    refs: vec![],
+                    confidence: 0.0,
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    cost: 0.0,
+                })
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -984,6 +1227,418 @@ mod tests {
                 actions[0]
             );
             assert!(matches!(&actions[1], Action::Complete { .. }));
+        }
+    }
+
+    // ── BlackboardEffectRunner (Task 4) ──────────────────────────────
+    //
+    // Named `effect_runner` so `cargo test es::blackboard::tests::effect_runner`
+    // targets this module — mirrors the naming convention used by
+    // `es::hierarchical::tests::effect_runner`.
+    mod effect_runner {
+        use super::*;
+        use crate::core::agent::AgentMetadata;
+        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use std::path::PathBuf;
+        use std::sync::Mutex;
+
+        /// Minimal `Agent` for effect-runner tests: a concrete (non
+        /// `latest:auto`) model by default.
+        fn test_agent(name: &str, model: &str) -> Agent {
+            Agent {
+                name: name.to_string(),
+                source: PathBuf::from(format!("{name}.md")),
+                metadata: AgentMetadata {
+                    provider: "anthropic".to_string(),
+                    model: Some(model.to_string()),
+                    command: None,
+                    args: None,
+                    temperature: 0.5,
+                    max_tokens: Some(256),
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: format!("You are {name}."),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        /// Returns a fixed response with fixed token/cost/model metrics,
+        /// regardless of the request.
+        struct FixedProvider {
+            content: String,
+            tokens_in: u32,
+            tokens_out: u32,
+            cost: f64,
+            model: String,
+        }
+
+        #[async_trait]
+        impl Provider for FixedProvider {
+            async fn complete(
+                &self,
+                _request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                Ok(CompletionResponse {
+                    content: self.content.clone(),
+                    model: self.model.clone(),
+                    tokens_in: self.tokens_in,
+                    tokens_out: self.tokens_out,
+                    cost: self.cost,
+                })
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by BlackboardEffectRunner tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "fixed".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        /// Like `FixedProvider`, but records every `CompletionRequest` it
+        /// receives, so tests can assert what `run_invoke` actually sent
+        /// (namely, the assembled prompt) — mirrors `CapturingProvider` in
+        /// `es::hierarchical`'s own effect-runner tests.
+        struct CapturingProvider {
+            requests: Mutex<Vec<CompletionRequest>>,
+            response: String,
+        }
+
+        impl CapturingProvider {
+            fn new(response: &str) -> Self {
+                Self {
+                    requests: Mutex::new(Vec::new()),
+                    response: response.to_string(),
+                }
+            }
+
+            fn requests(&self) -> Vec<CompletionRequest> {
+                self.requests.lock().unwrap().clone()
+            }
+        }
+
+        #[async_trait]
+        impl Provider for CapturingProvider {
+            async fn complete(
+                &self,
+                request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                let model = request.model.clone();
+                self.requests.lock().unwrap().push(request);
+                Ok(CompletionResponse {
+                    content: self.response.clone(),
+                    model,
+                    tokens_in: 1,
+                    tokens_out: 1,
+                    cost: 0.0,
+                })
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by BlackboardEffectRunner tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "capturing".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        /// Always fails — proves `run_invoke` degrades gracefully (a
+        /// `BoardEntryAdded` with a marker content) instead of propagating
+        /// the provider's error through the run.
+        struct FailingProvider;
+
+        #[async_trait]
+        impl Provider for FailingProvider {
+            async fn complete(
+                &self,
+                _request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                anyhow::bail!("simulated provider outage")
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by BlackboardEffectRunner tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "failing".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        fn board_run_started(agents: &[&str]) -> ExecutionEvent {
+            ExecutionEvent::RunStarted {
+                run_id: "r".into(),
+                pattern: "blackboard".into(),
+                agents: agents.iter().map(|a| a.to_string()).collect(),
+                input: "task".into(),
+                project: None,
+            }
+        }
+
+        // (a) Step 1 (brief): a fixed structured response
+        // (`ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:ok`) →
+        // `BoardEntryAdded` with kind="confirmation", refs=[0], confidence
+        // 0.9, the state's current round, and the *real* token/cost figures
+        // from the `CompletionResponse` (not the entry-level defaults
+        // `parse_board_action` would produce on a fallback).
+        #[tokio::test]
+        async fn run_invoke_parses_structured_action_into_board_entry_added() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), test_agent("a", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(FixedProvider {
+                    content: "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:ok"
+                        .to_string(),
+                    tokens_in: 7,
+                    tokens_out: 5,
+                    cost: 0.03,
+                    model: "concrete-model".to_string(),
+                }),
+            );
+            let runner =
+                BlackboardEffectRunner::new(agents, providers, BlackboardConfig::default());
+
+            let state = fold(&[
+                board_run_started(&["a"]),
+                ExecutionEvent::RoundStarted { round: 0 },
+            ]);
+            let ev = runner.run_invoke("a", "task", &state).await.unwrap();
+
+            match ev {
+                ExecutionEvent::BoardEntryAdded {
+                    agent,
+                    round,
+                    kind,
+                    content,
+                    refs,
+                    confidence,
+                    tokens_in,
+                    tokens_out,
+                    cost,
+                } => {
+                    assert_eq!(agent, "a");
+                    assert_eq!(round, 0);
+                    assert_eq!(kind, "confirmation");
+                    assert_eq!(refs, vec![0]);
+                    assert!((confidence - 0.9).abs() < 1e-6);
+                    assert_eq!(content, "ok");
+                    assert_eq!(tokens_in, 7);
+                    assert_eq!(tokens_out, 5);
+                    assert!((cost - 0.03).abs() < 1e-9);
+                }
+                other => panic!("expected BoardEntryAdded, got {other:?}"),
+            }
+        }
+
+        // (b) Step 1 (brief): the captured prompt must NOT contain the
+        // current round's entries (its peers' in-flight contributions) but
+        // MUST contain entries from earlier, already-completed rounds — the
+        // snapshot-filter requirement documented on `build_prompt`.
+        #[tokio::test]
+        async fn run_invoke_prompt_snapshot_excludes_current_round_entries() {
+            let mut agents = BTreeMap::new();
+            agents.insert("b".to_string(), test_agent("b", "concrete-model"));
+            let capturing = Arc::new(CapturingProvider::new(
+                "ACTION:FINDING\nCONFIDENCE:0.5\nCONTENT:noted",
+            ));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("b".to_string(), capturing.clone() as Arc<dyn Provider>);
+            let runner =
+                BlackboardEffectRunner::new(agents, providers, BlackboardConfig::default());
+
+            let events = vec![
+                board_run_started(&["a", "b"]),
+                ExecutionEvent::RoundStarted { round: 0 },
+                ExecutionEvent::BoardEntryAdded {
+                    agent: "a".into(),
+                    round: 0,
+                    kind: "finding".into(),
+                    content: "prev-round-content".into(),
+                    refs: vec![],
+                    confidence: 0.7,
+                    tokens_in: 1,
+                    tokens_out: 1,
+                    cost: 0.0,
+                },
+                ExecutionEvent::RoundStarted { round: 1 },
+                ExecutionEvent::BoardEntryAdded {
+                    agent: "a".into(),
+                    round: 1,
+                    kind: "finding".into(),
+                    content: "current-round-content".into(),
+                    refs: vec![],
+                    confidence: 0.7,
+                    tokens_in: 1,
+                    tokens_out: 1,
+                    cost: 0.0,
+                },
+            ];
+            let state = fold(&events);
+            runner.run_invoke("b", "task", &state).await.unwrap();
+
+            let sent = capturing.requests();
+            assert_eq!(sent.len(), 1);
+            let prompt = &sent[0].messages[0].content;
+            assert!(
+                prompt.contains("prev-round-content"),
+                "expected the previous round's entry in the prompt, got: {prompt}"
+            );
+            assert!(
+                !prompt.contains("current-round-content"),
+                "must not leak the current round's peer entries into the prompt, got: {prompt}"
+            );
+        }
+
+        // (c) Step 1 (brief): a provider error must NOT propagate as an
+        // `Err` — `run_invoke` degrades gracefully into a `BoardEntryAdded`
+        // with kind="finding", a "[agent failed]" content marker, confidence
+        // 0.0, and zeroed tokens/cost.
+        #[tokio::test]
+        async fn run_invoke_degrades_gracefully_on_provider_error() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), test_agent("a", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), Arc::new(FailingProvider));
+            let runner =
+                BlackboardEffectRunner::new(agents, providers, BlackboardConfig::default());
+
+            let state = fold(&[
+                board_run_started(&["a"]),
+                ExecutionEvent::RoundStarted { round: 2 },
+            ]);
+            let ev = runner
+                .run_invoke("a", "task", &state)
+                .await
+                .expect("a provider error must not propagate as Err");
+
+            match ev {
+                ExecutionEvent::BoardEntryAdded {
+                    agent,
+                    round,
+                    kind,
+                    content,
+                    refs,
+                    confidence,
+                    tokens_in,
+                    tokens_out,
+                    cost,
+                } => {
+                    assert_eq!(agent, "a");
+                    assert_eq!(round, 2);
+                    assert_eq!(kind, "finding");
+                    assert!(
+                        content.contains("[agent failed]"),
+                        "expected a degraded-entry marker, got: {content}"
+                    );
+                    assert!(refs.is_empty());
+                    assert_eq!(confidence, 0.0);
+                    assert_eq!(tokens_in, 0);
+                    assert_eq!(tokens_out, 0);
+                    assert_eq!(cost, 0.0);
+                }
+                other => panic!("expected a degraded BoardEntryAdded, got {other:?}"),
+            }
+        }
+
+        // `"latest:auto"` is resolved the same way as
+        // `HierarchicalEffectRunner`: `BlackboardDecider::model_routed_event`
+        // emits `ModelRouted{agent, tier, ..}` ahead of the matching
+        // `Invoke`, which `es::state::apply` projects into
+        // `state.routed_tiers`; `run_invoke` reads that tier back and
+        // resolves it via `resolve_model_for_tier` — never leaking the
+        // literal `"latest:auto"` string to the provider. The agent's
+        // `provider` is deliberately a name no on-disk `models.dev` cache
+        // could contain, forcing the hermetic, pure `fallback_model_for_tier`
+        // path (see the identical rationale on
+        // `es::hierarchical::run_invoke_resolves_latest_auto_to_concrete_model`).
+        #[tokio::test]
+        async fn run_invoke_resolves_latest_auto_to_concrete_model() {
+            let mut agent = test_agent("a", "latest:auto");
+            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), agent);
+            let capturing = Arc::new(CapturingProvider::new(
+                "ACTION:FINDING\nCONFIDENCE:0.5\nCONTENT:noted",
+            ));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), capturing.clone() as Arc<dyn Provider>);
+            let runner =
+                BlackboardEffectRunner::new(agents, providers, BlackboardConfig::default());
+
+            let state = fold(&[
+                board_run_started(&["a"]),
+                ExecutionEvent::RoundStarted { round: 0 },
+                ExecutionEvent::ModelRouted {
+                    agent: "a".into(),
+                    tier: "Fast".into(),
+                    reason: "Length".into(),
+                },
+            ]);
+            runner.run_invoke("a", "task", &state).await.unwrap();
+
+            let expected =
+                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Fast).to_string();
+            let sent = capturing.requests();
+            assert_eq!(sent[0].model, expected);
+            assert_ne!(sent[0].model, "latest:auto");
+        }
+
+        // Config errors (unknown agent / no provider registered) are
+        // distinct from a provider *call* failure: these still propagate as
+        // `Err`, mirroring `HierarchicalEffectRunner`'s equivalent tests —
+        // there is no "agent" to degrade gracefully on behalf of.
+        #[tokio::test]
+        async fn run_invoke_errors_for_unknown_agent() {
+            let runner = BlackboardEffectRunner::new(
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BlackboardConfig::default(),
+            );
+            let state = ExecutionState::default();
+            let err = runner
+                .run_invoke("missing", "task", &state)
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("missing"));
+        }
+
+        #[tokio::test]
+        async fn run_invoke_errors_when_provider_missing_for_known_agent() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), test_agent("a", "concrete-model"));
+            let runner =
+                BlackboardEffectRunner::new(agents, BTreeMap::new(), BlackboardConfig::default());
+            let state = ExecutionState::default();
+            let err = runner.run_invoke("a", "task", &state).await.unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("provider") && msg.contains("'a'"),
+                "expected a distinctive missing-provider message, got: {msg}"
+            );
         }
     }
 }

--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -13,9 +13,12 @@
 
 use std::collections::BTreeMap;
 
+use super::engine::{Action, Decider};
+use super::event::ExecutionEvent;
 use super::state::{BoardEntryRec, ExecutionState};
 use crate::core::agent::Agent;
 use crate::core::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
+use crate::core::routing::{BudgetState, RoutingRules, route};
 
 /// Agents eligible to contribute on the board's current round, ordered by
 /// the run's roster (`state.agents`) rather than `agents`' own (`BTreeMap`,
@@ -167,6 +170,284 @@ pub(crate) fn entry_kind_to_rec(kind: &EntryKind) -> (String, Vec<usize>) {
         EntryKind::Answer { question } => vec![*question],
     };
     (entry_kind_name(kind).to_string(), refs)
+}
+
+// ── BlackboardDecider (Task 3): pure decision function ────────────
+
+/// Pure blackboard [`Decider`]: given the current [`ExecutionState`],
+/// decides the next batch of [`Action`]s — kick off round 0, invoke a
+/// round's eligible agents, advance to the next round, or halt/complete on
+/// convergence, `max_rounds`, or budget exhaustion.
+///
+/// Mirrors `HierarchicalDecider` (`es::hierarchical`, OH1 Lot 2): all fields
+/// are immutable inputs captured at construction time, `decide` performs no
+/// I/O and reads no mutable state — every decision is a pure function of
+/// `state`, which is what keeps event-log replay deterministic.
+#[derive(Debug, Clone)]
+pub struct BlackboardDecider {
+    /// All known agents by name, for model/tag lookups (routing) and
+    /// trigger-based eligibility ([`eligible_agents`]).
+    pub agents: BTreeMap<String, Agent>,
+    /// Declared agent order (as configured). Reserved for seeding the run's
+    /// `RunStarted { agents, .. }` roster in a future assembly function
+    /// (the blackboard counterpart of `run_hierarchical_es`) — `decide`
+    /// itself never reads it, deriving eligibility ordering from
+    /// `state.agents` instead (populated from that same roster once the run
+    /// has started).
+    pub agent_order: Vec<String>,
+    /// The original user input/task, given to every invoked agent. The
+    /// actual per-round board prompt (filtered to `round < round_courant`,
+    /// per the module's Task 4 note) is assembled by the effect runner, not
+    /// here.
+    pub input: String,
+    /// Blackboard configuration (`max_rounds`/`consensus_threshold`/
+    /// `convergence_rounds`/…), read by [`eligible_agents`],
+    /// [`check_convergence`], and [`consecutive_convergence`].
+    pub config: BlackboardConfig,
+    /// Routing rules for `latest:auto` agents.
+    pub routing_rules: RoutingRules,
+    /// Max rounds before the run is force-completed. Kept as its own field
+    /// (like `HierarchicalDecider::max_depth`) rather than always reading
+    /// `config.max_rounds`, so callers may override it independently.
+    pub max_rounds: u32,
+    /// Optional total token budget (in + out) before the run is
+    /// force-completed.
+    pub token_budget: Option<u32>,
+    /// Optional total cost budget (USD) before the run is force-completed.
+    pub cost_limit: Option<f64>,
+}
+
+impl BlackboardDecider {
+    /// Construct a new `BlackboardDecider`. All arguments become immutable
+    /// fields read by `decide`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        agents: BTreeMap<String, Agent>,
+        agent_order: Vec<String>,
+        input: impl Into<String>,
+        config: BlackboardConfig,
+        routing_rules: RoutingRules,
+        max_rounds: u32,
+        token_budget: Option<u32>,
+        cost_limit: Option<f64>,
+    ) -> Self {
+        Self {
+            agents,
+            agent_order,
+            input: input.into(),
+            config,
+            routing_rules,
+            max_rounds,
+            token_budget,
+            cost_limit,
+        }
+    }
+
+    /// Check budget/cost guards, returning the `Warned` code for whichever
+    /// one has been breached (token budget checked first — same convention
+    /// as `HierarchicalDecider::breached_limit`).
+    fn breached_budget(&self, state: &ExecutionState) -> Option<&'static str> {
+        if let Some(budget) = self.token_budget
+            && state.budget_tokens_in + state.budget_tokens_out >= u64::from(budget)
+        {
+            return Some("token_budget");
+        }
+        if let Some(limit) = self.cost_limit
+            && state.budget_cost >= limit
+        {
+            return Some("cost_limit");
+        }
+        None
+    }
+
+    /// If `agent_name` is a known agent configured with the exact
+    /// `"latest:auto"` model placeholder, resolve the tier for
+    /// `routing_input` (pure, via `crate::core::routing::route`) and return
+    /// the `ModelRouted` event to emit before invoking it. Concrete models,
+    /// other `latest:*` placeholders, and unknown agents all return `None`.
+    ///
+    /// Identical in spirit to `HierarchicalDecider::model_routed_event` —
+    /// duplicated rather than shared, since the two deciders' `agents` /
+    /// `routing_rules` / `token_budget` fields live on unrelated structs
+    /// with no common trait today.
+    fn model_routed_event(
+        &self,
+        agent_name: &str,
+        routing_input: &str,
+        state: &ExecutionState,
+    ) -> Option<ExecutionEvent> {
+        let agent = self.agents.get(agent_name)?;
+        let raw_model = agent.metadata.model.as_deref().unwrap_or("default");
+        if raw_model != "latest:auto" {
+            return None;
+        }
+        let tokens_consumed = state.budget_tokens_in + state.budget_tokens_out;
+        let budget = self.token_budget.filter(|&b| b > 0).map(|total| {
+            let total = u64::from(total);
+            BudgetState {
+                remaining_ratio: total.saturating_sub(tokens_consumed) as f64 / total as f64,
+            }
+        });
+        let (tier, reason) = route(
+            routing_input,
+            &agent.metadata.tags,
+            budget,
+            &self.routing_rules,
+        );
+        Some(ExecutionEvent::ModelRouted {
+            agent: agent_name.to_string(),
+            tier: format!("{tier:?}"),
+            reason: format!("{reason:?}"),
+        })
+    }
+
+    /// Build the action batch that starts `round`: `Emit(RoundStarted)`
+    /// followed by, for each of `eligible` (in roster order), an optional
+    /// `Emit(ModelRouted)` then its `Invoke`.
+    fn round_actions(
+        &self,
+        round: u32,
+        eligible: &[String],
+        state: &ExecutionState,
+    ) -> Vec<Action> {
+        let mut actions = vec![Action::Emit(ExecutionEvent::RoundStarted { round })];
+        for agent in eligible {
+            if let Some(event) = self.model_routed_event(agent, &self.input, state) {
+                actions.push(Action::Emit(event));
+            }
+            actions.push(Action::Invoke {
+                agent: agent.clone(),
+                input: self.input.clone(),
+            });
+        }
+        actions
+    }
+
+    /// Whether every one of `eligible` has already produced a
+    /// `BoardEntryAdded` for `state.board.round` — the deterministic "round
+    /// complete" signal `decide` needs, derived purely from
+    /// `state.board.entries` (no separate bookkeeping counter to keep in
+    /// sync).
+    ///
+    /// An empty `eligible` list never reads as complete: with nothing to
+    /// wait for, treating it as "complete" would let a round with no
+    /// eligible agents silently auto-advance round after round with no
+    /// entries ever posted. `decide` therefore idles on that state instead
+    /// (see the task report for this documented edge case — it does not
+    /// arise in any of the four required test scenarios, all of which keep
+    /// at least one agent eligible throughout).
+    fn round_complete(&self, state: &ExecutionState, eligible: &[String]) -> bool {
+        !eligible.is_empty()
+            && eligible.iter().all(|agent| {
+                state
+                    .board
+                    .entries
+                    .iter()
+                    .any(|e| e.round == state.board.round && &e.agent == agent)
+            })
+    }
+}
+
+impl Decider for BlackboardDecider {
+    fn decide(&self, state: &ExecutionState) -> Vec<Action> {
+        // 1. Nothing posted yet: kick off round 0 with its eligible agents.
+        // This is the only branch reachable before any `BoardEntryAdded` has
+        // been folded — in the production loop, `decide` is never called
+        // again mid-round (a batch's `Invoke`s and their effects all land
+        // before the next `decide`), so this state is exactly "the run just
+        // started".
+        if state.board.entries.is_empty() {
+            let eligible = eligible_agents(state, &self.agents);
+            return self.round_actions(0, &eligible, state);
+        }
+
+        let round = state.board.round;
+        let eligible = eligible_agents(state, &self.agents);
+
+        // 2. Still waiting on some eligible agent's contribution this round
+        // — nothing to decide yet. A genuine wait, mirroring
+        // `HierarchicalDecider::awaiting_in_flight`: in the real socle loop
+        // an `Invoke`'s effect resolves within the same batch, so this only
+        // arises for a synthetic/partial state (e.g. in a test).
+        if !self.round_complete(state, &eligible) {
+            return Vec::new();
+        }
+
+        // 3. Round complete: evaluate halt conditions in priority order —
+        // budget/cost first (a hard external limit), then `max_rounds` (a
+        // hard configured cap), then convergence (the "happy path" halt).
+        if let Some(code) = self.breached_budget(state) {
+            return vec![
+                Action::Emit(ExecutionEvent::Warned {
+                    code: code.to_string(),
+                }),
+                Action::Complete {
+                    content: build_board_result(state),
+                },
+            ];
+        }
+
+        if round.saturating_add(1) >= self.max_rounds {
+            return vec![
+                Action::Emit(ExecutionEvent::Warned {
+                    code: "max_rounds".to_string(),
+                }),
+                Action::Complete {
+                    content: build_board_result(state),
+                },
+            ];
+        }
+
+        if consecutive_convergence(state, &self.config) >= self.config.convergence_rounds {
+            // `consecutive_convergence >= 1` implies the current round's own
+            // confirmation ratio already met `consensus_threshold` (it is
+            // the first round counted, backward from the latest one present
+            // in `state.board.entries`) — `check_convergence` therefore
+            // returns `Some` here in practice. The fallback only guards a
+            // theoretical drift between the two functions, never observed
+            // in the four required test scenarios.
+            let score =
+                check_convergence(state, &self.config).unwrap_or(self.config.consensus_threshold);
+            return vec![
+                Action::Emit(ExecutionEvent::ConsensusReached { score }),
+                Action::Complete {
+                    content: build_board_result(state),
+                },
+            ];
+        }
+
+        // 4. Otherwise: advance to the next round. Eligibility for the new
+        // round can differ from the current one (trigger `min_round`/
+        // `max_round` windows), so it is recomputed against a
+        // round-advanced *clone* of `state` — pure lookahead, no mutation of
+        // the real state (that only happens once the engine applies the
+        // `RoundStarted` event this batch emits).
+        let next_round = round + 1;
+        let mut lookahead = state.clone();
+        lookahead.board.round = next_round;
+        let next_eligible = eligible_agents(&lookahead, &self.agents);
+        self.round_actions(next_round, &next_eligible, state)
+    }
+}
+
+/// Deterministic synthesis of the final board result: every entry, in the
+/// order it was recorded (`state.board.entries` — a `Vec`, so this is the
+/// chronological append order of the underlying event log), formatted as
+/// `[agent] content`, one per line.
+///
+/// Matches the legacy engine's blackboard outcome text verbatim
+/// (`cli::run`: `board.entries().iter().map(|entry| format!("[{}] {}",
+/// entry.agent, entry.content))...join("\n")`), so the event-sourced and
+/// legacy engines produce the same shape of final answer for the same
+/// entry sequence.
+pub(crate) fn build_board_result(state: &ExecutionState) -> String {
+    state
+        .board
+        .entries
+        .iter()
+        .map(|entry| format!("[{}] {}", entry.agent, entry.content))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[cfg(test)]
@@ -513,5 +794,196 @@ mod tests {
             entry_kind_to_rec(&EntryKind::Answer { question: 5 }),
             ("answer".to_string(), vec![5])
         );
+    }
+
+    // ── BlackboardDecider (Task 3) ───────────────────────────────────
+
+    /// Tests for `BlackboardDecider` (Task 3): pure decision function built
+    /// on top of `eligible_agents`/`check_convergence`/
+    /// `consecutive_convergence` (Task 2). Named `decide` so
+    /// `cargo test es::blackboard::tests::decide` targets this module —
+    /// mirrors the naming convention used by `es::hierarchical::tests::decide`.
+    mod decide {
+        use super::*;
+        use crate::core::orchestration::es::engine::{Action, Decider};
+        use crate::core::orchestration::es::state::fold;
+        use crate::core::routing::RoutingRules;
+
+        #[allow(clippy::too_many_arguments)]
+        fn test_decider(
+            agent_names: &[&str],
+            config: BlackboardConfig,
+            max_rounds: u32,
+            token_budget: Option<u32>,
+            cost_limit: Option<f64>,
+        ) -> BlackboardDecider {
+            let mut agents = BTreeMap::new();
+            for name in agent_names {
+                agents.insert((*name).to_string(), test_agent(name, None));
+            }
+            BlackboardDecider::new(
+                agents,
+                agent_names.iter().map(|a| (*a).to_string()).collect(),
+                "task".to_string(),
+                config,
+                RoutingRules::default(),
+                max_rounds,
+                token_budget,
+                cost_limit,
+            )
+        }
+
+        fn invoked_agents(actions: &[Action]) -> Vec<&str> {
+            actions
+                .iter()
+                .filter_map(|a| match a {
+                    Action::Invoke { agent, .. } => Some(agent.as_str()),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        // (a) empty state → RoundStarted{0} + Invokes of the eligible agents.
+        #[test]
+        fn empty_state_starts_round_zero_and_invokes_eligible() {
+            let dec = test_decider(&["a", "b"], BlackboardConfig::default(), 5, None, None);
+            let state = fold(&[run_started(&["a", "b"])]);
+            let actions = dec.decide(&state);
+
+            assert!(
+                matches!(&actions[0], Action::Emit(E::RoundStarted { round }) if *round == 0),
+                "expected Emit(RoundStarted{{round: 0}}) first, got {actions:?}"
+            );
+            assert_eq!(invoked_agents(&actions), vec!["a", "b"]);
+        }
+
+        // (b) round complete, not convergent, < max_rounds → RoundStarted{1}
+        // + Invokes of the (re-evaluated) eligible agents.
+        #[test]
+        fn round_complete_not_convergent_advances_round() {
+            let dec = test_decider(&["a", "b"], BlackboardConfig::default(), 5, None, None);
+            let events = vec![
+                run_started(&["a", "b"]),
+                E::RoundStarted { round: 0 },
+                board_entry("a", 0, "finding", vec![], 0.5),
+                board_entry("b", 0, "finding", vec![], 0.5),
+            ];
+            let state = fold(&events);
+            let actions = dec.decide(&state);
+
+            assert!(
+                matches!(&actions[0], Action::Emit(E::RoundStarted { round }) if *round == 1),
+                "expected Emit(RoundStarted{{round: 1}}) first, got {actions:?}"
+            );
+            assert_eq!(invoked_agents(&actions), vec!["a", "b"]);
+        }
+
+        // (c) convergence reached `convergence_rounds` times consecutively
+        // → ConsensusReached + Complete (synthesis of the board).
+        #[test]
+        fn convergence_reached_completes_with_consensus() {
+            let config = BlackboardConfig {
+                convergence_rounds: 1,
+                ..BlackboardConfig::default()
+            };
+            let dec = test_decider(&["a", "b"], config, 5, None, None);
+            let events = vec![
+                run_started(&["a", "b"]),
+                E::RoundStarted { round: 0 },
+                board_entry("a", 0, "confirmation", vec![0], 0.9),
+                board_entry("b", 0, "confirmation", vec![0], 0.9),
+            ];
+            let state = fold(&events);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 2, "got {actions:?}");
+            assert!(
+                matches!(&actions[0], Action::Emit(E::ConsensusReached { score }) if (*score - 1.0).abs() < 1e-6),
+                "expected ConsensusReached{{score: 1.0}}, got {:?}",
+                actions[0]
+            );
+            assert!(
+                matches!(&actions[1], Action::Complete { content } if content.contains("[a]") && content.contains("[b]")),
+                "expected Complete with both entries, got {:?}",
+                actions[1]
+            );
+        }
+
+        // (d) round+1 >= max_rounds → Warned{max_rounds} + Complete, even
+        // though nothing has converged.
+        #[test]
+        fn max_rounds_reached_warns_and_completes() {
+            let dec = test_decider(&["a", "b"], BlackboardConfig::default(), 1, None, None);
+            let events = vec![
+                run_started(&["a", "b"]),
+                E::RoundStarted { round: 0 },
+                board_entry("a", 0, "finding", vec![], 0.5),
+                board_entry("b", 0, "finding", vec![], 0.5),
+            ];
+            let state = fold(&events);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 2, "got {actions:?}");
+            assert!(
+                matches!(&actions[0], Action::Emit(E::Warned { code }) if code == "max_rounds"),
+                "expected Warned{{code: \"max_rounds\"}}, got {:?}",
+                actions[0]
+            );
+            assert!(
+                matches!(&actions[1], Action::Complete { content } if content.contains("[a]") && content.contains("[b]")),
+                "expected Complete with both entries, got {:?}",
+                actions[1]
+            );
+        }
+
+        // Round not yet complete (only one of two eligible agents has
+        // contributed) → idle (no actions), the "genuine wait" documented on
+        // `BlackboardDecider::decide`.
+        #[test]
+        fn incomplete_round_is_idle() {
+            let dec = test_decider(&["a", "b"], BlackboardConfig::default(), 5, None, None);
+            let events = vec![
+                run_started(&["a", "b"]),
+                E::RoundStarted { round: 0 },
+                board_entry("a", 0, "finding", vec![], 0.5),
+            ];
+            let state = fold(&events);
+            let actions = dec.decide(&state);
+            assert!(actions.is_empty(), "got {actions:?}");
+        }
+
+        // Budget exhaustion is checked ahead of `max_rounds`/convergence: a
+        // round complete with the token budget already spent halts
+        // immediately, regardless of round count.
+        #[test]
+        fn token_budget_exhausted_warns_and_completes() {
+            let dec = test_decider(&["a", "b"], BlackboardConfig::default(), 5, Some(10), None);
+            let events = vec![
+                run_started(&["a", "b"]),
+                E::RoundStarted { round: 0 },
+                E::BoardEntryAdded {
+                    agent: "a".into(),
+                    round: 0,
+                    kind: "finding".into(),
+                    content: "c".into(),
+                    refs: vec![],
+                    confidence: 0.5,
+                    tokens_in: 6,
+                    tokens_out: 6,
+                    cost: 0.0,
+                },
+                board_entry("b", 0, "finding", vec![], 0.5),
+            ];
+            let state = fold(&events);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 2, "got {actions:?}");
+            assert!(
+                matches!(&actions[0], Action::Emit(E::Warned { code }) if code == "token_budget"),
+                "expected Warned{{code: \"token_budget\"}}, got {:?}",
+                actions[0]
+            );
+            assert!(matches!(&actions[1], Action::Complete { .. }));
+        }
     }
 }

--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -16,8 +16,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use super::engine::{Action, Decider, EffectRunner};
+use super::engine::{Action, Decider, EffectRunner, run_event_sourced};
 use super::event::ExecutionEvent;
+use super::log::EventLog;
 use super::state::{BoardEntryRec, ExecutionState};
 use crate::core::agent::Agent;
 use crate::core::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
@@ -691,6 +692,73 @@ impl EffectRunner for BlackboardEffectRunner {
             }
         }
     }
+}
+
+// ── run_blackboard_es (Task 5): end-to-end assembly ──────────────────
+
+/// Run a complete blackboard orchestration end-to-end through the
+/// event-sourced engine: builds the initial `RunStarted` event, constructs a
+/// [`BlackboardDecider`] + [`BlackboardEffectRunner`] from `config` /
+/// `agents` / `providers` / `routing_rules`, and drives them through
+/// [`run_event_sourced`], returning the final [`ExecutionState`].
+///
+/// `run_id` is accepted explicitly rather than generated internally, so
+/// callers — notably tests proving replay determinism — can pass a fixed id
+/// and later reconstruct the same state purely from the log via
+/// [`super::engine::replay`].
+///
+/// The run's roster (`RunStarted { agents, .. }`, and `BlackboardDecider`'s
+/// `agent_order`) is `agents.keys()`, i.e. name-sorted (`BTreeMap`
+/// iteration order) — the same convention `run_hierarchical_es` uses for its
+/// own `agent_names`.
+///
+/// `max_rounds` and `token_budget` are derived from `config`
+/// (`BlackboardConfig::max_rounds`/`token_budget`, both concrete `u32`/`u64`
+/// values with documented defaults — unlike `OrchestrationConfig`'s
+/// `Option` fields, `BlackboardConfig` has no "unset" state for either, so
+/// `token_budget` narrows to `Option<u32>` as `Some(..)` unconditionally,
+/// saturating at `u32::MAX`). `BlackboardConfig` carries no cost-budget
+/// field (unlike `OrchestrationConfig::cost_limit`), so `cost_limit` is
+/// always `None` here — no cost guard applies to the event-sourced
+/// blackboard run.
+///
+/// Coexists with the legacy `core::orchestration::blackboard::run_blackboard`
+/// — this function is not called from `run.rs`; wiring it in as the active
+/// engine is a later lot (the bascule).
+pub async fn run_blackboard_es(
+    run_id: &str,
+    input: &str,
+    agents: BTreeMap<String, Agent>,
+    providers: BTreeMap<String, Arc<dyn Provider>>,
+    config: BlackboardConfig,
+    routing_rules: RoutingRules,
+    log: &mut impl EventLog,
+) -> anyhow::Result<ExecutionState> {
+    let agent_order: Vec<String> = agents.keys().cloned().collect();
+    let initial = vec![ExecutionEvent::RunStarted {
+        run_id: run_id.to_string(),
+        pattern: "blackboard".to_string(),
+        agents: agent_order.clone(),
+        input: input.to_string(),
+        project: None,
+    }];
+
+    let max_rounds = config.max_rounds;
+    let token_budget = Some(u32::try_from(config.token_budget).unwrap_or(u32::MAX));
+
+    let decider = BlackboardDecider::new(
+        agents.clone(),
+        agent_order,
+        input.to_string(),
+        config.clone(),
+        routing_rules,
+        max_rounds,
+        token_budget,
+        None,
+    );
+    let effects = BlackboardEffectRunner::new(agents, providers, config);
+
+    run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
 
 #[cfg(test)]
@@ -1638,6 +1706,325 @@ mod tests {
             assert!(
                 msg.contains("provider") && msg.contains("'a'"),
                 "expected a distinctive missing-provider message, got: {msg}"
+            );
+        }
+    }
+
+    // ── run_blackboard_es (Task 5): end-to-end + replay determinism ──
+    //
+    // Exercises `run_blackboard_es` as a whole (unlike `decide` and
+    // `effect_runner` above, which drive `BlackboardDecider` /
+    // `BlackboardEffectRunner` directly) — the same scenarios the legacy
+    // `core::orchestration::blackboard::run_blackboard` engine covers, plus
+    // a proof that `replay` reconstructs an identical `ExecutionState`
+    // purely from the log, with no effect re-executed.
+    //
+    // IMPORTANT: every agent below uses a CONCRETE model string (never
+    // `latest:auto`) — see the identical rationale on
+    // `es::hierarchical::tests::run_hierarchical_es`'s own module doc:
+    // resolving `latest:auto` reads an on-disk `models.dev` cache, which
+    // would make these tests non-hermetic/flaky.
+    mod run_blackboard_es_tests {
+        use super::*;
+        use crate::core::orchestration::es::engine::replay;
+        use crate::core::orchestration::es::log::InMemoryLog;
+        use crate::core::orchestration::es::state::RunStatus;
+        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use std::collections::VecDeque;
+        use std::path::PathBuf;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Minimal `Agent` for `run_blackboard_es` E2E tests: always a
+        /// concrete model (see module note above).
+        fn es_test_agent(name: &str, model: &str) -> Agent {
+            Agent {
+                name: name.to_string(),
+                source: PathBuf::from(format!("{name}.md")),
+                metadata: AgentMetadata {
+                    provider: "anthropic".to_string(),
+                    model: Some(model.to_string()),
+                    command: None,
+                    args: None,
+                    temperature: 0.7,
+                    max_tokens: None,
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: format!("You are {name}."),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        /// Provider scripted with a fixed sequence of responses, one per
+        /// call (repeating the last one for any call beyond the scripted
+        /// list, so a test can under-provision — e.g. a single response
+        /// reused every round — without panicking). Also counts calls, so
+        /// `es_blackboard_replay_reconstructs_state` can prove `replay`
+        /// triggers none. Identical in spirit to
+        /// `es::hierarchical::tests::ScriptedProvider` — duplicated rather
+        /// than shared (no common test-helpers module exists for the ES
+        /// engines today).
+        struct ScriptedProvider {
+            responses: std::sync::Mutex<VecDeque<String>>,
+            last: std::sync::Mutex<String>,
+            calls: AtomicUsize,
+        }
+
+        impl ScriptedProvider {
+            fn new(responses: &[&str]) -> Self {
+                Self {
+                    responses: std::sync::Mutex::new(
+                        responses.iter().map(|s| (*s).to_string()).collect(),
+                    ),
+                    last: std::sync::Mutex::new(String::new()),
+                    calls: AtomicUsize::new(0),
+                }
+            }
+
+            fn call_count(&self) -> usize {
+                self.calls.load(Ordering::SeqCst)
+            }
+        }
+
+        #[async_trait]
+        impl Provider for ScriptedProvider {
+            async fn complete(
+                &self,
+                request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let mut queue = self.responses.lock().unwrap();
+                let content = queue
+                    .pop_front()
+                    .unwrap_or_else(|| self.last.lock().unwrap().clone());
+                *self.last.lock().unwrap() = content.clone();
+                Ok(CompletionResponse {
+                    content,
+                    model: request.model,
+                    tokens_in: 1,
+                    tokens_out: 1,
+                    cost: 0.0,
+                })
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by run_blackboard_es tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "scripted".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        /// Extract the `content` of the last `Completed` event recorded for
+        /// `run_id`, if any. `ExecutionState` itself carries no `content`
+        /// field (only `status`), so asserting the final answer's content
+        /// requires reading it back from the log.
+        fn final_content(log: &InMemoryLog, run_id: &str) -> String {
+            log.events(run_id)
+                .unwrap()
+                .into_iter()
+                .rev()
+                .find_map(|e| match e {
+                    ExecutionEvent::Completed { content } => Some(content),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        }
+
+        /// Whether `run_id`'s log contains a `Warned{code}` event matching
+        /// `code` exactly. `apply` treats `Warned` as a no-op on
+        /// `ExecutionState` (see `es::state::apply`), so — like
+        /// `final_content` above — this can only be checked against the
+        /// log, not the projected state.
+        fn log_has_warned(log: &InMemoryLog, run_id: &str, code: &str) -> bool {
+            log.events(run_id)
+                .unwrap()
+                .iter()
+                .any(|e| matches!(e, ExecutionEvent::Warned { code: c } if c == code))
+        }
+
+        // Scenario 1: both agents post a `CONFIRMATION` targeting entry 0 in
+        // round 0 — a 2/2 = 1.0 confirmation ratio, above the default
+        // `consensus_threshold` (0.75), reaching consensus on the very
+        // first round (default `convergence_rounds` is 1). The run must
+        // `Complete`, and the final board digest must be non-empty.
+        #[tokio::test]
+        async fn es_blackboard_converges_and_completes() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:tout est cohérent",
+                ])),
+            );
+            providers.insert(
+                "b".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:confirmé",
+                ])),
+            );
+
+            let mut log = InMemoryLog::default();
+            let st = run_blackboard_es(
+                "run-converge",
+                "task",
+                agents,
+                providers,
+                BlackboardConfig::default(),
+                RoutingRules::default(),
+                &mut log,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(st.status, RunStatus::Completed);
+            assert!(
+                st.board.entries.iter().all(|e| e.kind == "confirmation"),
+                "expected only confirmation entries, got {:?}",
+                st.board.entries
+            );
+            assert!(
+                !final_content(&log, "run-converge").trim().is_empty(),
+                "expected a non-empty final board digest"
+            );
+        }
+
+        // Scenario 2: both agents post plain `FINDING`s every round — never
+        // a `CONFIRMATION` — so convergence never triggers. With
+        // `max_rounds: 2`, the run must halt via `Warned{max_rounds}` (once
+        // round 1 completes, since `round + 1 >= max_rounds` first holds at
+        // round 1) rather than spin forever, and still end `Completed`
+        // (the guard *completes* the run with the board digest, it does
+        // not error).
+        #[tokio::test]
+        async fn es_blackboard_halts_at_max_rounds() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION:FINDING\nCONFIDENCE:0.5\nCONTENT:piste A",
+                ])),
+            );
+            providers.insert(
+                "b".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION:FINDING\nCONFIDENCE:0.5\nCONTENT:piste B",
+                ])),
+            );
+
+            let config = BlackboardConfig {
+                max_rounds: 2,
+                ..BlackboardConfig::default()
+            };
+
+            let mut log = InMemoryLog::default();
+            let st = run_blackboard_es(
+                "run-maxrounds",
+                "task",
+                agents,
+                providers,
+                config,
+                RoutingRules::default(),
+                &mut log,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(st.status, RunStatus::Completed);
+            assert!(
+                log_has_warned(&log, "run-maxrounds", "max_rounds"),
+                "expected a max_rounds Warned event in the log"
+            );
+            assert!(
+                !final_content(&log, "run-maxrounds").trim().is_empty(),
+                "expected a non-empty board digest"
+            );
+        }
+
+        // Scenario 3: replay determinism. After a full run, `replay(run_id,
+        // &log)` must reconstruct an `ExecutionState` identical (`Debug`
+        // format) to the one `run_blackboard_es` returned — and it must do
+        // so without invoking any provider again (`replay` takes no
+        // `EffectRunner` at all; the call-count assertions below are an
+        // extra, belt-and-braces proof that no effect silently re-runs).
+        #[tokio::test]
+        async fn es_blackboard_replay_reconstructs_state() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let provider_a = Arc::new(ScriptedProvider::new(&[
+                "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:tout est cohérent",
+            ]));
+            let provider_b = Arc::new(ScriptedProvider::new(&[
+                "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:confirmé",
+            ]));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), provider_a.clone() as Arc<dyn Provider>);
+            providers.insert("b".to_string(), provider_b.clone() as Arc<dyn Provider>);
+
+            let mut log = InMemoryLog::default();
+            let st = run_blackboard_es(
+                "run-replay",
+                "task",
+                agents,
+                providers,
+                BlackboardConfig::default(),
+                RoutingRules::default(),
+                &mut log,
+            )
+            .await
+            .unwrap();
+            assert_eq!(st.status, RunStatus::Completed);
+
+            let calls_a_before = provider_a.call_count();
+            let calls_b_before = provider_b.call_count();
+            assert!(
+                calls_a_before > 0,
+                "expected provider 'a' to have been invoked during the run"
+            );
+            assert!(
+                calls_b_before > 0,
+                "expected provider 'b' to have been invoked during the run"
+            );
+
+            let replayed = replay("run-replay", &log).unwrap();
+
+            assert_eq!(
+                format!("{st:?}"),
+                format!("{replayed:?}"),
+                "replay must reconstruct an identical ExecutionState"
+            );
+            assert_eq!(
+                provider_a.call_count(),
+                calls_a_before,
+                "replay must not re-invoke provider 'a'"
+            );
+            assert_eq!(
+                provider_b.call_count(),
+                calls_b_before,
+                "replay must not re-invoke provider 'b'"
             );
         }
     }

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -16,16 +16,20 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use super::blackboard::{build_board_result, run_blackboard_es};
 use super::engine::{Action, Decider, EffectRunner, run_event_sourced};
 use super::event::ExecutionEvent;
-use super::log::EventLog;
+use super::log::{EventLog, InMemoryLog};
+use super::ring::{resolve_votes, run_ring_es, vote_weights_from_agents};
 use super::state::ExecutionState;
 use crate::core::agent::Agent;
-use crate::core::orchestration::OrchestrationConfig;
+use crate::core::orchestration::blackboard::BlackboardConfig;
 use crate::core::orchestration::context_injection::{AgentInfo, build_orchestration_prompt};
 use crate::core::orchestration::protocol::{
     DelegationAction, extract_narrative, parse_delegations,
 };
+use crate::core::orchestration::ring::RingConfig;
+use crate::core::orchestration::{NestedPattern, OrchestrationConfig, TeamConfig};
 use crate::core::routing::{BudgetState, RoutingRules, route};
 #[cfg(test)]
 use crate::linker::model_resolution::fallback_model_for_tier;
@@ -513,20 +517,36 @@ impl HierarchicalDecider {
     /// expected to change for that; the hook lives entirely on the impure
     /// `EffectRunner` side.
     fn nested_started_event(&self, agent_name: &str) -> Option<ExecutionEvent> {
-        self.config
-            .teams
-            .iter()
-            .find_map(|team| {
-                if team.lead.as_deref() == Some(agent_name) {
-                    team.pattern
-                } else {
-                    None
-                }
-            })
-            .map(|pattern| ExecutionEvent::NestedStarted {
+        nested_team_for(&self.config, agent_name).map(|(_, pattern)| {
+            ExecutionEvent::NestedStarted {
                 team_lead: agent_name.to_string(),
                 pattern: pattern.to_string(),
-            })
+            }
+        })
+    }
+
+    /// First team lead (in `state.open_nested`'s `BTreeSet` order) whose
+    /// nested C9 boundary is still open *and* whose sub-run outcome has
+    /// already been surfaced as an `AgentObserved` (`assistant_turn_count >=
+    /// 1`). Returning it means `decide` should emit a deferred
+    /// `NestedEnded { team_lead }` to close that boundary.
+    ///
+    /// Pure and deterministic: reads only the projected `state.open_nested`
+    /// set (maintained by `es::state::apply` from `NestedStarted`/`NestedEnded`
+    /// events) plus the lead's observed-turn count — no log scan, no I/O. The
+    /// "observed" guard mirrors the legacy `run_nested_team`, which emits
+    /// `NestedEnd` only *after* the sub-run has produced its outcome; on the
+    /// production path the lead's `Invoke` (and the `AgentObserved` the nested
+    /// `run_invoke` returns for it) is applied in the very same action batch as
+    /// the opening `NestedStarted`, so by the next `decide` round the lead is
+    /// always already observed — the guard only matters for hand-built partial
+    /// states in tests.
+    fn pending_nested_ended(&self, state: &ExecutionState) -> Option<String> {
+        state
+            .open_nested
+            .iter()
+            .find(|lead| assistant_turn_count(state, lead) >= 1)
+            .cloned()
     }
 
     /// Build the ordered action batch for invoking `agent_name` with
@@ -690,6 +710,19 @@ impl Decider for HierarchicalDecider {
             return self.invoke_actions(&self.coordinator, &self.input, state, None);
         }
 
+        // 1b. C9 nested boundary close-off: a team lead's sub-run has been
+        // launched (`NestedStarted`) and its outcome observed
+        // (`AgentObserved`, produced by the nested `run_invoke` short-circuit),
+        // but the boundary is still open. Emit the deferred `NestedEnded` to
+        // balance it — as its own single-action batch, so the next `decide`
+        // round (with `open_nested` now empty) proceeds to the parent's normal
+        // synthesis/arbitration of the lead's outcome. Checked ahead of the
+        // guards so the boundary always closes, matching the legacy
+        // `run_nested_team`, which emits `NestedEnd` regardless of outcome.
+        if let Some(team_lead) = self.pending_nested_ended(state) {
+            return vec![Action::Emit(ExecutionEvent::NestedEnded { team_lead })];
+        }
+
         // 2. Guards: depth / iteration / budget caps, checked before
         // considering any further delegation.
         if let Some(code) = self.breached_limit(state) {
@@ -806,6 +839,87 @@ fn parse_routed_tier(tier: &str) -> ModelTier {
     }
 }
 
+/// Shared C9 detection: if `agent` is the declared lead of a team that runs a
+/// nested sub-pattern (blackboard/ring), return that `(team, pattern)`.
+///
+/// Single source of truth for "is this agent a nested-team lead?", used both
+/// by the pure `HierarchicalDecider::nested_started_event` (to *mark* the
+/// boundary) and by the impure `HierarchicalEffectRunner::run_invoke` (to
+/// actually *launch* the sub-run). Config validation (`validate_config`,
+/// `DuplicateLead`) guarantees a lead appears in at most one team, so the
+/// first match is the only match.
+fn nested_team_for<'a>(
+    config: &'a OrchestrationConfig,
+    agent: &str,
+) -> Option<(&'a TeamConfig, NestedPattern)> {
+    config.teams.iter().find_map(|team| {
+        if team.lead.as_deref() == Some(agent) {
+            team.pattern.map(|pattern| (team, pattern))
+        } else {
+            None
+        }
+    })
+}
+
+/// Resolve the effective `BlackboardConfig` for a nested team: start from
+/// `base` (which already carries the remaining shared token budget) and apply
+/// team-level overrides, falling back to the parent orchestration config.
+/// Mirrors the legacy `apply_team_blackboard_overrides`
+/// (`core::orchestration::hierarchical.rs`) — reimplemented over `&TeamConfig`
+/// / `&OrchestrationConfig` rather than `&EngineContext`, keeping strict
+/// coexistence with the legacy engine.
+fn team_blackboard_config(
+    mut base: BlackboardConfig,
+    team: &TeamConfig,
+    config: &OrchestrationConfig,
+) -> BlackboardConfig {
+    if let Some(v) = team.max_rounds.or(config.max_rounds) {
+        base.max_rounds = v;
+    }
+    if let Some(v) = team.consensus_threshold.or(config.consensus_threshold) {
+        base.consensus_threshold = v;
+    }
+    base
+}
+
+/// Fold a finished nested sub-run into the single `AgentObserved` event the
+/// parent run records for `team_lead`: the sub-run's `outcome` text as the
+/// lead's "response", and the child run's aggregated budget as the lead's
+/// token/cost accounting (so it flows into the parent budget exactly like a
+/// real LLM turn). The child's `budget_tokens_in/out` are `u64`; they are
+/// narrowed to the `AgentObserved` `u32` fields with a saturating cast
+/// (`u32::MAX` on the — practically impossible — overflow) rather than a
+/// silent wrap. `model` is the sentinel `"nested"`, marking this observation
+/// as a folded sub-run rather than a direct provider call.
+fn nested_observed(team_lead: &str, outcome: String, child: &ExecutionState) -> ExecutionEvent {
+    ExecutionEvent::AgentObserved {
+        agent: team_lead.to_string(),
+        content: outcome,
+        tokens_in: u32::try_from(child.budget_tokens_in).unwrap_or(u32::MAX),
+        tokens_out: u32::try_from(child.budget_tokens_out).unwrap_or(u32::MAX),
+        cost: child.budget_cost,
+        model: "nested".to_string(),
+    }
+}
+
+/// Resolve the effective `RingConfig` for a nested team. Mirrors the legacy
+/// `apply_team_ring_overrides`: `max_laps` takes the team override only (no
+/// global fallback, matching legacy), `consensus_threshold` falls back to the
+/// parent config.
+fn team_ring_config(
+    mut base: RingConfig,
+    team: &TeamConfig,
+    config: &OrchestrationConfig,
+) -> RingConfig {
+    if let Some(v) = team.max_laps {
+        base.max_laps = v;
+    }
+    if let Some(v) = team.consensus_threshold.or(config.consensus_threshold) {
+        base.consensus_threshold = v;
+    }
+    base
+}
+
 // ── HierarchicalEffectRunner (Task 4): the sole async/impure effect ──
 
 /// Executes the actual LLM call behind `Action::Invoke` for the hierarchical
@@ -826,10 +940,21 @@ pub struct HierarchicalEffectRunner {
     /// (orchestration-aware) system prompt via
     /// `context_injection::build_orchestration_prompt`.
     pub config: OrchestrationConfig,
+    /// Routing rules forwarded to a nested C9 sub-run
+    /// (`run_blackboard_es`/`run_ring_es`) so its `latest:auto` members route
+    /// consistently with the parent run. Defaults to `RoutingRules::default()`
+    /// via [`HierarchicalEffectRunner::new`]; production callers thread the
+    /// real rules in with [`HierarchicalEffectRunner::with_routing_rules`].
+    /// Unused on the flat (non-nested) invoke path.
+    pub routing_rules: RoutingRules,
 }
 
 impl HierarchicalEffectRunner {
     /// Construct a new `HierarchicalEffectRunner` from its immutable inputs.
+    /// `routing_rules` defaults to `RoutingRules::default()` — the correct
+    /// "no custom routing" value for the many unit tests that don't exercise
+    /// nested sub-runs; production assembly (`run_hierarchical_es`) overrides
+    /// it via [`Self::with_routing_rules`].
     pub fn new(
         agents: BTreeMap<String, Agent>,
         providers: BTreeMap<String, Arc<dyn Provider>>,
@@ -839,7 +964,148 @@ impl HierarchicalEffectRunner {
             agents,
             providers,
             config,
+            routing_rules: RoutingRules::default(),
         }
+    }
+
+    /// Thread the run's `routing_rules` into this effect runner, so a nested
+    /// C9 sub-run launched from `run_invoke` routes its members' `latest:auto`
+    /// models the same way the parent run does. Builder style to keep `new`'s
+    /// signature stable for the existing unit tests.
+    pub fn with_routing_rules(mut self, routing_rules: RoutingRules) -> Self {
+        self.routing_rules = routing_rules;
+        self
+    }
+
+    /// Launch a nested C9 sub-run for a team `team_lead` leads: run the team's
+    /// members (`team.agents`) through the event-sourced blackboard/ring
+    /// engine on a **dedicated, ephemeral child `InMemoryLog`**, then surface
+    /// the sub-run's outcome + aggregated metrics back into the parent run as
+    /// a single `AgentObserved` for `team_lead`.
+    ///
+    /// ## Child log choice
+    /// The sub-run writes its fine-grained events (`RoundStarted`,
+    /// `BoardEntryAdded`, `VoteCast`, …) to a *local* `InMemoryLog` that is
+    /// discarded when this function returns — they never enter the parent log.
+    /// Only three things cross the boundary into the parent log: the
+    /// `NestedStarted`/`NestedEnded` markers (emitted by the decider) and this
+    /// one folded `AgentObserved` carrying the outcome text + aggregated
+    /// tokens/cost. This is deliberate: it keeps the parent log's *replay*
+    /// deterministic and effect-free — replay reconstructs `team_lead`'s
+    /// observed outcome directly from the baked-in `AgentObserved`, with no
+    /// need to (and no risk of) re-executing the sub-run. The trade-off,
+    /// matching the intent of the legacy `run_nested_team` (which surfaced only
+    /// outcome + metrics upward, stashing the full `NestedRun` separately), is
+    /// that the sub-run's internal event trace is not persisted in the parent
+    /// log.
+    ///
+    /// ## Budget
+    /// The sub-run receives the parent's *remaining* shared token budget
+    /// (`config.token_budget − tokens already consumed`, saturating at 0), or
+    /// the sub-pattern's own default when the parent sets no budget — exactly
+    /// as legacy `run_nested_team` computes it. The tokens the sub-run consumes
+    /// flow back into the parent budget through the aggregated `AgentObserved`
+    /// (folded by `es::state::apply` like any other observation).
+    async fn run_nested(
+        &self,
+        team_lead: &str,
+        task: &str,
+        team: &TeamConfig,
+        pattern: NestedPattern,
+        state: &ExecutionState,
+    ) -> anyhow::Result<ExecutionEvent> {
+        // Scope agents/providers to the team's members (the lead is the
+        // arbiter, not a sub-run participant — matching legacy).
+        let mut member_agents: BTreeMap<String, Agent> = BTreeMap::new();
+        let mut member_providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        for name in &team.agents {
+            let agent = self
+                .agents
+                .get(name)
+                .ok_or_else(|| anyhow::anyhow!("nested team agent '{name}' not found"))?
+                .clone();
+            let provider = self
+                .providers
+                .get(name)
+                .ok_or_else(|| anyhow::anyhow!("no provider for nested team agent '{name}'"))?;
+            member_agents.insert(name.clone(), agent);
+            member_providers.insert(name.clone(), Arc::clone(provider));
+        }
+
+        // Remaining shared token budget (never below zero), or the
+        // sub-pattern default when the parent run sets no global budget.
+        let remaining_budget = match self.config.token_budget {
+            Some(total) => total.saturating_sub(state.budget_tokens_in + state.budget_tokens_out),
+            None => match pattern {
+                NestedPattern::Blackboard => BlackboardConfig::default().token_budget,
+                NestedPattern::Ring => RingConfig::default().token_budget,
+            },
+        };
+
+        // Deterministic child run_id (carries the parent id + lead) on a
+        // dedicated, ephemeral child log (see the doc comment above).
+        let child_run_id = format!("{}::nested::{}", state.run_id, team_lead);
+        let mut child_log = InMemoryLog::default();
+
+        let child_state = match pattern {
+            NestedPattern::Blackboard => {
+                let cfg = team_blackboard_config(
+                    BlackboardConfig {
+                        token_budget: remaining_budget,
+                        ..BlackboardConfig::default()
+                    },
+                    team,
+                    &self.config,
+                );
+                run_blackboard_es(
+                    &child_run_id,
+                    task,
+                    member_agents,
+                    member_providers,
+                    cfg,
+                    self.routing_rules.clone(),
+                    &mut child_log,
+                )
+                .await?
+            }
+            NestedPattern::Ring => {
+                let cfg = team_ring_config(
+                    RingConfig {
+                        token_budget: remaining_budget,
+                        ..RingConfig::default()
+                    },
+                    team,
+                    &self.config,
+                );
+                // `resolve_votes` needs the same vote weights the sub-run's
+                // `RingDecider` used — rebuild them from the scoped members
+                // before ownership moves into `run_ring_es`.
+                let vote_weights = vote_weights_from_agents(&member_agents);
+                let child = run_ring_es(
+                    &child_run_id,
+                    task,
+                    member_agents,
+                    member_providers,
+                    cfg.clone(),
+                    self.routing_rules.clone(),
+                    &mut child_log,
+                )
+                .await?;
+                // Re-derive the outcome from the child state (the ring outcome
+                // is `resolve_votes` over the recorded votes — see
+                // `RingDecider`). Stash it in a closure-free local by short-
+                // circuiting: build the AgentObserved right here for ring, so
+                // the borrow of `cfg`/`vote_weights` stays local.
+                let outcome = resolve_votes(&child, &vote_weights, &cfg);
+                return Ok(nested_observed(team_lead, outcome, &child));
+            }
+        };
+
+        // Blackboard outcome: the deterministic board digest (`[agent]
+        // content` per entry), identical to the legacy engine's blackboard
+        // final answer.
+        let outcome = build_board_result(&child_state);
+        Ok(nested_observed(team_lead, outcome, &child_state))
     }
 
     /// Reconstruct `agents_info` (name → description, the first non-empty
@@ -898,6 +1164,16 @@ impl EffectRunner for HierarchicalEffectRunner {
         input: &str,
         state: &ExecutionState,
     ) -> anyhow::Result<ExecutionEvent> {
+        // C9 short-circuit: if `agent` leads a team declaring a nested
+        // sub-pattern, drive a full event-sourced blackboard/ring sub-run for
+        // that team instead of a flat LLM call, and surface its outcome +
+        // aggregated metrics as the lead's `AgentObserved` (see `run_nested`).
+        // Detection is the exact same `nested_team_for` test the decider used
+        // to emit the matching `NestedStarted`.
+        if let Some((team, pattern)) = nested_team_for(&self.config, agent) {
+            return self.run_nested(agent, input, team, pattern, state).await;
+        }
+
         let agent_def = self
             .agents
             .get(agent)
@@ -1053,13 +1329,14 @@ pub async fn run_hierarchical_es(
         input.to_string(),
         config.clone(),
         agents.clone(),
-        routing_rules,
+        routing_rules.clone(),
         max_depth,
         max_iterations,
         token_budget,
         cost_limit,
     );
-    let effects = HierarchicalEffectRunner::new(agents, providers, config);
+    let effects =
+        HierarchicalEffectRunner::new(agents, providers, config).with_routing_rules(routing_rules);
 
     run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
@@ -3167,5 +3444,250 @@ mod tests {
             core_calls_before,
             "replay must not re-invoke the core-specialist provider"
         );
+    }
+
+    // ── Nested C9 sub-runs (Task 10) ─────────────────────────────────
+    //
+    // These mirror the legacy `hierarchical::tests::
+    // test_nested_blackboard_runs_and_folds_metrics` /
+    // `test_nested_ring_runs_and_folds_metrics`: the coordinator delegates to
+    // a lead of a team declaring a nested sub-pattern; `run_invoke`
+    // short-circuits into a full event-sourced blackboard/ring sub-run on a
+    // dedicated child log, and folds its outcome + aggregated metrics back
+    // into the parent run as a single `AgentObserved` for the lead.
+
+    /// Config: coordinator `dev-lead`, one team led by `core-lead` running the
+    /// nested `pattern` over members `core-a`/`core-b`.
+    fn nested_team_config(pattern: NestedPattern) -> OrchestrationConfig {
+        OrchestrationConfig {
+            enabled: true,
+            pattern: OrchestrationPattern::Hierarchical,
+            coordinator: Some("dev-lead".to_string()),
+            teams: vec![TeamConfig {
+                lead: Some("core-lead".to_string()),
+                agents: vec!["core-a".to_string(), "core-b".to_string()],
+                pattern: Some(pattern),
+                // Keep the sub-run short/deterministic (one lap/round).
+                max_rounds: Some(1),
+                max_laps: Some(1),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// The `AgentObserved` recorded for `agent` in `run_id`'s log, if any —
+    /// returns `(content, tokens_in, tokens_out, model)`.
+    fn observed_for(
+        log: &InMemoryLog,
+        run_id: &str,
+        agent: &str,
+    ) -> Option<(String, u32, u32, String)> {
+        log.events(run_id)
+            .unwrap()
+            .into_iter()
+            .find_map(|e| match e {
+                ExecutionEvent::AgentObserved {
+                    agent: a,
+                    content,
+                    tokens_in,
+                    tokens_out,
+                    model,
+                    ..
+                } if a == agent => Some((content, tokens_in, tokens_out, model)),
+                _ => None,
+            })
+    }
+
+    /// Position (index) of the first `NestedStarted`/`NestedEnded` for
+    /// `team_lead` in `run_id`'s log, for ordering assertions.
+    fn nested_marker_positions(
+        log: &InMemoryLog,
+        run_id: &str,
+        team_lead: &str,
+    ) -> (Option<usize>, Option<usize>) {
+        let events = log.events(run_id).unwrap();
+        let started = events.iter().position(
+            |e| matches!(e, ExecutionEvent::NestedStarted { team_lead: tl, .. } if tl == team_lead),
+        );
+        let ended = events.iter().position(
+            |e| matches!(e, ExecutionEvent::NestedEnded { team_lead: tl } if tl == team_lead),
+        );
+        (started, ended)
+    }
+
+    // Scenario: coordinator delegates to a `blackboard` team lead. The nested
+    // sub-run executes (both members contribute), the lead's `AgentObserved`
+    // carries the board digest + aggregated metrics with `model == "nested"`,
+    // the parent log records `NestedStarted` then `NestedEnded`, the parent
+    // budget includes the sub-run's tokens, and replay reconstructs the state.
+    #[tokio::test]
+    async fn es_nested_blackboard_runs_and_folds_metrics() {
+        let mut agents = BTreeMap::new();
+        for name in ["dev-lead", "core-lead", "core-a", "core-b"] {
+            agents.insert(name.to_string(), es_test_agent(name, "concrete-model"));
+        }
+
+        let core_a = Arc::new(ScriptedProvider::new(&[
+            "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:core-a confirme",
+        ]));
+        let core_b = Arc::new(ScriptedProvider::new(&[
+            "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:core-b confirme",
+        ]));
+        // `core-lead` is the arbiter, not a sub-run participant — its provider
+        // must never be called on the nested path (sentinel proves the
+        // short-circuit fired instead of a flat LLM call).
+        let core_lead = Arc::new(ScriptedProvider::new(&["LEAD-FLAT-CALL-SHOULD-NOT-HAPPEN"]));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert("dev-lead".to_string(), {
+            Arc::new(ScriptedProvider::new(&[
+                "@core-lead: gère la feature",
+                "Synthèse : livré.",
+            ])) as Arc<dyn Provider>
+        });
+        providers.insert(
+            "core-lead".to_string(),
+            core_lead.clone() as Arc<dyn Provider>,
+        );
+        providers.insert("core-a".to_string(), core_a.clone() as Arc<dyn Provider>);
+        providers.insert("core-b".to_string(), core_b.clone() as Arc<dyn Provider>);
+
+        let mut log = InMemoryLog::default();
+        let st = run_hierarchical_es(
+            "run-nested-bb",
+            "dev-lead",
+            "build X",
+            nested_team_config(NestedPattern::Blackboard),
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(st.status, RunStatus::Completed);
+
+        // Sub-run actually executed: both members were invoked...
+        assert!(core_a.call_count() > 0 && core_b.call_count() > 0);
+        // ...but the lead's own provider was never called (short-circuit).
+        assert_eq!(
+            core_lead.call_count(),
+            0,
+            "lead must not make a flat LLM call"
+        );
+
+        // The lead's observed turn is the folded sub-run: board digest,
+        // aggregated tokens (2 members × 1 in / 1 out), model "nested".
+        let (content, tin, tout, model) =
+            observed_for(&log, "run-nested-bb", "core-lead").expect("lead observation");
+        assert_eq!(model, "nested");
+        assert_eq!((tin, tout), (2, 2), "aggregated sub-run metrics");
+        assert_eq!(
+            content,
+            "[core-a] core-a confirme\n[core-b] core-b confirme"
+        );
+
+        // The parent log records NestedStarted before NestedEnded.
+        let (started, ended) = nested_marker_positions(&log, "run-nested-bb", "core-lead");
+        assert!(
+            matches!((started, ended), (Some(s), Some(e)) if s < e),
+            "expected NestedStarted before NestedEnded, got {started:?}/{ended:?}"
+        );
+
+        // Parent budget includes the sub-run: dev-lead delegate (1) +
+        // nested (2) + dev-lead synthesis (1) = 4 tokens in.
+        assert_eq!(st.budget_tokens_in, 4);
+        assert_eq!(st.budget_tokens_out, 4);
+
+        // Sub-run stays isolated: members never leak into the parent state.
+        assert!(!st.conversations.contains_key("core-a"));
+        assert!(!st.conversations.contains_key("core-b"));
+        // Boundary is closed in the terminal state.
+        assert!(st.open_nested.is_empty());
+
+        // Replay reconstructs the identical state from the parent log alone
+        // (the child sub-run is never re-executed).
+        let replayed = replay("run-nested-bb", &log).unwrap();
+        assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
+    }
+
+    // Scenario: same topology, `ring` sub-pattern. The nested ring circulates
+    // one lap, both members vote for the same position, the outcome resolves
+    // to that position, and it is folded into the lead's `AgentObserved`.
+    #[tokio::test]
+    async fn es_nested_ring_runs_and_folds_metrics() {
+        let mut agents = BTreeMap::new();
+        for name in ["dev-lead", "core-lead", "core-a", "core-b"] {
+            agents.insert(name.to_string(), es_test_agent(name, "concrete-model"));
+        }
+
+        let core_a = Arc::new(ScriptedProvider::new(&[
+            "ACTION: PROPOSE\nCONTENT: use Rust",
+            "CONFIDENCE: 0.9\nUse Rust",
+        ]));
+        let core_b = Arc::new(ScriptedProvider::new(&[
+            "ACTION: PROPOSE\nCONTENT: agreed, Rust",
+            "CONFIDENCE: 0.8\nUse Rust",
+        ]));
+        let core_lead = Arc::new(ScriptedProvider::new(&["LEAD-FLAT-CALL-SHOULD-NOT-HAPPEN"]));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert("dev-lead".to_string(), {
+            Arc::new(ScriptedProvider::new(&[
+                "@core-lead: gère la feature",
+                "Synthèse : livré.",
+            ])) as Arc<dyn Provider>
+        });
+        providers.insert(
+            "core-lead".to_string(),
+            core_lead.clone() as Arc<dyn Provider>,
+        );
+        providers.insert("core-a".to_string(), core_a.clone() as Arc<dyn Provider>);
+        providers.insert("core-b".to_string(), core_b.clone() as Arc<dyn Provider>);
+
+        let mut log = InMemoryLog::default();
+        let st = run_hierarchical_es(
+            "run-nested-ring",
+            "dev-lead",
+            "build X",
+            nested_team_config(NestedPattern::Ring),
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(st.status, RunStatus::Completed);
+        assert!(core_a.call_count() > 0 && core_b.call_count() > 0);
+        assert_eq!(
+            core_lead.call_count(),
+            0,
+            "lead must not make a flat LLM call"
+        );
+
+        // Ring outcome = resolved representative position; metrics aggregate
+        // the two contributions (votes carry no tokens in the ES projection).
+        let (content, tin, tout, model) =
+            observed_for(&log, "run-nested-ring", "core-lead").expect("lead observation");
+        assert_eq!(model, "nested");
+        assert_eq!(content, "Use Rust");
+        assert_eq!((tin, tout), (2, 2), "aggregated sub-run metrics");
+
+        let (started, ended) = nested_marker_positions(&log, "run-nested-ring", "core-lead");
+        assert!(
+            matches!((started, ended), (Some(s), Some(e)) if s < e),
+            "expected NestedStarted before NestedEnded, got {started:?}/{ended:?}"
+        );
+
+        assert_eq!(st.budget_tokens_in, 4);
+        assert_eq!(st.budget_tokens_out, 4);
+        assert!(!st.conversations.contains_key("core-a"));
+        assert!(!st.conversations.contains_key("core-b"));
+        assert!(st.open_nested.is_empty());
+
+        let replayed = replay("run-nested-ring", &log).unwrap();
+        assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
     }
 }

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -790,8 +790,8 @@ impl Decider for HierarchicalDecider {
     }
 }
 
-/// Parse a tier string as stored in `HierState::routed_tiers` — the `Debug`
-/// format of `ModelTier` (`"Fast"`/`"Pro"`/`"Max"`), matched
+/// Parse a tier string as stored in `ExecutionState::routed_tiers` — the
+/// `Debug` format of `ModelTier` (`"Fast"`/`"Pro"`/`"Max"`), matched
 /// case-insensitively since `ModelRouted.tier` is produced via
 /// `format!("{tier:?}")` in `HierarchicalDecider::model_routed_event` — back
 /// into a `ModelTier`. Unrecognized strings fall back to `Pro`, the same
@@ -934,7 +934,7 @@ impl EffectRunner for HierarchicalEffectRunner {
         // (Task 3) always emits a `ModelRouted{agent, tier, ..}` event ahead
         // of the matching `Invoke` for such an agent (see
         // `model_routed_event`/`invoke_actions`), which `es::state::apply`
-        // projects into `state.hier.routed_tiers`. We read that tier back
+        // projects into `state.routed_tiers`. We read that tier back
         // here and resolve it to a concrete model via
         // `crate::linker::model_resolution::resolve_model_for_tier` — this
         // is the only place in the event-sourced hierarchical engine that
@@ -948,7 +948,7 @@ impl EffectRunner for HierarchicalEffectRunner {
             .clone()
             .unwrap_or_else(|| "default".to_string());
         let model = if raw_model == "latest:auto" {
-            let tier = match state.hier.routed_tiers.get(agent) {
+            let tier = match state.routed_tiers.get(agent) {
                 Some(tier_str) => parse_routed_tier(tier_str),
                 None => {
                     // Defensive fallback: `HierarchicalDecider` always emits
@@ -2682,7 +2682,7 @@ mod tests {
         // itself: `HierarchicalDecider` always emits `ModelRouted{agent,
         // tier, ..}` ahead of the matching `Invoke` for such an agent (see
         // `model_routed_event`), which `es::state::apply` projects into
-        // `state.hier.routed_tiers`. `run_invoke` must read that tier back
+        // `state.routed_tiers`. `run_invoke` must read that tier back
         // and turn it into a concrete model via
         // `resolve_model_for_tier` — both in the `CompletionRequest` sent to
         // the provider, and in the `model` field of the returned

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -3569,7 +3569,12 @@ mod tests {
         assert_eq!(st.status, RunStatus::Completed);
 
         // Sub-run actually executed: both members were invoked...
-        assert!(core_a.call_count() > 0 && core_b.call_count() > 0);
+        let core_a_calls_before = core_a.call_count();
+        let core_b_calls_before = core_b.call_count();
+        assert!(
+            core_a_calls_before > 0 && core_b_calls_before > 0,
+            "le sous-run doit avoir invoqué les membres pendant le run"
+        );
         // ...but the lead's own provider was never called (short-circuit).
         assert_eq!(
             core_lead.call_count(),
@@ -3610,6 +3615,16 @@ mod tests {
         // (the child sub-run is never re-executed).
         let replayed = replay("run-nested-bb", &log).unwrap();
         assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
+        assert_eq!(
+            core_a.call_count(),
+            core_a_calls_before,
+            "le replay ne doit pas ré-exécuter le sous-run (core-a)"
+        );
+        assert_eq!(
+            core_b.call_count(),
+            core_b_calls_before,
+            "le replay ne doit pas ré-exécuter le sous-run (core-b)"
+        );
     }
 
     // Scenario: same topology, `ring` sub-pattern. The nested ring circulates
@@ -3660,7 +3675,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(st.status, RunStatus::Completed);
-        assert!(core_a.call_count() > 0 && core_b.call_count() > 0);
+        let core_a_calls_before = core_a.call_count();
+        let core_b_calls_before = core_b.call_count();
+        assert!(
+            core_a_calls_before > 0 && core_b_calls_before > 0,
+            "le sous-run doit avoir invoqué les membres pendant le run"
+        );
         assert_eq!(
             core_lead.call_count(),
             0,
@@ -3689,5 +3709,15 @@ mod tests {
 
         let replayed = replay("run-nested-ring", &log).unwrap();
         assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
+        assert_eq!(
+            core_a.call_count(),
+            core_a_calls_before,
+            "le replay ne doit pas ré-exécuter le sous-run (core-a)"
+        );
+        assert_eq!(
+            core_b.call_count(),
+            core_b_calls_before,
+            "le replay ne doit pas ré-exécuter le sous-run (core-b)"
+        );
     }
 }

--- a/src/core/orchestration/es/mod.rs
+++ b/src/core/orchestration/es/mod.rs
@@ -10,6 +10,7 @@ pub mod engine;
 pub mod event;
 pub mod hierarchical;
 pub mod log;
+pub mod ring;
 pub mod state;
 
 // Not yet consumed by any engine (this lot only lays the socle down) — the

--- a/src/core/orchestration/es/mod.rs
+++ b/src/core/orchestration/es/mod.rs
@@ -5,6 +5,7 @@
 //! orchestration engine is wired to this module yet — it is pure domain
 //! plumbing for later lots to build on.
 
+pub mod blackboard;
 pub mod engine;
 pub mod event;
 pub mod hierarchical;

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -21,8 +21,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use super::engine::{Action, Decider, EffectRunner};
+use super::engine::{Action, Decider, EffectRunner, run_event_sourced};
 use super::event::ExecutionEvent;
+use super::log::EventLog;
 use super::state::{ExecutionState, RunStatus, VoteRec};
 use crate::core::agent::Agent;
 use crate::core::orchestration::llm_agents::{
@@ -917,6 +918,109 @@ impl EffectRunner for RingEffectRunner {
             }
         }
     }
+}
+
+// ── run_ring_es (Task 9): end-to-end assembly ────────────────────────
+
+/// Per-agent vote weight, read from `agent.metadata.ring_config.vote_weight`
+/// (default `1.0` for an agent with no ring config at all) — the same
+/// convention the legacy `run_ring` uses to populate `RingToken::vote_weights`
+/// before circulation (`core::orchestration::ring::run_ring`: `token
+/// .vote_weights.insert(agent.name().to_string(), agent.vote_weight())`,
+/// where `LlmRingAgent::vote_weight` reads the identical
+/// `ring_config.vote_weight` field).
+fn vote_weights_from_agents(agents: &BTreeMap<String, Agent>) -> BTreeMap<String, f32> {
+    agents
+        .iter()
+        .map(|(name, agent)| {
+            let weight = agent
+                .metadata
+                .ring_config
+                .as_ref()
+                .map(|c| c.vote_weight)
+                .unwrap_or(1.0);
+            (name.clone(), weight)
+        })
+        .collect()
+}
+
+/// Run a complete ring orchestration end-to-end through the event-sourced
+/// engine: builds the initial `RunStarted` event, constructs a
+/// [`RingDecider`] + [`RingEffectRunner`] from `config`/`agents`/`providers`/
+/// `routing_rules`, and drives them through [`run_event_sourced`], returning
+/// the final [`ExecutionState`].
+///
+/// `run_id` is accepted explicitly rather than generated internally, so
+/// callers — notably tests proving replay determinism — can pass a fixed id
+/// and later reconstruct the same state purely from the log via
+/// [`super::engine::replay`].
+///
+/// The run's roster (`RunStarted { agents, .. }`, and `RingDecider`'s
+/// `agent_order`) is `agents.keys()`, i.e. name-sorted (`BTreeMap` iteration
+/// order) — the same convention `run_hierarchical_es`/`run_blackboard_es` use
+/// for their own roster. **Contract (Task 6/7)**: `RingDecider::agent_order`
+/// must be the exact same order/set as `RunStarted { agents, .. }` for the
+/// circulation rotation ([`next_ring_agent`]) and lap-completeness check
+/// ([`ring_phase`]) to stay coherent — both are built from this single
+/// `agent_order` vector here, so there is no risk of the two drifting apart.
+///
+/// `RingDecider::max_laps` is deliberately set equal to `config.max_laps`
+/// (rather than an independently configurable cap, as a caller *could* pass
+/// per the decider's own doc comment) — two divergent sources for "how many
+/// laps before we force-stop" would be a footgun this assembly function
+/// forecloses; a caller wanting a stricter cap than `config.max_laps` should
+/// lower `config.max_laps` itself instead.
+///
+/// `vote_weights` is built from `agents` via [`vote_weights_from_agents`] —
+/// legacy fidelity with `run_ring`'s own `RingToken::vote_weights` seeding.
+///
+/// `token_budget` is derived from `config.token_budget` (a concrete `u64`
+/// with a documented default — unlike `OrchestrationConfig`'s `Option`
+/// fields, `RingConfig` has no "unset" state for it), narrowed to `Option<u32>`
+/// as `Some(..)` unconditionally, saturating at `u32::MAX` — same convention
+/// as `run_blackboard_es`. `RingConfig` carries no cost-budget field (unlike
+/// `OrchestrationConfig::cost_limit`), so `cost_limit` is always `None` here
+/// — no cost guard applies to the event-sourced ring run.
+///
+/// Coexists with the legacy `core::orchestration::ring::run_ring` — this
+/// function is not called from `run.rs`; wiring it in as the active engine
+/// is a later lot (the bascule).
+pub async fn run_ring_es(
+    run_id: &str,
+    input: &str,
+    agents: BTreeMap<String, Agent>,
+    providers: BTreeMap<String, Arc<dyn Provider>>,
+    config: RingConfig,
+    routing_rules: RoutingRules,
+    log: &mut impl EventLog,
+) -> anyhow::Result<ExecutionState> {
+    let agent_order: Vec<String> = agents.keys().cloned().collect();
+    let initial = vec![ExecutionEvent::RunStarted {
+        run_id: run_id.to_string(),
+        pattern: "ring".to_string(),
+        agents: agent_order.clone(),
+        input: input.to_string(),
+        project: None,
+    }];
+
+    let vote_weights = vote_weights_from_agents(&agents);
+    let max_laps = config.max_laps;
+    let token_budget = Some(u32::try_from(config.token_budget).unwrap_or(u32::MAX));
+
+    let decider = RingDecider::new(
+        agents.clone(),
+        agent_order,
+        input.to_string(),
+        config.clone(),
+        routing_rules,
+        max_laps,
+        vote_weights.clone(),
+        token_budget,
+        None,
+    );
+    let effects = RingEffectRunner::new(agents, providers, config, vote_weights);
+
+    run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
 
 #[cfg(test)]
@@ -1900,6 +2004,388 @@ mod tests {
             let sent = capturing.requests();
             assert_eq!(sent[0].model, expected);
             assert_ne!(sent[0].model, "latest:auto");
+        }
+    }
+
+    // ── run_ring_es (Task 9): end-to-end + replay determinism ────────
+    //
+    // Exercises `run_ring_es` as a whole (unlike `decide` and `effect_runner`
+    // above, which drive `RingDecider`/`RingEffectRunner` directly) — the
+    // same circulation → vote → resolution flow the legacy
+    // `core::orchestration::ring::run_ring` engine covers, plus a proof that
+    // `replay` reconstructs an identical `ExecutionState` purely from the
+    // log, with no effect re-executed.
+    //
+    // IMPORTANT: every agent below uses a CONCRETE model string (never
+    // `latest:auto`) — see the identical rationale on
+    // `es::hierarchical`/`es::blackboard`'s own `run_*_es` end-to-end test
+    // modules: resolving `latest:auto` reads an on-disk `models.dev` cache,
+    // which would make these tests non-hermetic/flaky.
+    mod run_ring_es_tests {
+        use super::*;
+        use crate::core::agent::AgentMetadata;
+        use crate::core::orchestration::es::engine::replay;
+        use crate::core::orchestration::es::log::InMemoryLog;
+        use crate::core::orchestration::es::state::RunStatus;
+        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use std::collections::VecDeque;
+        use std::path::PathBuf;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Minimal `Agent` for `run_ring_es` E2E tests: always a concrete
+        /// model (see module note above).
+        fn es_test_agent(name: &str, model: &str) -> Agent {
+            Agent {
+                name: name.to_string(),
+                source: PathBuf::from(format!("{name}.md")),
+                metadata: AgentMetadata {
+                    provider: "anthropic".to_string(),
+                    model: Some(model.to_string()),
+                    command: None,
+                    args: None,
+                    temperature: 0.7,
+                    max_tokens: None,
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: format!("You are {name}."),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        /// Provider scripted with a fixed sequence of responses, one per
+        /// call (repeating the last one for any call beyond the scripted
+        /// list, so a test can under-provision without panicking). Also
+        /// counts calls, so `es_ring_replay_reconstructs_state` can prove
+        /// `replay` triggers none. Identical in spirit to
+        /// `es::blackboard::tests::run_blackboard_es_tests::ScriptedProvider`
+        /// / `es::hierarchical::tests::ScriptedProvider` — duplicated rather
+        /// than shared (no common test-helpers module exists for the ES
+        /// engines today).
+        struct ScriptedProvider {
+            responses: std::sync::Mutex<VecDeque<String>>,
+            last: std::sync::Mutex<String>,
+            calls: AtomicUsize,
+        }
+
+        impl ScriptedProvider {
+            fn new(responses: &[&str]) -> Self {
+                Self {
+                    responses: std::sync::Mutex::new(
+                        responses.iter().map(|s| (*s).to_string()).collect(),
+                    ),
+                    last: std::sync::Mutex::new(String::new()),
+                    calls: AtomicUsize::new(0),
+                }
+            }
+
+            fn call_count(&self) -> usize {
+                self.calls.load(Ordering::SeqCst)
+            }
+        }
+
+        #[async_trait]
+        impl Provider for ScriptedProvider {
+            async fn complete(
+                &self,
+                request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let mut queue = self.responses.lock().unwrap();
+                let content = queue
+                    .pop_front()
+                    .unwrap_or_else(|| self.last.lock().unwrap().clone());
+                *self.last.lock().unwrap() = content.clone();
+                Ok(CompletionResponse {
+                    content,
+                    model: request.model,
+                    tokens_in: 1,
+                    tokens_out: 1,
+                    cost: 0.0,
+                })
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by run_ring_es tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "scripted".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        /// Extract the `content` of the last `Completed` event recorded for
+        /// `run_id`, if any.
+        fn final_content(log: &InMemoryLog, run_id: &str) -> String {
+            log.events(run_id)
+                .unwrap()
+                .into_iter()
+                .rev()
+                .find_map(|e| match e {
+                    E::Completed { content } => Some(content),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        }
+
+        /// Whether `run_id`'s log contains a `Warned{code}` event matching
+        /// `code` exactly.
+        fn log_has_warned(log: &InMemoryLog, run_id: &str, code: &str) -> bool {
+            log.events(run_id)
+                .unwrap()
+                .iter()
+                .any(|e| matches!(e, E::Warned { code: c } if c == code))
+        }
+
+        /// Whether `run_id`'s log contains an `E::OutcomeResolved` event.
+        fn log_has_outcome_resolved(log: &InMemoryLog, run_id: &str) -> bool {
+            log.events(run_id)
+                .unwrap()
+                .iter()
+                .any(|e| matches!(e, E::OutcomeResolved { .. }))
+        }
+
+        // Scenario 1: two agents circulate one substantial (non-pass) lap
+        // each (`max_laps: 1`, so circulation ends after lap 0 without
+        // advancing), then both vote for the same position — a unanimous
+        // 2/2 group, above any similarity/weight tie concern. The run must
+        // resolve via `OutcomeResolved` and `Complete` with that position as
+        // the non-empty final content.
+        #[tokio::test]
+        async fn es_ring_circulates_votes_and_resolves() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION: PROPOSE\nCONTENT: use Rust with Axum",
+                    "CONFIDENCE: 0.9\nUse Rust with Axum",
+                ])),
+            );
+            providers.insert(
+                "b".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION: PROPOSE\nCONTENT: agreed, Rust and Axum",
+                    "CONFIDENCE: 0.8\nUse Rust with Axum",
+                ])),
+            );
+
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+
+            let mut log = InMemoryLog::default();
+            let st = run_ring_es(
+                "run-ring-resolve",
+                "task",
+                agents,
+                providers,
+                config,
+                RoutingRules::default(),
+                &mut log,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(st.status, RunStatus::Completed);
+            assert_eq!(
+                st.ring.contributions.len(),
+                2,
+                "expected exactly one substantial lap's worth of contributions, got {:?}",
+                st.ring.contributions
+            );
+            assert!(
+                st.ring.contributions.iter().all(|c| c.action == "propose"),
+                "expected only substantive (non-pass) contributions, got {:?}",
+                st.ring.contributions
+            );
+            assert_eq!(st.ring.votes.len(), 2, "expected both agents to have voted");
+            assert!(
+                log_has_outcome_resolved(&log, "run-ring-resolve"),
+                "expected an OutcomeResolved event in the log"
+            );
+            let content = final_content(&log, "run-ring-resolve");
+            assert!(
+                !content.trim().is_empty(),
+                "expected a non-empty resolved outcome"
+            );
+            assert_eq!(content, "Use Rust with Axum");
+        }
+
+        // Scenario 2: two agents contribute a substantive (non-pass)
+        // proposal every lap, for exactly `config.max_laps` laps —
+        // `RingDecider::max_laps` is aligned with `config.max_laps` by
+        // `run_ring_es` (Task 9's contract), so once lap
+        // `config.max_laps - 1` completes, `ring_phase` itself transitions
+        // straight to `Vote` (its own natural circulation-exhaustion path,
+        // documented on `ring_phase`) — `RingDecider`'s own independent
+        // `max_laps >= self.max_laps` guard never actually fires here, since
+        // `ring_phase` never hands back a `Circulate { lap }` at or beyond
+        // `config.max_laps`. The run must still reach every configured lap
+        // (proving the cap is respected, not exited early by convergence)
+        // and then resolve normally via voting — asserted here as the
+        // actually-observed behavior per the task brief ("vérifie le
+        // comportement réel"), not an assumed `Warned{max_laps}`.
+        #[tokio::test]
+        async fn es_ring_halts_at_max_laps() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION: PROPOSE\nCONTENT: lap0 from a",
+                    "ACTION: PROPOSE\nCONTENT: lap1 from a",
+                    "CONFIDENCE: 0.7\nFinal position A",
+                ])),
+            );
+            providers.insert(
+                "b".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION: PROPOSE\nCONTENT: lap0 from b",
+                    "ACTION: PROPOSE\nCONTENT: lap1 from b",
+                    "CONFIDENCE: 0.7\nFinal position A",
+                ])),
+            );
+
+            let config = RingConfig {
+                max_laps: 2,
+                ..RingConfig::default()
+            };
+
+            let mut log = InMemoryLog::default();
+            let st = run_ring_es(
+                "run-ring-maxlaps",
+                "task",
+                agents,
+                providers,
+                config,
+                RoutingRules::default(),
+                &mut log,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(st.status, RunStatus::Completed);
+            assert_eq!(
+                st.ring.contributions.len(),
+                4,
+                "expected 2 agents x 2 configured laps of substantive contributions, got {:?}",
+                st.ring.contributions
+            );
+            assert!(
+                st.ring.contributions.iter().any(|c| c.lap == 1),
+                "expected circulation to have run through lap 1 (config.max_laps == 2), got {:?}",
+                st.ring.contributions
+            );
+            // Aligned max_laps: `ring_phase` exhausts circulation on its own
+            // once every configured lap has run, so the decider's own
+            // `Warned{max_laps}` guard never fires — the run resolves via
+            // normal voting instead.
+            assert!(
+                !log_has_warned(&log, "run-ring-maxlaps", "max_laps"),
+                "aligned RingDecider.max_laps/config.max_laps must never trip the decider's own max_laps guard"
+            );
+            assert!(
+                log_has_outcome_resolved(&log, "run-ring-maxlaps"),
+                "expected the run to resolve via voting once max_laps was reached"
+            );
+            let content = final_content(&log, "run-ring-maxlaps");
+            assert!(
+                !content.trim().is_empty(),
+                "expected a non-empty resolved outcome"
+            );
+        }
+
+        // Scenario 3: replay determinism. After a full run, `replay(run_id,
+        // &log)` must reconstruct an `ExecutionState` identical (`Debug`
+        // format) to the one `run_ring_es` returned — and it must do so
+        // without invoking any provider again (`replay` takes no
+        // `EffectRunner` at all; the call-count assertions below are an
+        // extra, belt-and-braces proof that no effect silently re-runs).
+        #[tokio::test]
+        async fn es_ring_replay_reconstructs_state() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let provider_a = Arc::new(ScriptedProvider::new(&[
+                "ACTION: PROPOSE\nCONTENT: use Rust with Axum",
+                "CONFIDENCE: 0.9\nUse Rust with Axum",
+            ]));
+            let provider_b = Arc::new(ScriptedProvider::new(&[
+                "ACTION: PROPOSE\nCONTENT: agreed, Rust and Axum",
+                "CONFIDENCE: 0.8\nUse Rust with Axum",
+            ]));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), provider_a.clone() as Arc<dyn Provider>);
+            providers.insert("b".to_string(), provider_b.clone() as Arc<dyn Provider>);
+
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+
+            let mut log = InMemoryLog::default();
+            let st = run_ring_es(
+                "run-ring-replay",
+                "task",
+                agents,
+                providers,
+                config,
+                RoutingRules::default(),
+                &mut log,
+            )
+            .await
+            .unwrap();
+            assert_eq!(st.status, RunStatus::Completed);
+
+            let calls_a_before = provider_a.call_count();
+            let calls_b_before = provider_b.call_count();
+            assert!(
+                calls_a_before > 0,
+                "expected provider 'a' to have been invoked during the run"
+            );
+            assert!(
+                calls_b_before > 0,
+                "expected provider 'b' to have been invoked during the run"
+            );
+
+            let replayed = replay("run-ring-replay", &log).unwrap();
+
+            assert_eq!(
+                format!("{st:?}"),
+                format!("{replayed:?}"),
+                "replay must reconstruct an identical ExecutionState"
+            );
+            assert_eq!(
+                provider_a.call_count(),
+                calls_a_before,
+                "replay must not re-invoke provider 'a'"
+            );
+            assert_eq!(
+                provider_b.call_count(),
+                calls_b_before,
+                "replay must not re-invoke provider 'b'"
+            );
         }
     }
 }

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -17,13 +17,23 @@
 //! machine.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use super::engine::{Action, Decider};
+use async_trait::async_trait;
+
+use super::engine::{Action, Decider, EffectRunner};
 use super::event::ExecutionEvent;
 use super::state::{ExecutionState, RunStatus, VoteRec};
 use crate::core::agent::Agent;
-use crate::core::orchestration::ring::RingConfig;
+use crate::core::orchestration::llm_agents::{
+    RING_ACTION_INSTRUCTIONS, parse_ring_action, parse_vote_confidence,
+};
+use crate::core::orchestration::ring::{ContributionAction, RingConfig};
 use crate::core::routing::{BudgetState, RoutingRules, route};
+#[cfg(test)]
+use crate::linker::model_resolution::fallback_model_for_tier;
+use crate::linker::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
 /// The ring pattern's current phase, derived purely from [`ExecutionState`].
 ///
@@ -581,6 +591,330 @@ impl Decider for RingDecider {
             // batch for exhaustiveness rather than a `match` catch-all that
             // could silently swallow a future `RingPhase` variant.
             RingPhase::Done => Vec::new(),
+        }
+    }
+}
+
+/// Parse a tier string as stored in `ExecutionState::routed_tiers` back into
+/// a `ModelTier`.
+///
+/// Identical in spirit to `es::hierarchical::parse_routed_tier`/
+/// `es::blackboard::parse_routed_tier` — duplicated rather than shared (same
+/// rationale: the three effect runners' `agents`/model-resolution concerns
+/// live on unrelated structs with no common trait today). Unrecognized
+/// strings fall back to `Pro`, matching the other two.
+fn parse_routed_tier(tier: &str) -> ModelTier {
+    match tier.to_lowercase().as_str() {
+        "fast" => ModelTier::Fast,
+        "max" => ModelTier::Max,
+        _ => ModelTier::Pro,
+    }
+}
+
+/// Map a parsed [`ContributionAction`] onto the lowercase `action` string
+/// carried by `ExecutionEvent::ContributionAdded` — the single source of
+/// truth [`ring_phase`]/[`next_ring_agent`] read back (via
+/// `ContribRec::action`) to detect early-convergence (every contribution in
+/// a lap is exactly `"pass"`) and to rotate the circulation. **Contract**:
+/// the `Pass` arm must map to the exact lowercase string `"pass"` — nothing
+/// else — since that is the literal `ring_phase` compares against
+/// (`lap_contribs.iter().all(|c| c.action == "pass")`); any other casing or
+/// wording would silently break the early-exit detection.
+fn action_string(action: &ContributionAction) -> &'static str {
+    match action {
+        ContributionAction::Propose => "propose",
+        ContributionAction::Enrich { .. } => "enrich",
+        ContributionAction::Contest { .. } => "contest",
+        ContributionAction::Endorse { .. } => "endorse",
+        ContributionAction::Synthesize => "synthesize",
+        ContributionAction::Pass { .. } => "pass",
+    }
+}
+
+// ── RingEffectRunner (Task 8): the sole async/impure effect ───────────
+
+/// Executes the actual LLM call behind `Action::Invoke` for the ring pattern
+/// and turns the raw provider response into the `ContributionAdded` (during
+/// circulation) or `VoteCast` (during voting) event the pure loop/
+/// [`RingDecider`] expect, per the current [`RingPhase`] (derived via
+/// [`ring_phase`]).
+///
+/// This is the *only* impure/async piece of the event-sourced ring engine —
+/// every other function in this module is a pure, synchronous helper over
+/// `ExecutionState`. Coexists with the legacy
+/// `core::orchestration::ring::run_ring`/`llm_agents::LlmRingAgent` (this
+/// struct is not wired into it, and does not import from it beyond the
+/// plain, side-effect-free `parse_ring_action`/`parse_vote_confidence`
+/// parsers and `RING_ACTION_INSTRUCTIONS` constant it explicitly reuses —
+/// strict coexistence, mirroring `HierarchicalEffectRunner`/
+/// `BlackboardEffectRunner`).
+pub struct RingEffectRunner {
+    /// All known agents by name (system prompt, model, temperature, …).
+    pub agents: BTreeMap<String, Agent>,
+    /// Provider instance per agent name.
+    pub providers: BTreeMap<String, Arc<dyn Provider>>,
+    /// Ring configuration, read by [`ring_phase`] to derive the current
+    /// phase for `agent`.
+    pub config: RingConfig,
+    /// Per-agent vote weight — reserved for a future synthesis/resolution
+    /// step; `run_invoke` itself doesn't read it (voting only records each
+    /// agent's own position/confidence, unweighted — weighting happens in
+    /// [`resolve_votes`], the `Decider`'s concern), kept here for symmetry
+    /// with [`RingDecider::vote_weights`] and so callers can construct both
+    /// from a single source of truth.
+    pub vote_weights: BTreeMap<String, f32>,
+}
+
+impl RingEffectRunner {
+    /// Construct a new `RingEffectRunner` from its immutable inputs.
+    pub fn new(
+        agents: BTreeMap<String, Agent>,
+        providers: BTreeMap<String, Arc<dyn Provider>>,
+        config: RingConfig,
+        vote_weights: BTreeMap<String, f32>,
+    ) -> Self {
+        Self {
+            agents,
+            providers,
+            config,
+            vote_weights,
+        }
+    }
+
+    /// Assemble the circulation prompt for `agent_name` at `lap`, reproducing
+    /// the shape of `LlmRingAgent::process`'s `user_msg`
+    /// (`core::orchestration::llm_agents`) over the event-sourced
+    /// `state.ring` projection instead of a live `TokenSnapshot`: `"Task:
+    /// …\nLap: …\nYour position: …/…\n"`, then (only if any exist) a
+    /// `"Previous contributions:\n"` section listing *every* contribution
+    /// recorded so far (`state.ring.contributions`, in append order) as
+    /// `"- [#{index} Lap {lap} / {position}] {agent}: {content}\n"`, then
+    /// [`RING_ACTION_INSTRUCTIONS`] verbatim.
+    ///
+    /// `position` (0-based, "your position in *this* lap") is the number of
+    /// contributions already recorded for `lap` — the same count
+    /// [`next_ring_agent`] and `ring_phase`'s lap-completeness check use, and
+    /// exactly the index this invocation's own `ContributionAdded` will
+    /// carry once it completes (see `run_invoke`'s `Circulate` branch below).
+    /// The roster size (`state.agents.len()`) stands in for
+    /// `TokenSnapshot::ring_order.len()` — the total agents.
+    fn build_circulate_prompt(&self, input: &str, lap: u32, state: &ExecutionState) -> String {
+        let position = state
+            .ring
+            .contributions
+            .iter()
+            .filter(|c| c.lap == lap)
+            .count();
+        let mut user_msg = format!(
+            "Task: {input}\nLap: {lap}\nYour position: {}/{}\n",
+            position + 1,
+            state.agents.len()
+        );
+
+        if !state.ring.contributions.is_empty() {
+            user_msg.push_str("\nPrevious contributions:\n");
+            for (i, c) in state.ring.contributions.iter().enumerate() {
+                user_msg.push_str(&format!(
+                    "- [#{i} Lap {} / {}] {}: {}\n",
+                    c.lap, c.position, c.agent, c.content
+                ));
+            }
+        }
+
+        user_msg.push_str(RING_ACTION_INSTRUCTIONS);
+        user_msg
+    }
+
+    /// Assemble the voting prompt, reproducing the shape of
+    /// `LlmRingAgent::vote`'s `user_msg` verbatim: `"Task: …\n\nAll
+    /// contributions:\n"`, one `"- [Lap … / …] {agent}: {content}\n"` line
+    /// per recorded contribution (`state.ring.contributions`, in append
+    /// order), then the fixed synthesis instructions asking for a
+    /// `CONFIDENCE: <0.0-1.0>` header followed by the agent's final
+    /// position.
+    fn build_vote_prompt(&self, input: &str, state: &ExecutionState) -> String {
+        let mut user_msg = format!("Task: {input}\n\nAll contributions:\n");
+        for c in &state.ring.contributions {
+            user_msg.push_str(&format!(
+                "- [Lap {} / {}] {}: {}\n",
+                c.lap, c.position, c.agent, c.content
+            ));
+        }
+        user_msg.push_str(
+            "\nSynthesize the contributions above. Identify areas of agreement, \
+             unresolved disagreements, and any gaps. Then state your final \
+             position in one or two sentences.\n\n\
+             Format your response as:\n\
+             CONFIDENCE: <0.0-1.0>\n\
+             <your synthesized position>",
+        );
+        user_msg
+    }
+}
+
+#[async_trait]
+impl EffectRunner for RingEffectRunner {
+    async fn run_invoke(
+        &self,
+        agent: &str,
+        input: &str,
+        state: &ExecutionState,
+    ) -> anyhow::Result<ExecutionEvent> {
+        let agent_def = self
+            .agents
+            .get(agent)
+            .ok_or_else(|| anyhow::anyhow!("Unknown agent '{agent}' — no Agent definition"))?;
+        let provider = self
+            .providers
+            .get(agent)
+            .ok_or_else(|| anyhow::anyhow!("No provider configured for agent '{agent}'"))?;
+
+        // Same `"latest:auto"` resolution as `HierarchicalEffectRunner`/
+        // `BlackboardEffectRunner`: see their doc comments for the full
+        // rationale. `RingDecider` (Task 7) emits `ModelRouted` ahead of
+        // every `latest:auto` agent's `Invoke`, so `state.routed_tiers`
+        // should already carry its tier by the time this runs; the `None`
+        // branch is a defensive fallback for a hand-built state (tests) or a
+        // future decider regression.
+        let raw_model = agent_def
+            .metadata
+            .model
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+        let model = if raw_model == "latest:auto" {
+            let tier = match state.routed_tiers.get(agent) {
+                Some(tier_str) => parse_routed_tier(tier_str),
+                None => {
+                    tracing::warn!(
+                        agent,
+                        "no ModelRouted tier recorded for latest:auto agent; falling back to Pro tier"
+                    );
+                    ModelTier::Pro
+                }
+            };
+            resolve_model_for_tier(&agent_def.metadata.provider, tier)
+        } else {
+            raw_model
+        };
+
+        match ring_phase(state, &self.config) {
+            RingPhase::Circulate { lap } => {
+                let position = state
+                    .ring
+                    .contributions
+                    .iter()
+                    .filter(|c| c.lap == lap)
+                    .count();
+                let prompt = self.build_circulate_prompt(input, lap, state);
+                let request = CompletionRequest {
+                    model,
+                    system_prompt: agent_def.system_prompt.clone(),
+                    messages: vec![ChatMessage {
+                        role: "user".to_string(),
+                        content: prompt,
+                    }],
+                    temperature: agent_def.metadata.temperature,
+                    max_tokens: agent_def.metadata.max_tokens,
+                };
+
+                // Graceful degradation (brief, "erreur provider"): a provider
+                // error must NOT abort the run — the ring must keep
+                // circulating even when one agent's LLM call fails outright.
+                // Swallow the error and manufacture a degraded
+                // `ContributionAdded` with `action: "pass"` (the exact
+                // lowercase string `ring_phase`'s early-convergence check
+                // compares against — see `action_string`'s doc comment), a
+                // `"[agent failed]"` marker so the failure is visible in the
+                // transcript, and zero tokens/cost (nothing was actually
+                // consumed/billed).
+                match provider.complete(request).await {
+                    Ok(response) => {
+                        let (action, content) = parse_ring_action(&response.content);
+                        Ok(ExecutionEvent::ContributionAdded {
+                            agent: agent.to_string(),
+                            lap,
+                            position,
+                            action: action_string(&action).to_string(),
+                            content,
+                            tokens_in: response.tokens_in,
+                            tokens_out: response.tokens_out,
+                            cost: response.cost,
+                        })
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            agent,
+                            error = %err,
+                            "ring agent provider call failed during circulation; recording a Pass instead of aborting the run"
+                        );
+                        Ok(ExecutionEvent::ContributionAdded {
+                            agent: agent.to_string(),
+                            lap,
+                            position,
+                            action: "pass".to_string(),
+                            content: "[agent failed]".to_string(),
+                            tokens_in: 0,
+                            tokens_out: 0,
+                            cost: 0.0,
+                        })
+                    }
+                }
+            }
+            // `Vote` is the only other phase `RingDecider` ever dispatches an
+            // `Invoke` for (`Resolve`/`Done` only ever `Emit`/`Complete`, never
+            // `Invoke` — see `RingDecider::decide`); the catch-all below is a
+            // defensive fallback for a hand-built state (tests) or a future
+            // decider regression, treated identically to `Vote` since both
+            // have nothing left to circulate.
+            _ => {
+                let n = state.ring.contributions.len();
+                let prompt = self.build_vote_prompt(input, state);
+                let request = CompletionRequest {
+                    model,
+                    system_prompt: agent_def.system_prompt.clone(),
+                    messages: vec![ChatMessage {
+                        role: "user".to_string(),
+                        content: prompt,
+                    }],
+                    temperature: agent_def.metadata.temperature,
+                    max_tokens: agent_def.metadata.max_tokens,
+                };
+
+                // Graceful degradation, voting phase: a provider error
+                // records a neutral abstention (`confidence: 0.0`, a
+                // documented `"[agent failed]"` position) rather than
+                // aborting the run — fidelity with the circulation branch
+                // above. `supports` still covers the full contribution range
+                // (fidèle au legacy shape even for a degraded vote); `concerns`
+                // documents the failure so it's distinguishable from a
+                // genuine (if unconfident) vote.
+                match provider.complete(request).await {
+                    Ok(response) => {
+                        let (confidence, position) = parse_vote_confidence(&response.content);
+                        Ok(ExecutionEvent::VoteCast {
+                            agent: agent.to_string(),
+                            position,
+                            confidence,
+                            supports: (0..n).collect(),
+                            concerns: vec![],
+                        })
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            agent,
+                            error = %err,
+                            "ring agent provider call failed during voting; recording a neutral abstention instead of aborting the run"
+                        );
+                        Ok(ExecutionEvent::VoteCast {
+                            agent: agent.to_string(),
+                            position: "[agent failed]".to_string(),
+                            confidence: 0.0,
+                            supports: (0..n).collect(),
+                            concerns: vec!["provider error".to_string()],
+                        })
+                    }
+                }
+            }
         }
     }
 }
@@ -1156,6 +1490,416 @@ mod tests {
                 actions[0]
             );
             assert!(matches!(&actions[1], Action::Complete { .. }));
+        }
+    }
+
+    // ── RingEffectRunner (Task 8) ─────────────────────────────────────
+    //
+    // Named `effect_runner` so `cargo test es::ring::tests::effect_runner`
+    // targets this module — mirrors the naming convention used by
+    // `es::hierarchical::tests::effect_runner`/
+    // `es::blackboard::tests::effect_runner`.
+    mod effect_runner {
+        use super::*;
+        use crate::core::agent::AgentMetadata;
+        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use std::path::PathBuf;
+        use std::sync::Mutex;
+
+        /// Minimal `Agent` for effect-runner tests: a concrete (non
+        /// `latest:auto`) model by default.
+        fn test_agent(name: &str, model: &str) -> Agent {
+            Agent {
+                name: name.to_string(),
+                source: PathBuf::from(format!("{name}.md")),
+                metadata: AgentMetadata {
+                    provider: "anthropic".to_string(),
+                    model: Some(model.to_string()),
+                    command: None,
+                    args: None,
+                    temperature: 0.5,
+                    max_tokens: Some(256),
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: format!("You are {name}."),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        /// Records every `CompletionRequest` it receives and always returns
+        /// a fixed `response` with `tokens_in: 5, tokens_out: 7, cost: 0.03`
+        /// — mirrors `CapturingProvider` in `es::hierarchical`/
+        /// `es::blackboard`'s own effect-runner tests, so assertions can
+        /// check both what was sent and what came back.
+        struct CapturingProvider {
+            requests: Mutex<Vec<CompletionRequest>>,
+            response: String,
+        }
+
+        impl CapturingProvider {
+            fn new(response: &str) -> Self {
+                Self {
+                    requests: Mutex::new(Vec::new()),
+                    response: response.to_string(),
+                }
+            }
+
+            fn requests(&self) -> Vec<CompletionRequest> {
+                self.requests.lock().unwrap().clone()
+            }
+        }
+
+        #[async_trait]
+        impl Provider for CapturingProvider {
+            async fn complete(
+                &self,
+                request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                let model = request.model.clone();
+                self.requests.lock().unwrap().push(request);
+                Ok(CompletionResponse {
+                    content: self.response.clone(),
+                    model,
+                    tokens_in: 5,
+                    tokens_out: 7,
+                    cost: 0.03,
+                })
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by RingEffectRunner tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "capturing".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        /// Always fails — used to exercise the graceful-degradation
+        /// (Pass/abstention) branches.
+        struct FailingProvider;
+
+        #[async_trait]
+        impl Provider for FailingProvider {
+            async fn complete(
+                &self,
+                _request: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                anyhow::bail!("simulated provider failure")
+            }
+            async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("streaming not exercised by RingEffectRunner tests")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "failing".to_string(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        fn runner(
+            agent_names: &[&str],
+            config: RingConfig,
+            provider: Arc<dyn Provider>,
+        ) -> RingEffectRunner {
+            let mut agents = BTreeMap::new();
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            for name in agent_names {
+                agents.insert((*name).to_string(), test_agent(name, "concrete-model"));
+                providers.insert((*name).to_string(), provider.clone());
+            }
+            RingEffectRunner::new(agents, providers, config, BTreeMap::new())
+        }
+
+        // (a) Circulation phase: `ACTION: PROPOSE\nCONTENT: x` → `ContributionAdded`
+        // with the expected agent/lap/position/action/content/tokens.
+        #[tokio::test]
+        async fn circulate_propose_returns_contribution_added() {
+            let capturing = Arc::new(CapturingProvider::new("ACTION: PROPOSE\nCONTENT: x"));
+            let runner = runner(
+                &["a", "b"],
+                RingConfig::default(),
+                capturing.clone() as Arc<dyn Provider>,
+            );
+            let state = fold(&[run_started(&["a", "b"]), E::LapStarted { lap: 0 }]);
+
+            let event = runner.run_invoke("a", "task", &state).await.unwrap();
+
+            match event {
+                E::ContributionAdded {
+                    agent,
+                    lap,
+                    position,
+                    action,
+                    content,
+                    tokens_in,
+                    tokens_out,
+                    cost,
+                } => {
+                    assert_eq!(agent, "a");
+                    assert_eq!(lap, 0);
+                    assert_eq!(position, 0);
+                    assert_eq!(action, "propose");
+                    assert_eq!(content, "x");
+                    assert_eq!(tokens_in, 5);
+                    assert_eq!(tokens_out, 7);
+                    assert!((cost - 0.03).abs() < 1e-9);
+                }
+                other => panic!("expected ContributionAdded, got {other:?}"),
+            }
+
+            let sent = capturing.requests();
+            assert_eq!(sent.len(), 1);
+            assert!(sent[0].messages[0].content.contains("Lap: 0"));
+        }
+
+        // (b) `ACTION: PASS` must yield `action == "pass"` EXACTLY — the
+        // literal string `ring_phase`'s early-convergence check compares
+        // against (see `action_string`'s doc comment / the Task 6 review
+        // contract in the brief).
+        #[tokio::test]
+        async fn circulate_pass_action_is_exact_lowercase_string() {
+            let capturing = Arc::new(CapturingProvider::new(
+                "ACTION: PASS\nCONTENT: nothing to add",
+            ));
+            let runner = runner(
+                &["a", "b"],
+                RingConfig::default(),
+                capturing as Arc<dyn Provider>,
+            );
+            let state = fold(&[run_started(&["a", "b"]), E::LapStarted { lap: 0 }]);
+
+            let event = runner.run_invoke("a", "task", &state).await.unwrap();
+
+            match event {
+                E::ContributionAdded { action, .. } => assert_eq!(action, "pass"),
+                other => panic!("expected ContributionAdded, got {other:?}"),
+            }
+        }
+
+        // (c) Circulation finished (both agents contributed the only lap,
+        // max_laps == 1) → phase Vote → `CONFIDENCE: 0.7` → `VoteCast` with
+        // the expected confidence and full-range `supports`.
+        #[tokio::test]
+        async fn vote_phase_returns_vote_cast_with_confidence_and_supports() {
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+            let capturing = Arc::new(CapturingProvider::new("CONFIDENCE: 0.7\nUse Rust"));
+            let runner = runner(&["a", "b"], config, capturing as Arc<dyn Provider>);
+            let state = fold(&[
+                run_started(&["a", "b"]),
+                E::LapStarted { lap: 0 },
+                E::ContributionAdded {
+                    agent: "a".into(),
+                    lap: 0,
+                    position: 0,
+                    action: "propose".into(),
+                    content: "c1".into(),
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    cost: 0.0,
+                },
+                E::ContributionAdded {
+                    agent: "b".into(),
+                    lap: 0,
+                    position: 1,
+                    action: "propose".into(),
+                    content: "c2".into(),
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    cost: 0.0,
+                },
+            ]);
+            let event = runner.run_invoke("a", "task", &state).await.unwrap();
+
+            match event {
+                E::VoteCast {
+                    agent,
+                    confidence,
+                    supports,
+                    concerns,
+                    ..
+                } => {
+                    assert_eq!(agent, "a");
+                    assert!((confidence - 0.7).abs() < 1e-6);
+                    assert_eq!(supports, vec![0, 1]);
+                    assert!(concerns.is_empty());
+                }
+                other => panic!("expected VoteCast, got {other:?}"),
+            }
+        }
+
+        // (d) Provider error during circulation → degraded Pass, NOT an
+        // `Err` — the run must not abort.
+        #[tokio::test]
+        async fn circulate_provider_error_degrades_to_pass_not_err() {
+            let runner = runner(
+                &["a", "b"],
+                RingConfig::default(),
+                Arc::new(FailingProvider) as Arc<dyn Provider>,
+            );
+            let state = fold(&[run_started(&["a", "b"]), E::LapStarted { lap: 0 }]);
+
+            let event = runner.run_invoke("a", "task", &state).await.unwrap();
+
+            match event {
+                E::ContributionAdded {
+                    action,
+                    content,
+                    tokens_in,
+                    tokens_out,
+                    cost,
+                    ..
+                } => {
+                    assert_eq!(action, "pass");
+                    assert_eq!(content, "[agent failed]");
+                    assert_eq!(tokens_in, 0);
+                    assert_eq!(tokens_out, 0);
+                    assert!((cost - 0.0).abs() < 1e-9);
+                }
+                other => panic!("expected ContributionAdded (degraded), got {other:?}"),
+            }
+        }
+
+        // Provider error during voting → neutral abstention, NOT an `Err`.
+        #[tokio::test]
+        async fn vote_provider_error_degrades_to_neutral_abstention_not_err() {
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+            let runner = runner(
+                &["a", "b"],
+                config,
+                Arc::new(FailingProvider) as Arc<dyn Provider>,
+            );
+            let state = fold(&[
+                run_started(&["a", "b"]),
+                E::LapStarted { lap: 0 },
+                E::ContributionAdded {
+                    agent: "a".into(),
+                    lap: 0,
+                    position: 0,
+                    action: "propose".into(),
+                    content: "c1".into(),
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    cost: 0.0,
+                },
+                E::ContributionAdded {
+                    agent: "b".into(),
+                    lap: 0,
+                    position: 1,
+                    action: "propose".into(),
+                    content: "c2".into(),
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    cost: 0.0,
+                },
+            ]);
+
+            let event = runner.run_invoke("a", "task", &state).await.unwrap();
+
+            match event {
+                E::VoteCast {
+                    confidence,
+                    concerns,
+                    ..
+                } => {
+                    assert!((confidence - 0.0).abs() < 1e-9);
+                    assert!(!concerns.is_empty());
+                }
+                other => panic!("expected VoteCast (degraded), got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn run_invoke_errors_for_unknown_agent() {
+            let runner = RingEffectRunner::new(
+                BTreeMap::new(),
+                BTreeMap::new(),
+                RingConfig::default(),
+                BTreeMap::new(),
+            );
+            let state = ExecutionState::default();
+            let err = runner
+                .run_invoke("missing", "task", &state)
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("missing"));
+        }
+
+        #[tokio::test]
+        async fn run_invoke_errors_when_provider_missing_for_known_agent() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), test_agent("a", "concrete-model"));
+            let runner = RingEffectRunner::new(
+                agents,
+                BTreeMap::new(),
+                RingConfig::default(),
+                BTreeMap::new(),
+            );
+            let state = ExecutionState::default();
+            let err = runner.run_invoke("a", "task", &state).await.unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("provider") && msg.contains("'a'"),
+                "expected a distinctive missing-provider message, got: {msg}"
+            );
+        }
+
+        // `"latest:auto"` resolves to a concrete model via `state.routed_tiers`,
+        // the same as `HierarchicalEffectRunner`/`BlackboardEffectRunner`.
+        // Uses a deliberately uncached provider name so `resolve_model_for_tier`
+        // is forced onto its hermetic, pure `fallback_model_for_tier` path.
+        #[tokio::test]
+        async fn run_invoke_resolves_latest_auto_to_concrete_model() {
+            let mut agent = test_agent("a", "latest:auto");
+            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), agent);
+            let capturing = Arc::new(CapturingProvider::new("ACTION: PROPOSE\nCONTENT: x"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), capturing.clone() as Arc<dyn Provider>);
+            let runner =
+                RingEffectRunner::new(agents, providers, RingConfig::default(), BTreeMap::new());
+
+            let state = fold(&[
+                run_started(&["a"]),
+                E::LapStarted { lap: 0 },
+                E::ModelRouted {
+                    agent: "a".into(),
+                    tier: "Fast".into(),
+                    reason: "Length".into(),
+                },
+            ]);
+            runner.run_invoke("a", "task", &state).await.unwrap();
+
+            let expected =
+                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Fast).to_string();
+            let sent = capturing.requests();
+            assert_eq!(sent[0].model, expected);
+            assert_ne!(sent[0].model, "latest:auto");
         }
     }
 }

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -18,8 +18,12 @@
 
 use std::collections::BTreeMap;
 
+use super::engine::{Action, Decider};
+use super::event::ExecutionEvent;
 use super::state::{ExecutionState, RunStatus, VoteRec};
+use crate::core::agent::Agent;
 use crate::core::orchestration::ring::RingConfig;
+use crate::core::routing::{BudgetState, RoutingRules, route};
 
 /// The ring pattern's current phase, derived purely from [`ExecutionState`].
 ///
@@ -277,6 +281,308 @@ pub fn resolve_votes(
         .expect("groups must be non-empty because votes is non-empty");
 
     largest_group[0].1.position.clone()
+}
+
+// ── RingDecider (Task 7): pure decision function ──────────────────
+
+/// Best-effort partial digest of the run so far, built from every recorded
+/// ring contribution (`state.ring.contributions`, in append order — the
+/// chronological order the underlying event log recorded them), formatted as
+/// `[agent] content` per line. Ring counterpart of
+/// `es::blackboard::build_board_result`/`es::hierarchical::build_partial_content`,
+/// used as the fallback content for a guard-triggered `Complete` when no vote
+/// has been cast yet (see [`RingDecider::partial_or_outcome`]).
+fn build_ring_partial(state: &ExecutionState) -> String {
+    state
+        .ring
+        .contributions
+        .iter()
+        .map(|c| format!("[{}] {}", c.agent, c.content))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Pure ring [`Decider`]: given the current [`ExecutionState`], decides the
+/// next batch of [`Action`]s across the pattern's three phases — circulation
+/// (`Circulate`), voting (`Vote`), and resolution (`Resolve`) — derived via
+/// [`ring_phase`].
+///
+/// Mirrors `HierarchicalDecider`/`BlackboardDecider` (`es::hierarchical`/
+/// `es::blackboard`, OH1 Lot 2/3): all fields are immutable inputs captured
+/// at construction time, `decide` performs no I/O and reads no mutable
+/// state — every decision is a pure function of `state`, which is what keeps
+/// event-log replay deterministic.
+///
+/// # Roster contract
+/// `agent_order` must be the same set, in the same order, as `state.agents`
+/// (the run's roster, seeded from `RunStarted { agents, .. }`). This decider
+/// never checks or reconciles the two — it is the caller's responsibility
+/// (the future `run_ring_es`, Task 9's assembly function) to construct both
+/// from a single source of truth. [`ring_phase`]'s lap-completeness check
+/// reads `state.agents`; [`next_ring_agent`] and this decider's own
+/// vote-completeness check (`Vote`/`Resolve` branches) read `agent_order` —
+/// a mismatch between the two would desynchronize "who still owes a
+/// contribution/vote" from "who gets invoked next".
+#[derive(Debug, Clone)]
+pub struct RingDecider {
+    /// All known agents by name, for model/tag lookups (routing).
+    pub agents: BTreeMap<String, Agent>,
+    /// Declared agent order — the circulation/voting rotation. Must match
+    /// `state.agents` (see the roster contract above).
+    pub agent_order: Vec<String>,
+    /// The original user input/task, given to every invoked agent.
+    pub input: String,
+    /// Ring configuration (`max_laps`/`similarity_threshold`/…), read by
+    /// [`ring_phase`] and [`resolve_votes`].
+    pub config: RingConfig,
+    /// Routing rules for `latest:auto` agents.
+    pub routing_rules: RoutingRules,
+    /// Max laps before the run is force-completed, independent of
+    /// `config.max_laps` (which only drives [`ring_phase`]'s circulation →
+    /// vote transition). Kept as its own field — like
+    /// `BlackboardDecider::max_rounds` alongside `BlackboardConfig::max_rounds`
+    /// — so callers may cap circulation more aggressively than the pattern's
+    /// own configured lap count without touching `config`.
+    pub max_laps: u32,
+    /// Per-agent vote weight (default `1.0` when absent), read by
+    /// [`resolve_votes`].
+    pub vote_weights: BTreeMap<String, f32>,
+    /// Optional total token budget (in + out) before the run is
+    /// force-completed.
+    pub token_budget: Option<u32>,
+    /// Optional total cost budget (USD) before the run is force-completed.
+    pub cost_limit: Option<f64>,
+}
+
+impl RingDecider {
+    /// Construct a new `RingDecider`. All arguments become immutable fields
+    /// read by `decide`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        agents: BTreeMap<String, Agent>,
+        agent_order: Vec<String>,
+        input: impl Into<String>,
+        config: RingConfig,
+        routing_rules: RoutingRules,
+        max_laps: u32,
+        vote_weights: BTreeMap<String, f32>,
+        token_budget: Option<u32>,
+        cost_limit: Option<f64>,
+    ) -> Self {
+        Self {
+            agents,
+            agent_order,
+            input: input.into(),
+            config,
+            routing_rules,
+            max_laps,
+            vote_weights,
+            token_budget,
+            cost_limit,
+        }
+    }
+
+    /// Check budget/cost guards, returning the `Warned` code for whichever
+    /// one has been breached (token budget checked first — same convention
+    /// as `HierarchicalDecider::breached_limit`/`BlackboardDecider::breached_budget`).
+    fn breached_budget(&self, state: &ExecutionState) -> Option<&'static str> {
+        if let Some(budget) = self.token_budget
+            && state.budget_tokens_in + state.budget_tokens_out >= u64::from(budget)
+        {
+            return Some("token_budget");
+        }
+        if let Some(limit) = self.cost_limit
+            && state.budget_cost >= limit
+        {
+            return Some("cost_limit");
+        }
+        None
+    }
+
+    /// Best-effort final content for a guard-triggered `Complete`: the
+    /// resolved outcome if at least one vote has been cast (even a partial,
+    /// not-yet-complete vote round — [`resolve_votes`] tolerates that), or
+    /// else a digest of every ring contribution so far
+    /// ([`build_ring_partial`]). Matches the brief's "content: partiel ou
+    /// outcome".
+    fn partial_or_outcome(&self, state: &ExecutionState) -> String {
+        let outcome = resolve_votes(state, &self.vote_weights, &self.config);
+        if outcome.is_empty() {
+            build_ring_partial(state)
+        } else {
+            outcome
+        }
+    }
+
+    /// If `agent_name` is a known agent configured with the exact
+    /// `"latest:auto"` model placeholder, resolve the tier for
+    /// `routing_input` (pure, via `crate::core::routing::route`) and return
+    /// the `ModelRouted` event to emit before invoking it. Concrete models,
+    /// other `latest:*` placeholders, and unknown agents all return `None`.
+    ///
+    /// Identical in spirit to `HierarchicalDecider`/`BlackboardDecider`'s own
+    /// `model_routed_event` — duplicated rather than shared (same rationale:
+    /// the three deciders' `agents`/`routing_rules`/`token_budget` fields
+    /// live on unrelated structs with no common trait today).
+    fn model_routed_event(
+        &self,
+        agent_name: &str,
+        routing_input: &str,
+        state: &ExecutionState,
+    ) -> Option<ExecutionEvent> {
+        let agent = self.agents.get(agent_name)?;
+        let raw_model = agent.metadata.model.as_deref().unwrap_or("default");
+        if raw_model != "latest:auto" {
+            return None;
+        }
+        let tokens_consumed = state.budget_tokens_in + state.budget_tokens_out;
+        let budget = self.token_budget.filter(|&b| b > 0).map(|total| {
+            let total = u64::from(total);
+            BudgetState {
+                remaining_ratio: total.saturating_sub(tokens_consumed) as f64 / total as f64,
+            }
+        });
+        let (tier, reason) = route(
+            routing_input,
+            &agent.metadata.tags,
+            budget,
+            &self.routing_rules,
+        );
+        Some(ExecutionEvent::ModelRouted {
+            agent: agent_name.to_string(),
+            tier: format!("{tier:?}"),
+            reason: format!("{reason:?}"),
+        })
+    }
+
+    /// Build the action batch for circulation phase `lap`.
+    ///
+    /// **`LapStarted`-before-rotation contract**: whether `lap` has just
+    /// begun is decided purely from `state.ring.contributions` — no
+    /// contribution recorded yet for `lap` — rather than from
+    /// `state.ring.lap` (which still holds the *previous* lap's number until
+    /// the `LapStarted { lap }` this same batch emits is folded). When it has
+    /// just begun, `Emit(LapStarted { lap })` is pushed **first**, ahead of
+    /// anything else: [`next_ring_agent`] indexes by `state.ring.lap`, so
+    /// computing it against the raw (stale) `state` here would rotate off
+    /// the *previous* lap's contribution count instead of the new lap's
+    /// (vacuously `0`). We therefore compute the next agent against a
+    /// `state.ring.lap`-corrected lookahead clone — pure, local, no mutation
+    /// of the real state (mirrors `BlackboardDecider::decide`'s own
+    /// round-advance lookahead) — rather than against `state` directly, so
+    /// the very first invocation of a new lap always resolves to
+    /// `agent_order[0]` regardless of whether `LapStarted` has actually been
+    /// folded into `state` yet.
+    fn circulate_actions(&self, lap: u32, state: &ExecutionState) -> Vec<Action> {
+        let lap_just_started = !state.ring.contributions.iter().any(|c| c.lap == lap);
+
+        let mut lookahead = state.clone();
+        lookahead.ring.lap = lap;
+        let agent = next_ring_agent(&lookahead, &self.agent_order);
+
+        let mut actions = Vec::new();
+        if lap_just_started {
+            actions.push(Action::Emit(ExecutionEvent::LapStarted { lap }));
+        }
+        if let Some(agent) = agent {
+            if let Some(event) = self.model_routed_event(&agent, &self.input, state) {
+                actions.push(Action::Emit(event));
+            }
+            actions.push(Action::Invoke {
+                agent,
+                input: self.input.clone(),
+            });
+        }
+        actions
+    }
+
+    /// Build the action batch for the voting phase: `Invoke` the first agent
+    /// in `agent_order` that has not cast a vote yet (`state.ring.votes`).
+    /// Covers both the circulation→vote transition (nobody has voted:
+    /// resolves to `agent_order[0]`) and an in-progress vote round (resolves
+    /// to the next non-voter) — the same lookup serves both, since "first
+    /// non-voter in roster order" is exactly "next votant" either way.
+    ///
+    /// Returns an empty batch if every agent has already voted — defensive
+    /// only: `ring_phase` returns `RingPhase::Resolve` in that case, so
+    /// `decide` never calls this with an exhausted roster in practice.
+    fn vote_actions(&self, state: &ExecutionState) -> Vec<Action> {
+        let Some(agent) = self
+            .agent_order
+            .iter()
+            .find(|a| !state.ring.votes.contains_key(*a))
+            .cloned()
+        else {
+            return Vec::new();
+        };
+
+        let mut actions = Vec::new();
+        if let Some(event) = self.model_routed_event(&agent, &self.input, state) {
+            actions.push(Action::Emit(event));
+        }
+        actions.push(Action::Invoke {
+            agent,
+            input: self.input.clone(),
+        });
+        actions
+    }
+}
+
+impl Decider for RingDecider {
+    fn decide(&self, state: &ExecutionState) -> Vec<Action> {
+        // Budget/cost guards apply regardless of phase — a hard external
+        // limit that can be hit mid-circulation or mid-voting alike (same
+        // priority convention as `BlackboardDecider::decide`: checked ahead
+        // of any lap/round cap).
+        if let Some(code) = self.breached_budget(state) {
+            return vec![
+                Action::Emit(ExecutionEvent::Warned {
+                    code: code.to_string(),
+                }),
+                Action::Complete {
+                    content: self.partial_or_outcome(state),
+                },
+            ];
+        }
+
+        match ring_phase(state, &self.config) {
+            RingPhase::Circulate { lap } => {
+                // Independent cap: `self.max_laps` (not `config.max_laps`,
+                // which only drives `ring_phase`'s own circulation → vote
+                // transition — see the field doc comment above) stops
+                // circulation early, without having converged, when it is
+                // set below what `config` would otherwise allow.
+                if lap >= self.max_laps {
+                    return vec![
+                        Action::Emit(ExecutionEvent::Warned {
+                            code: "max_laps".to_string(),
+                        }),
+                        Action::Complete {
+                            content: self.partial_or_outcome(state),
+                        },
+                    ];
+                }
+                self.circulate_actions(lap, state)
+            }
+            RingPhase::Vote => self.vote_actions(state),
+            RingPhase::Resolve => {
+                let outcome = resolve_votes(state, &self.vote_weights, &self.config);
+                vec![
+                    Action::Emit(ExecutionEvent::OutcomeResolved {
+                        outcome: outcome.clone(),
+                    }),
+                    Action::Complete { content: outcome },
+                ]
+            }
+            // The generic loop (`run_event_sourced`) only calls `decide`
+            // while `state.status == RunStatus::Running`, so this should be
+            // unreachable in practice (a `Done` phase implies the run has
+            // already terminated) — kept as an explicit, harmless empty
+            // batch for exhaustiveness rather than a `match` catch-all that
+            // could silently swallow a future `RingPhase` variant.
+            RingPhase::Done => Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -548,5 +854,308 @@ mod tests {
             resolve_votes(&state, &BTreeMap::new(), &config),
             "Use Rust for the backend"
         );
+    }
+
+    /// Review hardening (Task 6 minor): the tie-break must still pick the
+    /// *last* group when there are three tied groups, not just two — proving
+    /// `max_by`'s "last element wins" isn't an artifact of only ever
+    /// comparing a pair.
+    #[test]
+    fn resolve_votes_tie_break_three_way_returns_last_key() {
+        // Three single-word, mutually dissimilar positions ("alpha", "beta",
+        // "gamma" — zero word overlap, so each starts its own group), each
+        // with exactly one vote at the default weight 1.0 → all three groups
+        // tied at weight 1.0. `groups.values()` iterates key-sorted:
+        // "alpha", "beta", "gamma" — the tie must resolve to "Gamma", the
+        // last key, never "Alpha" or "Beta".
+        let state = fold(&[
+            run_started(&["agent-a", "agent-b", "agent-c"]),
+            vote("agent-a", "Alpha", 0.9),
+            vote("agent-b", "Beta", 0.9),
+            vote("agent-c", "Gamma", 0.9),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(resolve_votes(&state, &BTreeMap::new(), &config), "Gamma");
+    }
+
+    /// Review hardening (Task 6 minor): the tie-break follows the *group
+    /// key's* (lowercased position) `BTreeMap` order, not the order in which
+    /// groups were first created while iterating `state.ring.votes` (itself
+    /// agent-name-sorted). `agent-a` (sorted first) casts "Zebra" — so the
+    /// "zebra" group is created *before* the "apple" group as iteration
+    /// proceeds — yet "apple" < "zebra" alphabetically, so on a tie
+    /// `groups.values()` must still resolve to "Zebra" (the alphabetically
+    /// *last* key), proving iteration order followed by `max_by` is the
+    /// `BTreeMap`'s key order, not creation/insertion order.
+    #[test]
+    fn resolve_votes_tie_break_follows_key_order_not_creation_order() {
+        let state = fold(&[
+            run_started(&["agent-a", "agent-b"]),
+            vote("agent-a", "Zebra", 0.9),
+            vote("agent-b", "Apple", 0.9),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(resolve_votes(&state, &BTreeMap::new(), &config), "Zebra");
+    }
+
+    // ── RingDecider (Task 7) ──────────────────────────────────────────
+
+    /// Tests for `RingDecider` (Task 7): pure decision function built on top
+    /// of `ring_phase`/`next_ring_agent`/`resolve_votes`. Named `decide` so
+    /// `cargo test es::ring::tests::decide` targets this module — mirrors
+    /// the naming convention used by `es::hierarchical::tests::decide` and
+    /// `es::blackboard::tests::decide`.
+    mod decide {
+        use super::*;
+        use crate::core::agent::AgentMetadata;
+        use crate::core::orchestration::es::engine::{Action, Decider};
+        use crate::core::routing::RoutingRules;
+        use std::path::PathBuf;
+
+        fn test_agent(name: &str, model: &str) -> Agent {
+            Agent {
+                name: name.to_string(),
+                source: PathBuf::from(format!("{name}.md")),
+                metadata: AgentMetadata {
+                    provider: "anthropic".to_string(),
+                    model: Some(model.to_string()),
+                    command: None,
+                    args: None,
+                    temperature: 0.7,
+                    max_tokens: None,
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: "prompt".to_string(),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn test_decider(
+            agent_names: &[&str],
+            config: RingConfig,
+            max_laps: u32,
+            vote_weights: BTreeMap<String, f32>,
+            token_budget: Option<u32>,
+            cost_limit: Option<f64>,
+        ) -> RingDecider {
+            let mut agents = BTreeMap::new();
+            for name in agent_names {
+                agents.insert((*name).to_string(), test_agent(name, "concrete-model"));
+            }
+            RingDecider::new(
+                agents,
+                agent_names.iter().map(|a| (*a).to_string()).collect(),
+                "task".to_string(),
+                config,
+                RoutingRules::default(),
+                max_laps,
+                vote_weights,
+                token_budget,
+                cost_limit,
+            )
+        }
+
+        fn invoked_agent(actions: &[Action]) -> Option<&str> {
+            actions.iter().find_map(|a| match a {
+                Action::Invoke { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+        }
+
+        // (a) empty state → `LapStarted{0}` first, then `Invoke` of the
+        // first agent in `agent_order`.
+        #[test]
+        fn empty_state_starts_lap_zero_and_invokes_first_agent() {
+            let dec = test_decider(
+                &["a", "b", "c"],
+                RingConfig::default(),
+                5,
+                BTreeMap::new(),
+                None,
+                None,
+            );
+            let state = fold(&[run_started(&["a", "b", "c"])]);
+            let actions = dec.decide(&state);
+
+            assert!(
+                matches!(&actions[0], Action::Emit(E::LapStarted { lap }) if *lap == 0),
+                "expected Emit(LapStarted{{lap: 0}}) first, got {actions:?}"
+            );
+            assert_eq!(invoked_agent(&actions), Some("a"));
+        }
+
+        // (b) circulation in progress (one contribution already recorded
+        // this lap) → no `LapStarted` re-emitted, `Invoke` of the next agent
+        // in roster order.
+        #[test]
+        fn circulation_in_progress_invokes_next_agent_without_lap_started() {
+            let dec = test_decider(
+                &["a", "b", "c"],
+                RingConfig::default(),
+                5,
+                BTreeMap::new(),
+                None,
+                None,
+            );
+            let state = fold(&[
+                run_started(&["a", "b", "c"]),
+                E::LapStarted { lap: 0 },
+                contribution("a", 0, 0, "propose"),
+            ]);
+            let actions = dec.decide(&state);
+
+            assert!(
+                !actions
+                    .iter()
+                    .any(|a| matches!(a, Action::Emit(E::LapStarted { .. }))),
+                "must not re-emit LapStarted mid-lap, got {actions:?}"
+            );
+            assert_eq!(actions.len(), 1, "got {actions:?}");
+            assert_eq!(invoked_agent(&actions), Some("b"));
+        }
+
+        // (c) end of circulation (max_laps == 1, lap 0 fully contributed,
+        // non-pass) → `Invoke` of the first voter (`agent_order[0]`), no
+        // agent having voted yet.
+        #[test]
+        fn end_of_circulation_invokes_first_voter() {
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+            let dec = test_decider(&["a", "b"], config, 5, BTreeMap::new(), None, None);
+            let state = fold(&[
+                run_started(&["a", "b"]),
+                E::LapStarted { lap: 0 },
+                contribution("a", 0, 0, "propose"),
+                contribution("b", 0, 1, "propose"),
+            ]);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 1, "got {actions:?}");
+            assert_eq!(invoked_agent(&actions), Some("a"));
+        }
+
+        // (d) every agent has voted → `OutcomeResolved` + `Complete`.
+        #[test]
+        fn all_voted_resolves_and_completes() {
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+            let dec = test_decider(&["a", "b"], config, 5, BTreeMap::new(), None, None);
+            let state = fold(&[
+                run_started(&["a", "b"]),
+                E::LapStarted { lap: 0 },
+                contribution("a", 0, 0, "propose"),
+                contribution("b", 0, 1, "propose"),
+                vote("a", "Use Rust", 0.9),
+                vote("b", "Use Rust", 0.8),
+            ]);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 2, "got {actions:?}");
+            assert!(
+                matches!(&actions[0], Action::Emit(E::OutcomeResolved { outcome }) if outcome == "Use Rust"),
+                "expected Emit(OutcomeResolved{{outcome: \"Use Rust\"}}), got {:?}",
+                actions[0]
+            );
+            assert!(
+                matches!(&actions[1], Action::Complete { content } if content == "Use Rust"),
+                "expected Complete{{content: \"Use Rust\"}}, got {:?}",
+                actions[1]
+            );
+        }
+
+        // (e) the decider's own `max_laps` cap (independent of
+        // `config.max_laps`) is reached while still circulating, without
+        // having converged → `Warned{max_laps}` + `Complete` with a partial
+        // digest.
+        #[test]
+        fn own_max_laps_cap_warns_and_completes() {
+            // `config.max_laps` is generous (3, the default) so `ring_phase`
+            // would happily advance to lap 1 — but the decider's own
+            // `max_laps` field is set to 1, independently capping
+            // circulation at lap 0.
+            let dec = test_decider(
+                &["a", "b"],
+                RingConfig::default(),
+                1,
+                BTreeMap::new(),
+                None,
+                None,
+            );
+            let state = fold(&[
+                run_started(&["a", "b"]),
+                E::LapStarted { lap: 0 },
+                contribution("a", 0, 0, "propose"),
+                contribution("b", 0, 1, "propose"),
+            ]);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 2, "got {actions:?}");
+            assert!(
+                matches!(&actions[0], Action::Emit(E::Warned { code }) if code == "max_laps"),
+                "expected Warned{{code: \"max_laps\"}}, got {:?}",
+                actions[0]
+            );
+            assert!(
+                matches!(&actions[1], Action::Complete { content } if content.contains('a') && content.contains('b')),
+                "expected Complete with a partial digest, got {:?}",
+                actions[1]
+            );
+        }
+
+        // Token budget guard fires ahead of any phase-specific logic, even
+        // mid-circulation.
+        #[test]
+        fn token_budget_exhausted_warns_and_completes() {
+            let dec = test_decider(
+                &["a", "b"],
+                RingConfig::default(),
+                5,
+                BTreeMap::new(),
+                Some(10),
+                None,
+            );
+            let state = fold(&[
+                run_started(&["a", "b"]),
+                E::LapStarted { lap: 0 },
+                E::ContributionAdded {
+                    agent: "a".into(),
+                    lap: 0,
+                    position: 0,
+                    action: "propose".into(),
+                    content: "c".into(),
+                    tokens_in: 6,
+                    tokens_out: 6,
+                    cost: 0.0,
+                },
+            ]);
+            let actions = dec.decide(&state);
+
+            assert_eq!(actions.len(), 2, "got {actions:?}");
+            assert!(
+                matches!(&actions[0], Action::Emit(E::Warned { code }) if code == "token_budget"),
+                "expected Warned{{code: \"token_budget\"}}, got {:?}",
+                actions[0]
+            );
+            assert!(matches!(&actions[1], Action::Complete { .. }));
+        }
     }
 }

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -1,0 +1,552 @@
+//! Pure helpers for the ring pattern (OH1 Lot 3): phase derivation, vote
+//! resolution (with its tie-break), and circulation rotation.
+//!
+//! Reproduces the *decision* logic of the legacy ring engine —
+//! `core::orchestration::ring::resolve_votes`/`position_similarity` and the
+//! three-phase loop (`run_ring`: circulation, voting, resolution) — as pure,
+//! synchronous functions over the event-sourced `ExecutionState` projection:
+//! no I/O, no clock, no randomness. Strict coexistence: the legacy
+//! `ring.rs`/`llm_agents.rs` engines are untouched; this module only reuses
+//! their plain, side-effect-free `RingConfig` type rather than duplicating
+//! its definition.
+//!
+//! `ring_phase` is shared by the future `RingDecider` (Task 7) and
+//! `RingEffectRunner` (Task 8) — both need the same answer to "what should
+//! happen next" from the same `ExecutionState`, which is exactly what keeps
+//! the derivation itself the single source of truth for the pattern's state
+//! machine.
+
+use std::collections::BTreeMap;
+
+use super::state::{ExecutionState, RunStatus, VoteRec};
+use crate::core::orchestration::ring::RingConfig;
+
+/// The ring pattern's current phase, derived purely from [`ExecutionState`].
+///
+/// Mirrors the legacy `TokenStatus` (`Circulating`/`Voting`/`Done { .. }`)
+/// but splits `Circulating` into an explicit lap number (needed by the
+/// decider/effect to know *which* lap's agents to invoke next) and adds a
+/// dedicated `Resolve` phase: the legacy engine performs voting and
+/// resolution back-to-back in the same synchronous block (`run_ring`'s phase
+/// 2 then phase 3), but the event-sourced loop re-derives the phase after
+/// every batch, so "all votes are in, resolve now" and "still voting" must
+/// be distinguishable states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RingPhase {
+    /// Circulation is in progress: agents still owe a contribution for
+    /// `lap`.
+    Circulate { lap: u32 },
+    /// Circulation has ended (either every configured lap ran, or every
+    /// agent passed within a lap — the legacy early-convergence exit) and at
+    /// least one agent has not cast its vote yet.
+    Vote,
+    /// Every agent has voted: ready to resolve the outcome.
+    Resolve,
+    /// The run has already terminated (`ExecutionState::status` is no
+    /// longer `Running`) — nothing left to derive.
+    Done,
+}
+
+/// Derive the ring pattern's current [`RingPhase`] from `state.ring`.
+///
+/// Reproduces `run_ring`'s phase progression purely:
+/// - `state.status != RunStatus::Running` → [`RingPhase::Done`] first,
+///   regardless of any other field (a completed/halted run has nothing left
+///   to circulate, vote, or resolve).
+/// - While `state.ring.lap < config.max_laps`: compare the number of
+///   contributions recorded for `state.ring.lap` against `state.agents.len()`
+///   (the roster size) to tell whether the current lap is complete yet —
+///   [`RingPhase::Circulate { lap: state.ring.lap }`] while it isn't.
+/// - Once a lap is complete: if every contribution in it has
+///   `action == "pass"` (the early-convergence exit — legacy's
+///   `!any_substantive` after a full lap), circulation ends immediately,
+///   even mid-run (mirrors `run_ring`'s unconditional `break`, without
+///   incrementing `lap`). Otherwise, if there is a next lap
+///   (`lap + 1 < config.max_laps`), the phase becomes
+///   `Circulate { lap: lap + 1 }`.
+/// - Once circulation has ended (by either route above, or by
+///   `state.ring.lap >= config.max_laps` from the start — the
+///   `max_laps == 0` case, matching `test_integration_ring_max_laps_zero`):
+///   [`RingPhase::Resolve`] once every name in `state.agents` has cast a
+///   vote (a key in `state.ring.votes`), [`RingPhase::Vote`] otherwise.
+///
+/// # Edge cases
+/// - **Zero agents** (`state.agents.is_empty()`): a lap with zero required
+///   contributions is vacuously complete, and "every contribution is
+///   `Pass`" is vacuously true over an empty set — circulation ends on the
+///   very first check, without ever incrementing `lap` (matching
+///   `run_ring`'s `for` loop over zero agents, which never sets
+///   `any_substantive` and breaks immediately). Likewise, "every agent has
+///   voted" is vacuously true with zero agents, so the phase resolves
+///   straight to [`RingPhase::Resolve`] without passing through
+///   [`RingPhase::Vote`] — legacy still transiently sets
+///   `TokenStatus::Voting` before an instant, agent-less voting loop, but
+///   there is no *observable* `ExecutionState` in which that phase has any
+///   agent left to vote for, so collapsing it here is a faithful,
+///   documented simplification (this pure function has no notion of "phase
+///   already visited", only of the state as given).
+/// - **`state.ring.contributions`/`state.ring.votes` containing entries for
+///   agents outside `state.agents`** (a malformed/partial/synthetic state):
+///   ignored — lap-completeness and vote-completeness are both checked
+///   against `state.agents`, so a stray, unroute-able contribution or vote
+///   from an unknown name can never mask an eligible agent's absence nor
+///   count towards its completion.
+pub fn ring_phase(state: &ExecutionState, config: &RingConfig) -> RingPhase {
+    if state.status != RunStatus::Running {
+        return RingPhase::Done;
+    }
+
+    let agents = &state.agents;
+    let lap = state.ring.lap;
+
+    if lap < config.max_laps {
+        let lap_contribs: Vec<_> = state
+            .ring
+            .contributions
+            .iter()
+            .filter(|c| c.lap == lap)
+            .collect();
+
+        let lap_complete = agents
+            .iter()
+            .all(|a| lap_contribs.iter().any(|c| &c.agent == a));
+
+        if !lap_complete {
+            return RingPhase::Circulate { lap };
+        }
+
+        // Lap complete: check the early-convergence exit (every contribution
+        // this lap is a `Pass`) before deciding whether another lap follows.
+        let all_pass = lap_contribs.iter().all(|c| c.action == "pass");
+        if !all_pass && lap + 1 < config.max_laps {
+            return RingPhase::Circulate { lap: lap + 1 };
+        }
+        // Either the lap converged early, or this was the last configured
+        // lap: circulation is over — fall through to vote/resolve below.
+    }
+
+    let votes_complete = agents.iter().all(|a| state.ring.votes.contains_key(a));
+    if votes_complete {
+        RingPhase::Resolve
+    } else {
+        RingPhase::Vote
+    }
+}
+
+/// Next agent to speak in the circulation, given the configured
+/// `agent_order`.
+///
+/// Position in the lap is the number of contributions already recorded for
+/// `state.ring.lap`, modulo `agent_order.len()` — the same indexing
+/// `run_ring`'s `for (pos, agent) in agents.iter().enumerate()` uses (`pos`
+/// is the loop index within the current lap, and `agent_order` here plays
+/// the role of that `agents` slice, addressed by name rather than by
+/// `Arc<dyn RingAgent>`).
+///
+/// Returns `None` for an empty `agent_order` (nothing to rotate through).
+/// Not meaningful to call once the current lap is already complete (per
+/// [`ring_phase`]) — the modulo wraps back to the start of `agent_order`
+/// rather than reporting "nothing left", since this helper has no way to
+/// signal that distinctly from "next agent is the first one again"; callers
+/// are expected to check [`ring_phase`] first.
+pub fn next_ring_agent(state: &ExecutionState, agent_order: &[String]) -> Option<String> {
+    if agent_order.is_empty() {
+        return None;
+    }
+    let lap = state.ring.lap;
+    let contributed_this_lap = state
+        .ring
+        .contributions
+        .iter()
+        .filter(|c| c.lap == lap)
+        .count();
+    let idx = contributed_this_lap % agent_order.len();
+    agent_order.get(idx).cloned()
+}
+
+/// Normalised string similarity (1.0 = identical, 0.0 = completely
+/// different).
+///
+/// Verbatim copy of `core::orchestration::ring::position_similarity` — a
+/// word-overlap Jaccard coefficient on lowercased words. Duplicated rather
+/// than shared (same rationale as `es::blackboard`/`es::hierarchical`'s own
+/// duplicated `parse_routed_tier`: the pure event-sourced module and the
+/// legacy engine have no common trait to hang a shared implementation off
+/// today, and strict coexistence means this module doesn't reach into
+/// `ring.rs`'s private items).
+fn position_similarity(a: &str, b: &str) -> f32 {
+    let words_a: std::collections::HashSet<&str> = a.split_whitespace().collect();
+    let words_b: std::collections::HashSet<&str> = b.split_whitespace().collect();
+    let intersection = words_a.intersection(&words_b).count();
+    let union = words_a.union(&words_b).count();
+    if union == 0 {
+        return 1.0; // both empty → identical
+    }
+    intersection as f32 / union as f32
+}
+
+/// Resolve `state.ring.votes` to the winning position's text, replicating
+/// the grouping + tie-break half of `core::orchestration::ring::resolve_votes`.
+///
+/// Deliberately narrower than the legacy function: legacy returns a full
+/// `RingOutcome` (`Consensus`/`Majority`/`NoConsensus`, each carrying a score
+/// and — for `Majority` — the dissenting votes), classified against
+/// `config.consensus_threshold`/`majority_threshold`. Classifying the
+/// majority ratio into that three-way outcome is effect/decider-level
+/// synthesis (a later task's concern, layered on top of this helper); this
+/// function reproduces only the delicate, easy-to-get-wrong part — grouping
+/// votes by position similarity and picking the winning group's
+/// representative text — which is exactly the part the task brief singles
+/// out as "le point le plus délicat".
+///
+/// Algorithm (identical to legacy, `ring.rs:387-429`):
+/// 1. Iterate `state.ring.votes` in `BTreeMap` order (agent-name-sorted).
+///    Each vote's lowercased position is compared, via
+///    [`position_similarity`], against every existing group's
+///    representative key (in the order those groups were first created); the
+///    vote joins the first group whose representative meets
+///    `config.similarity_threshold`, or starts a new group keyed by its own
+///    lowercased position.
+/// 2. Group weight = the sum of `vote_weights` (default `1.0` for an agent
+///    absent from the map) of every vote in that group.
+/// 3. The winning group is the one returned by `Iterator::max_by` comparing
+///    group weights — **and therefore, on a tie, the *last* group in
+///    iteration order wins**, not the first (`Iterator::max_by`'s documented
+///    behavior: "If several elements are equally maximum, the last element
+///    is returned"). Groups are keyed by their (lowercased) representative
+///    position text in a `BTreeMap`, so iteration order is alphabetical —
+///    this is the exact ordering fidelity the task brief calls for
+///    ("reproduis l'ordre EXACT du legacy").
+/// 4. The resolution string is the *original-case* `position` of the first
+///    vote ever inserted into the winning group (`largest_group[0]`) — the
+///    representative, not the lowercased grouping key.
+///
+/// Returns an empty `String` when `state.ring.votes` is empty (no votes to
+/// resolve — legacy's empty-votes case returns `RingOutcome::NoConsensus`
+/// with no representative position at all; there is no meaningful
+/// "resolution text" for this pure helper to produce, so it returns the
+/// empty string rather than panicking or fabricating one).
+pub fn resolve_votes(
+    state: &ExecutionState,
+    vote_weights: &BTreeMap<String, f32>,
+    config: &RingConfig,
+) -> String {
+    if state.ring.votes.is_empty() {
+        return String::new();
+    }
+
+    let weight_of = |name: &str| -> f32 { vote_weights.get(name).copied().unwrap_or(1.0) };
+
+    let mut groups: BTreeMap<String, Vec<(String, &VoteRec)>> = BTreeMap::new();
+    let mut group_reps: Vec<String> = Vec::new();
+
+    for (agent, vote) in &state.ring.votes {
+        let pos_lower = vote.position.to_lowercase();
+        let mut assigned = false;
+        for rep in &group_reps {
+            if position_similarity(&pos_lower, rep) >= config.similarity_threshold {
+                // SAFETY: `rep` always exists in `groups` because it comes
+                // from `group_reps`, which only ever tracks keys already
+                // inserted into `groups` below.
+                groups
+                    .get_mut(rep)
+                    .expect("group representative must exist in groups map")
+                    .push((agent.clone(), vote));
+                assigned = true;
+                break;
+            }
+        }
+        if !assigned {
+            group_reps.push(pos_lower.clone());
+            groups
+                .entry(pos_lower)
+                .or_default()
+                .push((agent.clone(), vote));
+        }
+    }
+
+    // SAFETY: `groups` is non-empty because `state.ring.votes` is non-empty
+    // (early return above).
+    let largest_group = groups
+        .values()
+        .max_by(|a, b| {
+            let wa: f32 = a.iter().map(|(n, _)| weight_of(n)).sum();
+            let wb: f32 = b.iter().map(|(n, _)| weight_of(n)).sum();
+            wa.partial_cmp(&wb).unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .expect("groups must be non-empty because votes is non-empty");
+
+    largest_group[0].1.position.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::orchestration::es::event::ExecutionEvent as E;
+    use crate::core::orchestration::es::state::fold;
+
+    fn run_started(agents: &[&str]) -> E {
+        E::RunStarted {
+            run_id: "r".into(),
+            pattern: "ring".into(),
+            agents: agents.iter().map(|a| a.to_string()).collect(),
+            input: "task".into(),
+            project: None,
+        }
+    }
+
+    fn contribution(agent: &str, lap: u32, position: usize, action: &str) -> E {
+        E::ContributionAdded {
+            agent: agent.to_string(),
+            lap,
+            position,
+            action: action.to_string(),
+            content: "c".to_string(),
+            tokens_in: 0,
+            tokens_out: 0,
+            cost: 0.0,
+        }
+    }
+
+    fn vote(agent: &str, position: &str, confidence: f32) -> E {
+        E::VoteCast {
+            agent: agent.to_string(),
+            position: position.to_string(),
+            confidence,
+            supports: vec![],
+            concerns: vec![],
+        }
+    }
+
+    // ── ring_phase ────────────────────────────────────────────────────
+
+    #[test]
+    fn ring_phase_circulation_partial_stays_on_current_lap() {
+        let state = fold(&[run_started(&["a", "b"]), contribution("a", 0, 0, "propose")]);
+        let config = RingConfig::default();
+        assert_eq!(ring_phase(&state, &config), RingPhase::Circulate { lap: 0 });
+    }
+
+    #[test]
+    fn ring_phase_circulation_complete_advances_to_next_lap() {
+        // max_laps default is 3, lap 0 fully contributed (non-pass) → lap 1.
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            contribution("a", 0, 0, "propose"),
+            contribution("b", 0, 1, "propose"),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(ring_phase(&state, &config), RingPhase::Circulate { lap: 1 });
+    }
+
+    #[test]
+    fn ring_phase_last_lap_complete_moves_to_vote() {
+        // max_laps = 1: lap 0 is the only lap. Once it's complete (and not
+        // all-pass), there is no lap 1 to advance to — straight to Vote.
+        let config = RingConfig {
+            max_laps: 1,
+            ..RingConfig::default()
+        };
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            contribution("a", 0, 0, "propose"),
+            contribution("b", 0, 1, "propose"),
+        ]);
+        assert_eq!(ring_phase(&state, &config), RingPhase::Vote);
+    }
+
+    #[test]
+    fn ring_phase_all_pass_exits_circulation_early() {
+        // max_laps = 3, but every contribution this lap is a Pass → early
+        // convergence exit straight to Vote, never advancing to lap 1.
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            contribution("a", 0, 0, "pass"),
+            contribution("b", 0, 1, "pass"),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(ring_phase(&state, &config), RingPhase::Vote);
+    }
+
+    #[test]
+    fn ring_phase_vote_phase_partial_votes() {
+        let config = RingConfig {
+            max_laps: 1,
+            ..RingConfig::default()
+        };
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            contribution("a", 0, 0, "propose"),
+            contribution("b", 0, 1, "propose"),
+            vote("a", "Use Rust", 0.9),
+        ]);
+        assert_eq!(ring_phase(&state, &config), RingPhase::Vote);
+    }
+
+    #[test]
+    fn ring_phase_resolve_once_every_agent_voted() {
+        let config = RingConfig {
+            max_laps: 1,
+            ..RingConfig::default()
+        };
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            contribution("a", 0, 0, "propose"),
+            contribution("b", 0, 1, "propose"),
+            vote("a", "Use Rust", 0.9),
+            vote("b", "Use Rust", 0.8),
+        ]);
+        assert_eq!(ring_phase(&state, &config), RingPhase::Resolve);
+    }
+
+    #[test]
+    fn ring_phase_max_laps_zero_goes_straight_to_vote_or_resolve() {
+        // Matches `test_integration_ring_max_laps_zero`: no circulation at
+        // all when max_laps == 0.
+        let config = RingConfig {
+            max_laps: 0,
+            ..RingConfig::default()
+        };
+        let state = fold(&[run_started(&["a"])]);
+        assert_eq!(ring_phase(&state, &config), RingPhase::Vote);
+    }
+
+    #[test]
+    fn ring_phase_zero_agents_resolves_immediately() {
+        // Vacuous completeness on both the lap and the votes side, per the
+        // documented edge case.
+        let config = RingConfig::default();
+        let state = fold(&[run_started(&[])]);
+        assert_eq!(ring_phase(&state, &config), RingPhase::Resolve);
+    }
+
+    #[test]
+    fn ring_phase_done_when_status_not_running() {
+        let config = RingConfig::default();
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            E::Halted {
+                reason: "budget".into(),
+            },
+        ]);
+        assert_eq!(ring_phase(&state, &config), RingPhase::Done);
+    }
+
+    // ── next_ring_agent ───────────────────────────────────────────────
+
+    #[test]
+    fn next_ring_agent_starts_at_first_agent() {
+        let state = fold(&[run_started(&["a", "b", "c"])]);
+        let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(next_ring_agent(&state, &order), Some("a".to_string()));
+    }
+
+    #[test]
+    fn next_ring_agent_rotates_after_a_contribution() {
+        let state = fold(&[
+            run_started(&["a", "b", "c"]),
+            contribution("a", 0, 0, "propose"),
+        ]);
+        let order = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(next_ring_agent(&state, &order), Some("b".to_string()));
+    }
+
+    #[test]
+    fn next_ring_agent_wraps_around_after_a_full_lap() {
+        let state = fold(&[
+            run_started(&["a", "b"]),
+            contribution("a", 0, 0, "propose"),
+            contribution("b", 0, 1, "propose"),
+        ]);
+        let order = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(next_ring_agent(&state, &order), Some("a".to_string()));
+    }
+
+    #[test]
+    fn next_ring_agent_empty_order_is_none() {
+        let state = fold(&[run_started(&["a"])]);
+        assert_eq!(next_ring_agent(&state, &[]), None);
+    }
+
+    // ── resolve_votes ─────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_votes_empty_is_empty_string() {
+        let state = fold(&[run_started(&["a"])]);
+        let config = RingConfig::default();
+        assert_eq!(resolve_votes(&state, &BTreeMap::new(), &config), "");
+    }
+
+    #[test]
+    fn resolve_votes_single_position_wins_outright() {
+        let state = fold(&[
+            run_started(&["a", "b", "c"]),
+            vote("a", "Rust/Axum", 0.9),
+            vote("b", "Rust/Axum", 0.9),
+            vote("c", "Rust/Axum", 0.9),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(
+            resolve_votes(&state, &BTreeMap::new(), &config),
+            "Rust/Axum"
+        );
+    }
+
+    #[test]
+    fn resolve_votes_largest_weighted_group_wins() {
+        // "Option A" carries 3 votes at default weight 1.0 (=3.0), "Option B"
+        // carries 1 vote weighted heavily (=5.0) — the weighted group must
+        // win even though it has fewer members.
+        let state = fold(&[
+            run_started(&["a", "b", "c", "d"]),
+            vote("a", "Option A", 0.8),
+            vote("b", "Option A", 0.8),
+            vote("c", "Option A", 0.8),
+            vote("d", "Option B", 0.7),
+        ]);
+        let mut weights = BTreeMap::new();
+        weights.insert("d".to_string(), 5.0);
+        let config = RingConfig::default();
+        assert_eq!(resolve_votes(&state, &weights, &config), "Option B");
+    }
+
+    /// THE property to lock in: on a tied group weight, `resolve_votes` must
+    /// return the representative of the *last* group in (alphabetical,
+    /// `BTreeMap`-ordered) iteration order — reproducing `Iterator::max_by`'s
+    /// documented "last element wins on a tie" behavior, not the first.
+    #[test]
+    fn resolve_votes_tie_break_returns_last_max_group_not_first() {
+        // Two groups, "alpha" and "beta" (lowercased grouping keys), each
+        // with 2 votes at default weight 1.0 → tied group weight (2.0 each).
+        // `groups.values()` iterates in BTreeMap key order: "alpha" before
+        // "beta". A tie must resolve to "beta" (the last group), never
+        // "alpha" (the first).
+        let state = fold(&[
+            run_started(&["agent-a", "agent-b", "agent-c", "agent-d"]),
+            vote("agent-a", "Alpha", 0.9),
+            vote("agent-b", "Alpha", 0.9),
+            vote("agent-c", "Beta", 0.9),
+            vote("agent-d", "Beta", 0.9),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(resolve_votes(&state, &BTreeMap::new(), &config), "Beta");
+    }
+
+    #[test]
+    fn resolve_votes_representative_is_first_vote_inserted_in_group() {
+        // Within the winning group, the representative text is the
+        // *original-case* position of the first vote inserted (agent-name
+        // order), not any later vote's differently-cased but
+        // similarity-matching position text.
+        let state = fold(&[
+            run_started(&["agent-a", "agent-b"]),
+            vote("agent-a", "Use Rust for the backend", 0.9),
+            vote("agent-b", "use rust for the backend", 0.8),
+        ]);
+        let config = RingConfig::default();
+        assert_eq!(
+            resolve_votes(&state, &BTreeMap::new(), &config),
+            "Use Rust for the backend"
+        );
+    }
+}

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -929,7 +929,7 @@ impl EffectRunner for RingEffectRunner {
 /// .vote_weights.insert(agent.name().to_string(), agent.vote_weight())`,
 /// where `LlmRingAgent::vote_weight` reads the identical
 /// `ring_config.vote_weight` field).
-fn vote_weights_from_agents(agents: &BTreeMap<String, Agent>) -> BTreeMap<String, f32> {
+pub(crate) fn vote_weights_from_agents(agents: &BTreeMap<String, Agent>) -> BTreeMap<String, f32> {
     agents
         .iter()
         .map(|(name, agent)| {

--- a/src/core/orchestration/es/state.rs
+++ b/src/core/orchestration/es/state.rs
@@ -5,7 +5,7 @@
 //! randomness. Given the same state and event it always produces the same
 //! next state, which is what makes the event log replayable.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::event::ExecutionEvent;
 use crate::providers::traits::ChatMessage;
@@ -101,6 +101,17 @@ pub struct ExecutionState {
     /// blackboard/ring patterns route models the same way. `BTreeMap` for
     /// deterministic iteration/ordering.
     pub routed_tiers: BTreeMap<String, String>,
+    /// Team leads whose nested C9 sub-run boundary is currently *open*: a
+    /// `NestedStarted { team_lead }` has been recorded with no matching
+    /// `NestedEnded { team_lead }` yet. Populated purely by `apply`
+    /// (`NestedStarted` inserts, `NestedEnded` removes), so the pure
+    /// `HierarchicalDecider` can detect — without scanning the whole log —
+    /// which nested boundaries still need a deferred `NestedEnded` emitted to
+    /// close them (see `HierarchicalDecider::pending_nested_ended`). `BTreeSet`
+    /// for deterministic iteration order. In any terminal (completed) run this
+    /// set is empty — every boundary opened during the run is closed before it
+    /// ends — so it never perturbs replay-vs-run `Debug` equality.
+    pub open_nested: BTreeSet<String>,
 }
 
 /// Apply a single event to `state` in place.
@@ -197,8 +208,16 @@ pub fn apply(state: &mut ExecutionState, event: &ExecutionEvent) {
                 .push((from.clone(), to.clone(), message.clone(), 0));
         }
         ExecutionEvent::Synthesized { .. } => {}
-        ExecutionEvent::NestedStarted { .. } => {}
-        ExecutionEvent::NestedEnded { .. } => {}
+        ExecutionEvent::NestedStarted { team_lead, .. } => {
+            // Open a nested C9 boundary for `team_lead`. The matching
+            // `NestedEnded` (emitted in deferred fashion by
+            // `HierarchicalDecider::decide`, once the lead's sub-run outcome
+            // has been observed) removes it below.
+            state.open_nested.insert(team_lead.clone());
+        }
+        ExecutionEvent::NestedEnded { team_lead } => {
+            state.open_nested.remove(team_lead);
+        }
         ExecutionEvent::RoundStarted { round } => {
             state.board.round = *round;
         }

--- a/src/core/orchestration/es/state.rs
+++ b/src/core/orchestration/es/state.rs
@@ -25,12 +25,6 @@ pub enum RunStatus {
 #[derive(Debug, Clone, Default)]
 pub struct HierState {
     pub trace: Vec<(String, String, String, u32)>,
-    /// Tier resolved for each `latest:auto` agent (agent name -> tier, e.g.
-    /// `"Fast"`/`"Pro"`/`"Max"`), populated by `ModelRouted` events. Read by
-    /// the `HierarchicalEffectRunner` to resolve a concrete model string
-    /// before invoking the provider — see `es::hierarchical::run_invoke`.
-    /// `BTreeMap` for deterministic iteration/ordering.
-    pub routed_tiers: BTreeMap<String, String>,
 }
 
 /// A single blackboard entry, as recorded in the ES projection.
@@ -99,6 +93,14 @@ pub struct ExecutionState {
     pub hier: HierState,
     pub board: BoardState,
     pub ring: RingState,
+    /// Tier resolved for each `latest:auto` agent (agent name -> tier, e.g.
+    /// `"Fast"`/`"Pro"`/`"Max"`), populated by `ModelRouted` events. Read by
+    /// the pattern effect runners (e.g. `HierarchicalEffectRunner`) to
+    /// resolve a concrete model string before invoking the provider — see
+    /// `es::hierarchical::run_invoke`. Run-level (not pattern-specific):
+    /// blackboard/ring patterns route models the same way. `BTreeMap` for
+    /// deterministic iteration/ordering.
+    pub routed_tiers: BTreeMap<String, String>,
 }
 
 /// Apply a single event to `state` in place.
@@ -153,7 +155,7 @@ pub fn apply(state: &mut ExecutionState, event: &ExecutionEvent) {
             state.budget_cost += *cost;
         }
         ExecutionEvent::ModelRouted { agent, tier, .. } => {
-            state.hier.routed_tiers.insert(agent.clone(), tier.clone());
+            state.routed_tiers.insert(agent.clone(), tier.clone());
         }
         ExecutionEvent::Warned { .. } => {}
         ExecutionEvent::Halted { .. } => {
@@ -383,7 +385,7 @@ mod tests {
     }
 
     #[test]
-    fn model_routed_projects_tier_into_hier_state() {
+    fn model_routed_projects_tier_into_run_state() {
         let events = vec![
             E::RunStarted {
                 run_id: "r".into(),
@@ -399,10 +401,7 @@ mod tests {
             },
         ];
         let st = fold(&events);
-        assert_eq!(
-            st.hier.routed_tiers.get("a").map(String::as_str),
-            Some("fast")
-        );
+        assert_eq!(st.routed_tiers.get("a").map(String::as_str), Some("fast"));
     }
 
     #[test]

--- a/src/core/orchestration/llm_agents.rs
+++ b/src/core/orchestration/llm_agents.rs
@@ -99,7 +99,11 @@ fn agent_model(
 
 /// Prompt suffix appended to board agent messages so the LLM returns a
 /// structured action header we can parse.
-const BOARD_ACTION_INSTRUCTIONS: &str = "\n\n\
+///
+/// `pub(crate)` (rather than private) so `es::blackboard::BlackboardEffectRunner`
+/// (OH1 Lot 3, Task 4) can reuse the exact same instructions when assembling
+/// its own board prompt, instead of duplicating this string.
+pub(crate) const BOARD_ACTION_INSTRUCTIONS: &str = "\n\n\
 Respond with the following structured header, then your content:\n\
 ACTION: <type> (one of: FINDING, CHALLENGE, CONFIRMATION, SYNTHESIS, QUESTION, ANSWER)\n\
 TARGET: <index> (required for CHALLENGE, CONFIRMATION, ANSWER; comma-separated for SYNTHESIS)\n\

--- a/src/core/orchestration/llm_agents.rs
+++ b/src/core/orchestration/llm_agents.rs
@@ -171,7 +171,7 @@ pub(crate) fn parse_board_action(response: &str) -> (EntryKind, f32, String) {
 }
 
 /// Prompt suffix for ring agent process messages.
-const RING_ACTION_INSTRUCTIONS: &str = "\n\n\
+pub(crate) const RING_ACTION_INSTRUCTIONS: &str = "\n\n\
 Respond with the following structured header, then your content:\n\
 ACTION: <type> (one of: PROPOSE, ENRICH, CONTEST, ENDORSE, SYNTHESIZE, PASS)\n\
 TARGET: <index> (required for ENRICH, CONTEST, ENDORSE)\n\
@@ -234,7 +234,7 @@ pub(crate) fn parse_ring_action(response: &str) -> (ContributionAction, String) 
 /// Parse a confidence value from the first line of a vote response.
 ///
 /// Falls back to 0.8 if the header is absent or malformed.
-fn parse_vote_confidence(response: &str) -> (f32, String) {
+pub(crate) fn parse_vote_confidence(response: &str) -> (f32, String) {
     if let Some(first_line) = response.lines().next() {
         let trimmed = first_line.trim();
         if let Some(rest) = trimmed.strip_prefix("CONFIDENCE:")


### PR DESCRIPTION
## Contexte

Lot 3 du programme **OH1 — orchestration event-sourcée**. Réécrit les patterns `blackboard` et `ring` en **event-sourcing pur** (nouveaux `es/blackboard.rs`, `es/ring.rs`) et câble le **sous-run nested C9** (hierarchical → blackboard/ring ES), **en coexistence stricte** avec les moteurs legacy (non modifiés — la bascule du chemin `run` est le Lot 4). Spec §5.

## Contenu

- **`es/state.rs`** : `routed_tiers` promu au niveau `ExecutionState` (state run-level) ; projection déterministe `open_nested: BTreeSet` (frontières nested ouvertes).
- **blackboard** : helpers purs (éligibilité, `check_convergence`/`consecutive_convergence` répliqués du legacy, mapping kind↔refs), `BlackboardDecider` (rounds/convergence/halt), `BlackboardEffectRunner` (**snapshot début-de-round** fidèle au legacy + dégradation gracieuse), `run_blackboard_es` + replay.
- **ring** : helpers purs (`ring_phase`, `resolve_votes` avec **tie-break** `max_by`=dernier max en ordre BTreeMap, rotation), `RingDecider` (3 phases circulation→vote→résolution), `RingEffectRunner` (phase-aware, contrat `action=="pass"`), `run_ring_es` + replay.
- **nested C9** : `HierarchicalEffectRunner` court-circuite un lead à `pattern` → sous-run ES sur log enfant, remonte l'outcome + métriques agrégées en `AgentObserved{model:"nested"}`, budget hérité (saturant), `NestedEnded` émis en différé (pur). Replay parent déterministe (sous-run jamais rejoué, verrouillé par test).
- **`llm_agents.rs`** : uniquement des bascules de visibilité `pub(crate)` (parsers/instructions réutilisés) — aucune logique changée.

## Qualité

- **947 tests** (896 legacy + 51 ES), **0 régression** ; 3 preuves de replay réelles (égalité Debug + baseline appels>0 + non-réexécution). Legacy + `run.rs` intacts (coexistence vérifiée).
- `decide`/`apply` purs/déterministes ; itération BTreeMap/BTreeSet/Vec. Clippy `-D warnings` (`tui`, `tui,providers-api`) + fmt.
- 10 tasks subagent-driven (dont 3 revues Opus) + revue finale de branche indépendante : **READY TO MERGE**, aucun blocker.

## Divergences connues (assumées, à réconcilier au Lot 4)

Exécution séquentielle déterministe (pas de `tokio::spawn`) ; snapshot blackboard sans plafond 10 entries (legacy tronque) ; nesting mono-niveau ; trace fine du sous-run non persistée (log enfant jeté) ; arbitrage du lead = tour de synthèse normal du parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)