### PR TITLE
feat(tui): workroom blackboard & ring layouts (T3b)

### DIFF
--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -536,6 +536,64 @@ impl Workroom {
         self.apply_stream_text(line);
     }
 
+    /// Index of the agent currently holding the ring token, if any.
+    fn token_holder_index(&self) -> Option<usize> {
+        let current = self.current_agent.as_deref()?;
+        self.agents.iter().position(|a| a.name == current)
+    }
+
+    /// The focused ring layout: sequential agents with flow arrows; the
+    /// token holder is highlighted (bold brass) with a "holds token" suffix.
+    fn ring_lines(&self) -> Vec<Line<'_>> {
+        let mut lines: Vec<Line> = Vec::new();
+        let g = theme::glyphs();
+        let holder = self.token_holder_index();
+        let last = self.agents.len().saturating_sub(1);
+        for (idx, agent) in self.agents.iter().enumerate() {
+            let (icon, state_str, style) = self.state_display(agent);
+            let is_holder = holder == Some(idx);
+            let is_selected = self.focused && idx == self.selected;
+            let name_style = if is_holder {
+                theme::selection()
+            } else if is_selected {
+                self.role_style(agent).add_modifier(Modifier::REVERSED)
+            } else {
+                self.role_style(agent)
+            };
+            let marker = if is_holder { "▸ " } else { "  " };
+            let mut spans = vec![
+                Span::raw(marker),
+                Span::styled(&agent.name, name_style),
+                Span::styled(format!(" {icon} "), style),
+                Span::styled(state_str, style),
+            ];
+            if is_holder {
+                spans.push(Span::styled("   ← holds token", theme::selection()));
+            }
+            lines.push(Line::from(spans));
+            if idx != last {
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", g.arrow_down),
+                    theme::muted(),
+                )));
+            }
+        }
+        if self.agents.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No agents configured",
+                theme::muted(),
+            )));
+        } else {
+            // Loop-back arrow closing the ring.
+            lines.push(Line::from(Span::styled(
+                format!("  {} (loops to top)", g.arrow_up),
+                theme::muted(),
+            )));
+        }
+        self.push_footer(&mut lines);
+        lines
+    }
+
     /// Render the workroom panel
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         let inner_width = area.width.saturating_sub(2); // exclude borders
@@ -543,7 +601,7 @@ impl Workroom {
             LayoutMode::Compact => self.compact_lines(),
             LayoutMode::Hierarchical => self.hierarchical_lines(),
             LayoutMode::Blackboard => self.blackboard_lines(),
-            LayoutMode::Ring => self.compact_lines(), // Ring lands in Task 5
+            LayoutMode::Ring => self.ring_lines(),
         };
 
         let panel = Paragraph::new(lines).block(
@@ -1188,5 +1246,35 @@ orchestration:
         let text: String = first.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains(theme::glyphs().board));
         assert!(text.contains("agents"));
+    }
+
+    #[test]
+    fn token_holder_index_matches_current_agent() {
+        let mut wr = Workroom::new();
+        wr.init_from_config(
+            "orchestration:\n  pattern: ring\ncoordinator: c\nagents:\n- alpha\n- beta\n",
+        );
+        // No token holder initially.
+        assert_eq!(wr.token_holder_index(), None);
+        // The token moves to an agent via a DELEGATE marker in the stream.
+        wr.parse_streaming_line("<!--ARMADAI_DELEGATE:alpha-->");
+        let idx = wr.token_holder_index().expect("alpha holds the token");
+        assert_eq!(wr.agents[idx].name, "alpha");
+    }
+
+    #[test]
+    fn ring_lines_marks_token_holder_bold_brass() {
+        let mut wr = Workroom::new();
+        wr.init_from_config(
+            "orchestration:\n  pattern: ring\ncoordinator: c\nagents:\n- alpha\n- beta\n",
+        );
+        wr.parse_streaming_line("<!--ARMADAI_DELEGATE:alpha-->");
+        let lines = wr.ring_lines();
+        // The span carrying the holder name uses the bold selection (brass) style.
+        let holder_styled = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .any(|s| s.content.contains("alpha") && s.style.add_modifier.contains(Modifier::BOLD));
+        assert!(holder_styled);
     }
 }

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -542,8 +542,8 @@ impl Workroom {
         let lines = match self.layout_mode(inner_width) {
             LayoutMode::Compact => self.compact_lines(),
             LayoutMode::Hierarchical => self.hierarchical_lines(),
-            // Blackboard/Ring rich layouts land in T3b; degrade until then.
-            LayoutMode::Blackboard | LayoutMode::Ring => self.compact_lines(),
+            LayoutMode::Blackboard => self.blackboard_lines(),
+            LayoutMode::Ring => self.compact_lines(), // Ring lands in Task 5
         };
 
         let panel = Paragraph::new(lines).block(
@@ -693,6 +693,46 @@ impl Workroom {
             ]));
         }
         if lines.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No agents configured",
+                theme::muted(),
+            )));
+        }
+        self.push_footer(&mut lines);
+        lines
+    }
+
+    /// The focused blackboard layout: a shared-board header, then a flat
+    /// list of agents (no hierarchy — all react to shared state).
+    fn blackboard_lines(&self) -> Vec<Line<'_>> {
+        let mut lines: Vec<Line> = Vec::new();
+        let g = theme::glyphs();
+        lines.push(Line::from(Span::styled(
+            format!("{} shared board · {} agents", g.board, self.agents.len()),
+            theme::heading(),
+        )));
+        for (idx, agent) in self.agents.iter().enumerate() {
+            let (icon, state_str, style) = self.state_display(agent);
+            let role_style = self.role_style(agent);
+            let is_selected = self.focused && idx == self.selected;
+            let name_style = if is_selected {
+                role_style.add_modifier(Modifier::REVERSED)
+            } else {
+                role_style
+            };
+            let suffix = if agent.state == AgentState::Idle {
+                "  idle (waiting on board)".to_string()
+            } else {
+                format!("  {state_str}")
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{icon} "), style),
+                Span::styled(&agent.name, name_style),
+                Span::styled(suffix, style),
+            ]));
+        }
+        if self.agents.is_empty() {
             lines.push(Line::from(Span::styled(
                 "No agents configured",
                 theme::muted(),
@@ -1134,5 +1174,19 @@ orchestration:
         assert!(md.contains("working"));
         assert!(md.contains("done"));
         assert!(md.contains("Last action:** complete"));
+    }
+
+    #[test]
+    fn blackboard_lines_has_board_header() {
+        let mut wr = Workroom::new();
+        wr.init_from_config(
+            "orchestration:\n  pattern: blackboard\ncoordinator: c\nagents:\n- a\n- b\n",
+        );
+        let lines = wr.blackboard_lines();
+        // First line is the shared-board header carrying the board glyph.
+        let first = &lines[0];
+        let text: String = first.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains(theme::glyphs().board));
+        assert!(text.contains("agents"));
     }
 }


### PR DESCRIPTION
## T3b — Design System TUI, sous-lot 2/3

Deuxième partie de T3 : les deux layouts riches restants de la Workroom (focus). Suite de #240 (T3a). Spec/plan : `docs/superpowers/specs|plans/2026-07-23-design-system-tui-t3*.md`.

### Contenu
- **Layout Blackboard** (`blackboard_lines`) : en-tête « board partagé » (glyphe `▤` + nombre d'agents) puis agents à plat (pas de hiérarchie) ; les agents idle portent `(waiting on board)`.
- **Layout Ring** (`ring_lines` + `token_holder_index`) : agents en séquence, **détenteur du jeton** (suivi via `current_agent`, positionné par les marqueurs `ARMADAI_DELEGATE:`) mis en évidence en laiton (`theme::selection()`) + `← holds token`, flèches de flux `↓` entre agents et `↑` de bouclage.
- Dispatch `render` branché : `LayoutMode::Blackboard → blackboard_lines`, `LayoutMode::Ring → ring_lines`.

### Gate
clippy 3 modes + fmt + `cargo test --features tui` (30/30 workroom). TDD par tâche.

### Validation
Visuelle par Dimitri (`armadai shell` sur projets orchestrés blackboard & ring, Ctrl+W) avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)