### PR TITLE
feat(cli): design-system accents for armadai run human output (lot CLI-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,8 @@ dependencies = [
 name = "armadai"
 version = "1.0.0-rc.4"
 dependencies = [
+ "anstream",
+ "anstyle",
  "anyhow",
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 portable-pty = { version = "0.8", optional = true }
 strip-ansi-escapes = { version = "0.2", optional = true }
 regex = "1"
+anstyle = "1.0.14"
+anstream = "1.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/docs/superpowers/plans/2026-07-24-design-system-cli-1.md
+++ b/docs/superpowers/plans/2026-07-24-design-system-cli-1.md
@@ -1,0 +1,276 @@
+# Design System → CLI, lot CLI-1 (module de style + `armadai run` humain) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Doter la sortie humaine du CLI d'un module de style ANSI cohérent avec l'identité DS (laiton + signaux), et l'appliquer à la sortie humaine de `armadai run`.
+
+**Architecture:** Nouveau module `src/cli/style.rs` (non feature-gated) : helpers sémantiques renvoyant des `anstyle::Style` (valeurs DS en RGB), rendus via `anstream` qui strippe automatiquement les codes ANSI selon `NO_COLOR`/`CLICOLOR`/TTY. Accent-only : le corps de texte reste en couleur par défaut du terminal ; on n'accentue que titres/actif/statuts/secondaire. Application aux `println!`/`eprintln!` humains de `src/cli/run.rs`.
+
+**Tech Stack:** Rust edition 2024, `anstyle` + `anstream` (déjà dans `Cargo.lock`).
+
+## Global Constraints
+- Gate à chaque tâche : clippy **3 modes** (`--no-default-features --features tui`, `--features tui,providers-api`, `--features tui,web,storage`) `-D warnings` + `cargo fmt -- --check` + `cargo test --no-default-features --features tui`.
+- `src/cli/style.rs` **NON gated `tui`** (la sortie CLI de base ne dépend pas de ratatui). C'est un module DISTINCT de `src/theme.rs` (ratatui) — ne pas les confondre.
+- **Accent-only** : corps de texte non coloré (fg par défaut, lisible fond clair ET sombre) ; accents = laiton (titres/actif), signaux (statuts), bright-black (secondaire).
+- **Détection couleur déléguée à `anstream`** — ne PAS réimplémenter NO_COLOR/TTY. Le contenu machine (`--json`) passe par `EventSink`, jamais par les helpers humains → jamais coloré.
+- Valeurs DS (de `assets/terminal-palette.json`) : brass `#c79a4a`, signal_ok `#5cbf87`, signal_warning `#e2b24c`, signal_critical `#d75f4d`, signal_running `#57a9cc` ; muted = `AnsiColor::BrightBlack`.
+- Branche `feat/cli-ds-1` (déjà créée depuis `release/1.0.0`, contient déjà la spec). Une PR, revue indépendante + validation visuelle Dimitri.
+- Hors périmètre : toutes les autres commandes (`list`/`new`/`link`/`init`/`models`/…) = lots CLI-2+.
+
+## File Structure
+- `Cargo.toml` — ajouter `anstyle` + `anstream` en `[dependencies]`. (Task 1)
+- `src/cli/style.rs` — nouveau module de style CLI (helpers + tests). (Task 1)
+- `src/cli/mod.rs` — déclarer `mod style;`. (Task 1)
+- `src/cli/run.rs` — styliser la sortie humaine. (Task 2)
+
+---
+
+### Task 1: Module `src/cli/style.rs` (socle ANSI)
+
+**Files:**
+- Modify: `Cargo.toml` (`[dependencies]`)
+- Create: `src/cli/style.rs`
+- Modify: `src/cli/mod.rs` (ajout `mod style;`)
+
+**Interfaces:**
+- Produces: `crate::cli::style::{header, accent, ok, warn, err, running, muted, agent} -> anstyle::Style`.
+
+- [ ] **Step 1 : Ajouter les dépendances.**
+
+Run: `cargo add anstyle anstream`
+Expected: `Cargo.toml` gagne `anstyle = "1.0"` (ou version résolue) et `anstream = "0.6"` (ou version résolue), cohérentes avec `Cargo.lock`. Vérifier qu'elles apparaissent sous `[dependencies]` (non-optional, non feature-gated).
+
+- [ ] **Step 2 : Écrire le module avec ses tests (le test rend le fichier compilable et vérifie le comportement).** Créer `src/cli/style.rs` :
+
+```rust
+//! ANSI styling for human CLI output (design system "pont de commandement").
+//!
+//! Distinct from `crate::theme` (ratatui `Color`, for the TUI/shell). This is
+//! for plain stdout/stderr. **Accent-only**: body text keeps the terminal's
+//! default foreground (legible on light AND dark backgrounds); only accents
+//! (brass), status signals, and secondary text are coloured. Colour on/off is
+//! delegated entirely to `anstream` (respects `NO_COLOR`/`CLICOLOR`/TTY) — the
+//! call sites print with `anstream::println!`/`anstream::eprintln!`.
+
+use anstyle::{AnsiColor, Color, RgbColor, Style};
+
+// Design-system accents (assets/terminal-palette.json).
+const BRASS: Color = Color::Rgb(RgbColor(0xc7, 0x9a, 0x4a));
+const SIGNAL_OK: Color = Color::Rgb(RgbColor(0x5c, 0xbf, 0x87));
+const SIGNAL_WARNING: Color = Color::Rgb(RgbColor(0xe2, 0xb2, 0x4c));
+const SIGNAL_CRITICAL: Color = Color::Rgb(RgbColor(0xd7, 0x5f, 0x4d));
+const SIGNAL_RUNNING: Color = Color::Rgb(RgbColor(0x57, 0xa9, 0xcc));
+
+/// Section heading / active element: bold brass.
+pub fn header() -> Style {
+    Style::new().bold().fg_color(Some(BRASS))
+}
+/// Accent (brass) without bold.
+pub fn accent() -> Style {
+    Style::new().fg_color(Some(BRASS))
+}
+/// Success / done status.
+pub fn ok() -> Style {
+    Style::new().fg_color(Some(SIGNAL_OK))
+}
+/// Warning status.
+pub fn warn() -> Style {
+    Style::new().fg_color(Some(SIGNAL_WARNING))
+}
+/// Error / critical status.
+pub fn err() -> Style {
+    Style::new().fg_color(Some(SIGNAL_CRITICAL))
+}
+/// In-progress / running status.
+pub fn running() -> Style {
+    Style::new().fg_color(Some(SIGNAL_RUNNING))
+}
+/// Secondary / muted text: bright-black (named, adapts to terminal theme).
+pub fn muted() -> Style {
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlack)))
+}
+/// Agent / role name: bold, no colour (avoids clashing with status colours).
+pub fn agent() -> Style {
+    Style::new().bold()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn accents_carry_expected_style() {
+        assert_eq!(header().get_fg_color(), Some(BRASS));
+        assert!(header().get_effects().contains(anstyle::Effects::BOLD));
+        assert_eq!(ok().get_fg_color(), Some(SIGNAL_OK));
+        assert_eq!(err().get_fg_color(), Some(SIGNAL_CRITICAL));
+        assert_eq!(
+            muted().get_fg_color(),
+            Some(Color::Ansi(AnsiColor::BrightBlack))
+        );
+        // agent(): bold, no colour.
+        assert_eq!(agent().get_fg_color(), None);
+        assert!(agent().get_effects().contains(anstyle::Effects::BOLD));
+    }
+
+    #[test]
+    fn anstream_emits_codes_when_forced_on_and_strips_when_off() {
+        let h = header();
+        let styled = format!("{h}hello{h:#}");
+        const ESC: u8 = 0x1b;
+
+        // Forced colour ON → ANSI escape present.
+        let mut on = anstream::AutoStream::always(Vec::new());
+        write!(on, "{styled}").unwrap();
+        assert!(on.into_inner().contains(&ESC), "expected ANSI codes when forced on");
+
+        // Forced colour OFF → escapes stripped.
+        let mut off = anstream::AutoStream::never(Vec::new());
+        write!(off, "{styled}").unwrap();
+        assert!(!off.into_inner().contains(&ESC), "expected no ANSI codes when forced off");
+    }
+}
+```
+
+Note : vérifier au compilateur les noms exacts de l'API `anstyle` de la version résolue — `Style::new()`, `.bold()`, `.fg_color(Some(Color))`, `.get_fg_color()`, `.get_effects()`, `Effects::BOLD`, `Color::Rgb(RgbColor(r,g,b))`, `Color::Ansi(AnsiColor::BrightBlack)` — et `anstream::AutoStream::{always,never}` + `.into_inner()`. Adapter si l'API diffère (ne PAS deviner : lire le crate).
+
+- [ ] **Step 3 : Déclarer le module.** Dans `src/cli/mod.rs`, ajouter (près des autres `mod`) :
+
+```rust
+mod style;
+```
+(non gated ; s'il faut le rendre visible ailleurs plus tard, `pub(crate) mod style;` — pour ce lot `run.rs` est dans le même crate/module, `crate::cli::style` suffit.)
+
+- [ ] **Step 4 : Compiler + tests.**
+
+Run: `cargo test --no-default-features --features tui cli::style 2>&1 | tail -8`
+Expected: `accents_carry_expected_style` + `anstream_emits_codes_when_forced_on_and_strips_when_off` verts.
+
+- [ ] **Step 5 : Gate 3 modes + commit** (les deps nouvelles touchent les 3 modes) :
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+git add Cargo.toml Cargo.lock src/cli/style.rs src/cli/mod.rs
+git commit -m "feat(cli): ANSI style module for human output (design-system accents via anstyle/anstream)"
+```
+
+---
+
+### Task 2: Appliquer le style à la sortie humaine de `armadai run`
+
+**Files:**
+- Modify: `src/cli/run.rs` (sorties humaines `println!`/`eprintln!` — voir ancrages)
+
+**Interfaces:**
+- Consumes: `crate::cli::style::{header, accent, ok, warn, err, running, muted, agent}` (Task 1) ; les macros `anstream::eprintln!`/`anstream::println!`.
+
+**Principe d'édition** : remplacer chaque `eprintln!`/`println!` HUMAIN identifié par son équivalent `anstream::eprintln!`/`anstream::println!` en injectant les styles via la syntaxe anstyle `{s}…{s:#}` (le spec `#` réinitialise). NE PAS toucher : les `sink.emit(...)`, le contenu `--json`, ni les `println!("{content}")`/`println!("{outcome_text}")` du RÉSULTAT final (le corps reste non coloré — accent-only ; on ne stylise QUE le chrome autour). NE PAS toucher les `tracing::` logs.
+
+- [ ] **Step 1 : En-tête d'étape pipeline** (~l.329). Remplacer :
+
+```rust
+            eprintln!("--- [{}/{} {}] ---", i + 1, chain.len(), name);
+```
+par :
+```rust
+            let h = crate::cli::style::header();
+            anstream::eprintln!("{h}--- [{}/{} {}] ---{h:#}", i + 1, chain.len(), name);
+```
+
+- [ ] **Step 2 : Fallback modèle** (~l.528). Remplacer :
+
+```rust
+                eprintln!("[{agent_name}] Model unavailable, falling back to {fallback_model}...");
+```
+par :
+```rust
+                let w = crate::cli::style::warn();
+                anstream::eprintln!("{w}[{agent_name}] Model unavailable, falling back to {fallback_model}...{w:#}");
+```
+
+- [ ] **Step 3 : Résumé (tokens/coût/durée)** (~l.565). Remplacer le bloc :
+
+```rust
+    eprintln!(
+        "\n[{}] model={} tokens={}/{} cost=${:.6} duration={}ms",
+        agent_name,
+        response.model,
+        response.tokens_in,
+        response.tokens_out,
+        response.cost,
+        duration_ms
+    );
+```
+par (nom d'agent accentué, métriques en muted) :
+```rust
+    let acc = crate::cli::style::accent();
+    let mut_ = crate::cli::style::muted();
+    anstream::eprintln!(
+        "\n{acc}[{}]{acc:#} {mut_}model={} tokens={}/{} cost=${:.6} duration={}ms{mut_:#}",
+        agent_name,
+        response.model,
+        response.tokens_in,
+        response.tokens_out,
+        response.cost,
+        duration_ms
+    );
+```
+
+- [ ] **Step 4 : Statuts d'orchestration humains** (branches blackboard/ring/hierarchical, déjà gated `human_output`). Styliser les lignes de statut (PAS le `println!("{outcome_text}")`/`println!("{}", result.content)` du résultat, qui restent bruts). Exemples à appliquer sur le même modèle :
+
+  - `eprintln!("[blackboard] Starting with {} agent(s), max {} rounds", …)` (~l.1352 zone) → préfixe `running()`.
+  - `eprintln!("[blackboard] Halted: {:?}", state.status)` (~l.1373) → `ok()` si l'issue est un succès, sinon `warn()`/`err()` selon `state.status` (utiliser une petite closure locale `status_style(&state.status)` si plusieurs branches en ont besoin ; sinon `warn()` par défaut pour un halt).
+  - Idem `[ring] status: …` (~l.1469) et l'en-tête de démarrage hierarchical (~l.1525/1552).
+
+  Modèle (Starting) :
+```rust
+            let r = crate::cli::style::running();
+            anstream::eprintln!(
+                "{r}[blackboard] Starting with {} agent(s), max {} rounds{r:#}",
+                agent_map.len(),
+                config.max_rounds
+            );
+```
+  Modèle (Halted) :
+```rust
+            let s = crate::cli::style::warn();
+            anstream::eprintln!("{s}[blackboard] Halted: {:?}{s:#}", state.status);
+```
+  (Appliquer l'équivalent aux branches ring et hierarchical avec le même vocabulaire de style. Rester factuel : `running` pour le démarrage, `warn`/`ok` pour l'issue.)
+
+- [ ] **Step 5 : Vérifier qu'aucun chemin machine n'est touché.**
+
+Run: `grep -n "anstream::" src/cli/run.rs` — doit n'apparaître que sur des chemins HUMAINS (jamais dans un bloc `if json` / autour d'un `sink.emit`). Vérifier aussi que les `println!` du résultat final (contenu) sont **inchangés**.
+
+- [ ] **Step 6 : Gate 3 modes + tests + e2e.**
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui 2>&1 | tail -5
+cargo test --test e2e --no-default-features --features tui,storage 2>&1 | tail -5
+```
+Expected : tout vert. L'e2e est **inchangé** : il capture stdout non-TTY → anstream strippe → octets identiques ; et le contenu `--json`/résultat n'est pas touché.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/cli/run.rs
+git commit -m "feat(cli): apply design-system accents to armadai run human output"
+```
+
+**➡️ Fin du lot CLI-1. PR + revue indépendante + validation visuelle Dimitri : `armadai run` (mode humain) montre les accents ; `armadai run … | cat` et `NO_COLOR=1 armadai run …` → aucune couleur ; `--json` inchangé.**
+
+---
+
+## Self-Review
+- **Spec coverage** : module `style.rs` non-gated, anstyle+anstream, API sémantique accent-only, valeurs DS → Task 1 ✓ ; application à `run` humain (pipeline header, fallback, résumé, statuts orchestration) sans toucher RunEvent/--json/résultat brut → Task 2 ✓ ; tests rendu on/off déterministes → Task 1 Step 2 ✓ ; e2e intact → Task 2 Step 6 ✓ ; gate 3 modes → chaque tâche ✓ ; hors-scope (autres commandes) non touché ✓.
+- **Placeholder scan** : pas de TODO ; les « ~l.X » sont des repères indicatifs, chaque Step donne le code before/after exact à matcher. Step 4 liste explicitement les lignes ; le `status_style` optionnel est décrit (pas un placeholder — fallback `warn()` par défaut donné).
+- **Type consistency** : helpers `style::{header,accent,ok,warn,err,running,muted,agent}` définis Task 1, consommés Task 2 ; API `anstyle`/`anstream` à confirmer au compilateur (noté). `anstream::eprintln!`/`println!` fully-qualified (pas de clash avec les macros std). Le corps résultat reste `println!` std non stylé (accent-only).

--- a/docs/superpowers/specs/2026-07-24-design-system-cli-design.md
+++ b/docs/superpowers/specs/2026-07-24-design-system-cli-design.md
@@ -1,0 +1,60 @@
+# Design System → CLI (sortie humaine) — Design
+
+## Contexte
+
+3ᵉ surface du chantier design system « pont de commandement » (Web Svelte ✅, TUI T3a-d ✅ — cf. mémoire `project_design_system_rollout`). Cible : la **sortie humaine des commandes CLI** (`armadai run` en mode humain d'abord). Différence clé vs le TUI : c'est du **texte plat sur stdout/stderr** (pas ratatui) → couleurs **ANSI**, avec strip automatique quand ce n'est pas pertinent (pipe, CI, `NO_COLOR`, `--json`). Aujourd'hui la sortie humaine n'a **aucune couleur** et les `println!`/`eprintln!` sont éparpillés sur ~15 fichiers `src/cli/` (aucun helper central).
+
+⚠️ Ne PAS confondre avec `src/theme.rs` (ratatui `Color`, pour le TUI/shell). Ce lot crée un module **séparé** pour la sortie CLI plate.
+
+## Objectif
+
+Un module de style CLI central, cohérent avec l'identité DS (laiton + signaux), appliqué d'abord à la sortie humaine de `armadai run`, avec gestion propre TTY / `NO_COLOR` / `--json`. Les autres commandes suivront dans des lots séparés.
+
+## Décisions validées (Dimitri, 2026-07-24)
+
+1. **Périmètre lot CLI-1** : module `src/cli/style.rs` (socle) + application à `armadai run` humain (+ résumé orchestration). Autres commandes = lots ultérieurs.
+2. **Approche** : `anstyle` + `anstream` (tous deux déjà dans `Cargo.lock` en transitif ; à ajouter en `[dependencies]`). `anstream` strippe automatiquement les codes ANSI selon `NO_COLOR`/`CLICOLOR[_FORCE]`/stdout non-TTY.
+3. **Accent-only** : le corps de texte reste en couleur par défaut du terminal (lisible fond clair ET sombre) ; on n'accentue que titres/actif (laiton), statuts (signaux ok/warn/err/running), secondaire (muted).
+4. **Module NON gated `tui`** : la sortie CLI de base doit fonctionner sans la feature `tui`.
+
+## Architecture
+
+### Module `src/cli/style.rs` (nouveau, non feature-gated)
+
+- **Dépendances** : `anstyle` (types `Style`/`AnsiColor`/`RgbColor`) + `anstream` (flux auto-strip). Ajoutées à `Cargo.toml [dependencies]` (déjà résolues dans le lock).
+- **Palette DS (accents), valeurs de `assets/terminal-palette.json`** — exprimées en `anstyle` :
+  - `brass #c79a4a`, `signal_ok #5cbf87`, `signal_warning #e2b24c`, `signal_critical #d75f4d`, `signal_running #57a9cc`, `muted` = gris (AnsiColor::BrightBlack). Utiliser `RgbColor` pour les accents (les terminaux modernes gèrent le truecolor ; anstream/NO_COLOR gèrent l'absence de couleur ; pas de dégradation tier 256/16 pour ce lot — YAGNI, à revoir si besoin).
+- **API sémantique** (miroir de `theme.rs` pour la cohérence) — chaque helper renvoie un `anstyle::Style` :
+  - `header()` = bold brass ; `accent()` = brass ; `ok()` = signal_ok ; `warn()` = signal_warning ; `err()` = signal_critical ; `running()` = signal_running ; `muted()` = bright-black ; `agent()` = bold (rôle/nom d'agent) .
+- **Rendu** : les call-sites utilisent les macros `anstream::println!`/`eprintln!` (ou un flux `AutoStream`) avec les styles inline via `anstyle`'s `Style` (`{style}texte{style:#}`). anstream décide seul de stripper. Fournir de petits helpers ergonomiques si utile (ex. `fn paint(style: Style, s: &str) -> impl Display`), sans sur-abstraire.
+- **`--json` / `--quiet`** : ces chemins n'émettent pas via les helpers humains (déjà séparés dans `run.rs` : le contenu `--json` passe par `EventSink`, jamais par ces `println!`). anstream strippe en plus si non-TTY. Donc pas de couleur en machine-output.
+
+### Application à `armadai run` (humain)
+
+Styler la sortie humaine (non-`--json`, non-`--quiet`) dans `src/cli/run.rs` :
+- résultat final (`println!("{content}")`, l.~107/317/1393/1472/1573) : encadré/label discret en muted, contenu brut non coloré.
+- en-têtes d'étape pipeline (`--- [i/n name] ---`, l.~329) : `header()`/accent.
+- fallback modèle (l.~528), warnings : `warn()` ; erreurs : `err()`.
+- résumé tokens/coût/durée (l.~565) : labels en muted, valeurs accentuées si pertinent.
+- statuts d'orchestration humains (branches blackboard/ring/hierarchical, l.~1313-1573, déjà gated `human_output`) : `[blackboard] Starting…` → `running()`/accent ; `Halted`/status → `ok()`/`warn()`/`err()` selon l'issue ; en cohérence avec les états de la Workroom TUI.
+
+Aucune modification du flux `RunEvent`/`EventSink` ni du chemin headless-machine.
+
+## Hors périmètre
+- Les autres commandes (`list`, `new`, `link`, `init`, `models`, `audit`, `validate`, `registry`, `skills`, `config`, `setup`, `inspect`…) — lots CLI-2+.
+- Dégradation tier 256/16 côté CLI (truecolor + strip suffisent ici).
+- Tableaux/box-drawing riches (rester en accents ANSI simples pour ce lot).
+
+## Tests
+
+- **`style.rs` (unitaire, déterministe, pas d'accès env réel)** :
+  - chaque helper renvoie le `anstyle::Style` attendu (couleur/bold).
+  - **rendu on/off** : rendre une chaîne stylée dans un flux forcé **plain** (ex. `anstream::StripStream` ou `AutoStream::never`) → **aucun** octet ANSI ; dans un flux forcé **couleur** (`AutoStream::always`) → les codes attendus présents. Assertion sur les octets.
+- **`armadai run` humain** : pas de test visuel automatisé. Le flux `--json`/e2e est **intact** (couleurs seulement dans le chemin humain ; en CI/non-TTY anstream strippe → octets identiques). Vérifier que la suite + e2e restent verts.
+- **Validation visuelle** : Dimitri lance `armadai run` en mode humain (démo fake-claude) — sur fond clair — et vérifie l'application des accents + l'absence de couleur en pipe (`| cat`) et avec `NO_COLOR=1`.
+- **Gate** : clippy **3 modes** (`tui` / `tui,providers-api` / `tui,web,storage`) `-D warnings` + `cargo fmt -- --check` + `cargo test`.
+
+## Risques
+- **anstream/anstyle en `[dependencies]`** : déjà dans le lock (transitif via clap) → pas de nouveau poids notable ; confirmer les versions au moment de l'ajout.
+- **Détection couleur** : déléguée à anstream (respecte `NO_COLOR`/`CLICOLOR`/TTY) — ne pas réimplémenter ; pour un flux non-stdout (ex. tests), utiliser `AutoStream::always/never` explicitement.
+- **Cohérence d'identité** : garder les valeurs d'accent alignées sur `assets/terminal-palette.json` (mêmes couleurs que le TUI), même si le code est distinct de `theme.rs`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ mod run;
 mod run_es_record;
 pub(crate) mod setup;
 mod skills;
+mod style;
 mod unlink;
 mod up;
 mod update;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -326,7 +326,8 @@ async fn run_inner(
 
     for (i, name) in chain.iter().enumerate() {
         if chain.len() > 1 && !json {
-            eprintln!("--- [{}/{} {}] ---", i + 1, chain.len(), name);
+            let h = crate::cli::style::header();
+            anstream::eprintln!("{h}--- [{}/{} {}] ---{h:#}", i + 1, chain.len(), name);
         }
 
         let agent_path = resolve_agent_path(&resolution, name)?;
@@ -525,7 +526,10 @@ async fn run_single_agent(
             let mut last_err = err;
             let mut fallback_resp = None;
             for fallback_model in &agent.metadata.model_fallback {
-                eprintln!("[{agent_name}] Model unavailable, falling back to {fallback_model}...");
+                let w = crate::cli::style::warn();
+                anstream::eprintln!(
+                    "{w}[{agent_name}] Model unavailable, falling back to {fallback_model}...{w:#}"
+                );
                 let mut retry_request = request.clone();
                 retry_request.model = fallback_model.clone();
                 match provider.complete(retry_request).await {
@@ -562,8 +566,10 @@ async fn run_single_agent(
 
     // 7. Print summary to stderr (so stdout is clean for piping)
     let duration_ms = duration.as_millis() as i64;
-    eprintln!(
-        "\n[{}] model={} tokens={}/{} cost=${:.6} duration={}ms",
+    let acc = crate::cli::style::accent();
+    let mut_ = crate::cli::style::muted();
+    anstream::eprintln!(
+        "\n{acc}[{}]{acc:#} {mut_}model={} tokens={}/{} cost=${:.6} duration={}ms{mut_:#}",
         agent_name,
         response.model,
         response.tokens_in,
@@ -1179,6 +1185,19 @@ async fn run_orchestrated(
 /// provider/model (via [`agent_meta_from_roster`]) and real per-turn content.
 /// Only `--pipe`/legacy sequential runs (`run_single_agent`) still emit their
 /// own inline `AgentStart`/`AgentEnd`; those paths never reach this fn.
+/// Style for a terminal orchestration status line: `Completed` reads as
+/// success, anything else (`Halted`, or the in-flight `Running` default,
+/// which should not appear at a terminal print site) as a warning — factual,
+/// not alarming, since a halt is often a budget/round limit rather than an
+/// error.
+fn status_style(status: &crate::core::orchestration::es::state::RunStatus) -> anstyle::Style {
+    use crate::core::orchestration::es::state::RunStatus;
+    match status {
+        RunStatus::Completed => crate::cli::style::ok(),
+        RunStatus::Halted | RunStatus::Running => crate::cli::style::warn(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_orchestrated_inner(
     resolution: &AgentResolution,
@@ -1349,8 +1368,9 @@ async fn run_orchestrated_inner(
             }
 
             if human_output {
-                eprintln!(
-                    "[blackboard] Starting with {} agent(s), max {} rounds",
+                let r = crate::cli::style::running();
+                anstream::eprintln!(
+                    "{r}[blackboard] Starting with {} agent(s), max {} rounds{r:#}",
                     agent_map.len(),
                     config.max_rounds
                 );
@@ -1370,7 +1390,8 @@ async fn run_orchestrated_inner(
             .await?;
 
             if human_output {
-                eprintln!("[blackboard] Halted: {:?}", state.status);
+                let s = status_style(&state.status);
+                anstream::eprintln!("{s}[blackboard] Halted: {:?}{s:#}", state.status);
             }
 
             #[cfg(feature = "storage")]
@@ -1429,8 +1450,9 @@ async fn run_orchestrated_inner(
             }
 
             if human_output {
-                eprintln!(
-                    "[ring] Starting with {} agent(s), max {} laps",
+                let r = crate::cli::style::running();
+                anstream::eprintln!(
+                    "{r}[ring] Starting with {} agent(s), max {} laps{r:#}",
                     agent_map.len(),
                     config.max_laps
                 );
@@ -1466,7 +1488,8 @@ async fn run_orchestrated_inner(
 
             let outcome_text = super::run_es_record::ring_display(&state, &events);
             if human_output {
-                eprintln!("[ring] status: {:?}", state.status);
+                let s = status_style(&state.status);
+                anstream::eprintln!("{s}[ring] status: {:?}{s:#}", state.status);
             }
             if !json && human_output {
                 println!("{outcome_text}");
@@ -1522,8 +1545,9 @@ async fn run_orchestrated_inner(
             }
 
             if human_output {
-                eprintln!(
-                    "[hierarchical] Starting with coordinator '{}', {} agent(s)",
+                let r = crate::cli::style::running();
+                anstream::eprintln!(
+                    "{r}[hierarchical] Starting with coordinator '{}', {} agent(s){r:#}",
                     coordinator_name,
                     agent_map.len()
                 );
@@ -1549,9 +1573,12 @@ async fn run_orchestrated_inner(
             let result = to_orchestration_result(&state, &events);
 
             if human_output {
-                eprintln!(
-                    "[hierarchical] Done: {} invocations, {} tokens in, {} tokens out",
-                    result.invocation_count, result.total_tokens_in, result.total_tokens_out
+                let s = status_style(&state.status);
+                anstream::eprintln!(
+                    "{s}[hierarchical] Done: {} invocations, {} tokens in, {} tokens out{s:#}",
+                    result.invocation_count,
+                    result.total_tokens_in,
+                    result.total_tokens_out
                 );
             }
 

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -1,0 +1,109 @@
+//! ANSI styling for human CLI output (design system "pont de commandement").
+//!
+//! Distinct from `crate::theme` (ratatui `Color`, for the TUI/shell). This is
+//! for plain stdout/stderr. **Accent-only**: body text keeps the terminal's
+//! default foreground (legible on light AND dark backgrounds); only accents
+//! (brass), status signals, and secondary text are coloured. Colour on/off is
+//! delegated entirely to `anstream` (respects `NO_COLOR`/`CLICOLOR`/TTY) — the
+//! call sites print with `anstream::println!`/`anstream::eprintln!`.
+
+use anstyle::{AnsiColor, Color, RgbColor, Style};
+
+// Design-system accents (assets/terminal-palette.json).
+// `#[allow(dead_code)]`: this lot only lands the module; call sites in `cli/*`
+// wire these up in a follow-up lot (same convention as `crate::theme`).
+#[allow(dead_code)]
+const BRASS: Color = Color::Rgb(RgbColor(0xc7, 0x9a, 0x4a));
+#[allow(dead_code)]
+const SIGNAL_OK: Color = Color::Rgb(RgbColor(0x5c, 0xbf, 0x87));
+#[allow(dead_code)]
+const SIGNAL_WARNING: Color = Color::Rgb(RgbColor(0xe2, 0xb2, 0x4c));
+#[allow(dead_code)]
+const SIGNAL_CRITICAL: Color = Color::Rgb(RgbColor(0xd7, 0x5f, 0x4d));
+#[allow(dead_code)]
+const SIGNAL_RUNNING: Color = Color::Rgb(RgbColor(0x57, 0xa9, 0xcc));
+
+/// Section heading / active element: bold brass.
+#[allow(dead_code)]
+pub fn header() -> Style {
+    Style::new().bold().fg_color(Some(BRASS))
+}
+/// Accent (brass) without bold.
+#[allow(dead_code)]
+pub fn accent() -> Style {
+    Style::new().fg_color(Some(BRASS))
+}
+/// Success / done status.
+#[allow(dead_code)]
+pub fn ok() -> Style {
+    Style::new().fg_color(Some(SIGNAL_OK))
+}
+/// Warning status.
+#[allow(dead_code)]
+pub fn warn() -> Style {
+    Style::new().fg_color(Some(SIGNAL_WARNING))
+}
+/// Error / critical status.
+#[allow(dead_code)]
+pub fn err() -> Style {
+    Style::new().fg_color(Some(SIGNAL_CRITICAL))
+}
+/// In-progress / running status.
+#[allow(dead_code)]
+pub fn running() -> Style {
+    Style::new().fg_color(Some(SIGNAL_RUNNING))
+}
+/// Secondary / muted text: bright-black (named, adapts to terminal theme).
+#[allow(dead_code)]
+pub fn muted() -> Style {
+    Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlack)))
+}
+/// Agent / role name: bold, no colour (avoids clashing with status colours).
+#[allow(dead_code)]
+pub fn agent() -> Style {
+    Style::new().bold()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn accents_carry_expected_style() {
+        assert_eq!(header().get_fg_color(), Some(BRASS));
+        assert!(header().get_effects().contains(anstyle::Effects::BOLD));
+        assert_eq!(ok().get_fg_color(), Some(SIGNAL_OK));
+        assert_eq!(err().get_fg_color(), Some(SIGNAL_CRITICAL));
+        assert_eq!(
+            muted().get_fg_color(),
+            Some(Color::Ansi(AnsiColor::BrightBlack))
+        );
+        // agent(): bold, no colour.
+        assert_eq!(agent().get_fg_color(), None);
+        assert!(agent().get_effects().contains(anstyle::Effects::BOLD));
+    }
+
+    #[test]
+    fn anstream_emits_codes_when_forced_on_and_strips_when_off() {
+        let h = header();
+        let styled = format!("{h}hello{h:#}");
+        const ESC: u8 = 0x1b;
+
+        // Forced colour ON → ANSI escape present.
+        let mut on = anstream::AutoStream::always(Vec::new());
+        write!(on, "{styled}").unwrap();
+        assert!(
+            on.into_inner().contains(&ESC),
+            "expected ANSI codes when forced on"
+        );
+
+        // Forced colour OFF → escapes stripped.
+        let mut off = anstream::AutoStream::never(Vec::new());
+        write!(off, "{styled}").unwrap();
+        assert!(
+            !off.into_inner().contains(&ESC),
+            "expected no ANSI codes when forced off"
+        );
+    }
+}

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -10,36 +10,29 @@
 use anstyle::{AnsiColor, Color, RgbColor, Style};
 
 // Design-system accents (assets/terminal-palette.json).
-// `#[allow(dead_code)]`: this lot only lands the module; call sites in `cli/*`
-// wire these up in a follow-up lot (same convention as `crate::theme`).
-#[allow(dead_code)]
+// `#[allow(dead_code)]` on the remaining unwired items below: this lot only
+// wires `cli/run.rs`; other call sites (and `err()`/`agent()`) land in a
+// follow-up lot (same convention as `crate::theme`).
 const BRASS: Color = Color::Rgb(RgbColor(0xc7, 0x9a, 0x4a));
-#[allow(dead_code)]
 const SIGNAL_OK: Color = Color::Rgb(RgbColor(0x5c, 0xbf, 0x87));
-#[allow(dead_code)]
 const SIGNAL_WARNING: Color = Color::Rgb(RgbColor(0xe2, 0xb2, 0x4c));
 #[allow(dead_code)]
 const SIGNAL_CRITICAL: Color = Color::Rgb(RgbColor(0xd7, 0x5f, 0x4d));
-#[allow(dead_code)]
 const SIGNAL_RUNNING: Color = Color::Rgb(RgbColor(0x57, 0xa9, 0xcc));
 
 /// Section heading / active element: bold brass.
-#[allow(dead_code)]
 pub fn header() -> Style {
     Style::new().bold().fg_color(Some(BRASS))
 }
 /// Accent (brass) without bold.
-#[allow(dead_code)]
 pub fn accent() -> Style {
     Style::new().fg_color(Some(BRASS))
 }
 /// Success / done status.
-#[allow(dead_code)]
 pub fn ok() -> Style {
     Style::new().fg_color(Some(SIGNAL_OK))
 }
 /// Warning status.
-#[allow(dead_code)]
 pub fn warn() -> Style {
     Style::new().fg_color(Some(SIGNAL_WARNING))
 }
@@ -49,12 +42,10 @@ pub fn err() -> Style {
     Style::new().fg_color(Some(SIGNAL_CRITICAL))
 }
 /// In-progress / running status.
-#[allow(dead_code)]
 pub fn running() -> Style {
     Style::new().fg_color(Some(SIGNAL_RUNNING))
 }
 /// Secondary / muted text: bright-black (named, adapts to terminal theme).
-#[allow(dead_code)]
 pub fn muted() -> Style {
     Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlack)))
 }


### PR DESCRIPTION
## Design System → CLI, lot CLI-1

1ère tranche de l'application du DS « pont de commandement » à la surface **CLI** (sortie humaine). Spec/plan : `docs/superpowers/specs|plans/2026-07-24-design-system-cli*`.

### Contenu
- **`src/cli/style.rs`** (nouveau, non gated `tui`) : module de style ANSI pour la sortie humaine, **distinct de `src/theme.rs`** (ratatui). `anstyle` + `anstream` (déjà dans le lock) ; API sémantique accent-only aux valeurs DS (`header`/`accent` laiton, `ok/warn/err/running` signaux, `muted`, `agent`). Détection couleur déléguée à `anstream` (NO_COLOR/CLICOLOR/TTY).
- **`armadai run` humain** : en-tête d'étape pipeline, fallback modèle, résumé tokens/coût/durée, statuts d'orchestration (blackboard/ring/hierarchical, gated `human_output`). Le contenu du **résultat reste non coloré** (accent-only) ; `--json`/`--quiet`/`RunEvent` **inchangés**.

### Gate
clippy 3 modes + fmt + `cargo test --features tui` (954) + `cargo test --test e2e` (30, inchangé — non-TTY strippe → octets identiques).

### Hors périmètre
Autres commandes (`list`/`new`/`link`/`init`/`models`/…) = lots CLI-2+.

### Validation
Visuelle Dimitri : `armadai run` (mode humain) montre les accents ; `armadai run … | cat` et `NO_COLOR=1 armadai run …` → aucune couleur ; `--json` inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)