### PR TITLE
ci: run clippy in all gated feature combinations (OH1 Lot 5c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,13 @@ jobs:
         with:
           shared-key: ci-cargo
           save-if: ${{ github.ref == 'refs/heads/develop' }}
+      # Clippy in every feature combination the code is gated for, so a lint
+      # that only trips under one combo (e.g. a needless_borrow visible only
+      # under web+storage, or providers-api-gated HTTP code) is caught in CI,
+      # not just locally. See CLAUDE.md and the OH1 event-sourcing spec §9.
       - run: cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+      - run: cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+      - run: cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
 
   test:
     name: Test


### PR DESCRIPTION
## Contexte

OH1 Lot 5 (projections), **sous-lot 5c** — le dernier. Les lectures (History/Costs/web/headless) puisent déjà dans les tables plates, que le Lot 5b (#223) a transformées en **projections dérivées du log** ; le « branchement » des chemins de lecture sur les projections était donc structurellement acquis. Le seul livrable concret restant : aligner la CI sur les modes clippy attendus.

## Changement

La CI ne lançait clippy qu'en `--features tui`. Un lint qui ne se déclenche que dans une autre combinaison passait entre les mailles (ex. le `needless_borrow` visible uniquement sous `tui,web,storage` corrigé en 5b, ou le code gated `providers-api` jamais linté en CI). Ajout de deux runs clippy : `tui,providers-api` et `tui,web,storage` — les combinaisons requises par CLAUDE.md et la spec OH1 §9.

Purement additif (durcissement CI), aucun changement de code produit. Les 3 modes sont verts en local (0 warning).

**→ Clôt OH1 Lot 5** (projections). Reste OH1 Lot 6 (resume/replay CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)