### PR TITLE
feat(tui): drill-down popup theming, color cleanup, shell --ascii (T3c)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-design-system-tui-t3.md
+++ b/docs/superpowers/plans/2026-07-23-design-system-tui-t3.md
@@ -908,7 +908,136 @@ git add src/tui/views/palette.rs src/tui/views/agent_detail.rs
 git commit -m "style(tui): route remaining hardcoded colors through the theme"
 ```
 
-**➡️ Fin du sous-lot T3c (Tasks 6–7). PR + revue indépendante + validation visuelle Dimitri (palette ⌃P, agent detail, popup) avant merge.**
+---
+
+### Task 8: Cohérence `--ascii` — glyphes `pointer`/`arrow_back` + flag shell + `theme::init`
+
+**Contexte (ajout T3c, décidé 2026-07-23) :** la revue de T3b a relevé que le marqueur `▸` (compact/ring) et le `←` de « holds token » sont des littéraux Unicode hors `glyphs()`, donc **non dégradés en `--ascii`**. De plus `armadai shell` — surface qui HÉBERGE la Workroom (seul vrai consommateur des glyphes) — n'a ni flag `--ascii` ni appel à `theme::init`, donc le fallback ASCII de la Workroom est intestable. Cette tâche route ces deux glyphes et câble `--ascii` sur le shell.
+
+**Files:**
+- Modify: `src/theme.rs` (struct `Glyphs` + `UNICODE`/`ASCII` + test)
+- Modify: `src/shell/workroom.rs` (routage `▸`/`←` dans `compact_lines`, `ring_lines`)
+- Modify: `src/cli/mod.rs` (variante `Shell` → `Shell { ascii: bool }`, handler)
+- Modify: `src/shell/app.rs` (`run_shell(ascii: bool)` + `theme::init(ascii)`)
+
+**Interfaces:**
+- Produces: champs `Glyphs.pointer: &'static str`, `Glyphs.arrow_back: &'static str`.
+
+- [ ] **Step 1: Étendre le test des glyphes** — dans `#[cfg(test)] mod tests` de `src/theme.rs`, ajouter à `glyphs_expose_tree_and_flow_symbols` (ou un nouveau test) :
+
+```rust
+    #[test]
+    fn glyphs_expose_pointer_and_back_arrow() {
+        assert_eq!(Glyphs::UNICODE.pointer, "▸");
+        assert_eq!(Glyphs::UNICODE.arrow_back, "←");
+        assert_eq!(Glyphs::ASCII.pointer, ">");
+        assert_eq!(Glyphs::ASCII.arrow_back, "<-");
+    }
+```
+
+- [ ] **Step 2: Lancer — échoue** (`no field pointer`).
+
+Run: `cargo test --no-default-features --features tui theme::tests::glyphs_expose_pointer 2>&1 | tail -5`
+Expected: erreur de compilation.
+
+- [ ] **Step 3: Ajouter les deux champs** à `pub struct Glyphs` (après `board`) :
+
+```rust
+    pub pointer: &'static str,
+    pub arrow_back: &'static str,
+```
+Dans `const UNICODE` (après `board: "▤",`) : `pointer: "▸",` et `arrow_back: "←",`.
+Dans `const ASCII` (après `board: "#",`) : `pointer: ">",` et `arrow_back: "<-",`.
+
+- [ ] **Step 4: Router les littéraux dans `src/shell/workroom.rs`.**
+Dans `compact_lines`, ajouter en tête `let g = theme::glyphs();` (s'il n'y est pas déjà) et remplacer :
+```rust
+            let marker = if is_selected { "▸ " } else { "" };
+```
+par :
+```rust
+            let marker = if is_selected {
+                format!("{} ", g.pointer)
+            } else {
+                String::new()
+            };
+```
+(adapter le `Span::raw(marker)` en `Span::raw(marker)` — `String` accepté par `Span::raw`.)
+
+Dans `ring_lines` (qui a déjà `let g = theme::glyphs();`), remplacer :
+```rust
+            let marker = if is_holder { "▸ " } else { "  " };
+```
+par :
+```rust
+            let marker = if is_holder {
+                format!("{} ", g.pointer)
+            } else {
+                "  ".to_string()
+            };
+```
+et remplacer :
+```rust
+                spans.push(Span::styled("   ← holds token", theme::selection()));
+```
+par :
+```rust
+                spans.push(Span::styled(
+                    format!("   {} holds token", g.arrow_back),
+                    theme::selection(),
+                ));
+```
+
+- [ ] **Step 5: Flag `--ascii` sur `armadai shell`.** Dans `src/cli/mod.rs`, remplacer la variante unit `Shell,` (~l.254, garder le `#[command(long_about = …)]` au-dessus) par :
+
+```rust
+    Shell {
+        /// Use ASCII glyphs instead of Unicode (for limited terminals)
+        #[arg(long)]
+        ascii: bool,
+    },
+```
+et le handler (~l.532) :
+```rust
+        Command::Shell => crate::shell::app::run_shell().await,
+```
+par :
+```rust
+        Command::Shell { ascii } => crate::shell::app::run_shell(ascii).await,
+```
+
+- [ ] **Step 6: `run_shell(ascii)` + `theme::init`.** Dans `src/shell/app.rs`, changer la signature :
+```rust
+pub async fn run_shell() -> Result<()> {
+```
+en :
+```rust
+pub async fn run_shell(ascii: bool) -> Result<()> {
+    crate::theme::init(ascii);
+```
+(l'appel `theme::init(ascii)` en toute première ligne du corps, avant tout rendu ; idempotent — cf. `src/theme.rs`.)
+
+- [ ] **Step 7: Gate 3 modes + suite.**
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui 2>&1 | tail -5
+grep -n '▸\|←' src/shell/workroom.rs
+```
+Expected: `No issues found` (3 modes) + suite verte + le `grep` ne renvoie que le commentaire doc (« holds token » en toutes lettres reste dans un commentaire, pas de littéral `▸`/`←` dans le code de rendu).
+
+- [ ] **Step 8: Commit (fin de T3c)**
+
+```bash
+git add src/theme.rs src/shell/workroom.rs src/cli/mod.rs src/shell/app.rs
+git commit -m "feat(shell): wire --ascii flag and route pointer/back-arrow glyphs for ASCII fallback"
+```
+
+**➡️ Fin du sous-lot T3c (Tasks 6–8). PR + revue indépendante + validation visuelle Dimitri (palette ⌃P, agent detail, popup, `armadai shell --ascii`) avant merge.**
 
 ---
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -251,7 +251,11 @@ pub enum Command {
             Conversational interface for interacting with LLM providers. \
             Type messages and press Enter to get responses. Use Ctrl+C or Esc to quit, \
             Ctrl+L to clear conversation.")]
-    Shell,
+    Shell {
+        /// Use ASCII glyphs instead of Unicode (for limited terminals)
+        #[arg(long)]
+        ascii: bool,
+    },
     /// Launch the TUI dashboard
     #[cfg(feature = "tui")]
     #[command(long_about = "Launch the TUI dashboard.\n\n\
@@ -462,7 +466,7 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         None => {
             // No subcommand — launch the interactive shell
             #[cfg(feature = "tui")]
-            return crate::shell::app::run_shell().await;
+            return crate::shell::app::run_shell(false).await;
             #[cfg(not(feature = "tui"))]
             anyhow::bail!(
                 "Shell requires the 'tui' feature. Use `armadai shell` or `armadai --help`."
@@ -529,7 +533,7 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         Command::Projections(action) => projections::execute(action).await,
         Command::Config { action } => config::execute(action).await,
         #[cfg(feature = "tui")]
-        Command::Shell => crate::shell::app::run_shell().await,
+        Command::Shell { ascii } => crate::shell::app::run_shell(ascii).await,
         #[cfg(feature = "tui")]
         Command::Tui { global, ascii } => {
             crate::core::config::set_force_global(global);

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -97,7 +97,9 @@ fn restore_terminal() {
 }
 
 /// Main shell entry point.
-pub async fn run_shell() -> Result<()> {
+pub async fn run_shell(ascii: bool) -> Result<()> {
+    crate::theme::init(ascii);
+
     // Run wizard to ensure project is ready
     let wizard_result = super::wizard::ensure_project_ready()?;
 

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -842,9 +842,9 @@ impl ShellApp {
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::Cyan))
+                    .border_style(theme::border_style())
                     .title(" ArmadAI ")
-                    .title_style(Style::default().fg(Color::Cyan).bold()),
+                    .title_style(theme::heading()),
             )
             .wrap(Wrap { trim: false })
             .scroll((self.popup_scroll, 0));

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -560,7 +560,11 @@ impl Workroom {
             } else {
                 self.role_style(agent)
             };
-            let marker = if is_holder { "▸ " } else { "  " };
+            let marker = if is_holder {
+                format!("{} ", g.pointer)
+            } else {
+                "  ".to_string()
+            };
             let mut spans = vec![
                 Span::raw(marker),
                 Span::styled(&agent.name, name_style),
@@ -568,7 +572,10 @@ impl Workroom {
                 Span::styled(state_str, style),
             ];
             if is_holder {
-                spans.push(Span::styled("   ← holds token", theme::selection()));
+                spans.push(Span::styled(
+                    format!("   {} holds token", g.arrow_back),
+                    theme::selection(),
+                ));
             }
             lines.push(Line::from(spans));
             if idx != last {
@@ -617,6 +624,7 @@ impl Workroom {
     /// The idle/narrow layout: role-indented flat list (historical rendering).
     fn compact_lines(&self) -> Vec<Line<'_>> {
         let mut lines: Vec<Line> = Vec::new();
+        let g = theme::glyphs();
         for (idx, agent) in self.agents.iter().enumerate() {
             let (icon, state_str, style) = self.state_display(agent);
             let role_style = self.role_style(agent);
@@ -631,7 +639,11 @@ impl Workroom {
             } else {
                 role_style
             };
-            let marker = if is_selected { "▸ " } else { "" };
+            let marker = if is_selected {
+                format!("{} ", g.pointer)
+            } else {
+                String::new()
+            };
             lines.push(Line::from(vec![
                 Span::raw(indent),
                 Span::raw(marker),

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -611,13 +611,19 @@ impl Workroom {
             LayoutMode::Ring => self.ring_lines(),
         };
 
-        let panel = Paragraph::new(lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(theme::border_style())
-                .title(format!(" Workroom · {} ", self.pattern))
-                .title_style(theme::heading()),
-        );
+        let panel = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(theme::border_style())
+                    .title(format!(" Workroom · {} ", self.pattern))
+                    .title_style(theme::heading()),
+            )
+            // Base style for the whole panel area so uncoloured content
+            // (e.g. plain `role_agent` names) inherits a neutral foreground
+            // instead of the terminal default fg (which reads blue on light
+            // terminals). Coloured roles/states override this.
+            .style(theme::border_style());
         frame.render_widget(panel, area);
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -197,6 +197,8 @@ pub struct Glyphs {
     pub arrow_down: &'static str,
     pub arrow_up: &'static str,
     pub board: &'static str,
+    pub pointer: &'static str,
+    pub arrow_back: &'static str,
 }
 
 impl Glyphs {
@@ -211,6 +213,8 @@ impl Glyphs {
         arrow_down: "↓",
         arrow_up: "↑",
         board: "▤",
+        pointer: "▸",
+        arrow_back: "←",
     };
 
     #[allow(dead_code)]
@@ -224,6 +228,8 @@ impl Glyphs {
         arrow_down: "v",
         arrow_up: "^",
         board: "#",
+        pointer: ">",
+        arrow_back: "<-",
     };
 }
 
@@ -316,6 +322,14 @@ mod tests {
         assert_eq!(a.arrow_down, "v");
         assert_eq!(a.arrow_up, "^");
         assert_eq!(a.board, "#");
+    }
+
+    #[test]
+    fn glyphs_expose_pointer_and_back_arrow() {
+        assert_eq!(Glyphs::UNICODE.pointer, "▸");
+        assert_eq!(Glyphs::UNICODE.arrow_back, "←");
+        assert_eq!(Glyphs::ASCII.pointer, ">");
+        assert_eq!(Glyphs::ASCII.arrow_back, "<-");
     }
 
     #[test]

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -106,7 +106,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if !meta.scope.is_empty() {
         meta_lines.push(Line::from(vec![
             Span::styled("Scope:    ", Style::default().add_modifier(Modifier::BOLD)),
-            Span::styled(meta.scope.join(", "), Style::default().fg(Color::Cyan)),
+            Span::styled(meta.scope.join(", "), theme::tag()),
         ]));
     }
 
@@ -142,7 +142,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         if let Some(ref pattern) = agent.metadata.orchestration {
             orch_lines.push(Line::from(vec![
                 Span::styled("Pattern:  ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::styled(pattern.to_string(), Style::default().fg(Color::Magenta)),
+                Span::styled(pattern.to_string(), theme::heading()),
             ]));
         }
 
@@ -163,7 +163,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             parts.push(format!("priority: {}", triggers.priority));
             orch_lines.push(Line::from(vec![
                 Span::styled("Triggers: ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::styled(parts.join(", "), Style::default().fg(Color::Yellow)),
+                Span::styled(parts.join(", "), theme::stack()),
             ]));
         }
 
@@ -177,7 +177,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             }
             orch_lines.push(Line::from(vec![
                 Span::styled("Ring:     ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::styled(parts.join(", "), Style::default().fg(Color::Blue)),
+                Span::styled(parts.join(", "), theme::working()),
             ]));
         }
 

--- a/src/tui/views/palette.rs
+++ b/src/tui/views/palette.rs
@@ -27,7 +27,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     // Input field
     let input = Paragraph::new(Line::from(vec![
-        Span::styled(": ", Style::default().fg(Color::Cyan)),
+        Span::styled(": ", theme::heading()),
         Span::raw(&app.palette.input),
         Span::styled("_", Style::default().fg(Color::DarkGray)),
     ]))
@@ -36,7 +36,6 @@ pub fn render(frame: &mut Frame, app: &App) {
             .borders(Borders::ALL)
             .title(" Command Palette ")
             .title_style(theme::heading())
-            .border_style(Style::default().fg(Color::Cyan))
             .style(theme::border_style()),
     );
     frame.render_widget(input, chunks[0]);
@@ -67,7 +66,6 @@ pub fn render(frame: &mut Frame, app: &App) {
     let list = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan))
             .style(theme::border_style()),
     );
     frame.render_widget(list, chunks[1]);


### PR DESCRIPTION
## T3c — Design System TUI, sous-lot 3/3 (dernier de T3)

Finitions de T3. Suite de #240 (T3a) et #241 (T3b). Spec/plan : `docs/superpowers/specs|plans/2026-07-23-design-system-tui-t3*.md`.

### Contenu
- **Popup drill-down** (`src/shell/tui.rs`, `render_popup`) : bordure + titre `Color::Cyan` en dur → `theme::border_style()` / `theme::heading()`.
- **Nettoyage couleurs** : `palette.rs` (prompt + bordures Cyan → thème) et `agent_detail.rs` (scope/pattern/parts : Cyan/Magenta/Yellow/Blue → `theme::tag/heading/stack/working`). Zéro `Color::Cyan/Magenta/Blue/Yellow/Rgb` littéral résiduel dans ces fichiers.
- **Cohérence `--ascii`** : `Glyphs` étendu (`pointer ▸/>`, `arrow_back ←/<-`), routage des littéraux `▸`/`←` de la Workroom (`compact_lines`/`ring_lines`), et flag `--ascii` câblé sur `armadai shell` (+ `theme::init(ascii)` dans `run_shell`) — le fallback ASCII de la Workroom est enfin testable.

### Gate
clippy 3 modes + fmt + `cargo test --features tui` (940). TDD pour les glyphes ; popup/couleurs = validation visuelle.

### Validation
Visuelle par Dimitri : palette ⌃P, vue agent detail, popup drill-down (Ctrl+W puis Enter dans le shell), et `armadai shell --ascii`.

### Note
Le theming complet du **chrome du shell** (en-tête, rôles de message, autocomplétion, popups d'aide) est un sous-lot séparé **T3d** (décidé avec Dimitri), hors de ce PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)