### PR TITLE
feat(tui): reskin remaining views/widgets to the DS theme (T2)

### DIFF
--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -55,7 +55,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(format!(" {} ", agent.name), theme::heading()),
         Span::styled(
             format!("  ({})", agent.source.display()),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         ),
     ]))
     .block(Block::default().borders(Borders::ALL));
@@ -79,7 +79,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("Fallback: ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(
                 meta.model_fallback.join(", "),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(app.theme.text_muted()),
             ),
         ]));
     }
@@ -101,7 +101,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if !meta.scope.is_empty() {
         meta_lines.push(Line::from(vec![
             Span::styled("Scope:    ", Style::default().add_modifier(Modifier::BOLD)),
-            Span::styled(meta.scope.join(", "), Style::default().fg(Color::Cyan)),
+            Span::styled(
+                meta.scope.join(", "),
+                Style::default().fg(app.theme.signal(crate::tui::theme::Signal::Running)),
+            ),
         ]));
     }
 
@@ -136,7 +139,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         if let Some(ref pattern) = agent.metadata.orchestration {
             orch_lines.push(Line::from(vec![
                 Span::styled("Pattern:  ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::styled(pattern.to_string(), Style::default().fg(Color::Magenta)),
+                Span::styled(
+                    pattern.to_string(),
+                    Style::default().fg(app.theme.brass_strong()),
+                ),
             ]));
         }
 
@@ -157,7 +163,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             parts.push(format!("priority: {}", triggers.priority));
             orch_lines.push(Line::from(vec![
                 Span::styled("Triggers: ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::styled(parts.join(", "), Style::default().fg(Color::Yellow)),
+                Span::styled(parts.join(", "), Style::default().fg(app.theme.brass())),
             ]));
         }
 
@@ -171,7 +177,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             }
             orch_lines.push(Line::from(vec![
                 Span::styled("Ring:     ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::styled(parts.join(", "), Style::default().fg(Color::Blue)),
+                Span::styled(
+                    parts.join(", "),
+                    Style::default().fg(app.theme.brass_strong()),
+                ),
             ]));
         }
 
@@ -200,8 +209,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                     format!("{:<10}", target),
                     Style::default().add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(" → ", Style::default().fg(Color::DarkGray)),
-                Span::styled(resolved.as_str(), Style::default().fg(Color::Green)),
+                Span::styled(" → ", Style::default().fg(app.theme.text_muted())),
+                Span::styled(
+                    resolved.as_str(),
+                    Style::default().fg(app.theme.signal(crate::tui::theme::Signal::Ok)),
+                ),
             ])
         })
         .collect();
@@ -243,7 +255,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .title(" Instructions ")
                 .title_style(Style::default().add_modifier(Modifier::BOLD)),
         )
-        .style(Style::default().fg(Color::Gray))
+        .style(Style::default().fg(app.theme.text_secondary()))
         .wrap(Wrap { trim: false });
     frame.render_widget(instr_widget, chunks[4 + orch_offset]);
 }

--- a/src/tui/views/costs.rs
+++ b/src/tui/views/costs.rs
@@ -109,6 +109,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -164,6 +164,6 @@ fn render_agent_list(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) 
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -112,7 +112,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }
 

--- a/src/tui/views/model_detail.rs
+++ b/src/tui/views/model_detail.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -38,7 +38,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(format!(" {} ", entry.id), theme::heading()),
         Span::styled(
             format!("  ({})", provider),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         ),
     ]))
     .block(Block::default().borders(Borders::ALL));
@@ -95,11 +95,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("Cost (input):   ", bold),
-            Span::styled(&cost_in, Style::default().fg(Color::Yellow)),
+            Span::styled(&cost_in, Style::default().fg(app.theme.brass())),
         ]),
         Line::from(vec![
             Span::styled("Cost (output):  ", bold),
-            Span::styled(&cost_out, Style::default().fg(Color::Yellow)),
+            Span::styled(&cost_out, Style::default().fg(app.theme.brass())),
         ]),
     ];
 
@@ -122,7 +122,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .title(" Display Label ")
                 .title_style(bold),
         )
-        .style(Style::default().fg(Color::Green))
+        .style(Style::default().fg(app.theme.signal(crate::tui::theme::Signal::Ok)))
         .wrap(Wrap { trim: false });
     frame.render_widget(label_widget, chunks[2]);
 }

--- a/src/tui/views/models_list.rs
+++ b/src/tui/views/models_list.rs
@@ -118,6 +118,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -101,7 +101,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }
 

--- a/src/tui/views/prompt_detail.rs
+++ b/src/tui/views/prompt_detail.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -38,7 +38,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(format!(" {} ", prompt.name), theme::heading()),
         Span::styled(
             format!("  ({})", prompt.source.display()),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         ),
     ]))
     .block(Block::default().borders(Borders::ALL));
@@ -65,7 +65,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ),
             Span::styled(
                 prompt.apply_to.join(", "),
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(app.theme.brass()),
             ),
         ]));
     }
@@ -73,7 +73,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if meta_lines.is_empty() {
         meta_lines.push(Line::from(Span::styled(
             "(no metadata)",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         )));
     }
 

--- a/src/tui/views/prompts_list.rs
+++ b/src/tui/views/prompts_list.rs
@@ -84,6 +84,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }

--- a/src/tui/views/shortcuts.rs
+++ b/src/tui/views/shortcuts.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
 };
@@ -139,11 +139,14 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Span::styled(
                     format!(" {key} "),
                     Style::default()
-                        .bg(Color::DarkGray)
-                        .fg(Color::White)
+                        .bg(app.theme.surface_panel())
+                        .fg(app.theme.text_primary())
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(format!(" {desc}  "), Style::default().fg(Color::Gray)),
+                Span::styled(
+                    format!(" {desc}  "),
+                    Style::default().fg(app.theme.text_secondary()),
+                ),
             ]
         })
         .collect();
@@ -153,7 +156,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         spans.push(Span::styled(
             format!("  {msg}"),
             Style::default()
-                .fg(Color::Green)
+                .fg(app.theme.signal(crate::tui::theme::Signal::Ok))
                 .add_modifier(Modifier::ITALIC),
         ));
     }

--- a/src/tui/views/skill_detail.rs
+++ b/src/tui/views/skill_detail.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -66,7 +66,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(format!(" {} ", skill.name), theme::heading()),
         Span::styled(
             format!("  ({})", skill.source.display()),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         ),
     ]))
     .block(Block::default().borders(Borders::ALL));
@@ -101,14 +101,17 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 "Tools:       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::styled(skill.tools.join(", "), Style::default().fg(Color::Green)),
+            Span::styled(
+                skill.tools.join(", "),
+                Style::default().fg(app.theme.signal(crate::tui::theme::Signal::Ok)),
+            ),
         ]));
     }
 
     if meta_lines.is_empty() {
         meta_lines.push(Line::from(Span::styled(
             "(no metadata)",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         )));
     }
 
@@ -150,11 +153,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                     .title(format!(" {name} "))
                     .title_style(
                         Style::default()
-                            .fg(Color::Yellow)
+                            .fg(app.theme.brass())
                             .add_modifier(Modifier::BOLD),
                     ),
             )
-            .style(Style::default().fg(Color::Gray))
+            .style(Style::default().fg(app.theme.text_secondary()))
             .wrap(Wrap { trim: false });
         frame.render_widget(ref_widget, chunks[3 + i]);
     }
@@ -183,7 +186,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                     .title(" Other Files ")
                     .title_style(Style::default().add_modifier(Modifier::BOLD)),
             )
-            .style(Style::default().fg(Color::DarkGray));
+            .style(Style::default().fg(app.theme.text_muted()));
         frame.render_widget(files_widget, chunks[3 + ref_contents.len()]);
     }
 }

--- a/src/tui/views/skills_list.rs
+++ b/src/tui/views/skills_list.rs
@@ -94,6 +94,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }

--- a/src/tui/views/starter_detail.rs
+++ b/src/tui/views/starter_detail.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -57,7 +57,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(format!(" {} ", pack.name), theme::heading()),
         Span::styled(
             format!("  — {}", pack.description),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app.theme.text_muted()),
         ),
     ]))
     .block(Block::default().borders(Borders::ALL));
@@ -70,8 +70,10 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             .agents
             .iter()
             .map(|a| {
-                // Was `fg(Color::White)` — white-on-white on a light terminal.
-                Line::from(Span::styled(format!("  • {a}"), Style::default()))
+                Line::from(Span::styled(
+                    format!("  • {a}"),
+                    Style::default().fg(app.theme.text_primary()),
+                ))
             })
             .collect();
         let widget = Paragraph::new(lines)
@@ -94,7 +96,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             .map(|p| {
                 Line::from(Span::styled(
                     format!("  • {p}"),
-                    Style::default().fg(Color::Yellow),
+                    Style::default().fg(app.theme.brass()),
                 ))
             })
             .collect();
@@ -118,7 +120,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             .map(|s| {
                 Line::from(Span::styled(
                     format!("  • {s}"),
-                    Style::default().fg(Color::Green),
+                    Style::default().fg(app.theme.signal(crate::tui::theme::Signal::Ok)),
                 ))
             })
             .collect();

--- a/src/tui/views/starters_list.rs
+++ b/src/tui/views/starters_list.rs
@@ -90,6 +90,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render search bar if in search mode
     if app.search_mode {
-        search_bar(frame, &app.search_query, area);
+        search_bar(frame, app, &app.search_query, area);
     }
 }

--- a/src/tui/widgets/search_bar.rs
+++ b/src/tui/widgets/search_bar.rs
@@ -8,12 +8,14 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Style},
+    style::Style,
     widgets::{Block, Paragraph},
 };
 
+use crate::tui::app::App;
+
 /// Render the search/filter bar as the last line of `list_area`.
-pub fn search_bar(frame: &mut Frame, query: &str, list_area: Rect) {
+pub fn search_bar(frame: &mut Frame, app: &App, query: &str, list_area: Rect) {
     let search_area = Rect {
         x: list_area.x,
         y: list_area.bottom() - 1,
@@ -23,7 +25,7 @@ pub fn search_bar(frame: &mut Frame, query: &str, list_area: Rect) {
 
     let query_display = format!("/ {query}\u{2588}");
     let search = Paragraph::new(query_display)
-        .style(Style::default().fg(Color::Yellow))
+        .style(Style::default().fg(app.theme.brass()))
         .block(Block::default());
     frame.render_widget(search, search_area);
 }


### PR DESCRIPTION
## Contexte
Chantier design system, TUI, **T2** (suite de T1 #237). Re-skin de toutes les vues/widgets restants via `app.theme`.

## Changements
Route tous les `Color::` en dur via `app.theme` (helpers accent/border/text/signal) dans : vues détail (agent/prompt/skill/starter/model), listes (models/prompts/skills/starters), history, costs, shortcuts, + widget `search_bar` (reçoit le thème via `&App`). Aucun changement de disposition/comportement. `palette.rs` + `orchestration.rs` → T3.

## Vérifs
890+8+30 tests (mono-thread déterministe), clippy **3 modes** 0, fmt. `theme.rs`/`app.rs`/`mod.rs`/`main.rs` intacts. 0 `Color::` en dur hors palette/orchestration.

⚠️ **User-facing** → **validation visuelle Dimitri** (`armadai tui`, toutes les vues) avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)