### PR TITLE
feat(run): provider-agnostic live workroom driven by the core event stream

### DIFF
--- a/docs/superpowers/plans/2026-07-23-workroom-executionevent.md
+++ b/docs/superpowers/plans/2026-07-23-workroom-executionevent.md
@@ -1,0 +1,581 @@
+# Workroom piloté par les événements cœur (agnostique provider) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Animer la Workroom depuis le flux cœur `RunEvent` d'ArmadAI (agnostique du provider) pendant `armadai run --orchestrate`, en réutilisant les layouts/drill-down de T3.
+
+**Architecture:** Projection pure `Workroom::on_run_event_at(&RunEvent, Instant)` (mapping event→état, horloge injectée pour des tests déterministes) ; `WorkroomSink` (implémente `EventSink`) qui pousse les `RunEvent` clonés dans un `tokio::sync::mpsc::UnboundedSender` ; renderer live ratatui sur `armadai run --orchestrate` (feature `tui`) qui lance l'orchestration en tâche async, draine le channel, redessine, restaure le terminal et imprime le résultat.
+
+**Tech Stack:** Rust edition 2024, ratatui/crossterm, tokio, feature `tui`.
+
+## Global Constraints
+- Gate à chaque tâche : clippy **3 modes** (`--no-default-features --features tui`, `--features tui,providers-api`, `--features tui,web,storage`) `-D warnings` + `cargo fmt -- --check` + `cargo test --no-default-features --features tui` (+ `--features tui,storage` pour l'e2e — voir Task 4).
+- **Ne PAS toucher le chemin headless existant** : `--json` / `--quiet` / stdout non-TTY → comportement inchangé (sink stdout/json via `make_sink`, aucune TUI). Les e2e existants (`--json`) doivent rester verts.
+- **Ne PAS toucher le mode relais du shell** (`src/shell/app.rs` marqueurs / `apply_stream_text` / `parse_streaming_line`) — hors périmètre.
+- Projection **pure et déterministe** : `on_run_event_at` prend `now: Instant` en paramètre (jamais `Instant::now()` dans la projection). Tests sans accès env.
+- Réutiliser l'API Workroom existante (`src/shell/workroom.rs`) : `AgentState {Working,Delegating,Done,Idle}`, `AgentRole {Coordinator,Lead,Agent}`, `TrackedAgent {name,state,role,started_at,finished_at,spinner_frame,last_action,transitions}`, `on_complete`, `set_state`, `coordinator_name`, `tick`, `init_from_config`. **Ne pas ajouter de variante `AgentState`** (pas d'état Error : `Error` → `last_action` sur l'agent courant).
+- Branche depuis `release/1.0.0`. Une PR, revue indépendante + validation visuelle Dimitri avant merge.
+
+## File Structure
+- `src/core/events.rs` — `#[derive(Clone)]` sur `RunEvent` (Task 2).
+- `src/shell/workroom.rs` — `on_run_event_at` + helpers privés + tests unitaires (Task 1).
+- `src/shell/run_view.rs` *(nouveau)* — `WorkroomSink` (Task 2) + le renderer live `run_orchestration_tui(...)` (Task 3).
+- `src/shell/mod.rs` — `pub mod run_view;` (Task 2).
+- `src/cli/mod.rs` — flag `--no-tui` sur `Run` (Task 3).
+- `src/cli/run.rs` — branchement TUI vs headless dans `execute` (Task 3).
+- `tests/e2e/` — helper de rejeu de projection + cas (Task 4).
+
+---
+
+### Task 1: Projection pure `Workroom::on_run_event_at`
+
+**Files:** Modify `src/shell/workroom.rs` (imports, `impl Workroom`, `mod tests`).
+
+**Interfaces:**
+- Consumes: `crate::core::events::RunEvent` (variantes ci-dessous), `std::time::Instant`.
+- Produces: `pub fn on_run_event_at(&mut self, ev: &RunEvent, now: Instant)`.
+
+- [ ] **Step 1 : Écrire les tests qui échouent** — dans `mod tests` de `src/shell/workroom.rs` :
+
+```rust
+    use crate::core::events::RunEvent;
+    use std::time::Instant;
+
+    fn rs(agents: &[&str]) -> RunEvent {
+        RunEvent::RunStart {
+            v: 1,
+            agents: agents.iter().map(|s| s.to_string()).collect(),
+            prov: "fake".into(),
+            model: "m".into(),
+            in_chars: 0,
+        }
+    }
+
+    #[test]
+    fn on_run_event_seeds_and_transitions() {
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(&rs(&["dev-lead", "core-specialist"]), t);
+        assert_eq!(wr.agents.len(), 2);
+        assert!(wr.is_visible());
+
+        wr.on_run_event_at(&RunEvent::Delegate { from: "dev-lead".into(), to: "core-specialist".into() }, t);
+        assert_eq!(wr.agents.iter().find(|a| a.name == "dev-lead").unwrap().state, AgentState::Delegating);
+
+        wr.on_run_event_at(&RunEvent::AgentStart { agent: "core-specialist".into(), prov: "fake".into(), model: "m".into() }, t);
+        assert_eq!(wr.agents.iter().find(|a| a.name == "core-specialist").unwrap().state, AgentState::Working);
+
+        wr.on_run_event_at(&RunEvent::AgentEnd { agent: "core-specialist".into(), tin: 1, tout: 2, cost: 0.0, content: "done reticulating\nsplines".into() }, t);
+        let a = wr.agents.iter().find(|a| a.name == "core-specialist").unwrap();
+        assert_eq!(a.state, AgentState::Done);
+        assert_eq!(a.last_action.as_deref(), Some("done reticulating"));
+    }
+
+    #[test]
+    fn on_run_event_result_finalizes() {
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(&rs(&["a"]), t);
+        wr.on_run_event_at(&RunEvent::AgentStart { agent: "a".into(), prov: "f".into(), model: "m".into() }, t);
+        wr.on_run_event_at(&RunEvent::Result { content: "x".into(), tin: 0, tout: 0, cost: 0.0, agents: 1 }, t);
+        // on_complete turns any Working agent into Done.
+        assert_eq!(wr.agents.iter().find(|a| a.name == "a").unwrap().state, AgentState::Done);
+    }
+
+    #[test]
+    fn on_run_event_unknown_variants_are_noops() {
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(&rs(&["a"]), t);
+        wr.on_run_event_at(&RunEvent::Warning { code: "w".into(), from: None, to: None }, t);
+        wr.on_run_event_at(&RunEvent::Route { agent: "a".into(), tier: "fast".into(), reason: "r".into() }, t);
+        assert_eq!(wr.agents.iter().find(|a| a.name == "a").unwrap().last_action.as_deref(), Some("→ fast"));
+    }
+```
+
+- [ ] **Step 2 : Lancer — échoue** (`no method on_run_event_at`).
+
+Run: `cargo test --no-default-features --features tui workroom::tests::on_run_event 2>&1 | tail -5`
+Expected: erreur de compilation.
+
+- [ ] **Step 3 : Ajouter l'import** en tête de `src/shell/workroom.rs` (après les `use` existants) :
+
+```rust
+use crate::core::events::RunEvent;
+```
+
+- [ ] **Step 4 : Implémenter la projection + helpers** dans `impl Workroom` :
+
+```rust
+    /// Apply one core `RunEvent` to the workroom state (provider-agnostic
+    /// projection). `now` is injected so timing is deterministic in tests;
+    /// the live renderer passes `Instant::now()`.
+    pub fn on_run_event_at(&mut self, ev: &RunEvent, now: Instant) {
+        match ev {
+            RunEvent::RunStart { agents, .. } => {
+                for name in agents {
+                    if !self.agents.iter().any(|a| a.name == *name) {
+                        self.agents.push(TrackedAgent {
+                            name: name.clone(),
+                            state: AgentState::Idle,
+                            role: AgentRole::Agent,
+                            started_at: None,
+                            finished_at: None,
+                            spinner_frame: 0,
+                            last_action: None,
+                            transitions: Vec::new(),
+                        });
+                    }
+                }
+                self.visible = true;
+            }
+            RunEvent::AgentStart { agent, .. } => self.mark_working(agent, now),
+            RunEvent::AgentEnd { agent, content, .. } => {
+                self.mark_done(agent, now);
+                let first = content.lines().next().unwrap_or("").trim();
+                if !first.is_empty() {
+                    self.set_action(agent, first.to_string());
+                }
+            }
+            RunEvent::Delegate { from, to } => {
+                self.transition(from, AgentState::Delegating, now);
+                self.current_agent = Some(to.clone());
+            }
+            RunEvent::NestedStart { team_lead, .. } => self.transition(team_lead, AgentState::Delegating, now),
+            RunEvent::NestedEnd { team_lead } => self.transition(team_lead, AgentState::Done, now),
+            RunEvent::AgentSelect { selected, .. } => {
+                for a in selected {
+                    self.mark_working(a, now);
+                }
+            }
+            RunEvent::Vote { agent, conf } => self.set_action(agent, format!("vote {conf:.2}")),
+            RunEvent::Board { agent, kind } => self.set_action(agent, format!("board {kind}")),
+            RunEvent::Route { agent, tier, .. } => self.set_action(agent, format!("→ {tier}")),
+            RunEvent::Result { .. } => self.on_complete(),
+            RunEvent::Error { msg, .. } => {
+                if let Some(cur) = self.current_agent.clone() {
+                    self.set_action(&cur, format!("error: {msg}"));
+                }
+            }
+            RunEvent::Warning { .. } => {}
+        }
+    }
+
+    fn mark_working(&mut self, name: &str, now: Instant) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            a.state = AgentState::Working;
+            a.started_at.get_or_insert(now);
+            a.transitions.push((AgentState::Working, now));
+        }
+    }
+
+    fn mark_done(&mut self, name: &str, now: Instant) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            a.state = AgentState::Done;
+            a.finished_at = Some(now);
+            a.transitions.push((AgentState::Done, now));
+        }
+    }
+
+    fn transition(&mut self, name: &str, state: AgentState, now: Instant) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            if state == AgentState::Delegating && a.started_at.is_none() {
+                a.started_at = Some(now);
+            }
+            a.transitions.push((state.clone(), now));
+            a.state = state;
+        }
+    }
+
+    fn set_action(&mut self, name: &str, action: String) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            a.last_action = Some(action);
+        }
+    }
+```
+
+Note : si `AgentState` ne dérive pas `Clone`, l'ajouter (`#[derive(Debug, Clone, PartialEq)]`) — vérifier la déclaration `enum AgentState` (~ligne 21). Réutiliser les champs de `TrackedAgent` exactement comme `init_from_config` les construit.
+
+- [ ] **Step 5 : Lancer — passe**
+
+Run: `cargo test --no-default-features --features tui workroom:: 2>&1 | tail -8`
+Expected: nouveaux tests verts, existants inchangés.
+
+- [ ] **Step 6 : Gate + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+git add src/shell/workroom.rs
+git commit -m "feat(workroom): pure projection of core RunEvent stream (on_run_event_at)"
+```
+
+---
+
+### Task 2: `RunEvent: Clone` + `WorkroomSink`
+
+**Files:** Modify `src/core/events.rs` ; Create `src/shell/run_view.rs` ; Modify `src/shell/mod.rs`.
+
+**Interfaces:**
+- Consumes: `RunEvent`, `EventSink` (`src/core/events.rs`), `Workroom::on_run_event_at` (Task 1).
+- Produces: `pub struct WorkroomSink { tx: tokio::sync::mpsc::UnboundedSender<RunEvent> }` impl `EventSink` ; `WorkroomSink::new() -> (Self, UnboundedReceiver<RunEvent>)`.
+
+- [ ] **Step 1 : Rendre `RunEvent` clonable.** Dans `src/core/events.rs`, sur `enum RunEvent` (~ligne 6) : `#[derive(Debug, Serialize)]` → `#[derive(Debug, Clone, Serialize)]`. (Tous les champs — String/Vec<String>/u32/f64/f32/usize — sont Clone.)
+
+- [ ] **Step 2 : Écrire le test d'intégration qui échoue** — créer `src/shell/run_view.rs` avec, pour l'instant, seulement le module de test :
+
+```rust
+#![cfg(feature = "tui")]
+
+// (implementation added in Step 4)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::events::{EventSink, RunEvent};
+    use crate::shell::workroom::Workroom;
+    use std::time::Instant;
+
+    #[test]
+    fn sink_forwards_events_to_projection() {
+        let (sink, mut rx) = WorkroomSink::new();
+        sink.emit(&RunEvent::RunStart { v: 1, agents: vec!["a".into(), "b".into()], prov: "f".into(), model: "m".into(), in_chars: 0 });
+        sink.emit(&RunEvent::AgentStart { agent: "a".into(), prov: "f".into(), model: "m".into() });
+        sink.emit(&RunEvent::AgentEnd { agent: "a".into(), tin: 0, tout: 0, cost: 0.0, content: "hi".into() });
+        drop(sink);
+
+        let mut wr = Workroom::new();
+        let now = Instant::now();
+        while let Ok(ev) = rx.try_recv() {
+            wr.on_run_event_at(&ev, now);
+        }
+        let agents = wr.agents_for_test();
+        assert_eq!(agents.len(), 2);
+        assert_eq!(agents.iter().find(|a| a.name == "a").unwrap().state, crate::shell::workroom::AgentState::Done);
+    }
+}
+```
+
+Note : rendre `Workroom::agents` accessible aux tests via `agents_for_test()` (déjà présent) et exporter `AgentState` (déjà `pub`).
+
+- [ ] **Step 3 : Déclarer le module** — dans `src/shell/mod.rs`, ajouter `pub mod run_view;` (sous le même `#[cfg(feature = "tui")]` que les autres modules shell si applicable).
+
+- [ ] **Step 4 : Implémenter `WorkroomSink`** en tête de `src/shell/run_view.rs` (avant le `mod tests`) :
+
+```rust
+use crate::core::events::{EventSink, RunEvent};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+/// An `EventSink` that forwards a clone of every `RunEvent` into a channel,
+/// so a TUI render loop can drain and project them onto a `Workroom`.
+pub struct WorkroomSink {
+    tx: UnboundedSender<RunEvent>,
+}
+
+impl WorkroomSink {
+    pub fn new() -> (Self, UnboundedReceiver<RunEvent>) {
+        let (tx, rx) = unbounded_channel();
+        (Self { tx }, rx)
+    }
+}
+
+impl EventSink for WorkroomSink {
+    fn emit(&self, ev: &RunEvent) {
+        // Receiver gone (TUI exited) → drop silently; the run still completes.
+        let _ = self.tx.send(ev.clone());
+    }
+}
+```
+
+- [ ] **Step 5 : Lancer — passe**
+
+Run: `cargo test --no-default-features --features tui shell::run_view 2>&1 | tail -6`
+Expected: `sink_forwards_events_to_projection` vert.
+
+- [ ] **Step 6 : Gate 3 modes + commit** (Clone sur RunEvent touche les 3 modes) :
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+git add src/core/events.rs src/shell/run_view.rs src/shell/mod.rs
+git commit -m "feat(shell): WorkroomSink bridges the core event stream to the workroom"
+```
+
+---
+
+### Task 3: Renderer live sur `armadai run --orchestrate` + flag `--no-tui`
+
+**Files:** Modify `src/shell/run_view.rs` (renderer) ; `src/cli/mod.rs` (flag) ; `src/cli/run.rs` (branchement).
+
+**Interfaces:**
+- Consumes: `WorkroomSink` (Task 2), `Workroom` (rendu T3), `crate::core::events::EventSink`.
+- Produces: `pub async fn run_orchestration_tui(run: impl FnOnce(std::sync::Arc<dyn EventSink>) -> F, config_yaml: Option<String>) -> anyhow::Result<()>` où `F: Future<Output = anyhow::Result<()>>` — lance `run` avec un `WorkroomSink`, affiche la Workroom live, restaure le terminal.
+
+- [ ] **Step 1 : Ajouter le flag `--no-tui`** dans `src/cli/mod.rs`, variante `Run { … }`, après `quiet` :
+
+```rust
+        /// Disable the live orchestration TUI (force plain headless output)
+        #[arg(long = "no-tui")]
+        no_tui: bool,
+```
+et propager dans le handler `Command::Run { … }` (~ligne 478) jusqu'à `run::execute(...)` (ajouter le paramètre `no_tui`).
+
+- [ ] **Step 2 : Implémenter le renderer** dans `src/shell/run_view.rs` :
+
+```rust
+use std::io;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+
+use crate::shell::workroom::Workroom;
+
+/// Run an orchestration (`run`) while showing a live Workroom TUI fed by its
+/// event stream. Restores the terminal on exit (including on error).
+pub async fn run_orchestration_tui<F>(
+    run: impl FnOnce(Arc<dyn EventSink>) -> F,
+    config_yaml: Option<String>,
+) -> anyhow::Result<()>
+where
+    F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let (sink, mut rx) = WorkroomSink::new();
+    let sink: Arc<dyn EventSink> = Arc::new(sink);
+
+    // Seed roles from the orchestration config if available (RunStart carries
+    // no roles); otherwise the flotte stays flat.
+    let mut workroom = Workroom::new();
+    if let Some(cfg) = config_yaml {
+        workroom.init_from_config(&cfg);
+    }
+    workroom.set_visible(true);
+
+    // Launch the orchestration in the background.
+    let handle = tokio::spawn(run(sink));
+
+    // Enter alternate screen (mirrors src/shell/app.rs).
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let render_result = run_loop(&mut terminal, &mut workroom, &mut rx, handle).await;
+
+    // Always restore the terminal.
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    render_result
+}
+
+async fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    workroom: &mut Workroom,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<RunEvent>,
+    mut handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let mut final_content: Option<String> = None;
+    loop {
+        // Drain all pending events.
+        while let Ok(ev) = rx.try_recv() {
+            if let RunEvent::Result { content, .. } = &ev {
+                final_content = Some(content.clone());
+            }
+            workroom.on_run_event_at(&ev, Instant::now());
+        }
+        workroom.tick();
+        terminal.draw(|f| workroom.render(f, f.area()))?;
+
+        // Input: Ctrl+W focus/drill-down (already implemented), Ctrl+C/q quit.
+        if event::poll(Duration::from_millis(80))?
+            && let Event::Key(k) = event::read()?
+            && k.kind == KeyEventKind::Press
+        {
+            match k.code {
+                KeyCode::Char('c') if k.modifiers.contains(KeyModifiers::CONTROL) => {
+                    handle.abort();
+                    break;
+                }
+                KeyCode::Char('w') if k.modifiers.contains(KeyModifiers::CONTROL) => {
+                    workroom.set_focused(!workroom.is_focused());
+                }
+                KeyCode::Up | KeyCode::Char('k') if workroom.is_focused() => workroom.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => workroom.select_next(),
+                KeyCode::Char('q') if !workroom.is_focused() => break,
+                _ => {}
+            }
+        }
+
+        // Exit once the orchestration finished and the channel is drained.
+        if handle.is_finished() && rx.is_empty() {
+            // Apply any last events.
+            while let Ok(ev) = rx.try_recv() {
+                workroom.on_run_event_at(&ev, Instant::now());
+            }
+            break;
+        }
+    }
+
+    // Propagate the orchestration's result / print final content after restore.
+    let outcome = handle.await;
+    match outcome {
+        Ok(Ok(())) => {
+            if let Some(content) = final_content {
+                // Printed after the caller restores the terminal (see caller).
+                PRINT_AFTER.with(|p| *p.borrow_mut() = Some(content));
+            }
+            Ok(())
+        }
+        Ok(Err(e)) => Err(e),
+        Err(join_err) if join_err.is_cancelled() => Ok(()), // Ctrl+C abort
+        Err(join_err) => Err(anyhow::anyhow!(join_err)),
+    }
+}
+```
+
+Note d'implémentation : le renvoi du `final_content` à imprimer après restauration du terminal peut se faire plus simplement en **retournant `Option<String>`** depuis `run_orchestration_tui` et en laissant `cli/run.rs` l'imprimer (préférer ça au `thread_local PRINT_AFTER` esquissé ci-dessus — le remplacer par un `-> anyhow::Result<Option<String>>`). Garder la restauration terminal AVANT le `println!`.
+
+- [ ] **Step 3 : Brancher dans `src/cli/run.rs::execute`.** Au début d'`execute`, décider le mode :
+
+```rust
+    let use_tui = orchestrate.is_some()
+        && !json
+        && !quiet
+        && !no_tui
+        && std::io::IsTerminal::is_terminal(&std::io::stdout());
+
+    #[cfg(feature = "tui")]
+    if use_tui {
+        // Load project orchestration config (for role seeding), best-effort.
+        let cfg_yaml = std::fs::read_to_string(".armadai/config.yaml")
+            .or_else(|_| std::fs::read_to_string("armadai.yaml"))
+            .ok();
+        let (agent_name, input, pipe, orchestrate, max_content, route, tags) =
+            (agent_name.clone(), input.clone(), pipe.clone(), orchestrate.clone(), max_content, route.clone(), tags.clone());
+        let printed = crate::shell::run_view::run_orchestration_tui(
+            move |sink| async move {
+                run_inner(agent_name, input, pipe, orchestrate, true, false, false, max_content, route, tags, dry_run, &sink).await
+            },
+            cfg_yaml,
+        ).await;
+        return match printed {
+            Ok(Some(content)) => { println!("{content}"); Ok(()) }
+            Ok(None) => Ok(()),
+            Err(e) => Err(e),
+        };
+    }
+    // else: existing headless path unchanged (make_sink, run_inner).
+```
+
+Adapter la capture des variables au vrai code d'`execute` (les noms/déplacements exacts). `IsTerminal` vient de `std::io::IsTerminal`.
+
+- [ ] **Step 4 : Compiler + gate 3 modes** (le renderer ne se teste pas unitairement — validation visuelle) :
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui 2>&1 | tail -5
+```
+Expected: `No issues found` (3 modes) + suite verte.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/shell/run_view.rs src/cli/mod.rs src/cli/run.rs
+git commit -m "feat(run): live workroom TUI for orchestrated runs (default on TTY, --no-tui to disable)"
+```
+
+---
+
+### Task 4: e2e systématiques (assertions du flux par pattern + `--no-tui`)
+
+**Contexte technique confirmé** : `armadai` est **binary-only** (pas de `src/lib.rs`) et le harnais e2e (`tests/e2e/`, cible `tests/e2e.rs` → `cargo test --test e2e`) **n'importe AUCUN type `armadai::`** — il lance le vrai binaire avec `fake-claude` et asserte sur la séquence JSONL `--json`. Le rejeu Rust de la projection est donc **non viable** en e2e ; on valide **le flux `RunEvent` que la projection consomme** via les assertions `events` (sous-séquence ordonnée, sous-ensemble de champs — cf. les tests de `evaluate` dans `runner.rs`). La projection elle-même (`on_run_event_at`) est déjà couverte unitairement en Task 1.
+
+**Files:** Modify `tests/e2e/cases/{hierarchical,blackboard,ring}.yaml` ; Create `tests/e2e/cases/no-tui.yaml`.
+
+**Interfaces:**
+- Consumes: le format de cas e2e existant (`setup`/`fake`/`expect.events` — cf. `tests/e2e/case.rs`) et le vocabulaire d'événements (`t: run_start | agent_start | agent_end | delegate | vote | board | nested_start | result | …`, clés courtes de `RunEvent` : `agent`, `from`, `to`).
+
+- [ ] **Step 1 : Comprendre le harnais + confirmer l'invocation** — lire `tests/e2e/runner.rs` et `tests/e2e.rs` : comment les cas `cases/*.yaml` sont découverts et exécutés, et avec quelles features le binaire `armadai` est construit pour l'e2e (confirmer la commande exacte à lancer en Step 5). Vérifier le format `expect.events` (sous-séquence, match de sous-ensemble de champs).
+
+- [ ] **Step 2 : Étendre `hierarchical.yaml`** — dans `expect.events`, compléter la sous-séquence pour asservir, pour CHAQUE specialist délégué, la paire `delegate` puis `agent_start`/`agent_end` (c'est l'info exacte que `on_run_event_at` transforme en Working→Done). Respecter le format existant (liste ordonnée, sous-ensemble de champs) et le vocabulaire réel du cas. Exemple d'entrées à ajouter (adapter aux noms d'agents du cas) :
+
+```yaml
+  events:
+    - { t: run_start }
+    - { t: delegate, from: coordinator, to: core-specialist }
+    - { t: agent_start, agent: core-specialist }
+    - { t: agent_end, agent: core-specialist }
+    - { t: result }
+```
+
+- [ ] **Step 3 : Étendre `blackboard.yaml` et `ring.yaml`** — même principe, avec le vocabulaire propre à chaque pattern :
+  - blackboard : asservir `agent_start`/`agent_end` (et `board`/`agent_select` s'ils sont émis) pour les agents participants.
+  - ring : asservir la circulation — `agent_start`/`agent_end` dans l'ordre de l'anneau, et `vote` en phase de vote (le cas `ring.yaml` script déjà les phases propose/vote).
+  Ne pas retirer d'assertions existantes ; ajouter les entrées manquantes en gardant la sous-séquence ordonnée cohérente avec la sortie réelle (lancer le cas pour caler l'ordre).
+
+- [ ] **Step 4 : Cas `no-tui.yaml`** — créer `tests/e2e/cases/no-tui.yaml`, aligné sur un cas ring minimal, avec le flag `--no-tui` ajouté ; objectif : prouver que `--no-tui` laisse `exit_code: 0` et la séquence `events` **identiques** au comportement headless (le harnais capture stdout non-TTY → déjà headless, `--no-tui` ne doit rien changer). Réutiliser des `fake.rules` d'un ring minimal (s'aligner sur `ring.yaml` pour les phases propose/vote) :
+
+```yaml
+name: no-tui
+weight: 1
+setup:
+  pattern: ring
+  agents: [t-a, t-b]
+  flags: ["--no-tui"]
+  input: "say hi"
+fake:
+  rules:
+    - match: { prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: hi"
+    - match: { prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.9\nhi is fine."
+    - match: {}
+      respond: "unexpected"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: result }
+```
+(Caler `fake.rules`/`events` sur le comportement réel du ring — lancer le cas et ajuster ; le point est `--no-tui` + exit 0 + séquence inchangée, pas la finesse ring. Confirmer que le harnais passe bien `--no-tui` via `setup.flags`.)
+
+- [ ] **Step 5 : Lancer l'e2e**
+
+Run: `cargo test --test e2e <features confirmées en Step 1> 2>&1 | tail -20`
+Expected: `hierarchical`, `blackboard`, `ring`, `no-tui` verts ; aucun cas existant cassé.
+
+- [ ] **Step 6 : Gate complet + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui
+cargo test --test e2e   # (avec les features confirmées en Step 1)
+git add tests/e2e/
+git commit -m "test(e2e): assert per-agent event stream across patterns + --no-tui headless parity"
+```
+
+---
+
+## Self-Review
+- **Spec coverage** : projection pure `on_run_event_at` (Task 1) ✓ ; `WorkroomSink`/channel + `RunEvent: Clone` (Task 2) ✓ ; renderer live + déclenchement TTY/`--no-tui`/json-quiet-headless-inchangé (Task 3) ✓ ; seed rôles depuis config, dégradation flotte plate (Task 3 Step 2/3) ✓ ; tests unitaires horloge injectée (Task 1), intégration sink→channel→projection (Task 2), e2e par pattern + `--no-tui` (Task 4) ✓ ; note fake-gemini = hors lot (spec) ✓ ; hors périmètre (relais shell, hooks/plugin) non touché ✓.
+- **Placeholder scan** : le `PRINT_AFTER thread_local` de Task 3 Step 2 est explicitement remplacé par un retour `Option<String>` dans la note qui suit (pas un placeholder — deux formulations, la note tranche ; l'implémenteur retient le retour `Option<String>`). Task 4 ne dépend plus d'aucun type interne (binary-only confirmé) : assertions `events` YAML uniquement.
+- **Type consistency** : `on_run_event_at(&mut self, &RunEvent, Instant)` défini Task 1, consommé Task 2 (test intégration) ; `WorkroomSink::new() -> (Self, UnboundedReceiver<RunEvent>)` défini Task 2, consommé Task 3 ; `RunEvent` variantes/champs repris verbatim de `src/core/events.rs` ; `AgentState`/`TrackedAgent`/`init_from_config`/`on_complete`/`tick`/`render` existants (vérifiés dans workroom.rs). `IsTerminal` via `std::io::IsTerminal`.
+- **Risque tranché** : `armadai` binary-only + e2e sans accès aux types `armadai::` → confirmé ; Task 4 valide le flux via assertions `events` (voie B), la projection est couverte unitairement en Task 1. Plus de dépendance à un rejeu Rust en e2e.
+- **Risque restant** : la boucle TUI (`run_loop`) mêle `crossterm::event::poll` (bloquant bref) et une tâche tokio — acceptable (poll court) ; l'implémenteur doit garantir la restauration terminal même en cas d'erreur (déjà structuré : restauration après `run_loop`, avant propagation de l'erreur).

--- a/docs/superpowers/specs/2026-07-23-workroom-executionevent-design.md
+++ b/docs/superpowers/specs/2026-07-23-workroom-executionevent-design.md
@@ -1,0 +1,87 @@
+# Workroom piloté par les événements cœur (agnostique provider) — Design
+
+## Contexte
+
+La Workroom du shell (`src/shell/workroom.rs`) s'anime aujourd'hui uniquement quand le flux d'un CLI externe contient des marqueurs-commentaires `<!--ARMADAI_DELEGATE/META/END-->`. Diagnostic empirique (systematic-debugging, 2026-07-23, cf. mémoire `project_workroom_marker_emission`) : dans `armadai shell`, ArmadAI **relaie un CLI externe** (claude/gemini) — c'est ce CLI qui orchestre, pas ArmadAI. Or :
+- **claude** délègue via l'outil natif `Agent`/Task (`tool_use` + `subagent_type`), n'émet pas les marqueurs de délégation ;
+- **gemini** (et vraisemblablement codex/copilot) n'a **pas de concept de sous-agent** — il répond en agent unique.
+
+Il n'existe donc **pas de norme de délégation uniforme** à lire dans la sortie hétérogène des providers. La bonne source agnostique existe déjà : **le moteur d'orchestration event-sourcé d'ArmadAI** (`src/core/orchestration/es/`) émet des `ExecutionEvent`, mappés par le bridge en **`RunEvent`** (`src/core/events.rs`) poussés en direct via `EventSink` (déjà utilisés pour la sortie `--json` de `armadai run`). Chaque agent n'est qu'un appel `Provider::complete/stream` (primitif mono-agent) ; c'est ArmadAI qui compose et émet les événements → **agnostique par construction**. Cette orientation s'aligne sur l'issue **#227** (« provider-neutral lifecycle policy engine ; les hooks Claude Code sont des adaptateurs *au-dessus* du cœur, pas la source de vérité »).
+
+## Objectif
+
+Faire de la Workroom un **consommateur du flux cœur `RunEvent`** afin qu'elle s'anime pendant `armadai run --orchestrate`, de façon **agnostique du provider**, en réutilisant les layouts et le drill-down livrés en T3 (hierarchical/blackboard/ring, ⌃W).
+
+## Hors périmètre
+- Le mode **relais du shell** (marqueurs / parsing `tool_use` claude) reste **inchangé/best-effort** — non touché par ce lot.
+- L'**adaptateur hooks/plugin Claude Code** (mode hébergé fait proprement, alimentant le cœur en mode relais) — **brainstorm stratégique séparé**, aligné #227. Hors de ce lot.
+- Le moteur lifecycle/policy complet de #227 — hors lot (on consomme le flux `RunEvent` existant).
+
+## Architecture
+
+Séparation **projection / rendu** (philosophie event-sourcing) :
+
+### 1. Projection pure — `Workroom::on_run_event(&RunEvent)`
+Fonction sans I/O, testable unitairement, qui applique un `RunEvent` à l'état de la Workroom. Réutilise l'état/API existants (`TrackedAgent`, `AgentState`, `pattern`, `on_complete`, transitions/last_action). Mapping :
+
+| `RunEvent` | Effet Workroom |
+|---|---|
+| `RunStart { agents, .. }` | (re)seed de la flotte : agents connus en `Idle` (rôles issus de la config d'orchestration déjà chargée ; à défaut, tous `Agent`). `visible = true`. |
+| `AgentStart { agent }` | agent → `Working`, `started_at = now` (via l'horloge injectée, cf. tests). |
+| `AgentEnd { agent }` | agent → `Done`, `finished_at`, `last_action` = extrait de `content`. |
+| `Delegate { from, to }` | `from` → `Delegating` ; `to` = agent actif/détenteur du jeton (ring) ou enfant courant (hierarchical) ; enregistre la transition. |
+| `Vote { agent, conf }` | `last_action(agent)` = `vote {conf}` (enrichissement ring). |
+| `Board { agent, kind }` | `last_action(agent)` = `board {kind}` (enrichissement blackboard). |
+| `NestedStart { team_lead, pattern }` | `team_lead` → `Delegating`, note le sous-pattern. |
+| `NestedEnd { team_lead }` | `team_lead` → `Done`. |
+| `AgentSelect { selected, .. }` | marque les `selected` actifs (blackboard/auto). |
+| `Route { agent, tier, .. }` | `last_action(agent)` = `→ {tier}` (info). |
+| `Result { .. }` | fin de run → `on_complete()`. |
+| `Error { .. }` | état d'erreur (agent courant / global). |
+| `Warning`, autres | ignorés (no-op). |
+
+**Injection d'horloge** : `started_at`/`finished_at` utilisent `Instant`. `Instant::now()` n'est pas testable de façon déterministe ; la projection prend le temps via un paramètre/closure (ou une méthode `on_run_event_at(ev, now)`) pour des tests déterministes. Le renderer passe `Instant::now()`.
+
+### 2. Pont — `WorkroomSink` (implémente `EventSink`)
+`struct WorkroomSink { tx: Sender<RunEvent> }` : `emit(&RunEvent)` clone l'événement et le pousse dans un channel (`std::sync::mpsc` ou `tokio`). Le moteur `run --orchestrate` reçoit ce sink (en plus, ou à la place, du sink stdout selon le mode — voir Rendu) et tourne dans une tâche async ; la boucle TUI draine le channel et applique `on_run_event`.
+
+### 3. Renderer — vue live sur `armadai run --orchestrate` (feature `tui`)
+Boucle ratatui minimale (alternate screen), réutilisant le rendu Workroom de T3 :
+- lance l'orchestration en tâche async (sink = `WorkroomSink`) ;
+- draine le channel (non bloquant) → `workroom.on_run_event_at(ev, Instant::now())` → redraw ; `tick()` pour les spinners ;
+- supporte le drill-down ⌃W (déjà en place) ;
+- à la réception de `Result`/fin de tâche : restaure le terminal (leave alternate screen) et imprime le résultat/summary normal (comportement headless actuel préservé).
+
+## Rendu — déclenchement
+- **Live TUI par défaut quand `stdout` est un TTY** et que le run n'est ni `--json` ni `--quiet`.
+- Flag **`--no-tui`** pour forcer la sortie plate.
+- `--json` / `--quiet` / stdout non-TTY (pipe, CI, e2e) → **pas de TUI**, comportement headless actuel **strictement inchangé** (le sink stdout/json reste seul).
+- Placement : `armadai run --orchestrate` uniquement (le chemin `armadai shell` relais n'est pas concerné par ce lot).
+
+## Tests
+
+### Unitaires (projection, feature `tui`, pas d'accès env)
+- `on_run_event_at` : chaque variante → effet attendu (`AgentStart`→Working, `AgentEnd`→Done + last_action, `Delegate`→from Delegating/to actif, `NestedStart/End`→delegating/done, `AgentSelect`→actifs, `Result`→on_complete). Horloge injectée pour un `started_at`/elapsed déterministe.
+- Séquence réaliste hierarchical/blackboard/ring → état final de la flotte attendu.
+
+### Intégration (sink → channel → projection, sans terminal)
+- Pousser une séquence de `RunEvent` via `WorkroomSink`, drainer, appliquer, vérifier l'état projeté final. Confirme le round-trip sink↔channel↔projection sans dépendre d'un terminal réel.
+
+### e2e (harnais `tests/e2e/`, systématiques par pattern)
+Le harnais lance le **vrai binaire** `armadai run` avec le provider **`fake-claude`** (réponses scriptées déterministes) et asserte la **séquence `RunEvent`** en `--json`. On s'y raccorde :
+- **Assertion de projection Workroom réutilisable** : rejouer le flux `RunEvent` capturé d'un cas à travers `on_run_event_at` et asserter l'**état final de la flotte** (working/done par agent, détenteur de jeton en ring, etc.) — ajoutée aux cas `hierarchical`, `blackboard`, `ring`. Déterministe, agnostique, sans TUI.
+- **Cas `--no-tui`** : confirmer que le flag laisse la sortie plate/headless intacte (mêmes events, exit 0).
+- Le flux `RunEvent` sous-jacent est déjà asservi par les cas existants (`hierarchical/blackboard/ring/nested/direct`), donc la source que consomme la Workroom est couverte de bout en bout.
+
+**Évolution du harnais (note, hors lot)** : ajouter un **`fake-gemini`** et un **faux modèle générique** (mappé par un proxy LLM ou stub) permettrait de *prouver* en e2e l'agnosticité multi-provider (même flux `RunEvent`, providers différents). Non requis pour ce lot (la Workroom ne dépend pas du provider ; `fake-claude` suffit comme primitif mono-agent), mais à cadrer ensuite.
+
+### Visuel
+La vue live TUI = validation manuelle Dimitri : `armadai run --orchestrate` sur les demos `examples/orchestration-patterns/{hierarchical,ring,blackboard}` (avec une clé API ou `fake-claude`), fond clair.
+
+## Gate & CI
+Clippy **3 modes** (`tui`, `tui,providers-api`, `tui,web,storage`) `-D warnings` + `cargo fmt -- --check` + `cargo test` (dont e2e). Feature `tui` pour le renderer et le sink TUI ; la projection reste sous `tui` (la Workroom l'est déjà). PR + revue indépendante + validation visuelle Dimitri avant merge sur `release/1.0.0`.
+
+## Risques
+- **Boucle TUI + orchestration async** : bien séparer la tâche moteur (async) et la boucle de rendu (draine le channel, non bloquant) ; restaurer le terminal proprement même en cas d'erreur/panic (guard). 
+- **Seed des rôles** : `RunStart` ne porte pas les rôles ; les dériver de la config d'orchestration chargée (comme `init_from_config`) pour que le layout hierarchical soit correct — sinon dégrader en flotte plate.
+- **Restauration terminal** : réutiliser le pattern d'entrée/sortie alternate-screen du shell (`src/shell/app.rs`) pour éviter un terminal cassé.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,9 @@ pub enum Command {
         /// C8: resolve and print the agent selection without executing (0 tokens)
         #[arg(long)]
         dry_run: bool,
+        /// Disable the live orchestration TUI (force plain headless output)
+        #[arg(long = "no-tui")]
+        no_tui: bool,
     },
     /// Create a new agent from a template
     #[command(
@@ -487,6 +490,7 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
             route,
             tags,
             dry_run,
+            no_tui,
         } => {
             run::execute(
                 agent,
@@ -500,6 +504,7 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
                 route,
                 tags,
                 dry_run,
+                no_tui,
             )
             .await
         }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -42,10 +42,21 @@ pub async fn execute(
     // headless is implied by json (machine output cannot be interrupted by a prompt)
     let headless = headless || json;
 
-    // Live Workroom TUI: only for orchestrated runs, only when nothing else
-    // demands plain/machine output, and only when attached to a real
-    // terminal. Falls through to the unchanged headless path otherwise.
-    let use_tui = orchestrate.is_some()
+    // Orchestration can also be turned on purely via project config
+    // (`orchestration.enabled: true` in armadai.yaml), with no explicit
+    // `--orchestrate` flag — `run_inner` auto-detects that case on its own
+    // (see the `AgentResolution::Project` branch below). The live TUI must
+    // trigger for that path too, or config-driven runs silently stay headless.
+    let config_orchestrated = project::find_project_config()
+        .and_then(|(_, cfg)| cfg.orchestration)
+        .map(|o| o.enabled)
+        .unwrap_or(false);
+
+    // Live Workroom TUI: only for orchestrated runs (explicit `--orchestrate`
+    // or config-driven auto-detect), only when nothing else demands
+    // plain/machine output, and only when attached to a real terminal. Falls
+    // through to the unchanged headless path otherwise.
+    let use_tui = (orchestrate.is_some() || config_orchestrated)
         && !json
         && !quiet
         && !no_tui

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -37,9 +37,59 @@ pub async fn execute(
     route: Option<String>,
     tags: Option<Vec<String>>,
     dry_run: bool,
+    no_tui: bool,
 ) -> anyhow::Result<()> {
     // headless is implied by json (machine output cannot be interrupted by a prompt)
     let headless = headless || json;
+
+    // Live Workroom TUI: only for orchestrated runs, only when nothing else
+    // demands plain/machine output, and only when attached to a real
+    // terminal. Falls through to the unchanged headless path otherwise.
+    let use_tui = orchestrate.is_some()
+        && !json
+        && !quiet
+        && !no_tui
+        && std::io::IsTerminal::is_terminal(&std::io::stdout());
+
+    #[cfg(feature = "tui")]
+    if use_tui {
+        // Load project orchestration config (for role seeding), best-effort.
+        let cfg_yaml = std::fs::read_to_string(".armadai/config.yaml")
+            .or_else(|_| std::fs::read_to_string("armadai.yaml"))
+            .ok();
+        let printed = crate::shell::run_view::run_orchestration_tui(
+            move |sink| async move {
+                run_inner(
+                    agent_name,
+                    input,
+                    pipe,
+                    orchestrate,
+                    true,
+                    false,
+                    false,
+                    max_content,
+                    route,
+                    tags,
+                    dry_run,
+                    &sink,
+                )
+                .await
+            },
+            cfg_yaml,
+        )
+        .await;
+        return match printed {
+            Ok(Some(content)) => {
+                println!("{content}");
+                Ok(())
+            }
+            Ok(None) => Ok(()),
+            Err(e) => Err(e),
+        };
+    }
+    #[cfg(not(feature = "tui"))]
+    let _ = use_tui;
+
     let sink = crate::core::events::make_sink(json);
 
     let result = run_inner(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -69,6 +69,16 @@ pub async fn execute(
         let cfg_yaml = std::fs::read_to_string(".armadai/config.yaml")
             .or_else(|_| std::fs::read_to_string("armadai.yaml"))
             .ok();
+        // Map an explicit `--orchestrate <pattern>` flag to the Workroom's
+        // pattern enum, so the fullscreen live view renders the matching
+        // rich layout (ring/blackboard) instead of relying on the project
+        // config's `pattern:` key, which is often absent for a one-off
+        // explicit run and would otherwise default to Hierarchical.
+        let explicit_pattern = orchestrate.as_deref().and_then(|o| match o {
+            "blackboard" => Some(crate::core::orchestration::OrchestrationPattern::Blackboard),
+            "ring" => Some(crate::core::orchestration::OrchestrationPattern::Ring),
+            _ => None,
+        });
         let printed = crate::shell::run_view::run_orchestration_tui(
             move |sink| async move {
                 run_inner(
@@ -89,6 +99,7 @@ pub async fn execute(
                 .await
             },
             cfg_yaml,
+            explicit_pattern,
         )
         .await;
         return match printed {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -49,6 +49,7 @@ pub async fn execute(
         && !json
         && !quiet
         && !no_tui
+        && !dry_run
         && std::io::IsTerminal::is_terminal(&std::io::stdout());
 
     #[cfg(feature = "tui")]
@@ -65,6 +66,7 @@ pub async fn execute(
                     pipe,
                     orchestrate,
                     true,
+                    false,
                     false,
                     false,
                     max_content,
@@ -100,6 +102,7 @@ pub async fn execute(
         headless,
         json,
         quiet,
+        true,
         max_content,
         route,
         tags,
@@ -158,6 +161,7 @@ async fn run_inner(
     headless: bool,
     json: bool,
     quiet: bool,
+    human_output: bool,
     max_content: Option<usize>,
     route: Option<String>,
     tags: Option<Vec<String>>,
@@ -193,6 +197,7 @@ async fn run_inner(
             route.as_deref(),
             &tags,
             dry_run,
+            human_output,
         )
         .await;
     }
@@ -227,6 +232,7 @@ async fn run_inner(
                 route.as_deref(),
                 &tags,
                 dry_run,
+                human_output,
             )
             .await;
         }
@@ -1088,6 +1094,7 @@ async fn run_orchestrated(
     route: Option<&str>,
     tags: &[String],
     dry_run: bool,
+    human_output: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
 
@@ -1130,6 +1137,7 @@ async fn run_orchestrated(
         route,
         tags,
         dry_run,
+        human_output,
     )
     .await
 }
@@ -1165,6 +1173,18 @@ async fn run_orchestrated_inner(
     route: Option<&str>,
     tags: &[String],
     dry_run: bool,
+    // Gate for the direct human-readable `eprintln!`/`println!` writes below
+    // (roster-size banners, "Halted"/"status"/"Done" lines, and the final
+    // outcome). `true` on the plain headless/TTY path (unchanged behavior).
+    // `false` only on the live Workroom TUI path (`run_view.rs`), where
+    // stdout/stderr are the alternate screen: these direct writes would
+    // corrupt the display, and the same final content already reaches the
+    // caller via the `RunEvent::Result` emitted at the end of each branch
+    // below (captured by `WorkroomSink`, printed after terminal restore).
+    // Deliberately NOT `quiet` — `quiet` also suppresses the `RunEvent`s
+    // themselves (agent_start/agent_end/board), which the Workroom needs to
+    // animate; see `tests/e2e/cases/quiet-orchestrated.yaml`.
+    human_output: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
 
@@ -1306,11 +1326,13 @@ async fn run_orchestrated_inner(
                 provider_map.insert(name.clone(), provider);
             }
 
-            eprintln!(
-                "[blackboard] Starting with {} agent(s), max {} rounds",
-                agent_map.len(),
-                config.max_rounds
-            );
+            if human_output {
+                eprintln!(
+                    "[blackboard] Starting with {} agent(s), max {} rounds",
+                    agent_map.len(),
+                    config.max_rounds
+                );
+            }
 
             let (state, _run_id) = dispatch_blackboard_es(
                 input,
@@ -1325,7 +1347,9 @@ async fn run_orchestrated_inner(
             )
             .await?;
 
-            eprintln!("[blackboard] Halted: {:?}", state.status);
+            if human_output {
+                eprintln!("[blackboard] Halted: {:?}", state.status);
+            }
 
             #[cfg(feature = "storage")]
             {
@@ -1343,7 +1367,7 @@ async fn run_orchestrated_inner(
 
             let outcome_text = super::run_es_record::blackboard_display(&state);
 
-            if !json {
+            if !json && human_output {
                 println!("{outcome_text}");
             }
 
@@ -1382,11 +1406,13 @@ async fn run_orchestrated_inner(
                 provider_map.insert(name.clone(), provider);
             }
 
-            eprintln!(
-                "[ring] Starting with {} agent(s), max {} laps",
-                agent_map.len(),
-                config.max_laps
-            );
+            if human_output {
+                eprintln!(
+                    "[ring] Starting with {} agent(s), max {} laps",
+                    agent_map.len(),
+                    config.max_laps
+                );
+            }
 
             let (state, events, _run_id) = dispatch_ring_es(
                 input,
@@ -1417,8 +1443,10 @@ async fn run_orchestrated_inner(
             }
 
             let outcome_text = super::run_es_record::ring_display(&state, &events);
-            eprintln!("[ring] status: {:?}", state.status);
-            if !json {
+            if human_output {
+                eprintln!("[ring] status: {:?}", state.status);
+            }
+            if !json && human_output {
                 println!("{outcome_text}");
             }
 
@@ -1471,11 +1499,13 @@ async fn run_orchestrated_inner(
                 agent_map.insert(name.clone(), agent);
             }
 
-            eprintln!(
-                "[hierarchical] Starting with coordinator '{}', {} agent(s)",
-                coordinator_name,
-                agent_map.len()
-            );
+            if human_output {
+                eprintln!(
+                    "[hierarchical] Starting with coordinator '{}', {} agent(s)",
+                    coordinator_name,
+                    agent_map.len()
+                );
+            }
 
             let (state, events, _run_id) = dispatch_hierarchical_es(
                 &coordinator_name,
@@ -1496,10 +1526,12 @@ async fn run_orchestrated_inner(
             // `to_orchestration_result`'s doc comment.
             let result = to_orchestration_result(&state, &events);
 
-            eprintln!(
-                "[hierarchical] Done: {} invocations, {} tokens in, {} tokens out",
-                result.invocation_count, result.total_tokens_in, result.total_tokens_out
-            );
+            if human_output {
+                eprintln!(
+                    "[hierarchical] Done: {} invocations, {} tokens in, {} tokens out",
+                    result.invocation_count, result.total_tokens_in, result.total_tokens_out
+                );
+            }
 
             #[cfg(feature = "storage")]
             {
@@ -1515,7 +1547,7 @@ async fn run_orchestrated_inner(
                 }
             }
 
-            if !json {
+            if !json && human_output {
                 println!("{}", result.content);
             }
 
@@ -3260,6 +3292,7 @@ mod es_switch_tests {
             None,
             &[],
             false,
+            true,
         )
         .await
         .unwrap();
@@ -3289,6 +3322,7 @@ mod es_switch_tests {
             None,
             &[],
             false,
+            true,
         )
         .await
         .unwrap();
@@ -3326,6 +3360,7 @@ mod es_switch_tests {
             None,
             &[],
             false,
+            true,
         )
         .await
         .unwrap();

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use serde::Serialize;
 
 /// Structured run events emitted in headless/JSON mode. Short keys for token economy.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "t", rename_all = "snake_case")]
 pub enum RunEvent {
     RunStart {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,66 @@
+//! Runtime control of the global `tracing` subscriber's filter.
+//!
+//! `main.rs` installs a `reload`-able `EnvFilter` layer and stores the reload
+//! handle here via [`install`]. This lets the live orchestration TUI
+//! ([`crate::shell::run_view`]) temporarily silence all `tracing` output
+//! while it owns the terminal (alternate screen + raw mode) — logging to
+//! stderr during that window corrupts the rendered frame — and restore the
+//! original filter on exit.
+//!
+//! Not feature-gated: this module always compiles (it's `mod`-declared from
+//! `main.rs` unconditionally), even though only `tui`-gated code calls
+//! [`suppress`]/[`restore`]. Headless commands never call either, so their
+//! logging behavior is unchanged.
+
+use std::sync::OnceLock;
+
+use tracing_subscriber::{EnvFilter, Registry, reload};
+
+/// Reload handle for the `EnvFilter` layer installed in `main.rs`.
+static RELOAD_HANDLE: OnceLock<reload::Handle<EnvFilter, Registry>> = OnceLock::new();
+
+/// Store the reload handle created in `main.rs`. Must be called at most once,
+/// before any call to [`suppress`]/[`restore`] can have an effect.
+pub fn install(handle: reload::Handle<EnvFilter, Registry>) {
+    // Ignore a second `install`: only the first handle registered (from
+    // `main.rs` startup) is meaningful; there is no legitimate call site that
+    // would install twice.
+    let _ = RELOAD_HANDLE.set(handle);
+}
+
+/// Silence all `tracing` output. No-op if [`install`] was never called (e.g.
+/// in unit tests that don't run through `main`).
+pub fn suppress() {
+    if let Some(handle) = RELOAD_HANDLE.get() {
+        let _ = handle.reload(EnvFilter::new("off"));
+    }
+}
+
+/// Restore the default filter (`armadai=info`, or whatever `RUST_LOG`
+/// specifies) after a [`suppress`] call. No-op if [`install`] was never
+/// called.
+pub fn restore() {
+    if let Some(handle) = RELOAD_HANDLE.get() {
+        let filter = EnvFilter::from_default_env().add_directive(
+            "armadai=info"
+                .parse()
+                .expect("static directive always parses"),
+        );
+        let _ = handle.reload(filter);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suppress_and_restore_are_noop_without_install() {
+        // `main()` never runs in the test binary, so `install` was never
+        // called here — both must degrade to no-ops rather than panicking,
+        // since headless commands and most tests never touch this module at
+        // all.
+        suppress();
+        restore();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod audit;
 mod cli;
 mod core;
 mod linker;
+mod logging;
 mod model_registry;
 mod parser;
 #[allow(dead_code)]
@@ -26,12 +27,18 @@ use clap::Parser;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("armadai=info".parse()?),
-        )
-        .init();
+    {
+        use tracing_subscriber::prelude::*;
+
+        let filter = tracing_subscriber::EnvFilter::from_default_env()
+            .add_directive("armadai=info".parse()?);
+        let (filter_layer, reload_handle) = tracing_subscriber::reload::Layer::new(filter);
+        tracing_subscriber::registry()
+            .with(filter_layer)
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+        logging::install(reload_handle);
+    }
 
     core::config::check_migration_hint();
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -29,6 +29,8 @@ pub mod session;
 #[cfg(feature = "tui")]
 pub mod pty_runner;
 #[cfg(feature = "tui")]
+pub mod run_view;
+#[cfg(feature = "tui")]
 pub mod workroom;
 
 /// Braille spinner frames shared by the shell TUI (`tui.rs`) and the

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -13,6 +13,7 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::core::events::{EventSink, RunEvent};
+use crate::core::orchestration::OrchestrationPattern;
 use crate::shell::workroom::Workroom;
 
 /// An `EventSink` that forwards a clone of every `RunEvent` into a channel,
@@ -55,6 +56,7 @@ fn restore_terminal() {
 pub async fn run_orchestration_tui<F>(
     run: impl FnOnce(Arc<dyn EventSink>) -> F,
     config_yaml: Option<String>,
+    explicit_pattern: Option<OrchestrationPattern>,
 ) -> anyhow::Result<Option<String>>
 where
     F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
@@ -68,7 +70,18 @@ where
     if let Some(cfg) = config_yaml {
         workroom.init_from_config(&cfg);
     }
+    // An explicit `--orchestrate <pattern>` flag overrides whatever
+    // `init_from_config` inferred (or its `Hierarchical` default) — the
+    // project config often has no `orchestration:` block at all for a
+    // one-off explicit run, which would otherwise render the wrong layout.
+    if let Some(pattern) = explicit_pattern {
+        workroom.set_pattern(pattern);
+    }
     workroom.set_visible(true);
+    // Fullscreen dedicated run view (unlike the shell's narrow sidebar): show
+    // the rich pattern layout (ring/tree/blackboard) by default rather than
+    // requiring Ctrl+W to focus first. Ctrl+W still toggles it off/on below.
+    workroom.set_focused(true);
 
     // Install a panic hook that restores the terminal before the default
     // handler runs (mirrors `src/shell/app.rs`). Without this, a panic while

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -117,9 +117,10 @@ where
     render_result
 }
 
-/// Drain events, redraw, and poll input until the orchestration finishes (or
-/// the user quits/aborts). Returns the final `RunEvent::Result` content (if
-/// any) for the caller to print once the terminal is restored.
+/// Drain events, redraw, and poll input until the orchestration finishes and
+/// the user dismisses the final frame (or aborts early). Returns the final
+/// `RunEvent::Result` content (if any) for the caller to print once the
+/// terminal is restored.
 async fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     workroom: &mut Workroom,
@@ -127,6 +128,12 @@ async fn run_loop(
     handle: tokio::task::JoinHandle<anyhow::Result<()>>,
 ) -> anyhow::Result<Option<String>> {
     let mut final_content: Option<String> = None;
+    // Flipped once the orchestration has finished and the channel is fully
+    // drained. From that point the loop no longer auto-exits: it keeps
+    // rendering the final Workroom frame (with a dismissal hint) and waits
+    // for the user to press q/Esc — otherwise fast providers make the
+    // workroom flash and disappear before it can be seen.
+    let mut finished = false;
     loop {
         // Drain all pending events.
         while let Ok(ev) = rx.try_recv() {
@@ -135,10 +142,18 @@ async fn run_loop(
             }
             workroom.on_run_event_at(&ev, Instant::now());
         }
+
+        if !finished && handle.is_finished() && rx.is_empty() {
+            finished = true;
+            workroom.set_completed(true);
+        }
+
         workroom.tick();
         terminal.draw(|f| workroom.render(f, f.area()))?;
 
-        // Input: Ctrl+W focus/drill-down (already implemented), Ctrl+C/q quit.
+        // Input: Ctrl+W focus/drill-down (already implemented, and still
+        // active during the post-completion hold), Ctrl+C aborts anytime,
+        // q/Esc dismiss the held final frame once `finished`.
         if event::poll(Duration::from_millis(80))?
             && let Event::Key(k) = event::read()?
             && k.kind == KeyEventKind::Press
@@ -155,24 +170,13 @@ async fn run_loop(
                 KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => {
                     workroom.select_next()
                 }
+                KeyCode::Char('q') | KeyCode::Esc if finished => break,
                 KeyCode::Char('q') if !workroom.is_focused() => {
                     handle.abort();
                     break;
                 }
                 _ => {}
             }
-        }
-
-        // Exit once the orchestration finished and the channel is drained.
-        if handle.is_finished() && rx.is_empty() {
-            // Apply any last events.
-            while let Ok(ev) = rx.try_recv() {
-                if let RunEvent::Result { content, .. } = &ev {
-                    final_content = Some(content.clone());
-                }
-                workroom.on_run_event_at(&ev, Instant::now());
-            }
-            break;
         }
     }
 

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -47,6 +47,10 @@ fn restore_terminal() {
     if let Err(e) = execute!(io::stdout(), LeaveAlternateScreen, crossterm::cursor::Show) {
         tracing::warn!("Failed to restore terminal state: {:?}", e);
     }
+    // Restore tracing output now that the alternate screen is gone — safe to
+    // interleave with stdout again. Must run after the terminal is restored
+    // (not before) so a log emitted between the two doesn't land mid-frame.
+    crate::logging::restore();
 }
 
 /// Run an orchestration (`run`) while showing a live Workroom TUI fed by its
@@ -96,6 +100,15 @@ where
 
     // Launch the orchestration in the background.
     let handle = tokio::spawn(run(sink));
+
+    // Silence tracing (e.g. the provider factory's `INFO … using CLI …` logs
+    // emitted while the background orchestration builds providers) before we
+    // ever touch the terminal: once the alternate screen is entered, stderr
+    // writes from other tasks interleave with the TUI's own draws, corrupting
+    // the rendered frame (observed as a cut-off top border on first render).
+    // Restored in `restore_terminal()` above once the alternate screen is
+    // torn down.
+    crate::logging::suppress();
 
     // Enter alternate screen (mirrors src/shell/app.rs). Each step is
     // unwound individually on failure rather than bare-`?`-ing through: if

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "tui")]
+
+use crate::core::events::{EventSink, RunEvent};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+/// An `EventSink` that forwards a clone of every `RunEvent` into a channel,
+/// so a TUI render loop can drain and project them onto a `Workroom`.
+pub struct WorkroomSink {
+    tx: UnboundedSender<RunEvent>,
+}
+
+impl WorkroomSink {
+    pub fn new() -> (Self, UnboundedReceiver<RunEvent>) {
+        let (tx, rx) = unbounded_channel();
+        (Self { tx }, rx)
+    }
+}
+
+impl EventSink for WorkroomSink {
+    fn emit(&self, ev: &RunEvent) {
+        // Receiver gone (TUI exited) → drop silently; the run still completes.
+        let _ = self.tx.send(ev.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::events::{EventSink, RunEvent};
+    use crate::shell::workroom::Workroom;
+    use std::time::Instant;
+
+    #[test]
+    fn sink_forwards_events_to_projection() {
+        let (sink, mut rx) = WorkroomSink::new();
+        sink.emit(&RunEvent::RunStart {
+            v: 1,
+            agents: vec!["a".into(), "b".into()],
+            prov: "f".into(),
+            model: "m".into(),
+            in_chars: 0,
+        });
+        sink.emit(&RunEvent::AgentStart {
+            agent: "a".into(),
+            prov: "f".into(),
+            model: "m".into(),
+        });
+        sink.emit(&RunEvent::AgentEnd {
+            agent: "a".into(),
+            tin: 0,
+            tout: 0,
+            cost: 0.0,
+            content: "hi".into(),
+        });
+        drop(sink);
+
+        let mut wr = Workroom::new();
+        let now = Instant::now();
+        while let Ok(ev) = rx.try_recv() {
+            wr.on_run_event_at(&ev, now);
+        }
+        let agents = wr.agents_for_test();
+        assert_eq!(agents.len(), 2);
+        assert_eq!(
+            agents.iter().find(|a| a.name == "a").unwrap().state,
+            crate::shell::workroom::AgentState::Done
+        );
+    }
+}

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -1,7 +1,19 @@
 #![cfg(feature = "tui")]
 
-use crate::core::events::{EventSink, RunEvent};
+use std::io;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+use crate::core::events::{EventSink, RunEvent};
+use crate::shell::workroom::Workroom;
 
 /// An `EventSink` that forwards a clone of every `RunEvent` into a channel,
 /// so a TUI render loop can drain and project them onto a `Workroom`.
@@ -20,6 +32,115 @@ impl EventSink for WorkroomSink {
     fn emit(&self, ev: &RunEvent) {
         // Receiver gone (TUI exited) → drop silently; the run still completes.
         let _ = self.tx.send(ev.clone());
+    }
+}
+
+/// Run an orchestration (`run`) while showing a live Workroom TUI fed by its
+/// event stream. Restores the terminal on exit (including on error), and
+/// returns the final answer (if the run produced one) for the caller to
+/// print *after* the terminal has been restored.
+pub async fn run_orchestration_tui<F>(
+    run: impl FnOnce(Arc<dyn EventSink>) -> F,
+    config_yaml: Option<String>,
+) -> anyhow::Result<Option<String>>
+where
+    F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let (sink, mut rx) = WorkroomSink::new();
+    let sink: Arc<dyn EventSink> = Arc::new(sink);
+
+    // Seed roles from the orchestration config if available (RunStart carries
+    // no roles); otherwise the flotte stays flat.
+    let mut workroom = Workroom::new();
+    if let Some(cfg) = config_yaml {
+        workroom.init_from_config(&cfg);
+    }
+    workroom.set_visible(true);
+
+    // Launch the orchestration in the background.
+    let handle = tokio::spawn(run(sink));
+
+    // Enter alternate screen (mirrors src/shell/app.rs).
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let render_result = run_loop(&mut terminal, &mut workroom, &mut rx, handle).await;
+
+    // Always restore the terminal, even if the loop errored.
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    render_result
+}
+
+/// Drain events, redraw, and poll input until the orchestration finishes (or
+/// the user quits/aborts). Returns the final `RunEvent::Result` content (if
+/// any) for the caller to print once the terminal is restored.
+async fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    workroom: &mut Workroom,
+    rx: &mut UnboundedReceiver<RunEvent>,
+    handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+) -> anyhow::Result<Option<String>> {
+    let mut final_content: Option<String> = None;
+    loop {
+        // Drain all pending events.
+        while let Ok(ev) = rx.try_recv() {
+            if let RunEvent::Result { content, .. } = &ev {
+                final_content = Some(content.clone());
+            }
+            workroom.on_run_event_at(&ev, Instant::now());
+        }
+        workroom.tick();
+        terminal.draw(|f| workroom.render(f, f.area()))?;
+
+        // Input: Ctrl+W focus/drill-down (already implemented), Ctrl+C/q quit.
+        if event::poll(Duration::from_millis(80))?
+            && let Event::Key(k) = event::read()?
+            && k.kind == KeyEventKind::Press
+        {
+            match k.code {
+                KeyCode::Char('c') if k.modifiers.contains(KeyModifiers::CONTROL) => {
+                    handle.abort();
+                    break;
+                }
+                KeyCode::Char('w') if k.modifiers.contains(KeyModifiers::CONTROL) => {
+                    workroom.set_focused(!workroom.is_focused());
+                }
+                KeyCode::Up | KeyCode::Char('k') if workroom.is_focused() => workroom.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => {
+                    workroom.select_next()
+                }
+                KeyCode::Char('q') if !workroom.is_focused() => break,
+                _ => {}
+            }
+        }
+
+        // Exit once the orchestration finished and the channel is drained.
+        if handle.is_finished() && rx.is_empty() {
+            // Apply any last events.
+            while let Ok(ev) = rx.try_recv() {
+                if let RunEvent::Result { content, .. } = &ev {
+                    final_content = Some(content.clone());
+                }
+                workroom.on_run_event_at(&ev, Instant::now());
+            }
+            break;
+        }
+    }
+
+    // Propagate the orchestration's result / return final content for the
+    // caller to print after restoring the terminal.
+    let outcome = handle.await;
+    match outcome {
+        Ok(Ok(())) => Ok(final_content),
+        Ok(Err(e)) => Err(e),
+        Err(join_err) if join_err.is_cancelled() => Ok(None), // Ctrl+C abort: nothing to print
+        Err(join_err) => Err(anyhow::anyhow!(join_err)),
     }
 }
 

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -9,12 +9,19 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::core::events::{EventSink, RunEvent};
 use crate::core::orchestration::OrchestrationPattern;
 use crate::shell::workroom::Workroom;
+use crate::theme;
 
 /// An `EventSink` that forwards a clone of every `RunEvent` into a channel,
 /// so a TUI render loop can drain and project them onto a `Workroom`.
@@ -143,6 +150,58 @@ where
     render_result
 }
 
+/// Minimum sensible Workroom panel width (columns) — narrower than this and
+/// the rich pattern layouts (ring/tree/blackboard) start wrapping awkwardly.
+const WORKROOM_WIDTH: u16 = 72;
+const WORKROOM_WIDTH_MIN: u16 = 50;
+
+/// Roughly two lines per agent (arrow connectors between them in the
+/// ring/tree layouts) plus room for the footer hint block.
+const WORKROOM_HEIGHT_PER_AGENT: u16 = 2;
+const WORKROOM_HEIGHT_BASE: u16 = 8;
+
+/// Compute a `width` x `height` `Rect` centered within `area`, clamped so it
+/// never exceeds the terminal's own bounds (a terminal smaller than the
+/// requested size just gets the whole area).
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let x = area.x + (area.width - w) / 2;
+    let y = area.y + (area.height - h) / 2;
+    Rect::new(x, y, w, h)
+}
+
+/// Render the agent detail popup (drill-down on `Enter`) as a centered
+/// overlay on top of the Workroom, mirroring `src/shell/tui.rs::render_popup`
+/// (Clear + markdown Paragraph + themed border) but sized ~70% of the
+/// terminal and titled " Detail ".
+fn render_detail_popup(frame: &mut Frame, area: Rect, markdown: &str) {
+    let popup_width = (area.width as f32 * 0.70) as u16;
+    let popup_height = (area.height as f32 * 0.70) as u16;
+    let popup_area = centered_rect(popup_width, popup_height, area);
+
+    frame.render_widget(Clear, popup_area);
+
+    let mut lines: Vec<Line> = crate::shell::md_render::render_markdown(markdown);
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Enter/Esc to close",
+        theme::muted(),
+    )));
+
+    let popup = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::border_style())
+                .title(" Detail ")
+                .title_style(theme::heading()),
+        )
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(popup, popup_area);
+}
+
 /// Drain events, redraw, and poll input until the orchestration finishes and
 /// the user dismisses the final frame (or aborts early). Returns the final
 /// `RunEvent::Result` content (if any) for the caller to print once the
@@ -160,6 +219,10 @@ async fn run_loop(
     // for the user to press q/Esc — otherwise fast providers make the
     // workroom flash and disappear before it can be seen.
     let mut finished = false;
+    // Markdown for the drill-down detail popup (Enter on a selected agent),
+    // built from `Workroom::selected_detail_markdown()`. `Some` while the
+    // popup overlay is open.
+    let mut detail: Option<String> = None;
     loop {
         // Drain all pending events.
         while let Ok(ev) = rx.try_recv() {
@@ -175,33 +238,67 @@ async fn run_loop(
         }
 
         workroom.tick();
-        terminal.draw(|f| workroom.render(f, f.area()))?;
+        terminal.draw(|f| {
+            let area = f.area();
+            // Clear the whole frame first so nothing from a previous
+            // (larger) draw lingers around the centered panel.
+            f.render_widget(Clear, area);
 
-        // Input: Ctrl+W focus/drill-down (already implemented, and still
-        // active during the post-completion hold), Ctrl+C aborts anytime,
-        // q/Esc dismiss the held final frame once `finished`.
+            let width = WORKROOM_WIDTH
+                .min(area.width)
+                .max(WORKROOM_WIDTH_MIN.min(area.width));
+            let needed_height = (workroom.agent_count() as u16)
+                .saturating_mul(WORKROOM_HEIGHT_PER_AGENT)
+                .saturating_add(WORKROOM_HEIGHT_BASE);
+            let height = needed_height.min(area.height);
+            let workroom_area = centered_rect(width, height, area);
+            workroom.render(f, workroom_area);
+
+            if let Some(md) = &detail {
+                render_detail_popup(f, area, md);
+            }
+        })?;
+
+        // Input: Ctrl+C aborts anytime (even with the popup open). While the
+        // detail popup is open, Enter/Esc close it first — that precedence
+        // matters so Esc doesn't fall through to the view-exit handler below
+        // in the same keypress. Ctrl+W toggles focus, Enter opens the detail
+        // popup for the selected agent (when focused), q/Esc dismiss the
+        // held final frame once `finished`.
         if event::poll(Duration::from_millis(80))?
             && let Event::Key(k) = event::read()?
             && k.kind == KeyEventKind::Press
         {
-            match k.code {
-                KeyCode::Char('c') if k.modifiers.contains(KeyModifiers::CONTROL) => {
-                    handle.abort();
-                    break;
+            if k.code == KeyCode::Char('c') && k.modifiers.contains(KeyModifiers::CONTROL) {
+                handle.abort();
+                break;
+            }
+
+            if detail.is_some() {
+                if matches!(k.code, KeyCode::Enter | KeyCode::Esc) {
+                    detail = None;
                 }
-                KeyCode::Char('w') if k.modifiers.contains(KeyModifiers::CONTROL) => {
-                    workroom.set_focused(!workroom.is_focused());
+            } else {
+                match k.code {
+                    KeyCode::Char('w') if k.modifiers.contains(KeyModifiers::CONTROL) => {
+                        workroom.set_focused(!workroom.is_focused());
+                    }
+                    KeyCode::Up | KeyCode::Char('k') if workroom.is_focused() => {
+                        workroom.select_prev()
+                    }
+                    KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => {
+                        workroom.select_next()
+                    }
+                    KeyCode::Enter if workroom.is_focused() => {
+                        detail = workroom.selected_detail_markdown();
+                    }
+                    KeyCode::Char('q') | KeyCode::Esc if finished => break,
+                    KeyCode::Char('q') if !workroom.is_focused() => {
+                        handle.abort();
+                        break;
+                    }
+                    _ => {}
                 }
-                KeyCode::Up | KeyCode::Char('k') if workroom.is_focused() => workroom.select_prev(),
-                KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => {
-                    workroom.select_next()
-                }
-                KeyCode::Char('q') | KeyCode::Esc if finished => break,
-                KeyCode::Char('q') if !workroom.is_focused() => {
-                    handle.abort();
-                    break;
-                }
-                _ => {}
             }
         }
     }

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -35,9 +35,22 @@ impl EventSink for WorkroomSink {
     }
 }
 
+/// Restore the terminal to normal state. Called on exit and on panic — mirrors
+/// `src/shell/app.rs::restore_terminal`. Operates on `io::stdout()` directly
+/// (rather than through a `Terminal`/backend handle) so it can also run from
+/// the panic hook, where no `Terminal` is reachable.
+fn restore_terminal() {
+    if let Err(e) = disable_raw_mode() {
+        tracing::warn!("Failed to disable raw mode: {:?}", e);
+    }
+    if let Err(e) = execute!(io::stdout(), LeaveAlternateScreen, crossterm::cursor::Show) {
+        tracing::warn!("Failed to restore terminal state: {:?}", e);
+    }
+}
+
 /// Run an orchestration (`run`) while showing a live Workroom TUI fed by its
-/// event stream. Restores the terminal on exit (including on error), and
-/// returns the final answer (if the run produced one) for the caller to
+/// event stream. Restores the terminal on exit (including on error or panic),
+/// and returns the final answer (if the run produced one) for the caller to
 /// print *after* the terminal has been restored.
 pub async fn run_orchestration_tui<F>(
     run: impl FnOnce(Arc<dyn EventSink>) -> F,
@@ -57,22 +70,49 @@ where
     }
     workroom.set_visible(true);
 
+    // Install a panic hook that restores the terminal before the default
+    // handler runs (mirrors `src/shell/app.rs`). Without this, a panic while
+    // raw mode + the alternate screen are active leaves the user's terminal
+    // unusable (no echo, stuck on the alternate buffer) after the process
+    // exits, since the sequential restore code below would never run.
+    let default_panic = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        default_panic(info);
+    }));
+
     // Launch the orchestration in the background.
     let handle = tokio::spawn(run(sink));
 
-    // Enter alternate screen (mirrors src/shell/app.rs).
-    enable_raw_mode()?;
+    // Enter alternate screen (mirrors src/shell/app.rs). Each step is
+    // unwound individually on failure rather than bare-`?`-ing through: if
+    // `EnterAlternateScreen` fails after raw mode was already enabled, or
+    // `Terminal::new` fails after the alternate screen was already entered,
+    // a bare `?` would return with the terminal left half-initialized.
+    if let Err(e) = enable_raw_mode() {
+        handle.abort();
+        return Err(e.into());
+    }
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    if let Err(e) = execute!(stdout, EnterAlternateScreen) {
+        disable_raw_mode().ok();
+        handle.abort();
+        return Err(e.into());
+    }
     let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(e) => {
+            restore_terminal();
+            handle.abort();
+            return Err(e.into());
+        }
+    };
 
     let render_result = run_loop(&mut terminal, &mut workroom, &mut rx, handle).await;
 
     // Always restore the terminal, even if the loop errored.
-    disable_raw_mode().ok();
-    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
-    terminal.show_cursor().ok();
+    restore_terminal();
 
     render_result
 }
@@ -115,7 +155,10 @@ async fn run_loop(
                 KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => {
                     workroom.select_next()
                 }
-                KeyCode::Char('q') if !workroom.is_focused() => break,
+                KeyCode::Char('q') if !workroom.is_focused() => {
+                    handle.abort();
+                    break;
+                }
                 _ => {}
             }
         }

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use std::time::Instant;
 
 use super::SPINNER_FRAMES as SPINNER;
+use crate::core::events::RunEvent;
 use crate::core::orchestration::OrchestrationPattern;
 use crate::theme;
 
@@ -426,6 +427,94 @@ impl Workroom {
     /// Set visibility directly
     pub fn set_visible(&mut self, visible: bool) {
         self.visible = visible;
+    }
+
+    /// Apply one core `RunEvent` to the workroom state (provider-agnostic
+    /// projection). `now` is injected so timing is deterministic in tests;
+    /// the live renderer passes `Instant::now()`.
+    pub fn on_run_event_at(&mut self, ev: &RunEvent, now: Instant) {
+        match ev {
+            RunEvent::RunStart { agents, .. } => {
+                for name in agents {
+                    if !self.agents.iter().any(|a| a.name == *name) {
+                        self.agents.push(TrackedAgent {
+                            name: name.clone(),
+                            state: AgentState::Idle,
+                            role: AgentRole::Agent,
+                            started_at: None,
+                            finished_at: None,
+                            spinner_frame: 0,
+                            last_action: None,
+                            transitions: Vec::new(),
+                        });
+                    }
+                }
+                self.visible = true;
+            }
+            RunEvent::AgentStart { agent, .. } => self.mark_working(agent, now),
+            RunEvent::AgentEnd { agent, content, .. } => {
+                self.mark_done(agent, now);
+                let first = content.lines().next().unwrap_or("").trim();
+                if !first.is_empty() {
+                    self.set_action(agent, first.to_string());
+                }
+            }
+            RunEvent::Delegate { from, to } => {
+                self.transition(from, AgentState::Delegating, now);
+                self.current_agent = Some(to.clone());
+            }
+            RunEvent::NestedStart { team_lead, .. } => {
+                self.transition(team_lead, AgentState::Delegating, now)
+            }
+            RunEvent::NestedEnd { team_lead } => self.transition(team_lead, AgentState::Done, now),
+            RunEvent::AgentSelect { selected, .. } => {
+                for a in selected {
+                    self.mark_working(a, now);
+                }
+            }
+            RunEvent::Vote { agent, conf } => self.set_action(agent, format!("vote {conf:.2}")),
+            RunEvent::Board { agent, kind } => self.set_action(agent, format!("board {kind}")),
+            RunEvent::Route { agent, tier, .. } => self.set_action(agent, format!("→ {tier}")),
+            RunEvent::Result { .. } => self.on_complete(),
+            RunEvent::Error { msg, .. } => {
+                if let Some(cur) = self.current_agent.clone() {
+                    self.set_action(&cur, format!("error: {msg}"));
+                }
+            }
+            RunEvent::Warning { .. } => {}
+        }
+    }
+
+    fn mark_working(&mut self, name: &str, now: Instant) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            a.state = AgentState::Working;
+            a.started_at.get_or_insert(now);
+            a.transitions.push((AgentState::Working, now));
+        }
+    }
+
+    fn mark_done(&mut self, name: &str, now: Instant) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            a.state = AgentState::Done;
+            a.finished_at = Some(now);
+            a.transitions.push((AgentState::Done, now));
+        }
+    }
+
+    fn transition(&mut self, name: &str, state: AgentState, now: Instant) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            if state == AgentState::Delegating && a.started_at.is_none() {
+                a.started_at = Some(now);
+            }
+            a.transitions.push((state.clone(), now));
+            a.state = state;
+        }
+    }
+
+    fn set_action(&mut self, name: &str, action: String) {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.name == name) {
+            a.last_action = Some(action);
+        }
     }
 
     /// Push a state transition for an agent, updating timestamps + history.
@@ -1294,5 +1383,140 @@ orchestration:
             .flat_map(|l| l.spans.iter())
             .any(|s| s.content.contains("alpha") && s.style.add_modifier.contains(Modifier::BOLD));
         assert!(holder_styled);
+    }
+
+    use crate::core::events::RunEvent;
+    use std::time::Instant;
+
+    fn rs(agents: &[&str]) -> RunEvent {
+        RunEvent::RunStart {
+            v: 1,
+            agents: agents.iter().map(|s| s.to_string()).collect(),
+            prov: "fake".into(),
+            model: "m".into(),
+            in_chars: 0,
+        }
+    }
+
+    #[test]
+    fn on_run_event_seeds_and_transitions() {
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(&rs(&["dev-lead", "core-specialist"]), t);
+        assert_eq!(wr.agents.len(), 2);
+        assert!(wr.is_visible());
+
+        wr.on_run_event_at(
+            &RunEvent::Delegate {
+                from: "dev-lead".into(),
+                to: "core-specialist".into(),
+            },
+            t,
+        );
+        assert_eq!(
+            wr.agents
+                .iter()
+                .find(|a| a.name == "dev-lead")
+                .unwrap()
+                .state,
+            AgentState::Delegating
+        );
+
+        wr.on_run_event_at(
+            &RunEvent::AgentStart {
+                agent: "core-specialist".into(),
+                prov: "fake".into(),
+                model: "m".into(),
+            },
+            t,
+        );
+        assert_eq!(
+            wr.agents
+                .iter()
+                .find(|a| a.name == "core-specialist")
+                .unwrap()
+                .state,
+            AgentState::Working
+        );
+
+        wr.on_run_event_at(
+            &RunEvent::AgentEnd {
+                agent: "core-specialist".into(),
+                tin: 1,
+                tout: 2,
+                cost: 0.0,
+                content: "done reticulating\nsplines".into(),
+            },
+            t,
+        );
+        let a = wr
+            .agents
+            .iter()
+            .find(|a| a.name == "core-specialist")
+            .unwrap();
+        assert_eq!(a.state, AgentState::Done);
+        assert_eq!(a.last_action.as_deref(), Some("done reticulating"));
+    }
+
+    #[test]
+    fn on_run_event_result_finalizes() {
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(&rs(&["a"]), t);
+        wr.on_run_event_at(
+            &RunEvent::AgentStart {
+                agent: "a".into(),
+                prov: "f".into(),
+                model: "m".into(),
+            },
+            t,
+        );
+        wr.on_run_event_at(
+            &RunEvent::Result {
+                content: "x".into(),
+                tin: 0,
+                tout: 0,
+                cost: 0.0,
+                agents: 1,
+            },
+            t,
+        );
+        // on_complete turns any Working agent into Done.
+        assert_eq!(
+            wr.agents.iter().find(|a| a.name == "a").unwrap().state,
+            AgentState::Done
+        );
+    }
+
+    #[test]
+    fn on_run_event_unknown_variants_are_noops() {
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(&rs(&["a"]), t);
+        wr.on_run_event_at(
+            &RunEvent::Warning {
+                code: "w".into(),
+                from: None,
+                to: None,
+            },
+            t,
+        );
+        wr.on_run_event_at(
+            &RunEvent::Route {
+                agent: "a".into(),
+                tier: "fast".into(),
+                reason: "r".into(),
+            },
+            t,
+        );
+        assert_eq!(
+            wr.agents
+                .iter()
+                .find(|a| a.name == "a")
+                .unwrap()
+                .last_action
+                .as_deref(),
+            Some("→ fast")
+        );
     }
 }

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -669,7 +669,12 @@ impl Workroom {
             let (icon, state_str, style) = self.state_display(agent);
             let is_holder = holder == Some(idx);
             let is_selected = self.focused && idx == self.selected;
-            let name_style = if is_holder {
+            let name_style = if is_holder && is_selected {
+                // Both the token holder and the keyboard selection: keep the
+                // brass accent but still show the selection (reversed), so the
+                // token holder stays focusable/visible when navigated to.
+                theme::selection().add_modifier(Modifier::REVERSED)
+            } else if is_holder {
                 theme::selection()
             } else if is_selected {
                 self.role_style(agent).add_modifier(Modifier::REVERSED)

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -108,6 +108,14 @@ impl Workroom {
         self.focused = focused;
     }
 
+    /// Override the active orchestration pattern (drives the focused layout).
+    /// Used to apply an explicit `--orchestrate <pattern>` flag, which takes
+    /// precedence over whatever `init_from_config` inferred from the project
+    /// config's `pattern:` key (or its `Hierarchical` default).
+    pub fn set_pattern(&mut self, pattern: OrchestrationPattern) {
+        self.pattern = pattern;
+    }
+
     /// Whether the workroom currently has keyboard focus.
     pub fn is_focused(&self) -> bool {
         self.focused
@@ -826,9 +834,10 @@ impl Workroom {
             lines.push(Line::from(Span::styled("Ctrl+W focus", theme::muted())));
         }
         if self.completed {
+            let check = theme::glyphs().check;
             lines.push(Line::from(Span::styled(
-                "✓ run complete · press q or Esc to exit",
-                theme::done(),
+                format!("{check} run complete · press q or Esc to exit"),
+                theme::muted(),
             )));
         }
     }
@@ -1330,6 +1339,61 @@ orchestration:
         wr.pattern = OrchestrationPattern::Blackboard;
         wr.set_focused(true);
         assert_eq!(wr.layout_mode(30), LayoutMode::Compact);
+    }
+
+    #[test]
+    fn completion_hint_uses_muted_theme_and_glyph_check() {
+        let mut wr = Workroom::new();
+        wr.set_completed(true);
+        let mut lines = Vec::new();
+        wr.push_footer(&mut lines);
+        let hint_line = lines
+            .iter()
+            .find(|l| l.spans.iter().any(|s| s.content.contains("run complete")))
+            .expect("completion hint line present");
+        let span = hint_line
+            .spans
+            .iter()
+            .find(|s| s.content.contains("run complete"))
+            .unwrap();
+        assert_eq!(span.style, theme::muted());
+        // Glyph comes from theme::glyphs() (unicode ✓ or its ASCII fallback
+        // depending on init(ascii)), never a hardcoded character.
+        assert!(span.content.starts_with(theme::glyphs().check));
+    }
+
+    #[test]
+    fn no_completion_hint_when_not_completed() {
+        let wr = Workroom::new();
+        let mut lines = Vec::new();
+        wr.push_footer(&mut lines);
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.spans.iter().any(|s| s.content.contains("run complete")))
+        );
+    }
+
+    #[test]
+    fn set_pattern_overrides_default() {
+        let mut wr = Workroom::new();
+        wr.set_focused(true);
+        // Default pattern (no config parsed) is Hierarchical → Hierarchical layout.
+        assert_eq!(wr.layout_mode(60), LayoutMode::Hierarchical);
+        wr.set_pattern(OrchestrationPattern::Ring);
+        assert_eq!(wr.layout_mode(60), LayoutMode::Ring);
+    }
+
+    #[test]
+    fn set_pattern_overrides_config_after_init() {
+        let mut wr = Workroom::new();
+        wr.set_focused(true);
+        // Config has no `pattern:` key → parse_pattern defaults to Hierarchical.
+        wr.init_from_config("coordinator: lead\nagents:\n- a\n- b\n");
+        assert_eq!(wr.layout_mode(60), LayoutMode::Hierarchical);
+        // An explicit `--orchestrate blackboard` flag must win over that default.
+        wr.set_pattern(OrchestrationPattern::Blackboard);
+        assert_eq!(wr.layout_mode(60), LayoutMode::Blackboard);
     }
 
     #[test]

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -82,6 +82,10 @@ pub struct Workroom {
     focused: bool,
     /// Active orchestration pattern (drives the focused layout).
     pattern: OrchestrationPattern,
+    /// Whether the orchestration has finished and the live TUI is holding the
+    /// final frame for the user to dismiss (Dimitri's visual-validation
+    /// request: fast providers used to make the workroom flash and vanish).
+    completed: bool,
 }
 
 impl Workroom {
@@ -95,6 +99,7 @@ impl Workroom {
             selected: 0,
             focused: false,
             pattern: OrchestrationPattern::Hierarchical,
+            completed: false,
         }
     }
 
@@ -106,6 +111,12 @@ impl Workroom {
     /// Whether the workroom currently has keyboard focus.
     pub fn is_focused(&self) -> bool {
         self.focused
+    }
+
+    /// Mark the orchestration as finished so the renderer holds the final
+    /// frame and shows the "press q/Esc to exit" hint instead of vanishing.
+    pub fn set_completed(&mut self, completed: bool) {
+        self.completed = completed;
     }
 
     /// Decide the layout from pattern, focus, and available inner width.
@@ -451,7 +462,15 @@ impl Workroom {
                 }
                 self.visible = true;
             }
-            RunEvent::AgentStart { agent, .. } => self.mark_working(agent, now),
+            RunEvent::AgentStart { agent, .. } => {
+                self.mark_working(agent, now);
+                // The ES ring/blackboard engines emit agent_start/agent_end/vote
+                // but never `Delegate`, so `current_agent` (which drives the
+                // ring layout's token-holder highlight via `token_holder_index`)
+                // would otherwise never update in the live path. The agent that
+                // just started is the one holding the token.
+                self.current_agent = Some(agent.clone());
+            }
             RunEvent::AgentEnd { agent, content, .. } => {
                 self.mark_done(agent, now);
                 let first = content.lines().next().unwrap_or("").trim();
@@ -805,6 +824,12 @@ impl Workroom {
             lines.push(Line::from(Span::styled("Enter detail", theme::muted())));
         } else {
             lines.push(Line::from(Span::styled("Ctrl+W focus", theme::muted())));
+        }
+        if self.completed {
+            lines.push(Line::from(Span::styled(
+                "✓ run complete · press q or Esc to exit",
+                theme::done(),
+            )));
         }
     }
 
@@ -1366,6 +1391,39 @@ orchestration:
         // The token moves to an agent via a DELEGATE marker in the stream.
         wr.parse_streaming_line("<!--ARMADAI_DELEGATE:alpha-->");
         let idx = wr.token_holder_index().expect("alpha holds the token");
+        assert_eq!(wr.agents[idx].name, "alpha");
+    }
+
+    #[test]
+    fn agent_start_sets_token_holder_without_delegate() {
+        // ES ring/blackboard engines never emit `Delegate` — only
+        // agent_start/agent_end/vote — so the token-holder highlight must be
+        // driven by `AgentStart` alone (review finding M2).
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(
+            &RunEvent::RunStart {
+                v: 1,
+                agents: vec!["alpha".into(), "beta".into()],
+                prov: "fake".into(),
+                model: "m".into(),
+                in_chars: 0,
+            },
+            t,
+        );
+        assert_eq!(wr.token_holder_index(), None);
+
+        wr.on_run_event_at(
+            &RunEvent::AgentStart {
+                agent: "alpha".into(),
+                prov: "fake".into(),
+                model: "m".into(),
+            },
+            t,
+        );
+        let idx = wr
+            .token_holder_index()
+            .expect("alpha holds the token after AgentStart");
         assert_eq!(wr.agents[idx].name, "alpha");
     }
 

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -121,6 +121,13 @@ impl Workroom {
         self.focused
     }
 
+    /// Number of tracked agents — used by the fullscreen run view to size the
+    /// centered panel (rich layouts need roughly two lines per agent, plus
+    /// arrows/footer).
+    pub fn agent_count(&self) -> usize {
+        self.agents.len()
+    }
+
     /// Mark the orchestration as finished so the renderer holds the final
     /// frame and shows the "press q/Esc to exit" hint instead of vanishing.
     pub fn set_completed(&mut self, completed: bool) {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -199,6 +199,7 @@ pub struct Glyphs {
     pub board: &'static str,
     pub pointer: &'static str,
     pub arrow_back: &'static str,
+    pub check: &'static str,
 }
 
 impl Glyphs {
@@ -215,6 +216,7 @@ impl Glyphs {
         board: "▤",
         pointer: "▸",
         arrow_back: "←",
+        check: "✓",
     };
 
     #[allow(dead_code)]
@@ -230,6 +232,7 @@ impl Glyphs {
         board: "#",
         pointer: ">",
         arrow_back: "<-",
+        check: "v",
     };
 }
 
@@ -337,6 +340,12 @@ mod tests {
         assert_eq!(Glyphs::UNICODE.arrow_back, "←");
         assert_eq!(Glyphs::ASCII.pointer, ">");
         assert_eq!(Glyphs::ASCII.arrow_back, "<-");
+    }
+
+    #[test]
+    fn glyphs_expose_check_mark() {
+        assert_eq!(Glyphs::UNICODE.check, "✓");
+        assert_eq!(Glyphs::ASCII.check, "v");
     }
 
     #[test]

--- a/tests/e2e/cases/blackboard.yaml
+++ b/tests/e2e/cases/blackboard.yaml
@@ -29,10 +29,26 @@ fake:
 expect:
   exit_code: 0
   events:
+    # Per-agent subsequence (asserted 2026-07-24): every participant's
+    # invocation is asserted as a full agent_start -> board -> agent_end
+    # triple, round by round — the exact info `on_run_event_at` (Task 1)
+    # transforms into a Workroom Working->Done transition per agent. Order
+    # confirmed by running this case against the real binary: round 1 is
+    # t-a then t-b (both FINDING), round 2 is t-a then t-b again (both
+    # CONFIRMATION, which triggers convergence).
     - { t: run_start }
     - { t: agent_start, agent: t-a }
-    - { t: board, kind: finding }
-    - { t: board, kind: confirmation }
+    - { t: board, agent: t-a, kind: finding }
+    - { t: agent_end, agent: t-a }
+    - { t: agent_start, agent: t-b }
+    - { t: board, agent: t-b, kind: finding }
+    - { t: agent_end, agent: t-b }
+    - { t: agent_start, agent: t-a }
+    - { t: board, agent: t-a, kind: confirmation }
+    - { t: agent_end, agent: t-a }
+    - { t: agent_start, agent: t-b }
+    - { t: board, agent: t-b, kind: confirmation }
+    - { t: agent_end, agent: t-b }
     - { t: result }
   # contrat per-tour ES (un start/end par invocation) — décision 2026-07-22
   # 2 agents x 2 rounds (round 2 converges via consensus, no round 3) = 4 invocations

--- a/tests/e2e/cases/hierarchical.yaml
+++ b/tests/e2e/cases/hierarchical.yaml
@@ -28,9 +28,21 @@ fake:
 expect:
   exit_code: 0
   events:
+    # Per-delegate subsequence (asserted 2026-07-24): each delegated specialist
+    # gets its own `delegate` immediately followed by its `agent_start`/
+    # `agent_end` pair — this is exactly the info `on_run_event_at` (Task 1)
+    # turns into a Workroom Working->Done transition. Order confirmed by
+    # running this case against the real binary: t-coord's synthesis call
+    # (`@t-a:`/`@t-b:` dispatch) is followed by t-a's full invocation, then
+    # t-b's, both before t-coord's second (synthesis) call.
     - { t: run_start }
     - { t: agent_start, agent: t-coord }
-    - { t: delegate, from: t-coord }
+    - { t: delegate, from: t-coord, to: t-a }
+    - { t: agent_start, agent: t-a }
+    - { t: agent_end, agent: t-a }
+    - { t: delegate, from: t-coord, to: t-b }
+    - { t: agent_start, agent: t-b }
+    - { t: agent_end, agent: t-b }
     - { t: result, content: "Synthesis: token flow and session store both check out." }
   # contrat per-tour ES (un start/end par invocation) — décision 2026-07-22
   # coordinator delegate call + 2 subordinates (parallel) + coordinator synthesis call = 4 invocations

--- a/tests/e2e/cases/no-tui.yaml
+++ b/tests/e2e/cases/no-tui.yaml
@@ -1,0 +1,37 @@
+name: no-tui
+weight: 5
+setup:
+  pattern: ring
+  agents: [t-a, t-b]
+  # `--no-tui` alongside `--json`: the point of this case is headless parity,
+  # not ring finesse — proves `--no-tui` doesn't change the emitted JSONL
+  # stream. The harness always captures stdout non-TTY (see `harness.rs`
+  # module doc), so `armadai run` is already headless without this flag; the
+  # `direct`/`ring`/etc. cases exercise that implicit path. This case instead
+  # exercises the explicit `--no-tui` opt-out (`src/cli/run.rs`) and confirms
+  # it's a genuine no-op on the event stream: same `events`/`event_counts` as
+  # a plain `--json` ring run (checked by hand against the real binary before
+  # writing this case — see `docs/superpowers/...task-4-report.md`).
+  flags: ["--json", "--no-tui"]
+  input: "say hi"
+fake:
+  rules:
+    - match: { prompt_contains: "ACTION: <type>" }
+      respond: "ACTION: PROPOSE\nCONTENT: hi"
+    - match: { prompt_contains: "Synthesize the contributions" }
+      respond: "CONFIDENCE: 0.9\nhi is fine."
+    - match: {}
+      respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-a }
+    - { t: agent_end, agent: t-a }
+    - { t: agent_start, agent: t-b }
+    - { t: agent_end, agent: t-b }
+    - { t: vote, agent: t-a }
+    - { t: vote, agent: t-b }
+    - { t: result }
+  event_counts: { agent_start: 8, agent_end: 8, vote: 2, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_model_non_empty, single_result, no_orphan_events]

--- a/tests/e2e/cases/no-tui.yaml
+++ b/tests/e2e/cases/no-tui.yaml
@@ -10,8 +10,8 @@ setup:
   # `direct`/`ring`/etc. cases exercise that implicit path. This case instead
   # exercises the explicit `--no-tui` opt-out (`src/cli/run.rs`) and confirms
   # it's a genuine no-op on the event stream: same `events`/`event_counts` as
-  # a plain `--json` ring run (checked by hand against the real binary before
-  # writing this case — see `docs/superpowers/...task-4-report.md`).
+  # a plain `--json` ring run (verified by hand against the real binary when
+  # this case was written).
   flags: ["--json", "--no-tui"]
   input: "say hi"
 fake:

--- a/tests/e2e/cases/ring.yaml
+++ b/tests/e2e/cases/ring.yaml
@@ -48,8 +48,21 @@ expect:
     # t-alpha, t-bravo), not the alphabetical BTreeMap order (t-alpha, t-bravo,
     # t-charlie) Bug A produced (`RingDecider`'s vote-completeness scan walks the
     # same `agent_order` circulation does).
+    #
+    # Circulation subsequence (asserted 2026-07-24): the first lap's
+    # agent_start -> agent_end pairs, in chain order (t-charlie, t-alpha,
+    # t-bravo), confirmed by running this case against the real binary. This
+    # is a *within-lap* check only (see the comment above on why a
+    # multi-lap `agent_start`-only chain wouldn't unambiguously prove chain
+    # order) — the `vote` sequence right after remains the proof that
+    # circulation itself used chain order, not the alphabetical one.
     - { t: run_start }
     - { t: agent_start, agent: t-charlie }
+    - { t: agent_end, agent: t-charlie }
+    - { t: agent_start, agent: t-alpha }
+    - { t: agent_end, agent: t-alpha }
+    - { t: agent_start, agent: t-bravo }
+    - { t: agent_end, agent: t-bravo }
     - { t: vote, agent: t-charlie }
     - { t: vote, agent: t-alpha }
     - { t: vote, agent: t-bravo }


### PR DESCRIPTION
## Workroom piloté par le flux cœur `RunEvent` (agnostique provider)

Spec : `docs/superpowers/specs/2026-07-23-workroom-executionevent-design.md` · Plan : `docs/superpowers/plans/2026-07-23-workroom-executionevent.md`.

### Contexte
Diagnostic (cf. session) : la Workroom du shell restait « tout idle » car elle dépendait de marqueurs `<!--ARMADAI_DELEGATE-->` que les modèles n'émettent pas de façon fiable, et le shell **relaie** un CLI externe (claude délègue via l'outil natif Agent, gemini n'a pas de sous-agents…). La source agnostique correcte est **le moteur d'orchestration event-sourcé d'ArmadAI** : chaque agent = un appel `Provider`, et c'est ArmadAI qui émet les `RunEvent` — indépendamment du provider. (Aligné sur l'issue #227 : cœur provider-neutre, les hooks CLI sont des adaptateurs par-dessus.)

### Contenu
- **Projection pure** `Workroom::on_run_event_at(&RunEvent, Instant)` — mapping event→état (horloge injectée, testable).
- **`RunEvent: Clone` + `WorkroomSink`** (`EventSink` → channel tokio).
- **Vue live TUI** sur `armadai run --orchestrate` (feature `tui`) : moteur en tâche async, boucle ratatui drainant le channel (layouts/drill-down de T3), restauration terminal panic-safe, résultat imprimé après restauration. Flag **`--no-tui`** ; déclenchement par défaut sur TTY (hors `--json`/`--quiet`/`--dry-run`/non-TTY = headless **inchangé**).
- **`human_output`** distinct de `quiet` : sous TUI, les `println!`/`eprintln!` du moteur sont supprimés (le contenu final passe par `RunEvent::Result`), sans toucher au flux d'événements.
- **e2e systématiques** : assertions du flux par agent (delegate/agent_start/agent_end/vote/board) sur hierarchical/blackboard/ring + cas `no-tui` (parité headless).

### Hors périmètre
Mode relais du shell (marqueurs / tool_use) inchangé ; adaptateur hooks/plugin Claude Code = brainstorm stratégique séparé (aligné #227).

### Gate
clippy 3 modes + fmt + `cargo test --features tui` (945) + e2e `--test e2e` (30/30, 9 cas). TDD (projection + sink).

### Validation
Visuelle par Dimitri : `armadai run --orchestrate` sur `examples/orchestration-patterns/{hierarchical,ring,blackboard}` (clé API ou fake-claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)