### PR TITLE
style(tui): theme the shell chrome + adaptive cursor (T3d)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-tui-t3d-shell-chrome.md
+++ b/docs/superpowers/plans/2026-07-23-tui-t3d-shell-chrome.md
@@ -1,0 +1,208 @@
+# Design System → TUI T3d (theming du chrome du shell) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Router toutes les couleurs codées en dur du chrome du shell (`src/shell/tui.rs`) via le thème central `src/theme.rs` (accent-only), avec un curseur d'input adaptatif (vidéo inverse) visible sur fond clair comme sombre.
+
+**Architecture:** Ajout d'un helper `theme::cursor()` (vidéo inverse). Puis remplacement, dans `src/shell/tui.rs`, de chaque `Color::` littéral du chrome (en-tête, rôles de message, spinner, bordures/titres d'input, curseur) par un helper `theme::*`. La détection de curseur du helper de test (`find_cursor_in_buffer`) est adaptée au nouveau style (modifier REVERSED sur une cellule espace).
+
+**Tech Stack:** Rust edition 2024, ratatui, feature `tui`.
+
+## Global Constraints
+
+- Feature `tui`. Gate à chaque tâche : clippy **3 modes** (`--features tui`, `--features tui,providers-api`, `--features tui,web,storage`) `-D warnings` + `cargo fmt -- --check` + `cargo test --no-default-features --features tui`.
+- **Thème accent-only** : n'utiliser QUE les helpers de `src/theme.rs`. Objectif ferme : plus aucun `Color::Cyan/Green/Yellow/White/Black` littéral dans `src/shell/tui.rs` (les `Color::DarkGray` déjà présents sont routés vers `theme::muted()`).
+- **Mapping sémantique validé (Dimitri 2026-07-23)** : en-tête + titres + assistant → `theme::heading()` (laiton gras) ; user → `theme::stack()` + BOLD (vert signal_ok) ; system + spinner + footer popup → `theme::muted()` (+ DIM / ITALIC conservés) ; bordures → `theme::border_style()` ; curseur → `theme::cursor()` (vidéo inverse).
+- **rust-analyzer non fiable** dans cet env (faux positifs ABI 1.97.0/1.97.1, unlinked-file, inactive-cfg, snapshots mi-édition) → vérifier TOUJOURS au compilateur.
+- Branche : `feat/tui-t3d-shell-chrome` (base release/1.0.0). Une PR, revue indépendante + validation visuelle Dimitri (`armadai shell`, fond clair) avant merge.
+
+## File Structure
+- `src/theme.rs` — nouveau helper `cursor()` + test. (Task 1)
+- `src/shell/tui.rs` — routage des couleurs du chrome + adaptation de `find_cursor_in_buffer`. (Task 2)
+
+---
+
+### Task 1: Helper `theme::cursor()` (vidéo inverse)
+
+**Files:** Modify `src/theme.rs` (nouveau helper + test).
+
+**Interfaces:**
+- Produces: `pub fn cursor() -> Style` — `Style::default().add_modifier(Modifier::REVERSED)`.
+
+- [ ] **Step 1: Test qui échoue** — dans `#[cfg(test)] mod tests` de `src/theme.rs` :
+
+```rust
+    #[test]
+    fn cursor_is_reversed() {
+        assert!(cursor().add_modifier.contains(Modifier::REVERSED));
+    }
+```
+
+- [ ] **Step 2: Lancer — échoue** (`cannot find function cursor`).
+
+Run: `cargo test --no-default-features --features tui theme::tests::cursor_is_reversed 2>&1 | tail -5`
+Expected: erreur de compilation.
+
+- [ ] **Step 3: Implémenter le helper** — dans `src/theme.rs`, à côté des autres helpers (ex. après `border_style()`), ajouter :
+
+```rust
+/// Style for the input block cursor: reverse-video (swaps the cell's
+/// foreground/background) so the cursor stays visible on both light and
+/// dark terminals. Rendered on a single space cell.
+pub fn cursor() -> Style {
+    Style::default().add_modifier(Modifier::REVERSED)
+}
+```
+
+- [ ] **Step 4: Lancer — passe**
+
+Run: `cargo test --no-default-features --features tui theme::tests::cursor_is_reversed 2>&1 | tail -5`
+Expected: `test result: ok. 1 passed`.
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+git add src/theme.rs
+git commit -m "feat(theme): add reverse-video cursor style helper"
+```
+
+---
+
+### Task 2: Router le chrome du shell + adapter la détection de curseur
+
+**Files:** Modify `src/shell/tui.rs` (en-tête ~782, footer popup ~838, rôles de message ~869-881, spinner ~912-914, curseur ~1071/1158/1165, bordures/titres input ~1079-1081/1192-1194, test helper `find_cursor_in_buffer` ~1414-1417).
+
+**Interfaces:**
+- Consumes: `theme::heading()`, `theme::stack()`, `theme::muted()`, `theme::border_style()`, `theme::cursor()` (Task 1). `use crate::theme;` est déjà présent (ajouté en T3c).
+
+- [ ] **Step 1: En-tête** (~782). Remplacer :
+```rust
+        let header = Paragraph::new(header_text).style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+```
+par :
+```rust
+        let header = Paragraph::new(header_text).style(theme::heading());
+```
+
+- [ ] **Step 2: Footer du popup** (~838). Remplacer `Style::default().fg(Color::DarkGray)` (la ligne du footer `" Esc to close │ ↑↓ scroll"`) par `theme::muted()`.
+
+- [ ] **Step 3: Rôles de message** (~869-881). Remplacer le bloc :
+```rust
+            let role_style = if msg.is_system {
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM)
+            } else if msg.is_user {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            };
+```
+par :
+```rust
+            let role_style = if msg.is_system {
+                theme::muted().add_modifier(Modifier::DIM)
+            } else if msg.is_user {
+                theme::stack().add_modifier(Modifier::BOLD)
+            } else {
+                theme::heading()
+            };
+```
+(`theme::heading()` porte déjà BOLD ; l'assistant garde donc gras + laiton.)
+
+- [ ] **Step 4: Spinner de chargement** (~912-914). Remplacer :
+```rust
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+```
+par :
+```rust
+                theme::muted().add_modifier(Modifier::ITALIC),
+```
+
+- [ ] **Step 5: Curseur bloc** — les TROIS occurrences (~1071, ~1158, ~1165) de :
+```rust
+                    Style::default().bg(Color::White).fg(Color::Black),
+```
+(et sa variante indentée) par :
+```rust
+                    theme::cursor(),
+```
+Attention : garder le `Span::styled(" ", …)` — le curseur reste une cellule espace.
+
+- [ ] **Step 6: Bordures + titres d'input** — les DEUX blocs (~1077-1082 et ~1190-1195). Remplacer dans chacun :
+```rust
+                        .border_style(Style::default().fg(Color::DarkGray))
+                        .title(" Input ")
+                        .title_style(Style::default().fg(Color::Cyan)),
+```
+par :
+```rust
+                        .border_style(theme::border_style())
+                        .title(" Input ")
+                        .title_style(theme::heading()),
+```
+
+- [ ] **Step 7: Adapter la détection de curseur du test** (`find_cursor_in_buffer`, ~1406-1424). Remplacer la condition :
+```rust
+                    // Cursor is styled with bg=White, fg=Black
+                    if cell.bg == ratatui::prelude::Color::White
+                        && cell.fg == ratatui::prelude::Color::Black
+                    {
+                        return Some((x, y));
+                    }
+```
+par (détecter le modifier REVERSED sur une cellule espace — le nom d'agent sélectionné de la Workroom utilise aussi REVERSED mais jamais sur un espace) :
+```rust
+                    // Cursor is styled reverse-video on a single space cell.
+                    if cell.symbol() == " "
+                        && cell.modifier.contains(ratatui::style::Modifier::REVERSED)
+                    {
+                        return Some((x, y));
+                    }
+```
+
+- [ ] **Step 8: Vérifier l'absence de résidus + imports.**
+
+Run: `grep -n "Color::Cyan\|Color::Green\|Color::Yellow\|Color::White\|Color::Black" src/shell/tui.rs`
+Expected: aucune ligne (les seules `Color::` restantes acceptables seraient `Color::DarkGray` si une occurrence hors scope subsiste — vérifier qu'il n'en reste pas d'inattendue). Si `Color` devient inutilisé, clippy le signalera → retirer l'import ; s'il reste utilisé, le garder.
+
+- [ ] **Step 9: Gate 3 modes + suite** (les tests de curseur `find_cursor_in_buffer` valident la nouvelle détection).
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui 2>&1 | tail -8
+```
+Expected: `No issues found` (3 modes) + suite verte (dont les tests d'input/curseur).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/shell/tui.rs
+git commit -m "style(shell): route chrome colors through the theme, adaptive reverse-video cursor"
+```
+
+**➡️ Fin de T3d. PR + revue indépendante + validation visuelle Dimitri (`armadai shell` fond clair : en-tête, messages user/assistant/system, curseur visible, input) avant merge.**
+
+---
+
+## Self-Review
+- **Spec coverage** : header→heading (T2.1) ; footer popup→muted (T2.2) ; rôles system/user/assistant→muted+DIM / stack+BOLD / heading (T2.3, mapping validé) ; spinner→muted+ITALIC (T2.4) ; curseur→cursor() (T2.5, helper T1) ; bordures/titres input→border_style/heading (T2.6) ; détection test adaptée (T2.7) ; grep de non-régression (T2.8). ✓
+- **Placeholder scan** : aucun.
+- **Type consistency** : `theme::cursor()` défini T1, consommé T2.5 ; helpers `heading/stack/muted/border_style` existants ; `cell.symbol()`/`cell.modifier` sont l'API ratatui de `Cell` (les tests existants lisent déjà `cell.bg`/`cell.fg`). Le modifier REVERSED sur espace évite la collision avec les noms d'agents REVERSED de la Workroom.
+- **Risque** : si un test existant s'appuyait sur `bg=White` du curseur autrement que via `find_cursor_in_buffer`, il casserait — vérifier via la suite complète (Step 9). Le curseur REVERSED sur cellule vide reste détectable et visible.

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -777,11 +777,7 @@ impl ShellApp {
             "ArmadAI Shell — {}{} — Turn #{}",
             model_info, pty_indicator, self.turn_count
         );
-        let header = Paragraph::new(header_text).style(
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        );
+        let header = Paragraph::new(header_text).style(theme::heading());
         frame.render_widget(header, chunks[0]);
 
         // Messages area (with optional workroom panel)
@@ -835,7 +831,7 @@ impl ShellApp {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             " Esc to close │ ↑↓ scroll",
-            Style::default().fg(Color::DarkGray),
+            theme::muted(),
         )));
 
         let popup = Paragraph::new(lines)
@@ -867,17 +863,11 @@ impl ShellApp {
         for msg in &self.messages {
             // Add role label
             let role_style = if msg.is_system {
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM)
+                theme::muted().add_modifier(Modifier::DIM)
             } else if msg.is_user {
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD)
+                theme::stack().add_modifier(Modifier::BOLD)
             } else {
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD)
+                theme::heading()
             };
 
             let role_prefix = if msg.is_system { "⚙ " } else { "" };
@@ -909,9 +899,7 @@ impl ShellApp {
                 .unwrap_or(0.0);
             lines.push(Line::from(vec![Span::styled(
                 format!("{spinner} Generating response… {elapsed:.0}s"),
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::ITALIC),
+                theme::muted().add_modifier(Modifier::ITALIC),
             )]));
         }
 
@@ -1066,19 +1054,16 @@ impl ShellApp {
                 input_spans.push(Span::raw(c.to_string()));
             }
             if !self.loading {
-                input_spans.push(Span::styled(
-                    " ",
-                    Style::default().bg(Color::White).fg(Color::Black),
-                ));
+                input_spans.push(Span::styled(" ", theme::cursor()));
             }
 
             let input_paragraph = Paragraph::new(Line::from(input_spans))
                 .block(
                     Block::default()
                         .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::DarkGray))
+                        .border_style(theme::border_style())
                         .title(" Input ")
-                        .title_style(Style::default().fg(Color::Cyan)),
+                        .title_style(theme::heading()),
                 )
                 .wrap(Wrap { trim: false });
 
@@ -1130,10 +1115,7 @@ impl ShellApp {
 
             // Add this character to current line
             if is_cursor_pos {
-                current_line_spans.push(Span::styled(
-                    c.to_string(),
-                    Style::default().bg(Color::White).fg(Color::Black),
-                ));
+                current_line_spans.push(Span::styled(c.to_string(), theme::cursor()));
             } else {
                 current_line_spans.push(Span::raw(c.to_string()));
             }
@@ -1153,17 +1135,11 @@ impl ShellApp {
             if current_col < available_width {
                 // Cursor fits on current line
                 if let Some(last_line) = lines.last_mut() {
-                    last_line.spans.push(Span::styled(
-                        " ",
-                        Style::default().bg(Color::White).fg(Color::Black),
-                    ));
+                    last_line.spans.push(Span::styled(" ", theme::cursor()));
                 }
             } else if current_col > 0 {
                 // Cursor would wrap to next line (edge case: cursor at exact wrap boundary)
-                let cursor_span = vec![Span::styled(
-                    " ",
-                    Style::default().bg(Color::White).fg(Color::Black),
-                )];
+                let cursor_span = vec![Span::styled(" ", theme::cursor())];
                 lines.push(Line::from(cursor_span));
                 cursor_on_new_line = true;
             }
@@ -1189,9 +1165,9 @@ impl ShellApp {
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::DarkGray))
+                    .border_style(theme::border_style())
                     .title(" Input ")
-                    .title_style(Style::default().fg(Color::Cyan)),
+                    .title_style(theme::heading()),
             )
             .wrap(Wrap { trim: false })
             .scroll((scroll_offset, 0));
@@ -1411,9 +1387,9 @@ mod tests {
         for y in 0..buf.area().height {
             for x in 0..buf.area().width {
                 if let Some(cell) = buf.cell((x, y)) {
-                    // Cursor is styled with bg=White, fg=Black
-                    if cell.bg == ratatui::prelude::Color::White
-                        && cell.fg == ratatui::prelude::Color::Black
+                    // Cursor is styled reverse-video on a single space cell.
+                    if cell.symbol() == " "
+                        && cell.modifier.contains(ratatui::style::Modifier::REVERSED)
                     {
                         return Some((x, y));
                     }

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -851,7 +851,12 @@ impl ShellApp {
     fn render_messages_area(&self, frame: &mut Frame, area: Rect) {
         if self.messages.is_empty() {
             let placeholder = Paragraph::new("Welcome to ArmadAI Shell!\n\nType your message and press Enter to get started. Press Ctrl+L to clear conversation, Ctrl+W to focus the workroom panel, Ctrl+C or Esc to quit.")
-                .block(Block::default().borders(Borders::ALL))
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(theme::border_style()),
+                )
+                .style(theme::border_style())
                 .wrap(Wrap { trim: false });
             frame.render_widget(placeholder, area);
             return;
@@ -931,9 +936,17 @@ impl ShellApp {
             max_scroll
         };
 
-        // Create paragraph with message content
+        // Create paragraph with message content. The base `.style()` gives the
+        // whole panel a neutral foreground so unstyled message bodies (plain
+        // user lines, markdown text) don't inherit the terminal default fg
+        // (which reads blue on light terminals). Styled role labels override it.
         let messages_text = Paragraph::new(lines)
-            .block(Block::default().borders(Borders::ALL))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(theme::border_style()),
+            )
+            .style(theme::border_style())
             .wrap(Wrap { trim: false })
             .scroll((scroll, 0));
 

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -1379,7 +1379,7 @@ mod tests {
         assert_eq!(byte_idx, 1);
     }
 
-    /// Helper to find cursor position in rendered buffer (background white/black)
+    /// Helper to find cursor position in rendered buffer (reverse-video space cell)
     fn find_cursor_in_buffer(
         terminal: &ratatui::Terminal<ratatui::backend::TestBackend>,
     ) -> Option<(u16, u16)> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -248,6 +248,14 @@ pub fn border_style() -> Style {
     Style::default().fg(BORDER.color())
 }
 
+/// Style for the input block cursor: reverse-video (swaps the cell's
+/// foreground/background) so the cursor stays visible on both light and
+/// dark terminals. Rendered on a single space cell.
+#[allow(dead_code)]
+pub fn cursor() -> Style {
+    Style::default().add_modifier(Modifier::REVERSED)
+}
+
 /// Alias for `selection()` (bold brass accent used for highlights).
 /// Named `accent_style()` for UI compatibility.
 pub fn accent_style() -> Style {
@@ -345,5 +353,10 @@ mod tests {
 
         // Note: can't test ASCII variant easily without resetting OnceLock.
         // The behavior is correct by code inspection.
+    }
+
+    #[test]
+    fn cursor_is_reversed() {
+        assert!(cursor().add_modifier.contains(Modifier::REVERSED));
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -251,7 +251,6 @@ pub fn border_style() -> Style {
 /// Style for the input block cursor: reverse-video (swaps the cell's
 /// foreground/background) so the cursor stays visible on both light and
 /// dark terminals. Rendered on a single space cell.
-#[allow(dead_code)]
 pub fn cursor() -> Style {
     Style::default().add_modifier(Modifier::REVERSED)
 }


### PR DESCRIPTION
## T3d — Design System TUI : chrome du shell

Dernière surface TUI du chantier design system. Complète T3 (#240/#241/#242) en routant **tout le chrome du shell** (`src/shell/tui.rs`) via le thème central `src/theme.rs`. Plan : `docs/superpowers/plans/2026-07-23-tui-t3d-shell-chrome.md`.

### Contenu
- **En-tête** « ArmadAI Shell » : Cyan → `theme::heading()` (laiton).
- **Rôles de message** (mapping validé) : assistant → laiton (`heading`), user → vert signal_ok (`stack`) + gras, system → gris (`muted`) + dim. Spinner de chargement → `muted` + italic.
- **Curseur d'input** : `bg(White)/fg(Black)` (invisible sur fond blanc) → nouveau `theme::cursor()` en **vidéo inverse adaptative** (visible fond clair ET sombre). Détection de test `find_cursor_in_buffer` adaptée (espace + `Modifier::REVERSED`).
- **Bordures/titres d'input** + footer popup → `theme::border_style()` / `heading` / `muted`.
- Objectif tenu : **zéro `Color::` littéral** restant dans `src/shell/tui.rs`.

### Gate
clippy 3 modes + fmt + `cargo test --features tui` (941). TDD pour `theme::cursor()`.

### Validation
Visuelle par Dimitri sur fond clair (`armadai shell`) : en-tête, messages user/assistant/system, curseur bien visible dans l'input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)