### PR TITLE
fix(orchestration): raise default token budgets and cap ring context growth

### DIFF
--- a/docs/wiki/orchestration-guide.md
+++ b/docs/wiki/orchestration-guide.md
@@ -67,7 +67,7 @@ orchestration:
     - backend-dev
     - devops
   max_rounds: 5
-  token_budget: 50000
+  token_budget: 500000
 ```
 
 **Key parameters:**
@@ -78,7 +78,7 @@ orchestration:
 | max_rounds             | 5       | Maximum number of rounds before halting |
 | consensus_threshold    | 0.75    | Ratio of confirmations needed for consensus |
 | divergence_threshold   | 0.60    | Challenge ratio that triggers divergence halt |
-| token_budget           | 50000   | Maximum tokens across all agents |
+| token_budget           | 500000  | Safety cap on total tokens across all agents |
 | agent_timeout_secs     | 60      | Timeout per agent per round |
 | convergence_rounds     | 1       | Consecutive stable rounds before halting |
 
@@ -125,7 +125,7 @@ orchestration:
 | consensus_threshold   | 0.80    | Vote ratio required for consensus |
 | majority_threshold    | 0.60    | Vote ratio required for majority (if not consensus) |
 | similarity_threshold  | 0.85    | Jaccard threshold for grouping similar positions |
-| token_budget          | 40000   | Maximum tokens across all laps |
+| token_budget          | 500000  | Safety cap on total tokens across all laps |
 | agent_timeout_secs    | 90      | Timeout per agent per lap |
 
 **Agent actions:** Agents respond with structured actions: **Propose** (introduce idea), **Enrich** (build on prior contribution), **Contest** (argue against), **Endorse** (support), **Synthesize** (combine insights), **Pass** (nothing to add).
@@ -298,7 +298,7 @@ orchestration:
     - backend-dev
     - devops
   max_rounds: 5
-  token_budget: 50000
+  token_budget: 500000
 ```
 
 **Run:**
@@ -411,7 +411,7 @@ When a budget or cost limit is hit:
 3. All completed contributions are returned in the result
 4. The halt reason is logged and visible in history (`armadai history`)
 
-**Best practice:** Start with conservative budgets (e.g., 50k tokens for Blackboard, 40k for Ring) and increase if needed. Monitor costs via `armadai costs`.
+**Best practice:** The default token budget (500k) is a generous safety cap meant to catch a runaway, not a tight limit — normal multi-round/multi-lap runs with verbose agents stay well under it. Lower it only if you want a tighter ceiling for a specific run, and monitor costs via `armadai costs`.
 
 ## Tips and Gotchas
 

--- a/docs/wiki/orchestration.md
+++ b/docs/wiki/orchestration.md
@@ -207,7 +207,7 @@ orchestration:
 | Divergence threshold | 0.60 | — | — |
 | Majority threshold | — | 0.60 | — |
 | Similarity threshold | — | 0.85 | — |
-| Token budget | 50,000 | 40,000 | — |
+| Token budget | 500,000 | 500,000 | — |
 | Agent timeout | 60s | 90s | — |
 | Convergence rounds | 1 | — | — |
 | Global timeout | — | — | 300s |

--- a/src/core/orchestration/blackboard.rs
+++ b/src/core/orchestration/blackboard.rs
@@ -385,7 +385,10 @@ const fn default_divergence_threshold() -> f32 {
     0.60
 }
 const fn default_bb_token_budget() -> u64 {
-    50_000
+    // Safety cap, not a tight limit (aligned with ring): high enough for
+    // normal multi-round blackboards with verbose real agents to converge,
+    // low enough to catch a runaway. Tunable via `blackboard.token_budget`.
+    500_000
 }
 const fn default_convergence_rounds() -> u32 {
     1
@@ -1068,7 +1071,7 @@ mod tests {
         assert_eq!(config.agent_timeout_secs, 60);
         assert!((config.consensus_threshold - 0.75).abs() < f32::EPSILON);
         assert!((config.divergence_threshold - 0.60).abs() < f32::EPSILON);
-        assert_eq!(config.token_budget, 50_000);
+        assert_eq!(config.token_budget, 500_000);
         assert_eq!(config.convergence_rounds, 1);
         assert_eq!(config.agent_timeout(), Duration::from_secs(60));
     }

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -36,6 +36,12 @@ use crate::linker::model_resolution::fallback_model_for_tier;
 use crate::linker::model_resolution::{ModelTier, resolve_model_for_tier};
 use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
+/// Maximum number of prior ring contributions re-emitted in a circulation
+/// prompt. Without a cap the ring re-sends the entire transcript on every
+/// turn (quadratic context growth) and exhausts the token budget before the
+/// vote phase. Mirrors the blackboard snapshot cap.
+const RING_CONTEXT_CAP: usize = 10;
+
 /// The ring pattern's current phase, derived purely from [`ExecutionState`].
 ///
 /// Mirrors the legacy `TokenStatus` (`Circulating`/`Voting`/`Done { .. }`)
@@ -687,10 +693,12 @@ impl RingEffectRunner {
     /// (`core::orchestration::llm_agents`) over the event-sourced
     /// `state.ring` projection instead of a live `TokenSnapshot`: `"Task:
     /// …\nLap: …\nYour position: …/…\n"`, then (only if any exist) a
-    /// `"Previous contributions:\n"` section listing *every* contribution
-    /// recorded so far (`state.ring.contributions`, in append order) as
-    /// `"- [#{index} Lap {lap} / {position}] {agent}: {content}\n"`, then
-    /// [`RING_ACTION_INSTRUCTIONS`] verbatim.
+    /// `"Previous contributions:\n"` section listing the most recent
+    /// contributions recorded so far (`state.ring.contributions`, in append
+    /// order, capped to the last [`RING_CONTEXT_CAP`] to bound prompt growth)
+    /// as `"- [#{index} Lap {lap} / {position}] {agent}: {content}\n"`, then
+    /// [`RING_ACTION_INSTRUCTIONS`] verbatim. When the history is truncated
+    /// the header reads `"Previous contributions (last N of M):\n"`.
     ///
     /// `position` (0-based, "your position in *this* lap") is the number of
     /// contributions already recorded for `lap` — the same count
@@ -713,8 +721,22 @@ impl RingEffectRunner {
         );
 
         if !state.ring.contributions.is_empty() {
-            user_msg.push_str("\nPrevious contributions:\n");
-            for (i, c) in state.ring.contributions.iter().enumerate() {
+            // Cap the re-emitted history to the most recent contributions to
+            // bound the prompt size (the ring otherwise re-sends the entire
+            // transcript every turn → quadratic context growth that eats the
+            // token budget before the vote phase). Mirrors the blackboard
+            // snapshot cap. Original indices are preserved for readability.
+            let all = &state.ring.contributions;
+            let start = all.len().saturating_sub(RING_CONTEXT_CAP);
+            if start > 0 {
+                user_msg.push_str(&format!(
+                    "\nPrevious contributions (last {RING_CONTEXT_CAP} of {}):\n",
+                    all.len()
+                ));
+            } else {
+                user_msg.push_str("\nPrevious contributions:\n");
+            }
+            for (i, c) in all.iter().enumerate().skip(start) {
                 user_msg.push_str(&format!(
                     "- [#{i} Lap {} / {}] {}: {}\n",
                     c.lap, c.position, c.agent, c.content
@@ -1431,6 +1453,62 @@ mod tests {
                 Action::Invoke { agent, .. } => Some(agent.as_str()),
                 _ => None,
             })
+        }
+
+        // ── build_circulate_prompt: history cap (budget-tuning) ──────────
+
+        fn test_runner() -> RingEffectRunner {
+            RingEffectRunner::new(
+                BTreeMap::new(),
+                BTreeMap::new(),
+                RingConfig::default(),
+                BTreeMap::new(),
+            )
+        }
+
+        #[test]
+        fn circulate_prompt_caps_history_to_last_ten() {
+            // 15 contributions recorded, but the circulation prompt must only
+            // re-emit the most recent RING_CONTEXT_CAP (10) — the older ones
+            // are dropped to bound prompt growth (quadratic → linear).
+            let mut events = vec![run_started(&["a", "b"])];
+            for i in 0..15 {
+                events.push(contribution("a", 0, i, "propose"));
+            }
+            let state = fold(&events);
+            let runner = test_runner();
+
+            let prompt = runner.build_circulate_prompt("task", 0, &state);
+
+            // Truncation header advertises "last 10 of 15".
+            assert!(
+                prompt.contains("Previous contributions (last 10 of 15):"),
+                "expected truncation header, got:\n{prompt}"
+            );
+            // The 10 most recent (indices 5..=14) survive; older ones are gone.
+            assert!(prompt.contains("[#14 "), "newest contribution missing");
+            assert!(prompt.contains("[#5 "), "oldest kept contribution missing");
+            assert!(!prompt.contains("[#4 "), "index 4 should have been dropped");
+            assert!(!prompt.contains("[#0 "), "index 0 should have been dropped");
+        }
+
+        #[test]
+        fn circulate_prompt_no_truncation_below_cap() {
+            // Under the cap the plain header is used and every contribution
+            // is present (no "last N of M" note).
+            let mut events = vec![run_started(&["a", "b"])];
+            for i in 0..3 {
+                events.push(contribution("a", 0, i, "propose"));
+            }
+            let state = fold(&events);
+            let runner = test_runner();
+
+            let prompt = runner.build_circulate_prompt("task", 0, &state);
+
+            assert!(prompt.contains("Previous contributions:\n"));
+            assert!(!prompt.contains("last "), "no truncation note expected");
+            assert!(prompt.contains("[#0 "));
+            assert!(prompt.contains("[#2 "));
         }
 
         // (a) empty state → `LapStarted{0}` first, then `Invoke` of the

--- a/src/core/orchestration/ring.rs
+++ b/src/core/orchestration/ring.rs
@@ -288,7 +288,11 @@ const fn default_similarity_threshold() -> f32 {
     0.85
 }
 const fn default_ring_token_budget() -> u64 {
-    40_000
+    // Safety cap, not a tight limit: high enough that normal multi-lap rings
+    // (verbose real agents, provider-side context overhead) reach the vote
+    // phase, low enough to still catch a runaway. The old 40k halted a real
+    // 2-agent ring before voting. Tunable via `ring.token_budget`.
+    500_000
 }
 
 impl Default for RingConfig {
@@ -653,7 +657,7 @@ mod tests {
         assert!((config.consensus_threshold - 0.80).abs() < f32::EPSILON);
         assert!((config.majority_threshold - 0.60).abs() < f32::EPSILON);
         assert!((config.similarity_threshold - 0.85).abs() < f32::EPSILON);
-        assert_eq!(config.token_budget, 40_000);
+        assert_eq!(config.token_budget, 500_000);
         assert_eq!(config.agent_timeout(), Duration::from_secs(90));
     }
 

--- a/tests/e2e/cases/ring-budget-reaches-vote.yaml
+++ b/tests/e2e/cases/ring-budget-reaches-vote.yaml
@@ -1,0 +1,62 @@
+name: ring-budget-reaches-vote
+weight: 5
+setup:
+  # Budget-tuning regression guard (fix/orchestration-budget-tuning): a
+  # verbose ring — every propose contribution reports a realistic ~8k
+  # tokens_in — must still reach the vote/resolve phase under the DEFAULT
+  # ring token budget. Nine propose contributions (3 agents x 3 laps) at
+  # 8000 tokens_in each total ~72k, which BREACHED the old 40k default and
+  # halted the ring before any vote was cast. With the default raised to
+  # 500k this run completes normally. No `token_budget` override here: the
+  # whole point is to exercise the shipped default. If someone lowers the
+  # ring default back below ~72k, this case fails (missing votes + a
+  # `warning` where none is expected).
+  pattern: ring
+  agents: [t-charlie, t-alpha, t-bravo]
+  flags: ["--json"]
+  input: "propose a caching strategy"
+fake:
+  rules:
+    # Propose phase — verbose contributions (~8k input tokens each). The
+    # same-order/same-content shape as cases/ring.yaml; only the token
+    # accounting differs.
+    - match: { agent: t-charlie, prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: t-charlie proposes a write-through cache"
+      tokens_in: 8000
+      tokens_out: 200
+    - match: { agent: t-alpha, prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: t-alpha proposes a read-through cache"
+      tokens_in: 8000
+      tokens_out: 200
+    - match: { agent: t-bravo, prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: t-bravo proposes a write-behind cache"
+      tokens_in: 8000
+      tokens_out: 200
+    # Voting phase.
+    - match: { agent: t-charlie, prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.8\nWrite-through is the safer default."
+      tokens_in: 2000
+      tokens_out: 100
+    - match: { agent: t-alpha, prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.75\nRead-through works if writes are rare."
+      tokens_in: 2000
+      tokens_out: 100
+    - match: { agent: t-bravo, prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.6\nWrite-behind risks data loss."
+      tokens_in: 2000
+      tokens_out: 100
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    # The ring reaches the vote phase: all three agents cast a vote and a
+    # single result is produced. Under the old 40k default the run halted
+    # after ~5 propose contributions and NONE of these votes were reached.
+    - { t: run_start }
+    - { t: vote, agent: t-charlie }
+    - { t: vote, agent: t-alpha }
+    - { t: vote, agent: t-bravo }
+    - { t: result }
+  event_counts: { agent_start: 12, agent_end: 12, vote: 3, result: 1, warning: 0 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]


### PR DESCRIPTION
## Contexte

Suivi post-Lot 4 OH1 (tuning budget). Les budgets de tokens par défaut étaient trop bas pour des agents réels verbeux : un ring 2-agents réel se coupait **avant la phase de vote**.

Cause racine : le ring ES ré-émettait **tout** son transcript à chaque tour (croissance quadratique du contexte) → le budget par défaut de 40k était épuisé avant le vote.

## Changements

- **Défauts relevés** : ring 40k → 500k, blackboard 50k → 500k (safety-cap cohérent — assez haut pour que les runs multi-laps/rounds verbeux aboutissent, assez bas pour attraper un runaway). Tunable via `ring.token_budget` / `blackboard.token_budget`.
- **Cap du contexte ring** : le prompt de circulation ES ne ré-émet plus que les `RING_CONTEXT_CAP` (10) dernières contributions (quadratique → linéaire), en miroir du cap snapshot du blackboard. Troncature signalée dans l'en-tête (`last N of M`).

## Tests

- 2 tests unitaires du cap ring (tronqué / non-tronqué)
- Asserts de défaut mis à jour (500k)
- Nouveau cas e2e `ring-budget-reaches-vote` : prouve qu'un ring verbeux atteint le vote sous le budget par défaut (aurait halté à 40k). `budget-halt-visible` (budget explicite 10) continue de prouver le halt gracieux visible.

CI locale verte : clippy (2 modes), fmt, 1017 unit + 30 e2e (8 cas).

⚠️ **Changement comportemental** (runs réels qui haltaient aboutissent désormais) → attente validation manuelle avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)