### PR TITLE
test(e2e): deterministic orchestration harness (fake-claude + case files + weighted report)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,21 @@ jobs:
       - run: cargo test --no-default-features --features tui
       # storage (SQLite) is not covered by the default `tui` feature set —
       # run its tests explicitly so src/storage/ and the storage-gated
-      # code paths (e.g. SqliteLog) are actually exercised in CI.
+      # code paths (e.g. SqliteLog) are actually exercised in CI. This is
+      # also the mode the `e2e` integration test target runs in (see
+      # tests/e2e/harness.rs `e2e_suite`), so its report ends up under
+      # target/e2e-report/ for the next step to upload.
       - run: cargo test --no-default-features --features tui,storage
+      - name: Upload e2e report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: |
+            target/e2e-report/e2e-report.html
+            target/e2e-report/e2e-report.json
+          if-no-files-found: warn
+          retention-days: 14
 
   build:
     name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ name = "armadai"
 version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "axum",
  "chrono",
@@ -110,6 +111,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -123,6 +125,21 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "uuid",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -249,6 +266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -590,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +658,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1750,6 +1790,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2073,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2298,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2381,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2556,6 +2679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2764,12 @@ checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "termwiz"
@@ -3089,6 +3229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/Dr0drigues/swarm-festai"
 name = "armadai"
 path = "src/main.rs"
 
+[[bin]]
+name = "fake-claude"
+path = "src/bin/fake-claude.rs"
+
 [features]
 default = ["tui", "web", "storage", "providers-api"]
 tui = ["dep:ratatui", "dep:crossterm", "dep:portable-pty", "dep:strip-ansi-escapes", "dep:unicode-width"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,6 @@ strip-ansi-escapes = { version = "0.2", optional = true }
 regex = "1"
 
 [dev-dependencies]
+assert_cmd = "2.2.2"
+schemars = "1.2.1"
 tempfile = "3"

--- a/docs/e2e-case.schema.json
+++ b/docs/e2e-case.schema.json
@@ -141,6 +141,32 @@
         }
       }
     },
+    "NestedTeamSetup": {
+      "description": "Describes a C9 nested team for a `hierarchical` [`Setup`]: `lead` runs the\nsub-`pattern` (`blackboard`/`ring`) over `agents` instead of delegating to\nthem individually. `lead` and every name in `agents` must also appear in\nthe parent [`Setup::agents`] list (that's what makes `harness::write_project`\ngenerate an `agents/<name>.md` file and a `fake-claude` provider for them).",
+      "type": "object",
+      "properties": {
+        "agents": {
+          "description": "Team members that actually run the sub-pattern (excludes `lead`).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lead": {
+          "description": "Agent id that arbitrates the sub-run (the team's `lead`).",
+          "type": "string"
+        },
+        "pattern": {
+          "description": "Sub-pattern the team runs: `blackboard` or `ring`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "lead",
+        "pattern",
+        "agents"
+      ]
+    },
     "Rule": {
       "description": "A single rule: a `match` predicate plus the scripted response/metrics.\n\nMirrors `Rule` in `src/bin/fake-claude.rs` — see the module-level doc comment on\nwhy this is a duplicate rather than a shared type, and keep the two in sync.",
       "type": "object",
@@ -235,6 +261,17 @@
           "description": "Input piped/passed to the run.",
           "type": "string",
           "default": ""
+        },
+        "nested_team": {
+          "description": "C9 override for `hierarchical` cases: when set, `harness::project_yaml`\nemits a single `orchestration.teams` entry with this `lead`/`pattern`/\n`agents` (a nested blackboard/ring sub-team) instead of the default flat\nteam made of every non-coordinator agent. `serde(default)` keeps every\nexisting (non-nested) case file parsing exactly as before.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NestedTeamSetup"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "pattern": {
           "description": "Orchestration pattern under test (e.g. `direct`, `hierarchical`, `blackboard`).",

--- a/docs/e2e-case.schema.json
+++ b/docs/e2e-case.schema.json
@@ -98,7 +98,7 @@
       ]
     },
     "FakeSpec": {
-      "description": "The scripted `fake-claude` scenario for this case.",
+      "description": "The scripted `fake-claude` scenario for this case.\n\n`Serialize` is needed so the harness can round-trip this block back to YAML for\n`fake-claude` to read (see the module doc) — that round-trip is itself the proof\nthat this shape stays compatible with `src/bin/fake-claude.rs::Scenario`.",
       "type": "object",
       "properties": {
         "rules": {
@@ -171,7 +171,12 @@
           "minimum": 0
         },
         "match": {
-          "$ref": "#/$defs/Match"
+          "$ref": "#/$defs/Match",
+          "default": {
+            "agent": null,
+            "call": null,
+            "prompt_contains": null
+          }
         },
         "model": {
           "type": [

--- a/docs/e2e-case.schema.json
+++ b/docs/e2e-case.schema.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CaseFile",
+  "description": "One end-to-end test case: setup + scripted fake responses + expectations.",
+  "type": "object",
+  "properties": {
+    "allow_fail": {
+      "description": "A known/tolerated failing case does not fail the overall suite.",
+      "type": "boolean",
+      "default": false
+    },
+    "expect": {
+      "$ref": "#/$defs/Expect"
+    },
+    "fake": {
+      "$ref": "#/$defs/FakeSpec"
+    },
+    "name": {
+      "description": "Human-readable case name (also used as the identifier in reports).",
+      "type": "string"
+    },
+    "setup": {
+      "$ref": "#/$defs/Setup"
+    },
+    "weight": {
+      "description": "Weight used by the report aggregator to prioritize failures.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "name",
+    "weight",
+    "setup",
+    "fake",
+    "expect"
+  ],
+  "$defs": {
+    "Expect": {
+      "description": "The expected outcome of a run.",
+      "type": "object",
+      "properties": {
+        "event_counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "default": {}
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedEvent"
+          }
+        },
+        "exit_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "invariants": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "storage": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "default": null
+        }
+      },
+      "required": [
+        "exit_code"
+      ]
+    },
+    "ExpectedEvent": {
+      "description": "A partial match against one emitted event: `t` is the event type, and any other\nfield present is matched against the corresponding field on the actual event\n(fields absent here are not checked).",
+      "type": "object",
+      "properties": {
+        "t": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "t"
+      ]
+    },
+    "FakeSpec": {
+      "description": "The scripted `fake-claude` scenario for this case.",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Rule"
+          }
+        }
+      },
+      "required": [
+        "rules"
+      ]
+    },
+    "Match": {
+      "description": "Match predicate for a [`Rule`]. All fields are optional; an empty `Match` (all\n`None`) is a catch-all that matches any agent/call/prompt.\n\nMirrors `Match` in `src/bin/fake-claude.rs` — keep in sync (see module doc).",
+      "type": "object",
+      "properties": {
+        "agent": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "call": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        },
+        "prompt_contains": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
+    "Rule": {
+      "description": "A single rule: a `match` predicate plus the scripted response/metrics.\n\nMirrors `Rule` in `src/bin/fake-claude.rs` — see the module-level doc comment on\nwhy this is a duplicate rather than a shared type, and keep the two in sync.",
+      "type": "object",
+      "properties": {
+        "cost": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double",
+          "default": null
+        },
+        "exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32",
+          "default": null
+        },
+        "latency_ms": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "default": null,
+          "minimum": 0
+        },
+        "match": {
+          "$ref": "#/$defs/Match"
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "respond": {
+          "type": "string"
+        },
+        "tokens_in": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        },
+        "tokens_out": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
+        }
+      },
+      "required": [
+        "respond"
+      ]
+    },
+    "Setup": {
+      "description": "How to invoke the real `armadai` binary for this case.",
+      "type": "object",
+      "properties": {
+        "agents": {
+          "description": "Agent ids involved in the run, in invocation order.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "flags": {
+          "description": "Extra CLI flags passed to `armadai run` (e.g. `--json`).",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "input": {
+          "description": "Input piped/passed to the run.",
+          "type": "string",
+          "default": ""
+        },
+        "pattern": {
+          "description": "Orchestration pattern under test (e.g. `direct`, `hierarchical`, `blackboard`).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pattern"
+      ]
+    }
+  }
+}

--- a/src/bin/fake-claude.rs
+++ b/src/bin/fake-claude.rs
@@ -1,0 +1,360 @@
+//! `fake-claude` — deterministic stand-in for the `claude` CLI, used by the e2e harness.
+//!
+//! It is a rule engine driven by a YAML scenario (`FAKE_SCENARIO`): given the agent id
+//! (extracted from the composed prompt via the `FAKE_AGENT_ID:` marker) and a per-agent
+//! call counter (persisted under `FAKE_STATE_DIR/<agent>.count`), it picks the first
+//! matching rule and emits Claude Code's `stream-json` output format on stdout so that
+//! `src/shell/json_runner.rs` parses it exactly like a real `claude -p --output-format
+//! stream-json` invocation.
+//!
+//! The e2e runner shadows `claude` on `PATH` with this binary (see the e2e harness plan),
+//! so `armadai`'s `CliProvider` (command = `claude`) shells out to us transparently.
+
+use serde::Deserialize;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+/// Top-level scenario loaded from `FAKE_SCENARIO` (YAML).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Scenario {
+    pub rules: Vec<Rule>,
+}
+
+/// A single rule: a `match` predicate plus the scripted response/metrics.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Rule {
+    #[serde(rename = "match", default)]
+    pub match_: Match,
+    pub respond: String,
+    #[serde(default)]
+    pub tokens_in: Option<u32>,
+    #[serde(default)]
+    pub tokens_out: Option<u32>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub latency_ms: Option<u64>,
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+}
+
+/// Match predicate for a [`Rule`]. All fields are optional; an empty `Match` (all `None`)
+/// is a catch-all that matches any agent/call/prompt.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Match {
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub call: Option<u32>,
+    #[serde(default)]
+    pub prompt_contains: Option<String>,
+}
+
+/// The marker inserted into an agent's system prompt so the fake can identify which
+/// agent is calling it (see `<system>…FAKE_AGENT_ID: <agent>…</system>` in the composed
+/// prompt built by the CLI provider).
+const AGENT_ID_MARKER: &str = "FAKE_AGENT_ID:";
+
+/// Extract the agent id from the composed prompt via the `FAKE_AGENT_ID:` marker.
+///
+/// The marker is expected on its own line as `FAKE_AGENT_ID: <agent>`; the agent id is
+/// the first whitespace-delimited token following the marker. Returns `None` if the
+/// marker is absent.
+pub fn agent_id_from_prompt(prompt: &str) -> Option<String> {
+    for line in prompt.lines() {
+        if let Some(rest) = line.trim_start().strip_prefix(AGENT_ID_MARKER) {
+            let id = rest.split_whitespace().next()?;
+            return Some(id.to_string());
+        }
+    }
+    None
+}
+
+/// Select the first rule in `scenario` whose `match` predicate is satisfied by
+/// `(agent, call, prompt)`. `call` is the 1-indexed call count for `agent` (i.e. this is
+/// the Nth time this agent has been invoked). An empty `Match` matches everything, so a
+/// trailing catch-all rule (last in the list) always wins if nothing more specific does.
+///
+/// # Panics
+/// Panics if no rule matches — the scenario author must always provide a catch-all rule
+/// (a `Rule` whose `match` is `Match::default()`), which is the documented contract.
+pub fn select_response<'s>(
+    scenario: &'s Scenario,
+    agent: &str,
+    call: u32,
+    prompt: &str,
+) -> &'s Rule {
+    scenario
+        .rules
+        .iter()
+        .find(|rule| rule_matches(&rule.match_, agent, call, prompt))
+        .unwrap_or_else(|| panic!("fake-claude: no rule matched agent={agent} call={call} — scenario needs a catch-all rule"))
+}
+
+fn rule_matches(m: &Match, agent: &str, call: u32, prompt: &str) -> bool {
+    if let Some(want_agent) = &m.agent
+        && want_agent != agent
+    {
+        return false;
+    }
+    if let Some(want_call) = m.call
+        && want_call != call
+    {
+        return false;
+    }
+    if let Some(needle) = &m.prompt_contains
+        && !prompt.contains(needle.as_str())
+    {
+        return false;
+    }
+    true
+}
+
+/// Emit the two `stream-json` lines (assistant message + result) for `rule`, joined by a
+/// newline. `agent` is currently unused by the payload itself (Claude Code's stream-json
+/// carries no agent id) but is accepted for symmetry with the rest of the engine and to
+/// leave room for future per-agent metadata.
+pub fn emit_claude_jsonl(rule: &Rule, _agent: &str) -> String {
+    let assistant = serde_json::json!({
+        "type": "assistant",
+        "message": {
+            "content": [
+                { "type": "text", "text": rule.respond }
+            ]
+        }
+    });
+
+    let model = rule
+        .model
+        .clone()
+        .unwrap_or_else(|| "fake-model".to_string());
+    let tokens_in = rule.tokens_in.unwrap_or(0);
+    let tokens_out = rule.tokens_out.unwrap_or(0);
+    let cost = rule.cost.unwrap_or(0.0);
+
+    let result = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "result": rule.respond,
+        "total_cost_usd": cost,
+        "usage": {
+            "input_tokens": tokens_in,
+            "output_tokens": tokens_out
+        },
+        "modelUsage": {
+            model: { "outputTokens": tokens_out }
+        }
+    });
+
+    format!("{assistant}\n{result}")
+}
+
+/// Read the current per-agent call count from `FAKE_STATE_DIR/<agent>.count`, increment
+/// it, persist the new value, and return the incremented (1-indexed) count.
+fn next_call_count(state_dir: &Path, agent: &str) -> u32 {
+    let path = state_dir.join(format!("{agent}.count"));
+    let current: u32 = fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+    let next = current + 1;
+    // Best-effort: an e2e harness controls this directory and creates it upfront, but we
+    // don't want a missing dir to crash the fake mid-suite.
+    let _ = fs::create_dir_all(state_dir);
+    let _ = fs::write(&path, next.to_string());
+    next
+}
+
+fn main() {
+    // The composed prompt is passed as the last CLI argument by the CLI provider
+    // (`-p`/`--print`-style invocation): `claude -p --output-format stream-json --verbose <prompt>`.
+    let prompt = env::args().next_back().unwrap_or_default();
+
+    let scenario_path = env::var("FAKE_SCENARIO")
+        .unwrap_or_else(|_| panic!("fake-claude: FAKE_SCENARIO env var is required"));
+    let scenario_raw = fs::read_to_string(&scenario_path)
+        .unwrap_or_else(|e| panic!("fake-claude: cannot read FAKE_SCENARIO {scenario_path}: {e}"));
+    let scenario: Scenario = serde_yaml_ng::from_str(&scenario_raw)
+        .unwrap_or_else(|e| panic!("fake-claude: invalid FAKE_SCENARIO YAML {scenario_path}: {e}"));
+
+    let agent = agent_id_from_prompt(&prompt).unwrap_or_else(|| "unknown".to_string());
+
+    let state_dir = env::var("FAKE_STATE_DIR")
+        .unwrap_or_else(|_| panic!("fake-claude: FAKE_STATE_DIR env var is required"));
+    let call = next_call_count(Path::new(&state_dir), &agent);
+
+    let rule = select_response(&scenario, &agent, call, &prompt);
+
+    if let Some(ms) = rule.latency_ms {
+        std::thread::sleep(std::time::Duration::from_millis(ms));
+    }
+
+    println!("{}", emit_claude_jsonl(rule, &agent));
+
+    std::process::exit(rule.exit_code.unwrap_or(0));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scen() -> Scenario {
+        Scenario {
+            rules: vec![
+                Rule {
+                    match_: Match {
+                        agent: Some("t-coord".into()),
+                        call: Some(1),
+                        prompt_contains: None,
+                    },
+                    respond: "@t-a: go".into(),
+                    tokens_in: Some(10),
+                    tokens_out: Some(3),
+                    cost: Some(0.001),
+                    model: Some("m".into()),
+                    latency_ms: None,
+                    exit_code: None,
+                },
+                Rule {
+                    match_: Match::default(),
+                    respond: "ok".into(),
+                    tokens_in: None,
+                    tokens_out: None,
+                    cost: None,
+                    model: None,
+                    latency_ms: None,
+                    exit_code: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn selects_by_agent_and_call() {
+        let s = scen();
+        let r = select_response(&s, "t-coord", 1, "prompt");
+        assert_eq!(r.respond, "@t-a: go");
+        // fallback catch-all for another agent
+        assert_eq!(select_response(&s, "t-x", 1, "p").respond, "ok");
+    }
+
+    #[test]
+    fn emits_parseable_claude_jsonl() {
+        let r = &scen().rules[0];
+        let out = emit_claude_jsonl(r, "t-coord");
+        // two lines: assistant (content) + result (metrics)
+        assert!(out.contains(r#""type":"assistant""#));
+        assert!(out.contains(r#""type":"result""#));
+        assert!(out.contains(r#""text":"@t-a: go""#));
+        assert!(out.contains(r#""input_tokens":10"#));
+        assert!(out.contains(r#""total_cost_usd":0.001"#));
+    }
+
+    #[test]
+    fn extracts_agent_id_from_prompt() {
+        let p = "<system>\nyou are X\nFAKE_AGENT_ID: t-coord\n</system>\n\ntask";
+        assert_eq!(agent_id_from_prompt(p), Some("t-coord".to_string()));
+        assert_eq!(agent_id_from_prompt("no marker"), None);
+    }
+
+    #[test]
+    fn selects_by_prompt_contains() {
+        let s = Scenario {
+            rules: vec![
+                Rule {
+                    match_: Match {
+                        agent: None,
+                        call: None,
+                        prompt_contains: Some("special".into()),
+                    },
+                    respond: "special-path".into(),
+                    tokens_in: None,
+                    tokens_out: None,
+                    cost: None,
+                    model: None,
+                    latency_ms: None,
+                    exit_code: None,
+                },
+                Rule {
+                    match_: Match::default(),
+                    respond: "default-path".into(),
+                    tokens_in: None,
+                    tokens_out: None,
+                    cost: None,
+                    model: None,
+                    latency_ms: None,
+                    exit_code: None,
+                },
+            ],
+        };
+        assert_eq!(
+            select_response(&s, "any", 1, "this has a special word").respond,
+            "special-path"
+        );
+        assert_eq!(
+            select_response(&s, "any", 1, "plain prompt").respond,
+            "default-path"
+        );
+    }
+
+    #[test]
+    fn emits_defaults_when_metrics_absent() {
+        let r = Rule {
+            match_: Match::default(),
+            respond: "ok".into(),
+            tokens_in: None,
+            tokens_out: None,
+            cost: None,
+            model: None,
+            latency_ms: None,
+            exit_code: None,
+        };
+        let out = emit_claude_jsonl(&r, "any");
+        assert!(out.contains(r#""total_cost_usd":0.0"#));
+        assert!(out.contains(r#""input_tokens":0"#));
+        assert!(out.contains(r#""output_tokens":0"#));
+        assert!(out.contains(r#""fake-model""#));
+    }
+
+    #[test]
+    fn extracts_agent_id_ignores_leading_whitespace() {
+        let p = "  FAKE_AGENT_ID: t-writer\nrest of prompt";
+        assert_eq!(agent_id_from_prompt(p), Some("t-writer".to_string()));
+    }
+
+    #[test]
+    #[should_panic(expected = "no rule matched")]
+    fn select_response_panics_without_catch_all() {
+        let s = Scenario {
+            rules: vec![Rule {
+                match_: Match {
+                    agent: Some("only-this".into()),
+                    call: None,
+                    prompt_contains: None,
+                },
+                respond: "x".into(),
+                tokens_in: None,
+                tokens_out: None,
+                cost: None,
+                model: None,
+                latency_ms: None,
+                exit_code: None,
+            }],
+        };
+        select_response(&s, "someone-else", 1, "p");
+    }
+
+    #[test]
+    fn next_call_count_increments_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(next_call_count(dir.path(), "t-a"), 1);
+        assert_eq!(next_call_count(dir.path(), "t-a"), 2);
+        assert_eq!(next_call_count(dir.path(), "t-a"), 3);
+        // Independent counters per agent.
+        assert_eq!(next_call_count(dir.path(), "t-b"), 1);
+    }
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,7 @@
+//! Entry point for the `e2e` integration test binary.
+//!
+//! Declares the `e2e` module tree rooted at `tests/e2e/mod.rs`, so that individual
+//! sub-modules (e.g. `e2e::case`) live under `tests/e2e/` while still being reachable
+//! as a single test target discovered by Cargo (`tests/*.rs`).
+#[path = "e2e/mod.rs"]
+mod e2e;

--- a/tests/e2e/case.rs
+++ b/tests/e2e/case.rs
@@ -10,25 +10,22 @@
 //! # Sync with `src/bin/fake-claude.rs`
 //!
 //! `armadai` is a binary-only crate (no `lib.rs`), so `src/bin/fake-claude.rs` cannot
-//! be imported from the integration test crate. The runner (a later task) serializes
-//! the `fake` block of a case file back to YAML for `fake-claude` to deserialize, so
-//! [`Rule`] and [`Match`] below **must keep the exact same serde shape** (field names,
+//! be imported from the integration test crate. `tests/e2e/harness.rs` serializes
+//! the `fake` block of a case file back to YAML (`serde_yaml_ng::to_string`) for
+//! `fake-claude` to deserialize, so [`Rule`] and [`Match`] below **must keep the exact
+//! same serde shape** (field names,
 //! `match` → `match_` rename, optionality) as their counterparts in
 //! `src/bin/fake-claude.rs`. They are duplicated here — not shared — because the bin
 //! target isn't a library crate. **If you change one, change the other.** A shape
 //! mismatch would only surface at runtime (a case file's `fake` block failing to
 //! deserialize inside `fake-claude`), so review both files together on any edit.
 //!
-//! Several fields below are only populated via `Deserialize` for now and read only
-//! from the upcoming e2e runner (a later task); until that lands, `dead_code` would
-//! otherwise fire on this module in isolation.
-#![allow(dead_code)]
 use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::Context;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// One end-to-end test case: setup + scripted fake responses + expectations.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -62,7 +59,11 @@ pub struct Setup {
 }
 
 /// The scripted `fake-claude` scenario for this case.
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+///
+/// `Serialize` is needed so the harness can round-trip this block back to YAML for
+/// `fake-claude` to read (see the module doc) — that round-trip is itself the proof
+/// that this shape stays compatible with `src/bin/fake-claude.rs::Scenario`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FakeSpec {
     pub rules: Vec<Rule>,
 }
@@ -71,7 +72,7 @@ pub struct FakeSpec {
 ///
 /// Mirrors `Rule` in `src/bin/fake-claude.rs` — see the module-level doc comment on
 /// why this is a duplicate rather than a shared type, and keep the two in sync.
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Rule {
     #[serde(rename = "match", default)]
     pub match_: Match,
@@ -94,7 +95,7 @@ pub struct Rule {
 /// `None`) is a catch-all that matches any agent/call/prompt.
 ///
 /// Mirrors `Match` in `src/bin/fake-claude.rs` — keep in sync (see module doc).
-#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct Match {
     #[serde(default)]
     pub agent: Option<String>,
@@ -132,8 +133,13 @@ pub struct ExpectedEvent {
 pub fn load_case(path: &Path) -> anyhow::Result<CaseFile> {
     let contents = std::fs::read_to_string(path)
         .with_context(|| format!("reading case file {}", path.display()))?;
-    serde_yaml_ng::from_str(&contents)
-        .with_context(|| format!("parsing case file {}", path.display()))
+    load_case_str(&contents).with_context(|| format!("parsing case file {}", path.display()))
+}
+
+/// Parse a case file directly from a YAML string (inline fixtures in tests, or any
+/// other in-memory source — `load_case` is just this plus a file read).
+pub fn load_case_str(yaml: &str) -> anyhow::Result<CaseFile> {
+    serde_yaml_ng::from_str(yaml).context("parsing case YAML")
 }
 
 /// Render the JSON Schema for [`CaseFile`] as a pretty-printed string.

--- a/tests/e2e/case.rs
+++ b/tests/e2e/case.rs
@@ -56,6 +56,28 @@ pub struct Setup {
     /// Input piped/passed to the run.
     #[serde(default)]
     pub input: String,
+    /// C9 override for `hierarchical` cases: when set, `harness::project_yaml`
+    /// emits a single `orchestration.teams` entry with this `lead`/`pattern`/
+    /// `agents` (a nested blackboard/ring sub-team) instead of the default flat
+    /// team made of every non-coordinator agent. `serde(default)` keeps every
+    /// existing (non-nested) case file parsing exactly as before.
+    #[serde(default)]
+    pub nested_team: Option<NestedTeamSetup>,
+}
+
+/// Describes a C9 nested team for a `hierarchical` [`Setup`]: `lead` runs the
+/// sub-`pattern` (`blackboard`/`ring`) over `agents` instead of delegating to
+/// them individually. `lead` and every name in `agents` must also appear in
+/// the parent [`Setup::agents`] list (that's what makes `harness::write_project`
+/// generate an `agents/<name>.md` file and a `fake-claude` provider for them).
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct NestedTeamSetup {
+    /// Agent id that arbitrates the sub-run (the team's `lead`).
+    pub lead: String,
+    /// Sub-pattern the team runs: `blackboard` or `ring`.
+    pub pattern: String,
+    /// Team members that actually run the sub-pattern (excludes `lead`).
+    pub agents: Vec<String>,
 }
 
 /// The scripted `fake-claude` scenario for this case.

--- a/tests/e2e/case.rs
+++ b/tests/e2e/case.rs
@@ -1,0 +1,212 @@
+//! Declarative case file format for the e2e harness.
+//!
+//! A **case file** is one YAML document = one test: it describes how to invoke the
+//! real `armadai` binary (`setup`), how the `fake-claude` stub should respond
+//! (`fake`), and what the run is expected to produce (`expect`). Case files are meant
+//! to be safe to hand-write or to generate with an agent, which is why the format is
+//! backed by a [`schemars`] JSON Schema (see [`case_json_schema`] and
+//! `docs/e2e-case.schema.json`).
+//!
+//! # Sync with `src/bin/fake-claude.rs`
+//!
+//! `armadai` is a binary-only crate (no `lib.rs`), so `src/bin/fake-claude.rs` cannot
+//! be imported from the integration test crate. The runner (a later task) serializes
+//! the `fake` block of a case file back to YAML for `fake-claude` to deserialize, so
+//! [`Rule`] and [`Match`] below **must keep the exact same serde shape** (field names,
+//! `match` → `match_` rename, optionality) as their counterparts in
+//! `src/bin/fake-claude.rs`. They are duplicated here — not shared — because the bin
+//! target isn't a library crate. **If you change one, change the other.** A shape
+//! mismatch would only surface at runtime (a case file's `fake` block failing to
+//! deserialize inside `fake-claude`), so review both files together on any edit.
+//!
+//! Several fields below are only populated via `Deserialize` for now and read only
+//! from the upcoming e2e runner (a later task); until that lands, `dead_code` would
+//! otherwise fire on this module in isolation.
+#![allow(dead_code)]
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Context;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// One end-to-end test case: setup + scripted fake responses + expectations.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct CaseFile {
+    /// Human-readable case name (also used as the identifier in reports).
+    pub name: String,
+    /// Weight used by the report aggregator to prioritize failures.
+    pub weight: u32,
+    /// A known/tolerated failing case does not fail the overall suite.
+    #[serde(default)]
+    pub allow_fail: bool,
+    pub setup: Setup,
+    pub fake: FakeSpec,
+    pub expect: Expect,
+}
+
+/// How to invoke the real `armadai` binary for this case.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Setup {
+    /// Orchestration pattern under test (e.g. `direct`, `hierarchical`, `blackboard`).
+    pub pattern: String,
+    /// Agent ids involved in the run, in invocation order.
+    #[serde(default)]
+    pub agents: Vec<String>,
+    /// Extra CLI flags passed to `armadai run` (e.g. `--json`).
+    #[serde(default)]
+    pub flags: Vec<String>,
+    /// Input piped/passed to the run.
+    #[serde(default)]
+    pub input: String,
+}
+
+/// The scripted `fake-claude` scenario for this case.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct FakeSpec {
+    pub rules: Vec<Rule>,
+}
+
+/// A single rule: a `match` predicate plus the scripted response/metrics.
+///
+/// Mirrors `Rule` in `src/bin/fake-claude.rs` — see the module-level doc comment on
+/// why this is a duplicate rather than a shared type, and keep the two in sync.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Rule {
+    #[serde(rename = "match", default)]
+    pub match_: Match,
+    pub respond: String,
+    #[serde(default)]
+    pub tokens_in: Option<u32>,
+    #[serde(default)]
+    pub tokens_out: Option<u32>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub latency_ms: Option<u64>,
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+}
+
+/// Match predicate for a [`Rule`]. All fields are optional; an empty `Match` (all
+/// `None`) is a catch-all that matches any agent/call/prompt.
+///
+/// Mirrors `Match` in `src/bin/fake-claude.rs` — keep in sync (see module doc).
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct Match {
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub call: Option<u32>,
+    #[serde(default)]
+    pub prompt_contains: Option<String>,
+}
+
+/// The expected outcome of a run.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Expect {
+    pub exit_code: i32,
+    #[serde(default)]
+    pub events: Vec<ExpectedEvent>,
+    #[serde(default)]
+    pub event_counts: BTreeMap<String, usize>,
+    #[serde(default)]
+    pub invariants: Vec<String>,
+    #[serde(default)]
+    pub storage: Option<BTreeMap<String, usize>>,
+}
+
+/// A partial match against one emitted event: `t` is the event type, and any other
+/// field present is matched against the corresponding field on the actual event
+/// (fields absent here are not checked).
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct ExpectedEvent {
+    pub t: String,
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+/// Load and parse a case file from `path`.
+pub fn load_case(path: &Path) -> anyhow::Result<CaseFile> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("reading case file {}", path.display()))?;
+    serde_yaml_ng::from_str(&contents)
+        .with_context(|| format!("parsing case file {}", path.display()))
+}
+
+/// Render the JSON Schema for [`CaseFile`] as a pretty-printed string.
+pub fn case_json_schema() -> String {
+    let schema = schemars::schema_for!(CaseFile);
+    serde_json::to_string_pretty(&schema).expect("schema serializes to JSON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_a_valid_case_file() {
+        let yaml = r#"
+name: direct-happy
+weight: 5
+setup: { pattern: direct, agents: [t-writer], flags: ["--json"], input: "hi" }
+fake: { rules: [ { match: { agent: t-writer }, respond: "done" } ] }
+expect:
+  exit_code: 0
+  events: [ { t: run_start }, { t: agent_start, agent: t-writer }, { t: result } ]
+  event_counts: { agent_start: 1, agent_end: 1 }
+  invariants: [agent_start_end_symmetric, single_result]
+"#;
+        let c: CaseFile = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(c.name, "direct-happy");
+        assert_eq!(c.weight, 5);
+        assert_eq!(c.setup.agents, vec!["t-writer"]);
+        assert_eq!(c.expect.events.len(), 3);
+        assert!(c.expect.invariants.contains(&"single_result".to_string()));
+    }
+
+    #[test]
+    fn rejects_unknown_pattern_or_missing_field() {
+        // missing `name` → serde error
+        assert!(serde_yaml_ng::from_str::<CaseFile>("weight: 1").is_err());
+    }
+
+    #[test]
+    fn load_case_reads_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("case.yaml");
+        std::fs::write(
+            &path,
+            r#"
+name: from-disk
+weight: 1
+setup: { pattern: direct, agents: [], flags: [], input: "" }
+fake: { rules: [ { match: {}, respond: "ok" } ] }
+expect: { exit_code: 0 }
+"#,
+        )
+        .unwrap();
+        let c = load_case(&path).unwrap();
+        assert_eq!(c.name, "from-disk");
+    }
+
+    #[test]
+    fn load_case_reports_error_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.yaml");
+        assert!(load_case(&missing).is_err());
+    }
+
+    /// Generates `docs/e2e-case.schema.json` from the current `CaseFile` shape. This
+    /// intentionally writes into the repo (not a tempdir): the schema is a committed
+    /// doc artifact, regenerated by running this test whenever the format changes.
+    #[test]
+    fn emit_schema() {
+        let schema = case_json_schema();
+        assert!(schema.contains("\"CaseFile\""));
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/e2e-case.schema.json");
+        std::fs::write(path, schema).unwrap();
+    }
+}

--- a/tests/e2e/cases/blackboard.yaml
+++ b/tests/e2e/cases/blackboard.yaml
@@ -1,0 +1,38 @@
+name: blackboard
+weight: 8
+setup:
+  pattern: blackboard
+  agents: [t-a, t-b]
+  flags: ["--json"]
+  input: "assess the caching layer"
+fake:
+  rules:
+    # Round 1 (call 1): both agents post a FINDING — no board entries exist yet
+    # (the round-1 snapshot is empty), so FINDING is the only structurally valid
+    # action (CHALLENGE/CONFIRMATION/ANSWER need a `TARGET:` into existing
+    # entries — see `parse_board_action` in src/core/orchestration/llm_agents.rs).
+    - match: { agent: t-a, call: 1 }
+      respond: "ACTION: FINDING\nCONFIDENCE: 0.9\nCONTENT: caching layer looks sound"
+    - match: { agent: t-b, call: 1 }
+      respond: "ACTION: FINDING\nCONFIDENCE: 0.85\nCONTENT: cache TTLs look reasonable"
+    # Round 2 (call 2): both agents CONFIRM entry #0 (the first round-1 finding
+    # applied to the board). `check_convergence` (blackboard.rs) computes
+    # confirmations/total == 1.0 >= consensus_threshold (0.75 default), and
+    # `convergence_rounds` defaults to 1, so the board halts on Consensus right
+    # after this round — no round 3 needed.
+    - match: { agent: t-a, call: 2 }
+      respond: "ACTION: CONFIRMATION\nTARGET: 0\nCONFIDENCE: 0.95\nCONTENT: agreed, no issues found"
+    - match: { agent: t-b, call: 2 }
+      respond: "ACTION: CONFIRMATION\nTARGET: 0\nCONFIDENCE: 0.9\nCONTENT: agreed, confirming the finding"
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-a }
+    - { t: board, kind: finding }
+    - { t: board, kind: confirmation }
+    - { t: result }
+  event_counts: { agent_start: 2, agent_end: 2, board: 4, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]

--- a/tests/e2e/cases/direct.yaml
+++ b/tests/e2e/cases/direct.yaml
@@ -1,0 +1,21 @@
+name: direct
+weight: 5
+setup:
+  pattern: direct
+  agents: [t-writer]
+  flags: ["--json"]
+  input: "hi"
+fake:
+  rules:
+    - match: { agent: t-writer }
+      respond: "done"
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-writer }
+    - { t: result }
+  event_counts: { agent_start: 1, agent_end: 1, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]

--- a/tests/e2e/cases/hierarchical.yaml
+++ b/tests/e2e/cases/hierarchical.yaml
@@ -1,0 +1,36 @@
+name: hierarchical
+weight: 8
+setup:
+  pattern: hierarchical
+  agents: [t-coord, t-a, t-b]
+  flags: ["--json"]
+  input: "audit the auth module"
+fake:
+  rules:
+    # 1st coordinator call: decompose into parallel delegations. Both `@t-x:`
+    # lines are classified `Superior -> Subordinate` (Delegate) because t-coord
+    # is `orchestration.coordinator` (see `classify_relationship` in
+    # src/core/orchestration/mod.rs) — dispatched in parallel by
+    # `invoke_agent`/`hierarchical.rs`.
+    - match: { agent: t-coord, call: 1 }
+      respond: "@t-a: investigate the token flow\n@t-b: review the session store"
+    # 2nd coordinator call: the engine re-injects both subordinates' results and
+    # asks for synthesis. No `@agent:` line here => `parse_delegations` returns a
+    # single `FinalAnswer`, so this is the run's terminal content.
+    - match: { agent: t-coord, call: 2 }
+      respond: "Synthesis: token flow and session store both check out."
+    - match: { agent: t-a }
+      respond: "t-a: token flow looks sound"
+    - match: { agent: t-b }
+      respond: "t-b: session store looks sound"
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-coord }
+    - { t: delegate, from: t-coord }
+    - { t: result, content: "Synthesis: token flow and session store both check out." }
+  event_counts: { agent_start: 3, agent_end: 3, delegate: 2, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]

--- a/tests/e2e/cases/nested.yaml
+++ b/tests/e2e/cases/nested.yaml
@@ -1,0 +1,55 @@
+name: nested
+weight: 8
+setup:
+  pattern: hierarchical
+  agents: [t-coord, t-lead, t-m1, t-m2]
+  flags: ["--json"]
+  input: "review the caching module"
+  # C9: t-lead is declared as the `lead` of a team that runs `blackboard`
+  # instead of flat delegation (see `NestedTeamSetup` in case.rs / the
+  # `orchestration.teams[0]` block `project_yaml` generates from this). Because
+  # of that, `invoke_agent` (hierarchical.rs) short-circuits t-lead's own LLM
+  # call into `run_nested_team` — t-lead is NEVER invoked as an agent itself,
+  # only t-m1/t-m2 are (hence no fake rule keyed on `agent: t-lead` below).
+  nested_team:
+    lead: t-lead
+    pattern: blackboard
+    agents: [t-m1, t-m2]
+fake:
+  rules:
+    # 1st coordinator call: delegate the whole task to the team lead.
+    - match: { agent: t-coord, call: 1 }
+      respond: "@t-lead: run a blackboard review of the caching module"
+    # 2nd coordinator call: synthesis over the nested team's (re-injected)
+    # outcome text. No `@agent:` line => FinalAnswer, the run's terminal content.
+    - match: { agent: t-coord, call: 2 }
+      respond: "Synthesis: caching module review complete."
+    # Nested sub-team (blackboard over t-m1/t-m2), same 2-round convergence
+    # shape as cases/blackboard.yaml: round 1 FINDING, round 2 CONFIRMATION of
+    # entry #0 reaches consensus_threshold (default 0.75) with
+    # convergence_rounds=1, so the sub-board halts after round 2. Per the task
+    # brief, the sub-board's internal turns are a known legacy regression that
+    # may not surface in the parent run's `--json` stream, so this case does
+    # NOT assert on `board` events — only `nested_start`/`nested_end`/
+    # `delegate`/`result`.
+    - match: { agent: t-m1, call: 1 }
+      respond: "ACTION: FINDING\nCONFIDENCE: 0.9\nCONTENT: cache invalidation looks correct"
+    - match: { agent: t-m1, call: 2 }
+      respond: "ACTION: CONFIRMATION\nTARGET: 0\nCONFIDENCE: 0.95\nCONTENT: agreed"
+    - match: { agent: t-m2, call: 1 }
+      respond: "ACTION: FINDING\nCONFIDENCE: 0.85\nCONTENT: TTLs are configured sanely"
+    - match: { agent: t-m2, call: 2 }
+      respond: "ACTION: CONFIRMATION\nTARGET: 0\nCONFIDENCE: 0.9\nCONTENT: agreed"
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-coord }
+    - { t: delegate, from: t-coord, to: t-lead }
+    - { t: nested_start, team_lead: t-lead, pattern: blackboard }
+    - { t: nested_end, team_lead: t-lead }
+    - { t: result, content: "Synthesis: caching module review complete." }
+  event_counts: { agent_start: 4, agent_end: 4, delegate: 1, nested_start: 1, nested_end: 1, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]

--- a/tests/e2e/cases/ring.yaml
+++ b/tests/e2e/cases/ring.yaml
@@ -1,0 +1,41 @@
+name: ring
+weight: 5
+# Known legacy-engine gap (validated manually on release/1.0.0, pre-Lot-4 ES
+# switch-over): the legacy ring (`src/core/orchestration/ring.rs`) circulates
+# contributions correctly, but this case's `vote` expectation is not reliably
+# observed through `armadai run --orchestrate ring --json` in this harness —
+# an observability gap in the legacy `--json` event stream. Débloqué au Lot 4
+# (émission `vote` côté event-sourcing). Do not let this case block the suite.
+allow_fail: true
+setup:
+  pattern: ring
+  agents: [t-a, t-b]
+  flags: ["--json"]
+  input: "propose a caching strategy"
+fake:
+  rules:
+    # Circulation phase: the ring runs `config.max_laps` laps regardless of
+    # call count (2 agents x N laps), so match on the propose-phase prompt
+    # text (`RING_ACTION_INSTRUCTIONS` in llm_agents.rs) rather than `call:`,
+    # to stay correct across however many laps the default config runs.
+    - match: { agent: t-a, prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: t-a proposes a write-through cache"
+    - match: { agent: t-b, prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: t-b proposes a read-through cache"
+    # Voting phase: matched on the vote prompt's distinct text (see
+    # `LlmRingAgent::vote` in llm_agents.rs) instead of a call index.
+    - match: { agent: t-a, prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.8\nWrite-through is the safer default."
+    - match: { agent: t-b, prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.75\nRead-through works if writes are rare."
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-a }
+    - { t: vote, agent: t-a }
+    - { t: result }
+  event_counts: { agent_start: 2, agent_end: 2, vote: 2, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -178,6 +178,10 @@ fn write_project(root: &Path, case: &CaseFile) -> anyhow::Result<()> {
 /// pattern selected via project config rather than a `--orchestrate` CLI flag (see
 /// `configure_invocation`). See `OrchestrationConfig`/`TeamConfig` in
 /// `src/core/orchestration/mod.rs` for the schema this must match.
+///
+/// When `case.setup.nested_team` is set (C9), the single `teams:` entry declares
+/// that team's `lead`/`pattern`/`agents` instead of the default flat team of every
+/// non-coordinator agent — see `NestedTeamSetup` in `case.rs`.
 fn project_yaml(case: &CaseFile) -> String {
     let agents_block: String = case
         .setup
@@ -190,18 +194,35 @@ fn project_yaml(case: &CaseFile) -> String {
 
     if case.setup.pattern == "hierarchical" {
         let coordinator = &case.setup.agents[0];
-        let team_agents = &case.setup.agents[1..];
-        let team_agents_block: String = team_agents
-            .iter()
-            .map(|a| format!("        - {a}\n"))
-            .collect();
+        let teams_block = match &case.setup.nested_team {
+            Some(nt) => {
+                let members_block: String = nt
+                    .agents
+                    .iter()
+                    .map(|a| format!("        - {a}\n"))
+                    .collect();
+                format!(
+                    "    - lead: {}\n      \
+                       pattern: {}\n      \
+                       agents:\n{members_block}",
+                    nt.lead, nt.pattern
+                )
+            }
+            None => {
+                let team_agents = &case.setup.agents[1..];
+                let team_agents_block: String = team_agents
+                    .iter()
+                    .map(|a| format!("        - {a}\n"))
+                    .collect();
+                format!("    - agents:\n{team_agents_block}")
+            }
+        };
         yaml.push_str(&format!(
             "orchestration:\n  \
              enabled: true\n  \
              pattern: hierarchical\n  \
              coordinator: {coordinator}\n  \
-             teams:\n    \
-             - agents:\n{team_agents_block}"
+             teams:\n{teams_block}"
         ));
     }
 
@@ -231,10 +252,77 @@ fn agent_markdown(agent: &str) -> String {
     )
 }
 
+/// Load every `*.yaml` case file under `dir`, sorted by filename for a deterministic
+/// run order (and therefore a deterministic report). Used by `e2e_suite` to discover
+/// `tests/e2e/cases/*.yaml`.
+///
+/// # Panics
+/// Panics if `dir` cannot be read, or if any file fails to parse as a [`CaseFile`] —
+/// a malformed baseline case file is a harness bug, not a runtime condition to
+/// tolerate silently.
+pub fn discover_cases(dir: &str) -> Vec<CaseFile> {
+    let mut paths: Vec<_> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("reading case dir {dir}: {e}"))
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|ext| ext == "yaml"))
+        .collect();
+    paths.sort();
+
+    paths
+        .iter()
+        .map(|p| {
+            super::case::load_case(p)
+                .unwrap_or_else(|e| panic!("loading case file {}: {e:#}", p.display()))
+        })
+        .collect()
+}
+
+/// Directory the e2e suite writes its `e2e-report.{json,html}` artifacts to
+/// (created if missing). Kept under `target/` so it's ignored by git and already
+/// present for CI's `actions/upload-artifact` step to pick up.
+pub fn report_dir() -> std::path::PathBuf {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/e2e-report");
+    let _ = std::fs::create_dir_all(&dir);
+    dir
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::e2e::case::load_case_str;
+
+    /// Discovers every case file under `tests/e2e/cases/`, runs each one against
+    /// the real `armadai` binary + `fake-claude` stub, and writes the aggregate
+    /// report (`e2e-report.json`/`.html`) to `report_dir()` — `if: always()` in CI
+    /// uploads it regardless of the outcome below, so a failing run still leaves a
+    /// diagnostic artifact behind.
+    ///
+    /// A case fails the suite unless it is marked `allow_fail: true` in its YAML
+    /// (see e.g. `cases/ring.yaml`, which documents a known legacy-engine gap).
+    #[test]
+    fn e2e_suite() {
+        let cases = discover_cases(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/e2e/cases"));
+        assert!(
+            !cases.is_empty(),
+            "no case files found under tests/e2e/cases — the suite would vacuously pass"
+        );
+
+        let outcomes: Vec<_> = cases.iter().map(run_case).collect();
+
+        crate::e2e::report::write_reports(&outcomes, &report_dir())
+            .expect("writing e2e-report.{json,html}");
+
+        let failed: Vec<&str> = outcomes
+            .iter()
+            .filter(|o| !o.passed && !o.allow_fail)
+            .map(|o| o.name.as_str())
+            .collect();
+        assert!(
+            failed.is_empty(),
+            "failed cases (not allow_fail): {failed:?} — see {}/e2e-report.html for diffs",
+            report_dir().display()
+        );
+    }
 
     /// A single-agent, `direct`-pattern case: no orchestration, no `--pipe`. This is
     /// the harness's own smoke test — the first real run of `armadai` against

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -1,0 +1,335 @@
+//! Generic e2e runner: for a given [`CaseFile`], build an isolated tempdir project
+//! (`armadai.yaml` + `agents/*.md`), shadow the `claude` CLI with the `fake-claude`
+//! stub (Task 1) on `PATH`, invoke the real `armadai run …` binary against it, and
+//! evaluate the result via `runner::evaluate`.
+//!
+//! # Isolation
+//!
+//! Every run gets its own `tempfile::tempdir()`. `HOME`, `XDG_CONFIG_HOME`,
+//! `XDG_DATA_HOME` are all pointed inside that tempdir (see `src/core/config.rs`
+//! `config_dir()`/`data_dir()`), so the harness never reads or writes the real
+//! user's `~/.config/armadai/` or `~/.local/share/armadai/armadai.sqlite`. This is
+//! the load-bearing property of the whole suite — a bug here would mean e2e cases
+//! quietly corrupt the developer's actual ArmadAI config/history.
+
+use std::path::Path;
+
+use assert_cmd::Command;
+
+use super::case::CaseFile;
+use super::runner::{self, CaseOutcome};
+
+/// Run one case end-to-end and return its outcome. Never panics: any setup failure
+/// (writing the tempdir project, spawning `armadai`) is reported as a failed
+/// [`CaseOutcome`] with a diagnostic in `diffs`, so a bad case can't take down a
+/// whole suite run.
+pub fn run_case(case: &CaseFile) -> CaseOutcome {
+    let tmp = match tempfile::tempdir() {
+        Ok(t) => t,
+        Err(e) => return setup_failure(case, format!("tempdir() failed: {e}")),
+    };
+    let root = tmp.path();
+
+    if case.setup.agents.is_empty() {
+        return setup_failure(case, "setup.agents is empty — nothing to run".to_string());
+    }
+
+    if let Err(e) = write_project(root, case) {
+        return setup_failure(case, format!("writing tempdir project failed: {e:#}"));
+    }
+
+    let state_dir = root.join("state");
+    if let Err(e) = std::fs::create_dir_all(&state_dir) {
+        return setup_failure(case, format!("creating FAKE_STATE_DIR failed: {e}"));
+    }
+
+    let mut cmd = match Command::cargo_bin("armadai") {
+        Ok(c) => c,
+        Err(e) => return setup_failure(case, format!("Command::cargo_bin(\"armadai\"): {e}")),
+    };
+
+    configure_invocation(&mut cmd, root, &state_dir, case);
+
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(e) => return setup_failure(case, format!("spawning armadai failed: {e}")),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit = output.status.code().unwrap_or(-1);
+
+    let mut outcome = runner::evaluate(case, &stdout, exit);
+
+    let storage_diffs = runner::check_storage(&case.expect.storage, root);
+    if !storage_diffs.is_empty() {
+        outcome.diffs.extend(storage_diffs);
+        outcome.passed = false;
+    }
+
+    if !outcome.passed {
+        outcome
+            .diffs
+            .push(format!("--- stderr ---\n{}", stderr.trim_end()));
+    }
+
+    outcome
+}
+
+/// Build a [`CaseOutcome`] for a failure that happened before `armadai` could even be
+/// invoked (tempdir/IO/spawn errors) — distinct from an `evaluate` mismatch, but
+/// reported the same way so callers don't need to special-case it.
+fn setup_failure(case: &CaseFile, reason: String) -> CaseOutcome {
+    CaseOutcome {
+        name: case.name.clone(),
+        weight: case.weight,
+        allow_fail: case.allow_fail,
+        passed: false,
+        diffs: vec![reason],
+        ..Default::default()
+    }
+}
+
+/// Set up the `armadai` process invocation: working directory, isolation env vars,
+/// and the `run <agent> <input> [flags…]` argument line for `case.setup.pattern`.
+fn configure_invocation(cmd: &mut Command, root: &Path, state_dir: &Path, case: &CaseFile) {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+
+    cmd.current_dir(root)
+        // Shadow `claude` with `fake-claude` (see `write_project`'s `<root>/bin/claude`
+        // symlink) by putting our stub dir first on PATH.
+        .env("PATH", format!("{}/bin:{path_var}", root.display()))
+        .env("FAKE_SCENARIO", root.join("scenario.yaml"))
+        .env("FAKE_STATE_DIR", state_dir)
+        // Isolation (see module doc): never touch the real user config/DB.
+        .env("HOME", root)
+        .env("XDG_CONFIG_HOME", root.join(".config"))
+        .env("XDG_DATA_HOME", root.join(".local/share"))
+        // `config_dir()` in src/core/config.rs checks this ahead of XDG/HOME — clear
+        // it in case the harness itself is invoked from an environment that sets it,
+        // so isolation can't be silently bypassed.
+        .env_remove("ARMADAI_CONFIG_DIR");
+
+    let coordinator = &case.setup.agents[0];
+    let rest: Vec<&str> = case.setup.agents[1..].iter().map(String::as_str).collect();
+
+    cmd.arg("run").arg(coordinator).arg(&case.setup.input);
+
+    match case.setup.pattern.as_str() {
+        // Hierarchical topology comes from `armadai.yaml`'s `orchestration:` block
+        // (see `write_project`/`hierarchical_yaml`) and is auto-detected by
+        // `armadai run` — no `--orchestrate`/`--pipe` needed on the CLI.
+        "hierarchical" => {}
+        // `--orchestrate` only accepts blackboard|ring (see `src/cli/mod.rs`
+        // `Command::Run`); the remaining agents ride along via `--pipe`.
+        "blackboard" | "ring" => {
+            if !rest.is_empty() {
+                cmd.arg("--pipe").args(&rest);
+            }
+            cmd.arg("--orchestrate").arg(&case.setup.pattern);
+        }
+        // "direct" (or anything else): plain sequential chain, no orchestration.
+        _ => {
+            if !rest.is_empty() {
+                cmd.arg("--pipe").args(&rest);
+            }
+        }
+    }
+
+    for flag in &case.setup.flags {
+        cmd.arg(flag);
+    }
+}
+
+/// Write the tempdir project: `armadai.yaml`, one `agents/<name>.md` per
+/// `setup.agents`, the `fake-claude` scenario, and the `claude` → `fake-claude`
+/// shadow symlink.
+fn write_project(root: &Path, case: &CaseFile) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    std::fs::create_dir_all(root.join("agents")).context("creating agents/ dir")?;
+    std::fs::write(root.join("armadai.yaml"), project_yaml(case))
+        .context("writing armadai.yaml")?;
+
+    for agent in &case.setup.agents {
+        let path = root.join("agents").join(format!("{agent}.md"));
+        std::fs::write(&path, agent_markdown(agent))
+            .with_context(|| format!("writing {}", path.display()))?;
+    }
+
+    let scenario_yaml =
+        serde_yaml_ng::to_string(&case.fake).context("serializing fake scenario to YAML")?;
+    std::fs::write(root.join("scenario.yaml"), scenario_yaml).context("writing scenario.yaml")?;
+
+    let bin_dir = root.join("bin");
+    std::fs::create_dir_all(&bin_dir).context("creating bin/ dir")?;
+    let claude_stub = bin_dir.join("claude");
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_fake-claude"), &claude_stub)
+        .context("symlinking bin/claude -> fake-claude")?;
+
+    Ok(())
+}
+
+/// Render `armadai.yaml` for `case`. The `agents:` list is always required (an empty
+/// list makes `armadai` fall back to the global agent library instead of resolving
+/// our tempdir's `agents/*.md` — see `resolve_agents_dir` in `src/cli/run.rs`).
+///
+/// Only `hierarchical` gets a top-level `orchestration:` block: it's the only
+/// pattern selected via project config rather than a `--orchestrate` CLI flag (see
+/// `configure_invocation`). See `OrchestrationConfig`/`TeamConfig` in
+/// `src/core/orchestration/mod.rs` for the schema this must match.
+fn project_yaml(case: &CaseFile) -> String {
+    let agents_block: String = case
+        .setup
+        .agents
+        .iter()
+        .map(|a| format!("  - name: {a}\n"))
+        .collect();
+
+    let mut yaml = format!("agents:\n{agents_block}");
+
+    if case.setup.pattern == "hierarchical" {
+        let coordinator = &case.setup.agents[0];
+        let team_agents = &case.setup.agents[1..];
+        let team_agents_block: String = team_agents
+            .iter()
+            .map(|a| format!("        - {a}\n"))
+            .collect();
+        yaml.push_str(&format!(
+            "orchestration:\n  \
+             enabled: true\n  \
+             pattern: hierarchical\n  \
+             coordinator: {coordinator}\n  \
+             teams:\n    \
+             - agents:\n{team_agents_block}"
+        ));
+    }
+
+    yaml
+}
+
+/// A minimal, valid agent Markdown file: H1 + `## Metadata` + `## System Prompt`
+/// (the three sections `src/parser/markdown.rs::parse_agent_file` requires). Uses a
+/// concrete `model:` (never `latest:auto`) so the run never touches the dynamic
+/// model router/registry — the point of this harness is to exercise the fake
+/// provider deterministically, not model resolution. The `FAKE_AGENT_ID:` line in
+/// the system prompt is how `fake-claude` identifies which agent is calling it (see
+/// `src/bin/fake-claude.rs::agent_id_from_prompt`).
+fn agent_markdown(agent: &str) -> String {
+    format!(
+        "# {agent}\n\
+         \n\
+         ## Metadata\n\
+         - provider: claude\n\
+         - model: fake-model\n\
+         \n\
+         ## System Prompt\n\
+         FAKE_AGENT_ID: {agent}\n\
+         \n\
+         You are `{agent}`, a deterministic test agent used by the e2e harness. Respond \
+         concisely to the task given.\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::e2e::case::load_case_str;
+
+    /// A single-agent, `direct`-pattern case: no orchestration, no `--pipe`. This is
+    /// the harness's own smoke test — the first real run of `armadai` against
+    /// `fake-claude` end to end. If agent identity, the composed prompt, or the
+    /// stream-json shape don't line up, this is what catches it.
+    const DIRECT_YAML: &str = r#"
+name: direct-happy
+weight: 5
+setup: { pattern: direct, agents: [t-writer], flags: ["--json"], input: "hi" }
+fake:
+  rules:
+    - match: { agent: t-writer }
+      respond: "done"
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-writer }
+    - { t: result }
+  event_counts: { agent_start: 1, agent_end: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result]
+"#;
+
+    #[test]
+    fn direct_baseline_passes_end_to_end() {
+        let case = load_case_str(DIRECT_YAML).expect("DIRECT_YAML parses as a CaseFile");
+        let outcome = run_case(&case);
+        assert!(outcome.passed, "diffs: {:?}", outcome.diffs);
+    }
+
+    #[test]
+    fn missing_agents_reports_a_diagnostic_instead_of_panicking() {
+        let case = load_case_str(
+            r#"
+name: empty-agents
+weight: 1
+setup: { pattern: direct, agents: [], flags: [], input: "" }
+fake: { rules: [ { match: {}, respond: "ok" } ] }
+expect: { exit_code: 0 }
+"#,
+        )
+        .unwrap();
+        let outcome = run_case(&case);
+        assert!(!outcome.passed);
+        assert!(outcome.diffs.iter().any(|d| d.contains("setup.agents")));
+    }
+
+    #[test]
+    fn project_yaml_emits_agents_list_for_direct() {
+        let case = load_case_str(
+            r#"
+name: t
+weight: 1
+setup: { pattern: direct, agents: [a, b], flags: [], input: "" }
+fake: { rules: [ { match: {}, respond: "ok" } ] }
+expect: { exit_code: 0 }
+"#,
+        )
+        .unwrap();
+        let yaml = project_yaml(&case);
+        assert!(yaml.contains("agents:"));
+        assert!(yaml.contains("- name: a"));
+        assert!(yaml.contains("- name: b"));
+        assert!(!yaml.contains("orchestration:"));
+    }
+
+    #[test]
+    fn project_yaml_emits_orchestration_block_for_hierarchical() {
+        let case = load_case_str(
+            r#"
+name: t
+weight: 1
+setup: { pattern: hierarchical, agents: [coord, lead-a], flags: [], input: "" }
+fake: { rules: [ { match: {}, respond: "ok" } ] }
+expect: { exit_code: 0 }
+"#,
+        )
+        .unwrap();
+        let yaml = project_yaml(&case);
+        assert!(yaml.contains("enabled: true"));
+        assert!(yaml.contains("pattern: hierarchical"));
+        assert!(yaml.contains("coordinator: coord"));
+        assert!(yaml.contains("- lead-a"));
+    }
+
+    #[test]
+    fn agent_markdown_has_required_sections_and_marker() {
+        let md = agent_markdown("t-writer");
+        assert!(md.starts_with("# t-writer"));
+        assert!(md.contains("## Metadata"));
+        assert!(md.contains("provider: claude"));
+        assert!(md.contains("model: fake-model"));
+        assert!(md.contains("## System Prompt"));
+        assert!(md.contains("FAKE_AGENT_ID: t-writer"));
+    }
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod case;
 pub mod harness;
+pub mod report;
 pub mod runner;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,4 +1,6 @@
-//! Module tree for the e2e harness (case file format, and — in later tasks — the
-//! runner that executes cases against the `fake-claude` stub).
+//! Module tree for the e2e harness: case file format, the generic runner that
+//! executes cases against the `fake-claude` stub, and declarative expect evaluation.
 
 pub mod case;
+pub mod harness;
+pub mod runner;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,0 +1,4 @@
+//! Module tree for the e2e harness (case file format, and — in later tasks — the
+//! runner that executes cases against the `fake-claude` stub).
+
+pub mod case;

--- a/tests/e2e/report.rs
+++ b/tests/e2e/report.rs
@@ -1,0 +1,429 @@
+//! Report aggregation for the e2e harness: turns a `Vec<CaseOutcome>` (produced by
+//! `runner::evaluate`/`harness::run_case`) into a weighted score plus two artifacts —
+//! `e2e-report.json` (machine-readable, for CI gating/history) and `e2e-report.html`
+//! (self-contained, human-readable, for local/CI-artifact viewing).
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use anyhow::Context;
+use serde::Serialize;
+
+use super::runner::CaseOutcome;
+
+/// Write `e2e-report.json` and `e2e-report.html` into `out_dir`.
+///
+/// `weighted_score = Σ(weight of passed cases) / Σ(weight of all cases)`, as an
+/// `f64` in `[0.0, 1.0]`. When the total weight is `0` (no cases, or all cases
+/// weighted `0`), the score is defined as `1.0` (vacuously "fully passing" — there's
+/// nothing to fail).
+pub fn write_reports(outcomes: &[CaseOutcome], out_dir: &Path) -> anyhow::Result<()> {
+    let summary = Summary::from_outcomes(outcomes);
+
+    let json = serde_json::to_string_pretty(&summary).context("serializing report to JSON")?;
+    std::fs::write(out_dir.join("e2e-report.json"), json).context("writing e2e-report.json")?;
+
+    let html = render_html(&summary, outcomes);
+    std::fs::write(out_dir.join("e2e-report.html"), html).context("writing e2e-report.html")?;
+
+    Ok(())
+}
+
+/// The JSON-serializable shape of the report: aggregate score/counts plus one
+/// [`CaseSummary`] per outcome. Mirrors the schema from the task brief — note
+/// `expected`/`observed` are deliberately **not** part of the JSON shape (large
+/// free-form debug dumps); the HTML report renders those straight from the
+/// `outcomes` slice instead (see `render_html`).
+#[derive(Debug, Serialize)]
+struct Summary {
+    weighted_score: f64,
+    total: usize,
+    passed: usize,
+    failed: usize,
+    cases: Vec<CaseSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct CaseSummary {
+    name: String,
+    weight: u32,
+    passed: bool,
+    allow_fail: bool,
+    diffs: Vec<String>,
+}
+
+impl Summary {
+    fn from_outcomes(outcomes: &[CaseOutcome]) -> Self {
+        let total_weight: u64 = outcomes.iter().map(|o| u64::from(o.weight)).sum();
+        let passed_weight: u64 = outcomes
+            .iter()
+            .filter(|o| o.passed)
+            .map(|o| u64::from(o.weight))
+            .sum();
+
+        let weighted_score = if total_weight == 0 {
+            1.0
+        } else {
+            passed_weight as f64 / total_weight as f64
+        };
+
+        let passed = outcomes.iter().filter(|o| o.passed).count();
+        let total = outcomes.len();
+
+        Summary {
+            weighted_score,
+            total,
+            passed,
+            failed: total - passed,
+            cases: outcomes
+                .iter()
+                .map(|o| CaseSummary {
+                    name: o.name.clone(),
+                    weight: o.weight,
+                    passed: o.passed,
+                    allow_fail: o.allow_fail,
+                    diffs: o.diffs.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Escape the five HTML-significant characters. All case-controlled strings
+/// (`name`, `expected`, `observed`, `diffs`) are run through this before being
+/// concatenated into the report — cases are meant to be hand-writable/agent-
+/// generatable (see `case.rs` module doc), so their content is untrusted input as
+/// far as the HTML renderer is concerned.
+fn escape_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Render the self-contained `e2e-report.html` artifact: design-token `<style>`,
+/// a weighted-score gauge + chip row, a scenario table, and an expected-vs-observed
+/// block per failing case. No external assets (fonts/CDN/JS libraries) — this is
+/// meant to be opened locally or archived as a CI artifact without network access.
+///
+/// Takes both `summary` (aggregate counts, already computed once by
+/// [`write_reports`]) and the raw `outcomes` (for `expected`/`observed`, which the
+/// JSON `Summary` intentionally drops — see its doc comment).
+fn render_html(summary: &Summary, outcomes: &[CaseOutcome]) -> String {
+    let score_pct = (summary.weighted_score * 100.0).round() as i64;
+
+    let mut rows = String::new();
+    for case in &summary.cases {
+        let badge = if case.passed {
+            r#"<span class="badge badge-ok">PASS</span>"#
+        } else if case.allow_fail {
+            r#"<span class="badge badge-warn">FAIL (allowed)</span>"#
+        } else {
+            r#"<span class="badge badge-fail">FAIL</span>"#
+        };
+        let _ = write!(
+            rows,
+            r#"<tr><td>{}</td><td class="mono">{}</td><td>{}</td></tr>"#,
+            escape_html(&case.name),
+            case.weight,
+            badge,
+        );
+    }
+
+    let mut failures = String::new();
+    for outcome in outcomes.iter().filter(|o| !o.passed) {
+        let diffs_html: String = outcome
+            .diffs
+            .iter()
+            .map(|d| format!("<li>{}</li>", escape_html(d)))
+            .collect();
+        let _ = write!(
+            failures,
+            r#"<section class="failure">
+  <h3>{name}</h3>
+  <ul class="diffs">{diffs}</ul>
+  <div class="expected-observed">
+    <div><h4>Expected</h4><pre class="mono">{expected}</pre></div>
+    <div><h4>Observed</h4><pre class="mono">{observed}</pre></div>
+  </div>
+</section>
+"#,
+            name = escape_html(&outcome.name),
+            diffs = diffs_html,
+            expected = escape_html(&outcome.expected),
+            observed = escape_html(&outcome.observed),
+        );
+    }
+
+    format!(
+        r##"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ArmadAI e2e report</title>
+<style>
+{tokens}
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0; padding: 2rem; background: var(--bg-base); color: var(--text-primary);
+  font-family: system-ui, sans-serif;
+}}
+h1, h2, h3, h4 {{ color: var(--text-primary); }}
+.mono {{ font-family: ui-monospace, "IBM Plex Mono", monospace; font-variant-numeric: tabular-nums; }}
+header {{ display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem; }}
+.theme-toggle {{
+  background: var(--surface-2); color: var(--text-primary); border: 1px solid var(--border);
+  border-radius: 0.4rem; padding: 0.4rem 0.8rem; cursor: pointer; font-family: system-ui, sans-serif;
+}}
+.gauge {{
+  display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 1rem;
+}}
+.gauge-value {{ font-size: 3rem; font-weight: 700; color: var(--brass); }}
+.gauge-track {{
+  width: 100%; height: 0.6rem; border-radius: 999px; background: var(--surface-2);
+  border: 1px solid var(--border-faint); overflow: hidden; margin-bottom: 1.5rem;
+}}
+.gauge-fill {{ height: 100%; background: var(--brass); }}
+.chips {{ display: flex; gap: 0.75rem; margin-bottom: 2rem; flex-wrap: wrap; }}
+.chip {{
+  background: var(--surface-1); border: 1px solid var(--border); border-radius: 0.5rem;
+  padding: 0.5rem 1rem; color: var(--text-secondary);
+}}
+.chip .mono {{ color: var(--text-primary); font-weight: 600; }}
+table {{
+  width: 100%; border-collapse: collapse; background: var(--surface-1);
+  border: 1px solid var(--border); border-radius: 0.5rem; overflow: hidden; margin-bottom: 2rem;
+}}
+th, td {{ text-align: left; padding: 0.6rem 1rem; border-bottom: 1px solid var(--border-faint); }}
+th {{ color: var(--text-muted); font-weight: 600; font-size: 0.85rem; text-transform: uppercase; }}
+tr:last-child td {{ border-bottom: none; }}
+.badge {{
+  display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600;
+}}
+.badge-ok {{ background: var(--signal-ok-bg); color: var(--signal-ok-fg); }}
+.badge-fail {{ background: var(--signal-critical-bg); color: var(--signal-critical-fg); }}
+.badge-warn {{ background: var(--signal-warning-bg); color: var(--text-primary); }}
+.failure {{
+  background: var(--surface-1); border: 1px solid var(--signal-critical); border-radius: 0.5rem;
+  padding: 1rem 1.25rem; margin-bottom: 1rem;
+}}
+.failure h3 {{ margin-top: 0; color: var(--signal-critical-fg); }}
+.diffs {{ color: var(--text-secondary); }}
+.expected-observed {{ display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }}
+.expected-observed pre {{
+  background: var(--surface-2); border: 1px solid var(--border-faint); border-radius: 0.4rem;
+  padding: 0.75rem; overflow-x: auto; white-space: pre-wrap; word-break: break-word; color: var(--text-secondary);
+  max-height: 20rem; overflow-y: auto;
+}}
+@media (max-width: 700px) {{ .expected-observed {{ grid-template-columns: 1fr; }} }}
+</style>
+</head>
+<body>
+<header>
+  <h1>ArmadAI — e2e command bridge report</h1>
+  <button class="theme-toggle" onclick="const r=document.documentElement;r.setAttribute('data-theme', r.getAttribute('data-theme')==='light'?'dark':'light');">Toggle theme</button>
+</header>
+<div class="gauge">
+  <span class="gauge-value mono">{score_pct}%</span>
+  <span>weighted score</span>
+</div>
+<div class="gauge-track"><div class="gauge-fill" style="width:{score_pct}%"></div></div>
+<div class="chips">
+  <div class="chip">total <span class="mono">{total}</span></div>
+  <div class="chip">passed <span class="mono">{passed}</span></div>
+  <div class="chip">failed <span class="mono">{failed}</span></div>
+</div>
+<table>
+<thead><tr><th>Scenario</th><th>Weight</th><th>Signal</th></tr></thead>
+<tbody>
+{rows}
+</tbody>
+</table>
+{failures}
+</body>
+</html>
+"##,
+        tokens = DESIGN_TOKENS,
+        score_pct = score_pct,
+        total = summary.total,
+        passed = summary.passed,
+        failed = summary.failed,
+        rows = rows,
+        failures = failures,
+    )
+}
+
+const DESIGN_TOKENS: &str = r#":root, [data-theme="dark"] { color-scheme: dark;
+  --bg-base: oklch(0.188 0.030 248); --surface-1: oklch(0.223 0.031 247); --surface-2: oklch(0.258 0.032 246);
+  --border: oklch(0.360 0.030 244); --border-faint: oklch(0.280 0.028 246);
+  --text-primary: oklch(0.955 0.008 240); --text-secondary: oklch(0.790 0.015 240); --text-muted: oklch(0.635 0.020 242); --text-faint: oklch(0.505 0.020 244); --text-on-accent: oklch(0.180 0.030 248);
+  --brass: oklch(0.790 0.100 84); --brass-strong: oklch(0.855 0.110 86); --brass-bg: oklch(0.300 0.045 82);
+  --signal-ok: oklch(0.760 0.150 152); --signal-ok-bg: oklch(0.320 0.070 152); --signal-ok-fg: oklch(0.860 0.160 152);
+  --signal-critical: oklch(0.660 0.190 25); --signal-critical-bg: oklch(0.320 0.085 25); --signal-critical-fg: oklch(0.800 0.170 25);
+  --signal-warning: oklch(0.820 0.155 70); --signal-warning-bg: oklch(0.340 0.070 70); }
+[data-theme="light"] { color-scheme: light;
+  --bg-base: oklch(0.966 0.008 236); --surface-1: oklch(0.996 0.003 236); --surface-2: oklch(0.980 0.006 237);
+  --border: oklch(0.868 0.013 240); --border-faint: oklch(0.910 0.010 239);
+  --text-primary: oklch(0.245 0.036 248); --text-secondary: oklch(0.400 0.030 246); --text-muted: oklch(0.520 0.026 245); --text-faint: oklch(0.630 0.022 244); --text-on-accent: oklch(0.985 0.004 236);
+  --brass: oklch(0.560 0.110 78); --brass-strong: oklch(0.475 0.108 76); --brass-bg: oklch(0.930 0.045 84);
+  --signal-ok: oklch(0.520 0.150 152); --signal-ok-bg: oklch(0.945 0.050 152); --signal-ok-fg: oklch(0.440 0.140 152);
+  --signal-critical: oklch(0.535 0.195 27); --signal-critical-bg: oklch(0.948 0.050 27); --signal-critical-fg: oklch(0.470 0.185 27);
+  --signal-warning: oklch(0.560 0.140 66); --signal-warning-bg: oklch(0.950 0.055 70); }
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_json_has_weighted_score_and_per_case() {
+        let outs = vec![
+            CaseOutcome {
+                name: "a".into(),
+                weight: 3,
+                passed: true,
+                ..Default::default()
+            },
+            CaseOutcome {
+                name: "b".into(),
+                weight: 1,
+                passed: false,
+                ..Default::default()
+            },
+        ];
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&outs, dir.path()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("e2e-report.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(json["weighted_score"].as_f64().unwrap(), 0.75); // 3/(3+1)
+        assert_eq!(json["cases"].as_array().unwrap().len(), 2);
+        assert!(dir.path().join("e2e-report.html").exists());
+    }
+
+    #[test]
+    fn zero_total_weight_scores_1_0() {
+        let outs = vec![CaseOutcome {
+            name: "z".into(),
+            weight: 0,
+            passed: false,
+            ..Default::default()
+        }];
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&outs, dir.path()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("e2e-report.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(json["weighted_score"].as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn empty_outcomes_scores_1_0_and_writes_empty_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&[], dir.path()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("e2e-report.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(json["weighted_score"].as_f64().unwrap(), 1.0);
+        assert_eq!(json["total"].as_u64().unwrap(), 0);
+        assert!(json["cases"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn json_omits_expected_and_observed_per_case() {
+        let outs = vec![CaseOutcome {
+            name: "a".into(),
+            weight: 1,
+            passed: true,
+            expected: "should not leak into json".into(),
+            observed: "should not leak into json".into(),
+            ..Default::default()
+        }];
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&outs, dir.path()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("e2e-report.json")).unwrap(),
+        )
+        .unwrap();
+        let case = &json["cases"][0];
+        assert!(case.get("expected").is_none());
+        assert!(case.get("observed").is_none());
+    }
+
+    #[test]
+    fn html_escapes_case_name_and_diffs() {
+        let outs = vec![CaseOutcome {
+            name: "<script>alert(1)</script>".into(),
+            weight: 1,
+            passed: false,
+            diffs: vec!["<img src=x onerror=alert(1)>".into()],
+            expected: "<b>x</b>".into(),
+            observed: "<i>y</i>".into(),
+            ..Default::default()
+        }];
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&outs, dir.path()).unwrap();
+        let html = std::fs::read_to_string(dir.path().join("e2e-report.html")).unwrap();
+        assert!(!html.contains("<script>alert(1)</script>"));
+        assert!(html.contains("&lt;script&gt;"));
+        assert!(!html.contains("<img src=x"));
+        assert!(html.contains("&lt;img"));
+    }
+
+    #[test]
+    fn html_contains_design_tokens_and_pass_fail_badges() {
+        let outs = vec![
+            CaseOutcome {
+                name: "ok-case".into(),
+                weight: 1,
+                passed: true,
+                ..Default::default()
+            },
+            CaseOutcome {
+                name: "bad-case".into(),
+                weight: 1,
+                passed: false,
+                diffs: vec!["boom".into()],
+                ..Default::default()
+            },
+        ];
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&outs, dir.path()).unwrap();
+        let html = std::fs::read_to_string(dir.path().join("e2e-report.html")).unwrap();
+        assert!(html.contains("--brass"));
+        assert!(html.contains("--signal-ok"));
+        assert!(html.contains("--signal-critical"));
+        assert!(html.contains("data-theme"));
+        assert!(html.contains("badge-ok"));
+        assert!(html.contains("badge-fail"));
+        assert!(html.contains("ok-case"));
+        assert!(html.contains("bad-case"));
+    }
+
+    #[test]
+    fn allow_fail_case_gets_warn_badge_not_fail_badge() {
+        let outs = vec![CaseOutcome {
+            name: "flaky".into(),
+            weight: 1,
+            passed: false,
+            allow_fail: true,
+            ..Default::default()
+        }];
+        let dir = tempfile::tempdir().unwrap();
+        write_reports(&outs, dir.path()).unwrap();
+        let html = std::fs::read_to_string(dir.path().join("e2e-report.html")).unwrap();
+        assert!(html.contains("badge-warn"));
+    }
+}

--- a/tests/e2e/runner.rs
+++ b/tests/e2e/runner.rs
@@ -1,0 +1,458 @@
+//! Declarative evaluation of a case's `expect` block against the captured
+//! stdout/exit code of a real `armadai run … --json` invocation.
+//!
+//! [`evaluate`] is pure (no filesystem/process access): it takes the raw stdout text
+//! and the process exit code and checks them against [`crate::e2e::case::Expect`].
+//! The one exception is `expect.storage`, which needs the tempdir root to open the
+//! isolated SQLite DB — that check lives in [`check_storage`] and is invoked
+//! separately by `harness::run_case` (which owns the tempdir), then merged into the
+//! [`CaseOutcome`] returned by `evaluate`.
+
+use std::collections::BTreeMap;
+#[cfg(feature = "storage")]
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::case::{CaseFile, ExpectedEvent};
+
+/// Outcome of running one case: pass/fail plus enough context to render a report.
+///
+/// `name`/`weight`/`allow_fail`/`expected`/`observed` are only consumed by the report
+/// aggregator (a later task, not yet in this repo) — `run_case` populates all of them
+/// today, `passed`/`diffs` are read by this task's own tests, but nothing here yet
+/// reads the rest back out. `#[allow(dead_code)]` until that lands; remove it once a
+/// consumer reads these fields.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default)]
+pub struct CaseOutcome {
+    pub name: String,
+    pub weight: u32,
+    pub passed: bool,
+    pub allow_fail: bool,
+    /// Debug rendering of `expect`, for report output.
+    pub expected: String,
+    /// Raw stdout captured from the `armadai` invocation.
+    pub observed: String,
+    /// Human-readable reasons the case failed (empty when `passed`).
+    pub diffs: Vec<String>,
+}
+
+/// Parse `stdout` as JSONL (ignoring non-JSON / plain-text log lines — anything that
+/// doesn't parse as a JSON object with a `t` field is skipped), then check `exit` and
+/// every part of `case.expect` against it.
+///
+/// Does **not** check `expect.storage` (see module doc) — callers that care about it
+/// should also call [`check_storage`] and fold its diffs in.
+pub fn evaluate(case: &CaseFile, stdout: &str, exit: i32) -> CaseOutcome {
+    let events: Vec<Value> = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
+        .filter(|v| v.get("t").is_some())
+        .collect();
+
+    let mut diffs = Vec::new();
+
+    if exit != case.expect.exit_code {
+        diffs.push(format!(
+            "exit_code: expected {}, got {exit}",
+            case.expect.exit_code
+        ));
+    }
+
+    check_events_order_and_fields(&case.expect.events, &events, &mut diffs);
+    check_event_counts(&case.expect.event_counts, &events, &mut diffs);
+    check_invariants(&case.expect.invariants, &events, &mut diffs);
+
+    CaseOutcome {
+        name: case.name.clone(),
+        weight: case.weight,
+        allow_fail: case.allow_fail,
+        passed: diffs.is_empty(),
+        expected: format!("{:#?}", case.expect),
+        observed: stdout.to_string(),
+        diffs,
+    }
+}
+
+/// Each [`ExpectedEvent`] must appear in `observed`, in the same relative order as
+/// `expected` (a subsequence match — unrelated events may appear in between, and
+/// events not listed in `expected` at all are ignored here; see `check_event_counts`
+/// for exhaustive counting). A matched event's index becomes the new search floor so
+/// two identical `expected` entries require two distinct `observed` occurrences.
+fn check_events_order_and_fields(
+    expected: &[ExpectedEvent],
+    observed: &[Value],
+    diffs: &mut Vec<String>,
+) {
+    let mut cursor = 0usize;
+    for exp in expected {
+        let found = observed
+            .iter()
+            .enumerate()
+            .skip(cursor)
+            .find(|(_, obs)| event_matches(exp, obs));
+        match found {
+            Some((i, _)) => cursor = i + 1,
+            None => diffs.push(format!(
+                "expected event t={:?} fields={:?} not found (in order) at/after position {cursor} \
+                 in observed stream ({} events)",
+                exp.t,
+                exp.fields,
+                observed.len()
+            )),
+        }
+    }
+}
+
+/// Whether `obs` matches `exp`: same `t`, and every field named in `exp.fields` is
+/// present in `obs` with the exact same value (fields absent from `exp` are not
+/// checked — this is a subset match, not an exact-equality match).
+fn event_matches(exp: &ExpectedEvent, obs: &Value) -> bool {
+    let Some(t) = obs.get("t").and_then(Value::as_str) else {
+        return false;
+    };
+    if t != exp.t {
+        return false;
+    }
+    exp.fields
+        .iter()
+        .all(|(k, v)| obs.get(k.as_str()) == Some(v))
+}
+
+/// Exact per-type counts across the whole observed stream (unlike
+/// `check_events_order_and_fields`, which only checks presence/order of the events
+/// named in `expect.events`).
+fn check_event_counts(
+    expected: &BTreeMap<String, usize>,
+    observed: &[Value],
+    diffs: &mut Vec<String>,
+) {
+    for (t, want) in expected {
+        let got = count_of(observed, t);
+        if got != *want {
+            diffs.push(format!("event_counts[{t}]: expected {want}, got {got}"));
+        }
+    }
+}
+
+fn count_of(observed: &[Value], t: &str) -> usize {
+    observed
+        .iter()
+        .filter(|v| v.get("t").and_then(Value::as_str) == Some(t))
+        .count()
+}
+
+/// Run each named invariant against the observed stream, collecting failures.
+fn check_invariants(names: &[String], observed: &[Value], diffs: &mut Vec<String>) {
+    for name in names {
+        let result = match name.as_str() {
+            "agent_start_end_symmetric" => agent_start_end_symmetric(observed),
+            "prov_model_non_empty" => prov_model_non_empty(observed),
+            "single_result" => single_result(observed),
+            "no_orphan_events" => no_orphan_events(observed),
+            other => Err(format!("unknown invariant '{other}'")),
+        };
+        if let Err(msg) = result {
+            diffs.push(format!("invariant '{name}' failed: {msg}"));
+        }
+    }
+}
+
+/// `agent_start` and `agent_end` counts must match — every agent that started must
+/// also have ended (success or failure both emit `agent_end` upstream; a mismatch
+/// here means a run was aborted mid-agent, e.g. a panic or a timeout).
+fn agent_start_end_symmetric(observed: &[Value]) -> Result<(), String> {
+    let starts = count_of(observed, "agent_start");
+    let ends = count_of(observed, "agent_end");
+    if starts == ends {
+        Ok(())
+    } else {
+        Err(format!("agent_start={starts} != agent_end={ends}"))
+    }
+}
+
+/// Every `agent_start` event must carry non-empty `prov` and `model` — these come
+/// straight from the agent's `## Metadata` (see `src/cli/run.rs`), so an empty value
+/// means the harness generated (or the CLI resolved) a malformed agent definition.
+fn prov_model_non_empty(observed: &[Value]) -> Result<(), String> {
+    for ev in observed
+        .iter()
+        .filter(|v| v.get("t").and_then(Value::as_str) == Some("agent_start"))
+    {
+        let prov = ev.get("prov").and_then(Value::as_str).unwrap_or("");
+        let model = ev.get("model").and_then(Value::as_str).unwrap_or("");
+        if prov.is_empty() || model.is_empty() {
+            return Err(format!("agent_start with empty prov/model: {ev}"));
+        }
+    }
+    Ok(())
+}
+
+/// Exactly one `result` event — `armadai run` emits one final aggregate result per
+/// invocation regardless of how many agents/rounds ran.
+fn single_result(observed: &[Value]) -> Result<(), String> {
+    let n = count_of(observed, "result");
+    if n == 1 {
+        Ok(())
+    } else {
+        Err(format!("expected exactly 1 result event, got {n}"))
+    }
+}
+
+/// No `agent_end` for an agent that never had a matching `agent_start`, and no agent
+/// left "open" (started but never ended) by the end of the stream. This is a
+/// per-agent balance check, not a strict global interleaving check (a well-behaved
+/// run never interleaves two `agent_start`s for the same agent without an `agent_end`
+/// in between, so balance is sufficient here).
+fn no_orphan_events(observed: &[Value]) -> Result<(), String> {
+    use std::collections::HashMap;
+    let mut open: HashMap<&str, i32> = HashMap::new();
+    for ev in observed {
+        match ev.get("t").and_then(Value::as_str) {
+            Some("agent_start") => {
+                if let Some(a) = ev.get("agent").and_then(Value::as_str) {
+                    *open.entry(a).or_insert(0) += 1;
+                }
+            }
+            Some("agent_end") => {
+                if let Some(a) = ev.get("agent").and_then(Value::as_str) {
+                    let c = open.entry(a).or_insert(0);
+                    *c -= 1;
+                    if *c < 0 {
+                        return Err(format!("agent_end for '{a}' with no matching agent_start"));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some((a, _)) = open.iter().find(|&(_, &c)| c != 0) {
+        return Err(format!(
+            "agent '{a}' has an unmatched agent_start (no agent_end)"
+        ));
+    }
+    Ok(())
+}
+
+/// Best-effort check of `expect.storage`: exact row counts for the tables listed
+/// (currently `runs`, `orchestration_runs`, `board_entries`, `ring_contributions`,
+/// `ring_votes` — the tables `src/storage/schema.rs` creates). Opens the SQLite DB at
+/// `<project_root>/.local/share/armadai/armadai.sqlite` — the path `armadai` itself
+/// resolves to given the harness's `XDG_DATA_HOME=<project_root>/.local/share`
+/// override (see `harness::run_case`).
+///
+/// Returns an empty `Vec` (no-op) when `expect.storage` is `None`. When the `storage`
+/// feature is off, also returns empty: this repo's e2e cases are meant to run in CI's
+/// `--features tui,storage` mode where the check is meaningful, so treating "feature
+/// off" as "not applicable" here (rather than a failure) avoids breaking cases in the
+/// `tui`-only / `tui,providers-api` clippy/build modes that never execute this check
+/// anyway. TODO: if a case ever needs to assert storage counts under a build that
+/// doesn't have `storage`, that's a signal the case belongs in a storage-gated test
+/// file instead.
+#[cfg(feature = "storage")]
+pub fn check_storage(expect: &Option<BTreeMap<String, usize>>, project_root: &Path) -> Vec<String> {
+    const KNOWN_TABLES: &[&str] = &[
+        "runs",
+        "orchestration_runs",
+        "board_entries",
+        "ring_contributions",
+        "ring_votes",
+    ];
+
+    let Some(expect) = expect else {
+        return Vec::new();
+    };
+
+    let mut diffs = Vec::new();
+    let db_path = project_root.join(".local/share/armadai/armadai.sqlite");
+    let conn = match rusqlite::Connection::open(&db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            diffs.push(format!(
+                "storage: cannot open db at {}: {e}",
+                db_path.display()
+            ));
+            return diffs;
+        }
+    };
+
+    for (table, want) in expect {
+        if !KNOWN_TABLES.contains(&table.as_str()) {
+            diffs.push(format!(
+                "storage: '{table}' is not a table src/storage/schema.rs creates \
+                 (known: {KNOWN_TABLES:?})"
+            ));
+            continue;
+        }
+        let got: usize = match conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| {
+            r.get::<_, i64>(0)
+        }) {
+            Ok(n) => n as usize,
+            Err(e) => {
+                diffs.push(format!("storage: query on '{table}' failed: {e}"));
+                continue;
+            }
+        };
+        if got != *want {
+            diffs.push(format!("storage[{table}]: expected {want} rows, got {got}"));
+        }
+    }
+
+    diffs
+}
+
+#[cfg(not(feature = "storage"))]
+pub fn check_storage(
+    _expect: &Option<BTreeMap<String, usize>>,
+    _project_root: &std::path::Path,
+) -> Vec<String> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::e2e::case::load_case_str;
+
+    fn case_with_expect(expect_yaml: &str) -> CaseFile {
+        let yaml = format!(
+            "name: t\nweight: 1\nsetup: {{ pattern: direct, agents: [a], flags: [], input: x }}\n\
+             fake: {{ rules: [ {{ match: {{}}, respond: ok }} ] }}\n{expect_yaml}"
+        );
+        load_case_str(&yaml).unwrap()
+    }
+
+    #[test]
+    fn passes_when_events_and_exit_match() {
+        let case = case_with_expect(
+            "expect:\n  exit_code: 0\n  events: [ { t: run_start }, { t: result } ]\n",
+        );
+        let stdout = "{\"t\":\"run_start\",\"v\":1}\n{\"t\":\"agent_start\",\"agent\":\"a\"}\n\
+             {\"t\":\"result\",\"content\":\"ok\"}\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(outcome.passed, "diffs: {:?}", outcome.diffs);
+    }
+
+    #[test]
+    fn fails_on_exit_code_mismatch() {
+        let case = case_with_expect("expect:\n  exit_code: 0\n");
+        let outcome = evaluate(&case, "", 1);
+        assert!(!outcome.passed);
+        assert!(outcome.diffs.iter().any(|d| d.contains("exit_code")));
+    }
+
+    #[test]
+    fn fails_when_expected_event_missing() {
+        let case = case_with_expect("expect:\n  exit_code: 0\n  events: [ { t: result } ]\n");
+        let outcome = evaluate(&case, "{\"t\":\"run_start\"}\n", 0);
+        assert!(!outcome.passed);
+        assert!(outcome.diffs.iter().any(|d| d.contains("t=\"result\"")));
+    }
+
+    #[test]
+    fn fails_when_event_out_of_order() {
+        let case = case_with_expect(
+            "expect:\n  exit_code: 0\n  events: [ { t: result }, { t: run_start } ]\n",
+        );
+        let stdout = "{\"t\":\"run_start\"}\n{\"t\":\"result\"}\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(!outcome.passed, "expected out-of-order events to fail");
+    }
+
+    #[test]
+    fn checks_event_fields_as_subset() {
+        let case = case_with_expect(
+            "expect:\n  exit_code: 0\n  events: [ { t: agent_start, agent: a } ]\n",
+        );
+        let stdout =
+            "{\"t\":\"agent_start\",\"agent\":\"a\",\"prov\":\"claude\",\"model\":\"m\"}\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(outcome.passed, "diffs: {:?}", outcome.diffs);
+
+        let stdout_wrong = "{\"t\":\"agent_start\",\"agent\":\"b\"}\n";
+        let outcome_wrong = evaluate(&case, stdout_wrong, 0);
+        assert!(!outcome_wrong.passed);
+    }
+
+    #[test]
+    fn checks_event_counts_exactly() {
+        let case =
+            case_with_expect("expect:\n  exit_code: 0\n  event_counts: { agent_start: 2 }\n");
+        let stdout = "{\"t\":\"agent_start\",\"agent\":\"a\"}\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(!outcome.passed);
+        assert!(
+            outcome
+                .diffs
+                .iter()
+                .any(|d| d.contains("event_counts[agent_start]"))
+        );
+    }
+
+    #[test]
+    fn ignores_non_json_lines() {
+        let case = case_with_expect("expect:\n  exit_code: 0\n  events: [ { t: result } ]\n");
+        let stdout = "not json\n{\"t\":\"result\"}\ntrailing garbage\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(outcome.passed, "diffs: {:?}", outcome.diffs);
+    }
+
+    #[test]
+    fn invariant_agent_start_end_symmetric_detects_mismatch() {
+        let case = case_with_expect(
+            "expect:\n  exit_code: 0\n  invariants: [agent_start_end_symmetric]\n",
+        );
+        let stdout = "{\"t\":\"agent_start\",\"agent\":\"a\"}\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(!outcome.passed);
+    }
+
+    #[test]
+    fn invariant_prov_model_non_empty_detects_empty_model() {
+        let case =
+            case_with_expect("expect:\n  exit_code: 0\n  invariants: [prov_model_non_empty]\n");
+        let stdout = "{\"t\":\"agent_start\",\"agent\":\"a\",\"prov\":\"claude\",\"model\":\"\"}\n";
+        let outcome = evaluate(&case, stdout, 0);
+        assert!(!outcome.passed);
+    }
+
+    #[test]
+    fn invariant_single_result_detects_zero_and_multiple() {
+        let case = case_with_expect("expect:\n  exit_code: 0\n  invariants: [single_result]\n");
+        assert!(!evaluate(&case, "", 0).passed);
+        assert!(!evaluate(&case, "{\"t\":\"result\"}\n{\"t\":\"result\"}\n", 0).passed);
+        assert!(evaluate(&case, "{\"t\":\"result\"}\n", 0).passed);
+    }
+
+    #[test]
+    fn invariant_no_orphan_events_detects_unbalanced_agent() {
+        let case = case_with_expect("expect:\n  exit_code: 0\n  invariants: [no_orphan_events]\n");
+        // agent_end with no agent_start
+        let outcome = evaluate(&case, "{\"t\":\"agent_end\",\"agent\":\"a\"}\n", 0);
+        assert!(!outcome.passed);
+        // agent_start with no agent_end
+        let outcome2 = evaluate(&case, "{\"t\":\"agent_start\",\"agent\":\"a\"}\n", 0);
+        assert!(!outcome2.passed);
+        // balanced
+        let outcome3 = evaluate(
+            &case,
+            "{\"t\":\"agent_start\",\"agent\":\"a\"}\n{\"t\":\"agent_end\",\"agent\":\"a\"}\n",
+            0,
+        );
+        assert!(outcome3.passed);
+    }
+
+    #[test]
+    fn unknown_invariant_fails_with_message() {
+        let case = case_with_expect("expect:\n  exit_code: 0\n  invariants: [nope]\n");
+        let outcome = evaluate(&case, "", 0);
+        assert!(!outcome.passed);
+        assert!(
+            outcome
+                .diffs
+                .iter()
+                .any(|d| d.contains("unknown invariant"))
+        );
+    }
+}

--- a/tests/e2e/runner.rs
+++ b/tests/e2e/runner.rs
@@ -18,12 +18,10 @@ use super::case::{CaseFile, ExpectedEvent};
 
 /// Outcome of running one case: pass/fail plus enough context to render a report.
 ///
-/// `name`/`weight`/`allow_fail`/`expected`/`observed` are only consumed by the report
-/// aggregator (a later task, not yet in this repo) — `run_case` populates all of them
-/// today, `passed`/`diffs` are read by this task's own tests, but nothing here yet
-/// reads the rest back out. `#[allow(dead_code)]` until that lands; remove it once a
-/// consumer reads these fields.
-#[allow(dead_code)]
+/// `name`/`weight`/`allow_fail`/`expected`/`observed` are read back out by
+/// `report::write_reports` (the report aggregator) to build both the JSON summary
+/// and the HTML expected-vs-observed blocks; `passed`/`diffs` are also exercised by
+/// this module's own tests.
 #[derive(Debug, Clone, Default)]
 pub struct CaseOutcome {
     pub name: String,


### PR DESCRIPTION
## Contexte

Banc de tests **e2e déterministe** pour l'orchestration — né du constat que ~1000 tests unitaires n'avaient pas vu les 2 bugs trouvés en validation manuelle du Lot 4. Il lance le **vrai binaire `armadai run --json`** contre un provider stub, sans réseau ni LLM.

## Contenu

- **`src/bin/fake-claude.rs`** — stub « moteur de règles » : lit un scénario, s'identifie via le marqueur `FAKE_AGENT_ID` (transmis dans l'argv grâce au fix #217), compteur d'appels par agent, émet du **claude stream-json** (parsé tel quel par `json_runner.rs`). Shadow-é comme `claude` sur le PATH par le runner.
- **`tests/e2e/`** — case files **déclaratifs** (setup + réponses fake + assertions), format `serde` + **JSON Schema (`schemars`)** (`docs/e2e-case.schema.json`), runner `assert_cmd`+`tempfile` (isolation stricte `HOME`/`XDG_*` → n'écrit jamais dans la config/DB réelle), évaluation (events/ordre/champs/counts + invariants `agent_start_end_symmetric`/`prov_model_non_empty`/`single_result`/`no_orphan_events`), **rapport JSON + HTML pondéré** (tokens « pont de commandement »).
- **Baselines vertes** : direct / hierarchical / blackboard / ring / nested C9 (5/5, weighted_score 1.0).
- **CI** : upload de `e2e-report.{html,json}` comme artefact (`if: always()`).

## Qualité

- **1013 tests** (dont 30 e2e + 8 fake-claude), **0 régression** (989 existants verts). Clippy `-D warnings` (`tui`, `tui,providers-api`, `tui,storage`) + fmt. **Zéro code prod touché** (uniquement `src/bin/`, `tests/`, dev-deps, `docs/`, `ci.yml`). Revue finale de branche indépendante : READY TO MERGE.

## Suites (hors PR)

- Cas 🔴 des Bugs A/B/`--quiet` → branche Lot 4 (TDD sur ce harnais).
- Record→replay depuis le log OH1 + génération de case files par agent → suivis.
- `ring` en `allow_fail` (tolérance à la « no-vote » observée en run réel = symptôme du halt budget, à réconcilier au Lot 4) — passe déjà en déterministe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)