### PR TITLE
test: serialize env-reading tests against env mutators (fix flakiness)

### DIFF
--- a/src/model_registry/fetch.rs
+++ b/src/model_registry/fetch.rs
@@ -437,6 +437,7 @@ mod tests {
     #[test]
     #[cfg(feature = "providers-api")]
     fn source_cache_path_is_stable_and_distinct_per_source() {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
         let a = source_cache_path("https://models.dev/api.json");
         let b = source_cache_path("https://example.com/custom-models.json");
         assert_ne!(a, b);

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -168,6 +168,17 @@ impl Provider for CliProvider {
 mod tests {
     use super::*;
 
+    /// Run `fut` while holding `ENV_MUTEX`, serialising the child-process spawn's
+    /// read of `environ` against tests that mutate it via `std::env::set_var`
+    /// (otherwise a data race — the reason `set_var` is `unsafe`). Holding the
+    /// guard across `.await` is safe here: no other async task contends for
+    /// `ENV_MUTEX`, so there is no deadlock risk.
+    #[allow(clippy::await_holding_lock)]
+    async fn with_env_lock<T>(fut: impl std::future::Future<Output = T>) -> T {
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        fut.await
+    }
+
     fn echo_request(text: &str) -> CompletionRequest {
         CompletionRequest {
             model: "echo".to_string(),
@@ -183,11 +194,14 @@ mod tests {
 
     #[tokio::test]
     async fn cli_complete_echo() {
-        let provider = CliProvider::new("echo".to_string(), vec![], 10);
-        let response = provider
-            .complete(echo_request("hello world"))
-            .await
-            .unwrap();
+        let response = with_env_lock(async {
+            let provider = CliProvider::new("echo".to_string(), vec![], 10);
+            provider
+                .complete(echo_request("hello world"))
+                .await
+                .unwrap()
+        })
+        .await;
         assert_eq!(response.content.trim(), "hello world");
         assert_eq!(response.tokens_in, 0);
         assert_eq!(response.cost, 0.0);
@@ -195,8 +209,11 @@ mod tests {
 
     #[tokio::test]
     async fn cli_complete_with_args() {
-        let provider = CliProvider::new("echo".to_string(), vec!["prefix".to_string()], 10);
-        let response = provider.complete(echo_request("test")).await.unwrap();
+        let response = with_env_lock(async {
+            let provider = CliProvider::new("echo".to_string(), vec!["prefix".to_string()], 10);
+            provider.complete(echo_request("test")).await.unwrap()
+        })
+        .await;
         assert_eq!(response.content.trim(), "prefix test");
     }
 
@@ -204,27 +221,37 @@ mod tests {
     async fn cli_stream_echo() {
         use tokio_stream::StreamExt;
 
-        let provider = CliProvider::new("echo".to_string(), vec![], 10);
-        let mut stream = provider.stream(echo_request("stream test")).await.unwrap();
+        let output = with_env_lock(async {
+            let provider = CliProvider::new("echo".to_string(), vec![], 10);
+            let mut stream = provider.stream(echo_request("stream test")).await.unwrap();
 
-        let mut output = Vec::new();
-        while let Some(line) = stream.next().await {
-            output.push(line.unwrap());
-        }
+            let mut output = Vec::new();
+            while let Some(line) = stream.next().await {
+                output.push(line.unwrap());
+            }
+            output
+        })
+        .await;
         assert_eq!(output, vec!["stream test"]);
     }
 
     #[tokio::test]
     async fn cli_complete_failure() {
-        let provider = CliProvider::new("false".to_string(), vec![], 10);
-        let result = provider.complete(echo_request("")).await;
+        let result = with_env_lock(async {
+            let provider = CliProvider::new("false".to_string(), vec![], 10);
+            provider.complete(echo_request("")).await
+        })
+        .await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn cli_complete_timeout() {
-        let provider = CliProvider::new("sleep".to_string(), vec![], 1);
-        let result = provider.complete(echo_request("30")).await;
+        let result = with_env_lock(async {
+            let provider = CliProvider::new("sleep".to_string(), vec![], 1);
+            provider.complete(echo_request("30")).await
+        })
+        .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("timed out"), "Error was: {err}");
@@ -307,11 +334,14 @@ mod tests {
 
     #[tokio::test]
     async fn non_empty_system_prompt_reaches_the_command() {
-        let provider = CliProvider::new("echo".to_string(), vec![], 10);
-        let request =
-            request_with_system("PERSONA-XYZ instructions de delegation", "fais la tache");
+        let response = with_env_lock(async {
+            let provider = CliProvider::new("echo".to_string(), vec![], 10);
+            let request =
+                request_with_system("PERSONA-XYZ instructions de delegation", "fais la tache");
 
-        let response = provider.complete(request).await.unwrap();
+            provider.complete(request).await.unwrap()
+        })
+        .await;
 
         assert!(
             response.content.contains("PERSONA-XYZ"),
@@ -334,10 +364,13 @@ mod tests {
 
     #[tokio::test]
     async fn empty_system_prompt_changes_nothing() {
-        let provider = CliProvider::new("echo".to_string(), vec![], 10);
-        let request = request_with_system("", "hello world");
+        let response = with_env_lock(async {
+            let provider = CliProvider::new("echo".to_string(), vec![], 10);
+            let request = request_with_system("", "hello world");
 
-        let response = provider.complete(request).await.unwrap();
+            provider.complete(request).await.unwrap()
+        })
+        .await;
 
         assert_eq!(response.content.trim(), "hello world");
     }


### PR DESCRIPTION
## Contexte

Deux tests flakaient sous `cargo test` parallèle (passaient en isolation), signalés pendant OH1 Lot 5b : `model_registry::fetch::source_cache_path_is_stable_and_distinct_per_source` et `providers::cli::empty_system_prompt_changes_nothing`.

## Cause racine

Plusieurs tests mutent l'environnement process-global via `std::env::set_var` (unsafe en edition 2024), sérialisés entre eux par `core::config::ENV_MUTEX`. Mais les tests **lecteurs** d'env ne prenaient pas le mutex → race contre les writers :
- Le test fetch lit `config_dir()` (`ARMADAI_CONFIG_DIR`) ; un writer concurrent changeait le chemin entre les deux appels.
- Les tests spawn de `cli.rs` font `Command::output()` qui lit `environ` pendant le fork/exec — data race avec un `set_var` concurrent (la raison pour laquelle `set_var` est `unsafe`).

## Fix (test-only, aucune modif de code produit)

Les lecteurs se sérialisent aussi via `ENV_MUTEX` : le test fetch prend le guard ; un helper `with_env_lock` (annoté `#[allow(clippy::await_holding_lock)]` — pas de risque de deadlock, rien d'autre n'attend `ENV_MUTEX`) enveloppe les 7 tests de `cli.rs` qui spawnent un process.

## Vérifications

Clippy 3 modes (`tui`, `tui,providers-api`, `tui,web,storage`) 0 warning, fmt propre, suite stable sur plusieurs runs parallèles consécutifs (aucune flakiness observée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)