### PR TITLE
feat(run): OH1 Lot 5b — flat tables as projections derived from the event log

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@ mod link;
 mod list;
 mod models;
 pub(crate) mod new;
+mod projections;
 mod prompts;
 mod registry;
 mod run;
@@ -218,6 +219,19 @@ pub enum Command {
         #[arg(long)]
         from: Option<String>,
     },
+    /// Manage flat-table projections from the event log
+    #[command(
+        subcommand,
+        long_about = "Manage flat-table projections from the event log.\n\n\
+            Re-derives flat tables (runs, orchestration_runs, board_entries, ring_contributions, \
+            ring_votes, delegation_events) from the immutable execution_events log. \
+            The projector is idempotent: multiple rebuilds produce the same result.",
+        after_help = "Examples:\n  \
+            armadai projections rebuild\n  \
+            armadai projections rebuild --all\n  \
+            armadai projections rebuild --run <run-id>"
+    )]
+    Projections(projections::ProjectionsAction),
     /// Manage providers and secrets
     #[command(
         long_about = "Manage providers and secrets.\n\n\
@@ -509,6 +523,7 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         } => audit::execute(path, report, min_severity, quiet, propose, deep).await,
         Command::History { agent } => history::execute(agent).await,
         Command::Costs { agent, from } => costs::execute(agent, from).await,
+        Command::Projections(action) => projections::execute(action).await,
         Command::Config { action } => config::execute(action).await,
         #[cfg(feature = "tui")]
         Command::Shell => crate::shell::app::run_shell().await,

--- a/src/cli/projections.rs
+++ b/src/cli/projections.rs
@@ -62,11 +62,12 @@ pub async fn execute(action: ProjectionsAction) -> anyhow::Result<()> {
 
                 if let Some(id) = run {
                     rebuild_run(&db, &id)?;
-                    println!("1 run(s) reprojected");
+                    println!("1 run reprojected");
                 } else {
                     // Default to --all if no flag specified
                     let count = rebuild_all(&db)?;
-                    println!("{} run(s) reprojected", count);
+                    let plural = if count == 1 { "run" } else { "runs" };
+                    println!("{count} {plural} reprojected");
                 }
 
                 Ok(())

--- a/src/cli/projections.rs
+++ b/src/cli/projections.rs
@@ -1,0 +1,198 @@
+//! Projection management commands — rebuild flat tables from the event log.
+//!
+//! The `projections rebuild` command allows re-deriving flat-table rows
+//! (`runs`, `orchestration_runs`, `board_entries`, `ring_contributions`,
+//! `ring_votes`, `delegation_events`) from the immutable `execution_events`
+//! log. Useful after schema migrations, data corruption, or when debugging
+//! the projector logic itself.
+//!
+//! The projector (`crate::cli::run_es_record::project_run`) is idempotent:
+//! calling it multiple times produces the same result (no duplicate rows).
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum ProjectionsAction {
+    /// Rebuild flat-table projections from the event log
+    Rebuild {
+        /// Rebuild projections for a specific run
+        #[arg(long)]
+        run: Option<String>,
+        /// Rebuild projections for all runs (default)
+        #[arg(long)]
+        all: bool,
+    },
+}
+
+#[cfg(feature = "storage")]
+use crate::storage::Database;
+
+/// Rebuild projections for a single run from its event log.
+///
+/// Calls the idempotent `project_run` projector on the given `run_id`.
+/// If the run doesn't exist in the log, no error is raised (idempotent no-op).
+#[cfg(feature = "storage")]
+pub fn rebuild_run(db: &Database, run_id: &str) -> anyhow::Result<()> {
+    crate::cli::run_es_record::project_run(db, run_id)
+}
+
+/// Rebuild projections for all runs present in the event log.
+///
+/// Iterates over all distinct `run_id` values in `execution_events` and
+/// projects each one via `rebuild_run`. Returns the total count of runs
+/// projected (including those that were already up-to-date, since the
+/// projector is idempotent).
+#[cfg(feature = "storage")]
+pub fn rebuild_all(db: &Database) -> anyhow::Result<usize> {
+    let run_ids = crate::storage::queries::all_event_log_run_ids(db)?;
+    let count = run_ids.len();
+    for run_id in run_ids {
+        rebuild_run(db, &run_id)?;
+    }
+    Ok(count)
+}
+
+/// Execute the `armadai projections` command dispatcher.
+pub async fn execute(action: ProjectionsAction) -> anyhow::Result<()> {
+    match action {
+        ProjectionsAction::Rebuild { run, all: _all } => {
+            #[cfg(feature = "storage")]
+            {
+                let db = crate::storage::init_db()?;
+
+                if let Some(id) = run {
+                    rebuild_run(&db, &id)?;
+                    println!("1 run(s) reprojected");
+                } else {
+                    // Default to --all if no flag specified
+                    let count = rebuild_all(&db)?;
+                    println!("{} run(s) reprojected", count);
+                }
+
+                Ok(())
+            }
+
+            #[cfg(not(feature = "storage"))]
+            {
+                let _ = (run, _all);
+                anyhow::bail!(
+                    "Projections require the 'storage' feature. Build with: cargo build --features storage"
+                )
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "storage"))]
+mod tests {
+    use super::*;
+    use crate::core::orchestration::es::event::ExecutionEvent;
+    use crate::core::orchestration::es::log::{EventLog, SqliteLog};
+    use crate::storage::{init_embedded, queries};
+
+    /// Helper: construct a minimal blackboard event log suitable for
+    /// projection tests (copied from run_es_record.rs storage_tests).
+    fn sample_blackboard_events(run_id: &str) -> Vec<ExecutionEvent> {
+        vec![
+            ExecutionEvent::RunStarted {
+                run_id: run_id.to_string(),
+                pattern: "blackboard".to_string(),
+                agents: vec!["a".to_string(), "b".to_string()],
+                input: "do research".to_string(),
+                project: None,
+            },
+            ExecutionEvent::ConfigSnapshot {
+                config_json:
+                    r#"{"max_rounds":5,"convergence_threshold":0.8,"consecutive_rounds":2}"#
+                        .to_string(),
+            },
+            ExecutionEvent::RoundStarted { round: 1 },
+            ExecutionEvent::AgentInvoked {
+                agent: "a".to_string(),
+                input: "task input".to_string(),
+            },
+            ExecutionEvent::BoardEntryAdded {
+                agent: "a".to_string(),
+                round: 1,
+                kind: "finding".to_string(),
+                content: "first finding".to_string(),
+                refs: vec![],
+                confidence: 0.9,
+                tokens_in: 50,
+                tokens_out: 100,
+                cost: 0.03,
+            },
+            ExecutionEvent::Completed {
+                content: "final result".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn rebuild_reprojects_a_run_from_the_log() {
+        let db = init_embedded().unwrap();
+
+        // Persist a log + project once.
+        let run_id = "run-y";
+        let mut log = SqliteLog::new(db.clone());
+        for e in sample_blackboard_events(run_id) {
+            log.append(run_id, &e).unwrap();
+        }
+        crate::cli::run_es_record::project_run(&db, run_id).unwrap();
+
+        // Verify projection exists.
+        assert!(
+            queries::get_orchestration_run(&db, run_id)
+                .unwrap()
+                .is_some()
+        );
+
+        // Delete the projection.
+        queries::delete_projection_for_run(&db, run_id).unwrap();
+        assert!(
+            queries::get_orchestration_run(&db, run_id)
+                .unwrap()
+                .is_none()
+        );
+
+        // Rebuild via our helper.
+        rebuild_run(&db, run_id).unwrap();
+
+        // Verify projection is back.
+        let orch = queries::get_orchestration_run(&db, run_id)
+            .unwrap()
+            .expect("orchestration run should exist after rebuild");
+        assert_eq!(orch.pattern, "blackboard");
+        assert_eq!(orch.run_id, run_id);
+    }
+
+    #[test]
+    fn rebuild_all_projects_all_runs_in_the_log() {
+        let db = init_embedded().unwrap();
+
+        // Persist two runs.
+        let mut log = SqliteLog::new(db.clone());
+        for e in sample_blackboard_events("run-a") {
+            log.append("run-a", &e).unwrap();
+        }
+        for e in sample_blackboard_events("run-b") {
+            log.append("run-b", &e).unwrap();
+        }
+
+        // Rebuild all.
+        let count = rebuild_all(&db).unwrap();
+        assert_eq!(count, 2);
+
+        // Both runs should be projected.
+        assert!(
+            queries::get_orchestration_run(&db, "run-a")
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            queries::get_orchestration_run(&db, "run-b")
+                .unwrap()
+                .is_some()
+        );
+    }
+}

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1140,10 +1140,6 @@ async fn run_orchestrated_inner(
         _ => crate::core::routing::RoutingRules::default(),
     };
 
-    // Project attribution for storage (mirrors the sequential path).
-    #[cfg(feature = "storage")]
-    let project = project_display_string(resolution);
-
     sink.emit(&RunEvent::RunStart {
         v: 1,
         agents: agent_names.to_vec(),
@@ -1283,7 +1279,16 @@ async fn run_orchestrated_inner(
 
             #[cfg(feature = "storage")]
             {
-                record_blackboard_es(&_run_id, &state, &config, input, project.as_deref());
+                match crate::storage::init_db() {
+                    Ok(db) => {
+                        if let Err(e) = crate::cli::run_es_record::project_run(&db, &_run_id) {
+                            tracing::warn!("failed to project run {}: {}", _run_id, e);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("event log storage unavailable, run not projected: {}", e);
+                    }
+                }
             }
 
             let outcome_text = super::run_es_record::blackboard_display(&state);
@@ -1349,7 +1354,16 @@ async fn run_orchestrated_inner(
 
             #[cfg(feature = "storage")]
             {
-                record_ring_es(&_run_id, &state, &config, input, project.as_deref());
+                match crate::storage::init_db() {
+                    Ok(db) => {
+                        if let Err(e) = crate::cli::run_es_record::project_run(&db, &_run_id) {
+                            tracing::warn!("failed to project run {}: {}", _run_id, e);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("event log storage unavailable, run not projected: {}", e);
+                    }
+                }
             }
 
             let outcome_text = super::run_es_record::ring_display(&state, &events);
@@ -1413,11 +1427,6 @@ async fn run_orchestrated_inner(
                 agent_map.len()
             );
 
-            // Kept alive for post-run persistence (`record_orchestration_hierarchical`)
-            // since `orch_config` itself is moved into the engine below.
-            #[cfg(feature = "storage")]
-            let orch_config_for_storage = orch_config.clone();
-
             let (state, events, _run_id) = dispatch_hierarchical_es(
                 &coordinator_name,
                 input,
@@ -1444,13 +1453,16 @@ async fn run_orchestrated_inner(
 
             #[cfg(feature = "storage")]
             {
-                record_orchestration_hierarchical(
-                    &_run_id,
-                    &result,
-                    &orch_config_for_storage,
-                    input,
-                    project.as_deref(),
-                );
+                match crate::storage::init_db() {
+                    Ok(db) => {
+                        if let Err(e) = crate::cli::run_es_record::project_run(&db, &_run_id) {
+                            tracing::warn!("failed to project run {}: {}", _run_id, e);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("event log storage unavailable, run not projected: {}", e);
+                    }
+                }
             }
 
             if !json {
@@ -1711,62 +1723,6 @@ async fn dispatch_hierarchical_es(
     Ok((state, events, run_id))
 }
 
-/// Top-level entry point for persisting a standalone blackboard run's
-/// ES projection (`armadai run --orchestrate blackboard`, OH1 Lot 5).
-/// Initializes storage and delegates to
-/// [`super::run_es_record::record_blackboard_es_into`] with no parent —
-/// the ES-native counterpart of the legacy [`record_orchestration_blackboard`]
-/// (which reads a live `blackboard::Board` instead of an `ExecutionState`).
-#[cfg(feature = "storage")]
-fn record_blackboard_es(
-    run_id: &str,
-    state: &ExecutionState,
-    config: &crate::core::orchestration::blackboard::BlackboardConfig,
-    input: &str,
-    project: Option<&str>,
-) {
-    let db = match crate::storage::init_db() {
-        Ok(db) => db,
-        Err(e) => {
-            tracing::warn!("Failed to init storage: {e}");
-            return;
-        }
-    };
-    if let Err(e) = super::run_es_record::record_blackboard_es_into(
-        &db, run_id, state, config, input, None, project,
-    ) {
-        tracing::warn!("Failed to record blackboard run: {e}");
-    }
-}
-
-/// Top-level entry point for persisting a standalone ring run's ES
-/// projection (`armadai run --orchestrate ring`, OH1 Lot 5). Initializes
-/// storage and delegates to [`super::run_es_record::record_ring_es_into`]
-/// with no parent — the ES-native counterpart of the legacy
-/// [`record_orchestration_ring`] (which reads a live `ring::RingToken`
-/// instead of an `ExecutionState`).
-#[cfg(feature = "storage")]
-fn record_ring_es(
-    run_id: &str,
-    state: &ExecutionState,
-    config: &crate::core::orchestration::ring::RingConfig,
-    input: &str,
-    project: Option<&str>,
-) {
-    let db = match crate::storage::init_db() {
-        Ok(db) => db,
-        Err(e) => {
-            tracing::warn!("Failed to init storage: {e}");
-            return;
-        }
-    };
-    if let Err(e) =
-        super::run_es_record::record_ring_es_into(&db, run_id, state, config, input, None, project)
-    {
-        tracing::warn!("Failed to record ring run: {e}");
-    }
-}
-
 /// Apply project-level orchestration overrides to a BlackboardConfig.
 fn apply_blackboard_overrides(
     mut config: crate::core::orchestration::blackboard::BlackboardConfig,
@@ -1878,29 +1834,6 @@ pub(crate) fn record_hierarchical_into(
     }
 
     Ok(run_id.to_string())
-}
-
-/// Top-level entry point for persisting a hierarchical run
-/// (`armadai run --orchestrate hierarchical`). Initializes storage and
-/// delegates to [`record_hierarchical_into`].
-#[cfg(feature = "storage")]
-fn record_orchestration_hierarchical(
-    run_id: &str,
-    result: &crate::core::orchestration::hierarchical::OrchestrationResult,
-    config: &crate::core::orchestration::OrchestrationConfig,
-    input: &str,
-    project: Option<&str>,
-) {
-    let db = match crate::storage::init_db() {
-        Ok(db) => db,
-        Err(e) => {
-            tracing::warn!("Failed to init storage: {e}");
-            return;
-        }
-    };
-    if let Err(e) = record_hierarchical_into(&db, run_id, result, config, input, project) {
-        tracing::warn!("Failed to record hierarchical run: {e}");
-    }
 }
 
 /// Check if an error indicates the model was not found (HTTP 404 or model-related 400).
@@ -2972,6 +2905,72 @@ mod es_switch_tests {
             matches!(events[0], ExecutionEvent::RunStarted { .. }),
             "first event should be RunStarted, got {:?}",
             events[0]
+        );
+    }
+
+    /// Verify that a blackboard run projects its flat tables from the event
+    /// log (OH1 Lot 5b Task 3). After the ES loop persists events to the log,
+    /// `project_run` derives the `runs`/`orchestration_runs`/`board_entries`
+    /// tables from it — the same flow the real `run_orchestrated` branches will
+    /// use after the Task 3 wiring.
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn blackboard_es_run_projects_tables_from_log() {
+        use crate::core::orchestration::es::blackboard::run_blackboard_es;
+        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::{init_embedded, queries};
+
+        let db = init_embedded().unwrap();
+        let run_id = "it-bb-proj-1";
+        let (agents, providers) = blackboard_roster();
+        let config = BlackboardConfig::default();
+
+        // (a): Execute the ES loop with a SqliteLog (persists events to the
+        // test's in-memory DB), wrapped in a SinkProjectingLog for observability.
+        let (_capture, sink) = capture_sink();
+        let filtered_sink = quiet_max_content_sink(&sink, false, None);
+        let mut log = SinkProjectingLog::with_meta(
+            SqliteLog::new(db.clone()),
+            &filtered_sink,
+            agent_meta_from_roster(&agents),
+        );
+        let state = run_blackboard_es(
+            run_id,
+            "task",
+            agents,
+            providers,
+            config,
+            RoutingRules::default(),
+            None,
+            &mut log,
+        )
+        .await
+        .unwrap();
+
+        // (b): Before projection, the flat tables should be empty for this run_id.
+        assert!(
+            queries::get_orchestration_run(&db, run_id)
+                .unwrap()
+                .is_none(),
+            "flat tables should be empty before projection"
+        );
+
+        // (c): Project the flat tables from the event log.
+        crate::cli::run_es_record::project_run(&db, run_id).unwrap();
+
+        // (d): Verify that the projection succeeded: `runs` + `orchestration_runs`
+        // tables should now have a row for this run with `pattern == "blackboard"`.
+        let run_record = queries::get_orchestration_run(&db, run_id)
+            .unwrap()
+            .expect("projection should have created a run record");
+        assert_eq!(run_record.pattern, "blackboard");
+
+        // (e): Verify that board entries were also projected.
+        let entries = queries::get_board_entries(&db, run_id).unwrap();
+        assert_eq!(
+            entries.len(),
+            state.board.entries.len(),
+            "all board entries should be projected"
         );
     }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1822,7 +1822,7 @@ fn apply_ring_overrides(
 /// Persist a hierarchical orchestration run: the parent run row and its
 /// delegation trace. Returns the provided hierarchical `run_id`.
 #[cfg(feature = "storage")]
-fn record_hierarchical_into(
+pub(crate) fn record_hierarchical_into(
     db: &crate::storage::Database,
     run_id: &str,
     result: &crate::core::orchestration::hierarchical::OrchestrationResult,

--- a/src/cli/run_es_record.rs
+++ b/src/cli/run_es_record.rs
@@ -300,7 +300,6 @@ pub fn record_ring_es_into(
 /// Returns `Ok(())` when the projection succeeds, or an error if the event log
 /// is malformed (e.g. no `RunStarted`) or storage fails.
 #[cfg(feature = "storage")]
-#[allow(dead_code)] // Wired in Task 3 (run.rs dispatch branches)
 pub fn project_run(db: &crate::storage::Database, run_id: &str) -> anyhow::Result<()> {
     use crate::core::orchestration::es::log::{EventLog, SqliteLog};
     use crate::core::orchestration::es::state::fold;

--- a/src/cli/run_es_record.rs
+++ b/src/cli/run_es_record.rs
@@ -287,6 +287,122 @@ pub fn record_ring_es_into(
     Ok(run_id.to_string())
 }
 
+/// Idempotent projector: re-derive all flat-table rows (`runs`,
+/// `orchestration_runs`, `board_entries`, `ring_contributions`, `ring_votes`,
+/// `delegation_events`) for a given `run_id` from its event log.
+///
+/// Reads `execution_events[run_id]`, folds them into an `ExecutionState`,
+/// extracts the runtime config (from `ConfigSnapshot` → `state.config_json`),
+/// deletes any existing projection rows, then calls the pattern-specific
+/// `record_*_es_into` function to rebuild them. Multiple calls on the same
+/// `run_id` produce the exact same rows (idempotence: DELETE before INSERT).
+///
+/// Returns `Ok(())` when the projection succeeds, or an error if the event log
+/// is malformed (e.g. no `RunStarted`) or storage fails.
+#[cfg(feature = "storage")]
+#[allow(dead_code)] // Wired in Task 3 (run.rs dispatch branches)
+pub fn project_run(db: &crate::storage::Database, run_id: &str) -> anyhow::Result<()> {
+    use crate::core::orchestration::es::log::{EventLog, SqliteLog};
+    use crate::core::orchestration::es::state::fold;
+
+    // 1. Read the event log for this run.
+    let log = SqliteLog::new(db.clone());
+    let events = log.events(run_id)?;
+
+    if events.is_empty() {
+        // No events = nothing to project (run doesn't exist or was never started).
+        return Ok(());
+    }
+
+    // 2. Fold into ExecutionState.
+    let state = fold(&events);
+
+    // 3. Extract pattern/input/project from the first RunStarted event.
+    let (pattern, input, project) = events
+        .iter()
+        .find_map(|e| match e {
+            ExecutionEvent::RunStarted {
+                pattern,
+                input,
+                project,
+                ..
+            } => Some((pattern.clone(), input.clone(), project.clone())),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow::anyhow!("No RunStarted event in log for run {}", run_id))?;
+
+    // 4. Delete any existing projection rows (idempotence: clear before rebuilding).
+    crate::storage::queries::delete_projection_for_run(db, run_id)?;
+
+    // 5. Rebuild the projection by calling the pattern-specific record function.
+    match pattern.as_str() {
+        "blackboard" => {
+            let config: BlackboardConfig = state
+                .config_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default();
+            record_blackboard_es_into(
+                db,
+                run_id,
+                &state,
+                &config,
+                &input,
+                None,
+                project.as_deref(),
+            )?;
+        }
+        "ring" => {
+            let config: RingConfig = state
+                .config_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default();
+            record_ring_es_into(
+                db,
+                run_id,
+                &state,
+                &config,
+                &input,
+                None,
+                project.as_deref(),
+            )?;
+        }
+        "hierarchical" => {
+            use crate::core::orchestration::OrchestrationConfig;
+            use crate::core::orchestration::es::bridge::to_orchestration_result;
+
+            let result = to_orchestration_result(&state, &events);
+            let config: OrchestrationConfig = state
+                .config_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default();
+
+            crate::cli::run::record_hierarchical_into(
+                db,
+                run_id,
+                &result,
+                &config,
+                &input,
+                project.as_deref(),
+            )?;
+        }
+        "direct" => {
+            // Direct runs have no orchestration metadata; nothing to project.
+        }
+        _ => {
+            anyhow::bail!(
+                "Unknown orchestration pattern '{}' for run {}",
+                pattern,
+                run_id
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -612,5 +728,81 @@ mod storage_tests {
             .unwrap()
             .unwrap();
         assert_eq!(run.run_id, "fixed-run-id-123");
+    }
+
+    /// Helper: construct a minimal blackboard event log suitable for
+    /// projection tests.
+    fn sample_blackboard_events(run_id: &str) -> Vec<ExecutionEvent> {
+        vec![
+            ExecutionEvent::RunStarted {
+                run_id: run_id.to_string(),
+                pattern: "blackboard".to_string(),
+                agents: vec!["a".to_string(), "b".to_string()],
+                input: "do research".to_string(),
+                project: None,
+            },
+            ExecutionEvent::ConfigSnapshot {
+                config_json:
+                    r#"{"max_rounds":5,"convergence_threshold":0.8,"consecutive_rounds":2}"#
+                        .to_string(),
+            },
+            ExecutionEvent::RoundStarted { round: 1 },
+            ExecutionEvent::AgentInvoked {
+                agent: "a".to_string(),
+                input: "task input".to_string(),
+            },
+            ExecutionEvent::BoardEntryAdded {
+                agent: "a".to_string(),
+                round: 1,
+                kind: "finding".to_string(),
+                content: "first finding".to_string(),
+                refs: vec![],
+                confidence: 0.9,
+                tokens_in: 50,
+                tokens_out: 100,
+                cost: 0.03,
+            },
+            ExecutionEvent::Completed {
+                content: "final result".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn project_run_is_idempotent() {
+        let db = init_embedded().unwrap();
+
+        // Persist a minimal blackboard log via SqliteLog.
+        let mut log = crate::core::orchestration::es::log::SqliteLog::new(db.clone());
+        for e in sample_blackboard_events("run-x") {
+            use crate::core::orchestration::es::log::EventLog;
+            log.append("run-x", &e).unwrap();
+        }
+
+        // Project twice.
+        super::project_run(&db, "run-x").unwrap();
+        super::project_run(&db, "run-x").unwrap();
+
+        // Exactly one row in runs + orchestration_runs, no duplication.
+        let run = queries::get_orchestration_run(&db, "run-x")
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.pattern, "blackboard");
+        assert_eq!(run.run_id, "run-x");
+
+        let history = queries::get_history(&db, None, 10).unwrap();
+        assert_eq!(
+            history
+                .iter()
+                .filter(|r| r.agent == "orchestration:blackboard")
+                .count(),
+            1
+        );
+
+        // Board entries: exactly one entry, not duplicated.
+        let entries = queries::get_board_entries(&db, "run-x").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].agent, "a");
+        assert_eq!(entries[0].kind, "finding");
     }
 }

--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -758,13 +758,18 @@ pub async fn run_blackboard_es(
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
     let agent_order: Vec<String> = agents.keys().cloned().collect();
-    let initial = vec![ExecutionEvent::RunStarted {
-        run_id: run_id.to_string(),
-        pattern: "blackboard".to_string(),
-        agents: agent_order.clone(),
-        input: input.to_string(),
-        project: None,
-    }];
+    let initial = vec![
+        ExecutionEvent::RunStarted {
+            run_id: run_id.to_string(),
+            pattern: "blackboard".to_string(),
+            agents: agent_order.clone(),
+            input: input.to_string(),
+            project: None,
+        },
+        ExecutionEvent::ConfigSnapshot {
+            config_json: serde_json::to_string(&config).unwrap_or_default(),
+        },
+    ];
 
     let max_rounds = config.max_rounds;
     let token_budget = Some(u32::try_from(config.token_budget).unwrap_or(u32::MAX));

--- a/src/core/orchestration/es/bridge.rs
+++ b/src/core/orchestration/es/bridge.rs
@@ -189,6 +189,7 @@ pub fn map_execution_to_run_events(
         }],
         ExecutionEvent::Completed { .. }
         | ExecutionEvent::RunStarted { .. }
+        | ExecutionEvent::ConfigSnapshot { .. }
         | ExecutionEvent::Halted { .. }
         | ExecutionEvent::AskedPeer { .. }
         | ExecutionEvent::Escalated { .. }

--- a/src/core/orchestration/es/event.rs
+++ b/src/core/orchestration/es/event.rs
@@ -25,6 +25,12 @@ pub enum ExecutionEvent {
         input: String,
         project: Option<String>,
     },
+    /// A snapshot of the run's orchestration config (serialized as JSON).
+    /// Emitted immediately after `RunStarted` by the blackboard, ring, and
+    /// hierarchical engines. Direct runs have no orchestration config and do
+    /// not emit this event.
+    #[serde(rename = "config")]
+    ConfigSnapshot { config_json: String },
     /// An agent was invoked with a given input.
     AgentInvoked { agent: String, input: String },
     /// An agent produced output (with token/cost accounting).

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -1361,13 +1361,18 @@ pub async fn run_hierarchical_es(
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
     let agent_names: Vec<String> = agents.keys().cloned().collect();
-    let initial = vec![ExecutionEvent::RunStarted {
-        run_id: run_id.to_string(),
-        pattern: "hierarchical".to_string(),
-        agents: agent_names,
-        input: input.to_string(),
-        project: None,
-    }];
+    let initial = vec![
+        ExecutionEvent::RunStarted {
+            run_id: run_id.to_string(),
+            pattern: "hierarchical".to_string(),
+            agents: agent_names,
+            input: input.to_string(),
+            project: None,
+        },
+        ExecutionEvent::ConfigSnapshot {
+            config_json: serde_json::to_string(&config).unwrap_or_default(),
+        },
+    ];
 
     let max_depth = config.max_depth();
     let max_iterations = config.max_iterations();

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -1035,13 +1035,18 @@ pub async fn run_ring_es(
     cost_limit: Option<f64>,
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
-    let initial = vec![ExecutionEvent::RunStarted {
-        run_id: run_id.to_string(),
-        pattern: "ring".to_string(),
-        agents: agent_order.clone(),
-        input: input.to_string(),
-        project: None,
-    }];
+    let initial = vec![
+        ExecutionEvent::RunStarted {
+            run_id: run_id.to_string(),
+            pattern: "ring".to_string(),
+            agents: agent_order.clone(),
+            input: input.to_string(),
+            project: None,
+        },
+        ExecutionEvent::ConfigSnapshot {
+            config_json: serde_json::to_string(&config).unwrap_or_default(),
+        },
+    ];
 
     let vote_weights = vote_weights_from_agents(&agents);
     let max_laps = config.max_laps;

--- a/src/core/orchestration/es/state.rs
+++ b/src/core/orchestration/es/state.rs
@@ -93,6 +93,10 @@ pub struct ExecutionState {
     pub hier: HierState,
     pub board: BoardState,
     pub ring: RingState,
+    /// The orchestration config (JSON serialized) captured from `ConfigSnapshot`.
+    /// Emitted by blackboard/ring/hierarchical engines right after `RunStarted`;
+    /// direct runs have no config and leave this `None`.
+    pub config_json: Option<String>,
     /// Tier resolved for each `latest:auto` agent (agent name -> tier, e.g.
     /// `"Fast"`/`"Pro"`/`"Max"`), populated by `ModelRouted` events. Read by
     /// the pattern effect runners (e.g. `HierarchicalEffectRunner`) to
@@ -134,6 +138,9 @@ pub fn apply(state: &mut ExecutionState, event: &ExecutionEvent) {
             state.run_id = run_id.clone();
             state.pattern = pattern.clone();
             state.agents = agents.clone();
+        }
+        ExecutionEvent::ConfigSnapshot { config_json } => {
+            state.config_json = Some(config_json.clone());
         }
         ExecutionEvent::AgentInvoked { agent, input } => {
             state
@@ -448,5 +455,23 @@ mod tests {
         assert_eq!(st.hier.trace.len(), 2);
         assert_eq!(st.hier.trace[0].1, "b"); // to
         assert_eq!(st.hier.trace[1].2, "up"); // message
+    }
+
+    #[test]
+    fn config_snapshot_is_captured_in_state() {
+        let events = vec![
+            E::RunStarted {
+                run_id: "r".into(),
+                pattern: "blackboard".into(),
+                agents: vec!["a".into()],
+                input: "x".into(),
+                project: None,
+            },
+            E::ConfigSnapshot {
+                config_json: "{\"max_rounds\":5}".into(),
+            },
+        ];
+        let state = fold(&events);
+        assert_eq!(state.config_json.as_deref(), Some("{\"max_rounds\":5}"));
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,9 +2,9 @@ pub mod queries;
 pub mod schema;
 
 use rusqlite::Connection;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
-pub type Database = Mutex<Connection>;
+pub type Database = Arc<Mutex<Connection>>;
 
 /// Initialize a persistent SQLite database at the configured path.
 pub fn init_db() -> anyhow::Result<Database> {
@@ -15,7 +15,7 @@ pub fn init_db() -> anyhow::Result<Database> {
     }
     let conn = Connection::open(path)?;
     schema::apply(&conn)?;
-    Ok(Mutex::new(conn))
+    Ok(Arc::new(Mutex::new(conn)))
 }
 
 /// Initialize an in-memory SQLite database (for tests).
@@ -23,5 +23,5 @@ pub fn init_db() -> anyhow::Result<Database> {
 pub fn init_embedded() -> anyhow::Result<Database> {
     let conn = Connection::open_in_memory()?;
     schema::apply(&conn)?;
-    Ok(Mutex::new(conn))
+    Ok(Arc::new(Mutex::new(conn)))
 }

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -646,6 +646,24 @@ pub fn delete_projection_for_run(db: &Database, run_id: &str) -> anyhow::Result<
     Ok(total_deleted)
 }
 
+/// Get all distinct run_ids present in the execution_events log.
+///
+/// Returns run IDs in sorted order. Used by `armadai projections rebuild --all`
+/// to enumerate all runs that can be re-projected from the event log.
+#[allow(dead_code)] // Called by projections rebuild --all
+pub fn all_event_log_run_ids(db: &Database) -> anyhow::Result<Vec<String>> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+    let mut stmt = conn.prepare("SELECT DISTINCT run_id FROM execution_events ORDER BY run_id")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let mut run_ids = Vec::new();
+    for row in rows {
+        run_ids.push(row?);
+    }
+    Ok(run_ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -596,6 +596,56 @@ pub fn get_child_orchestration_runs(
     Ok(out)
 }
 
+/// Delete all projection rows for a given `run_id` across all orchestration
+/// tables. Used by the idempotent projector (`project_run`) to clear any
+/// existing projection before re-deriving it from the event log. Returns the
+/// total number of rows deleted across all tables.
+///
+/// Tables cleared (in dependency order):
+/// - `delegation_events` (hierarchical child table)
+/// - `ring_votes` (ring child table)
+/// - `ring_contributions` (ring child table)
+/// - `board_entries` (blackboard child table)
+/// - `orchestration_runs` (parent metadata table)
+/// - `runs` (top-level parent row)
+///
+/// DELETEs are non-failing: removing a `run_id` that doesn't exist in a given
+/// table simply returns `0` rows affected, not an error.
+#[allow(dead_code)] // Called by project_run, wired in Task 3
+pub fn delete_projection_for_run(db: &Database, run_id: &str) -> anyhow::Result<usize> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+
+    let mut total_deleted = 0;
+
+    // Child tables first (no FK enforcement in schema, but logical order).
+    total_deleted += conn.execute(
+        "DELETE FROM delegation_events WHERE run_id = ?1",
+        params![run_id],
+    )?;
+    total_deleted += conn.execute("DELETE FROM ring_votes WHERE run_id = ?1", params![run_id])?;
+    total_deleted += conn.execute(
+        "DELETE FROM ring_contributions WHERE run_id = ?1",
+        params![run_id],
+    )?;
+    total_deleted += conn.execute(
+        "DELETE FROM board_entries WHERE run_id = ?1",
+        params![run_id],
+    )?;
+
+    // Parent metadata.
+    total_deleted += conn.execute(
+        "DELETE FROM orchestration_runs WHERE run_id = ?1",
+        params![run_id],
+    )?;
+
+    // Top-level parent row.
+    total_deleted += conn.execute("DELETE FROM runs WHERE id = ?1", params![run_id])?;
+
+    Ok(total_deleted)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Contexte

OH1 Lot 5 (projections), **sous-lot 5b**. Les tables plates deviennent des **projections dérivées du log** `execution_events` (source de vérité), matérialisées via un projecteur idempotent, avec une commande de reconstruction. Suite de 5a (#222, log persisté). Découpe + stratégie « matérialisées » validées avec Dimitri.

## Changements (4 tâches)

1. **`ConfigSnapshot { config_json }`** : nouvel event émis après `RunStarted` par les moteurs blackboard/ring/hierarchical, portant le config sérialisé, stocké dans `ExecutionState.config_json`. Le config est un paramètre runtime sinon absent du log — nécessaire à la projection fidèle **et** au resume (Lot 6). Décision Dimitri.
2. **`project_run(db, run_id)`** : projecteur idempotent — lit `execution_events[run_id]` → fold → state → écrit les tables plates (DELETE-puis-INSERT par `run_id` via `queries::delete_projection_for_run`). `Database` passe en `Arc<Mutex<Connection>>` pour partager le handle avec `SqliteLog`.
3. **Wiring** : chaque `dispatch_*_es` appelle `project_run(&db, &run_id)` en fin de run (sous storage) au lieu des `record_*_es` — les tables sont désormais dérivées du log. Wrappers `record_*_es` retirés (les `record_*_es_into` restent, utilisés par le projecteur).
4. **`armadai projections rebuild [--run <id>|--all]`** : re-dérive les tables depuis le log. Smoke : `--all` a reprojeté 148 runs d'un log réel.

## Vérifications

Aucune régression. Storage : **935 unit + 8 + 30 e2e**. Non-storage : **900 + 8 + 30** (mono-thread). Clippy **3 modes** (`tui`, `tui,providers-api`, `tui,web,storage`, `--all-targets`) 0 warning. fmt propre. Smoke `projections rebuild --all` OK.

⚠️ **Note QA** : 2 tests non-storage (`model_registry::fetch::source_cache_path_is_stable`, `providers::cli::empty_system_prompt_changes_nothing`) sont **flaky sous parallélisme** (état global partagé env/HOME) — **préexistants** (présents sur release/1.0.0, hors périmètre 5b), passent en isolation. Candidat à un fix d'isolation séparé.

⚠️ **Changement user-facing** (nouvelle commande, modèle de dérivation) → attente validation Dimitri avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)