### PR TITLE
feat(cli): design-system accents for all remaining commands (CLI-2)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-design-system-cli-2.md
+++ b/docs/superpowers/plans/2026-07-24-design-system-cli-2.md
@@ -1,0 +1,175 @@
+# Design System → CLI, lot CLI-2 (toutes les commandes restantes) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Appliquer le module de style CLI (`src/cli/style.rs`, livré en CLI-1) à la sortie humaine de toutes les commandes `src/cli/` restantes, de façon cohérente et accent-only.
+
+**Architecture:** Sweep mécanique guidé par un pattern déjà établi et exemplifié (CLI-1 : `src/cli/run.rs` + `src/cli/style.rs`). Chaque commande : identifier ses `println!`/`eprintln!` HUMAINS, les convertir en `anstream::println!`/`anstream::eprintln!` avec le helper sémantique adéquat ; laisser intactes les sorties machine (`--json`, `sink.emit`, valeurs scriptables destinées au pipe) et les logs `tracing::`. Découpé en 4 tâches par groupe de commandes.
+
+**Tech Stack:** Rust edition 2024, `anstyle` + `anstream` (déjà en deps depuis CLI-1).
+
+## Global Constraints
+- Gate à chaque tâche : clippy **3 modes** (`--no-default-features --features tui`, `--features tui,providers-api`, `--features tui,web,storage`) `-D warnings` + `cargo fmt -- --check` + `cargo test --no-default-features --features tui`. En fin de lot (dernière tâche) : `cargo test --test e2e --no-default-features --features tui,storage`.
+- **Ne styliser QUE la sortie HUMAINE.** NE PAS toucher : le contenu `--json`, les `sink.emit(...)`, les **valeurs brutes scriptables** (listes de noms destinées au pipe — ex. `list` sans filtre décoratif, `extract`), ni les `tracing::` logs.
+- **Accent-only** : le CONTENU / les données restent en couleur par défaut du terminal (lisible fond clair ET sombre) ; on n'accentue que titres, labels, statuts, secondaire.
+- **API** : `crate::cli::style::{header, accent, ok, warn, err, running, muted, agent} -> anstyle::Style`. Rendu inline `{s}texte{s:#}` (le `#` réinitialise), via `anstream::println!`/`anstream::eprintln!` **fully-qualified** (pas de clash avec les macros std). Détection couleur déléguée à `anstream` (ne rien réimplémenter).
+- **Mapping sémantique** :
+  - titres / en-têtes de section / colonnes → `header()`
+  - noms d'entités (agent, prompt, skill, starter, modèle, projet) → `accent()` (ou `agent()` pour un nom d'agent en gras)
+  - succès / « created » / « linked » / « done » / « ✓ » → `ok()`
+  - avertissements / hints → `warn()` (ton alerte) ou `muted()` (ton discret) selon le cas
+  - erreurs / échecs → `err()`
+  - secondaire (chemins, compteurs, métadonnées, séparateurs, « N found ») → `muted()`
+- **dead_code** : dans `src/cli/style.rs`, retirer le `#[allow(dead_code)]` sur `err()` et `agent()` (l.40/53 zone) dès qu'ils sont utilisés (ils le seront dans ce lot). Vérifier au clippy.
+- Branche `feat/cli-ds-2` (déjà créée depuis `release/1.0.0`, contient `style.rs`). Une PR, revue indépendante + validation visuelle Dimitri.
+- **rust-analyzer non fiable** (ABI/unlinked/inactive-cfg/snapshots) → vérifier au compilateur.
+
+## Worked example (template à suivre pour toutes les commandes) — `src/cli/list.rs`
+
+État actuel (extrait) et conversion cible :
+
+```rust
+// "No agents found." / hints → muted (secondaire, non-erreur)
+let m = crate::cli::style::muted();
+anstream::println!("{m}No agents found.{m:#}");
+anstream::println!("{m}Create one with: armadai new --template basic <name>{m:#}");
+
+// En-tête de colonnes → header
+let h = crate::cli::style::header();
+anstream::println!(
+    "{h}  {:<name_w$}  {:<provider_w$}  {:<model_w$}  TAGS  STACKS{h:#}",
+    "NAME", "PROVIDER", "MODEL",
+);
+// Ligne de séparation → muted
+let m = crate::cli::style::muted();
+anstream::println!(
+    "{m}  {:<name_w$}  {:<provider_w$}  {:<model_w$}  ----  ------{m:#}",
+    "-".repeat(name_w), "-".repeat(provider_w), "-".repeat(model_w),
+);
+
+// Lignes de données : le NOM d'agent accentué, le RESTE en couleur par défaut (données)
+let a = crate::cli::style::accent();
+anstream::println!(
+    "  {a}{:<name_w$}{a:#}  {:<provider_w$}  {:<model_w$}  {}  {}",
+    agent.name, agent.metadata.provider, agent.model_display(), tags_str, stacks_str,
+);
+
+// Compteur final → muted
+let m = crate::cli::style::muted();
+anstream::println!("\n{m}  {} agent(s) found.{m:#}", agents.len());
+
+// Les `eprintln!("  warn: {err}")` de load_agents → warn()
+let w = crate::cli::style::warn();
+anstream::eprintln!("{w}  warn: {err}{w:#}");
+```
+
+Points clés démontrés : en-têtes/colonnes = `header` ; noms = `accent` (données autour = défaut) ; compteurs/hints/séparateurs = `muted` ; `warn:` = `warn`. **Aucune valeur brute n'est perdue** (les données restent lisibles/parsables ; seuls les accents décoratifs sont ajoutés autour). Appliquer ce même raisonnement à chaque commande de chaque tâche.
+
+---
+
+### Task 1: Discovery / read — `list`, `models`, `inspect`, `prompts`, `validate`
+
+**Files:** Modify `src/cli/{list.rs, models.rs, inspect.rs, prompts.rs, validate.rs}` ; potentiellement `src/cli/style.rs` (retrait `allow(dead_code)` si `err`/`agent` utilisés ici).
+
+**Interfaces:**
+- Consumes: `crate::cli::style::*` + `anstream::{println,eprintln}` (CLI-1).
+
+- [ ] **Step 1 : `list.rs`** — appliquer le Worked example ci-dessus verbatim (en-têtes `header`, noms `accent`, séparateur/compteur/hints `muted`, `warn:` `warn`). NE PAS colorer les colonnes de données (provider/model/tags/stacks).
+- [ ] **Step 2 : `models.rs`** — lire le fichier ; en-têtes/sections de la liste de modèles → `header` ; nom de modèle/provider → `accent` ; coût/contexte/métadonnées → `muted` ; findings de dépréciation (`print_findings`) : le libellé d'alerte → `warn`, la cible de remplacement → `ok`/`accent`, le reste `muted`. Erreurs de fetch → `err`.
+- [ ] **Step 3 : `inspect.rs`** — vue détaillée d'un agent : les LABELS de champs (Name/Provider/Model/Tags/System Prompt…) → `header` ou `muted` (labels = muted, valeurs = défaut, titre principal = header) ; le nom d'agent en tête → `header`/`accent`. Le corps du system prompt reste non coloré. (33 prints — rester méthodique, un label/section à la fois.)
+- [ ] **Step 4 : `prompts.rs`** — même logique que `list`/`inspect` pour la liste/détail de prompts (en-têtes `header`, noms `accent`, secondaire `muted`).
+- [ ] **Step 5 : `validate.rs`** — sortie de validation : succès/« valid » → `ok` ; problèmes/erreurs → `err` ; avertissements → `warn` ; en-tête/nom du fichier validé → `header`/`accent`.
+- [ ] **Step 6 : Vérif + Gate.**
+
+Run:
+```bash
+grep -n "anstream::" src/cli/{list,models,inspect,prompts,validate}.rs   # sanity: uniquement chemins humains
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui 2>&1 | tail -5
+```
+Expected : `No issues found` (3 modes) + suite verte.
+
+- [ ] **Step 7 : Commit**
+```bash
+git add src/cli/list.rs src/cli/models.rs src/cli/inspect.rs src/cli/prompts.rs src/cli/validate.rs src/cli/style.rs
+git commit -m "feat(cli): design-system accents for discovery commands (list/models/inspect/prompts/validate)"
+```
+
+---
+
+### Task 2: Setup projet — `new`, `init`, `link`, `unlink`, `setup`, `update`
+
+**Files:** Modify `src/cli/{new.rs, init.rs, link.rs, unlink.rs, setup.rs, update.rs}`.
+
+**Interfaces:** Consumes `crate::cli::style::*` + `anstream::{println,eprintln}`.
+
+- [ ] **Step 1 : `new.rs`** — création d'agent : « Created agent <name> » / « ✓ » → `ok` (+ nom en `accent`) ; chemins écrits → `muted` ; prompts interactifs (dialoguer) NON concernés (ce n'est pas du `println!` stylable) ; hints de suite → `muted` ; erreurs → `err`.
+- [ ] **Step 2 : `init.rs`** — init projet / starter pack : titres d'étape → `header` ; « created … »/« ready » → `ok` ; fichiers/chemins → `muted` ; avertissements → `warn` ; erreurs → `err`. (24 prints.)
+- [ ] **Step 3 : `link.rs`** — génération de config par cible : « Linked N agent(s) … to '<target>' » → `ok` (nom de cible `accent`) ; « wrote <path> » → `muted` ; collisions/avertissements → `warn` ; erreurs → `err`. Attention : le contenu machine éventuel reste intact.
+- [ ] **Step 4 : `unlink.rs`** — « removed <path> »/« unlinked » → `ok`/`muted` ; avertissements → `warn`.
+- [ ] **Step 5 : `setup.rs`** — assistant de setup / complétion shell (`print_completion_hint`) : titres → `header` ; instructions/chemins → `muted` ; succès → `ok`. (26 prints.)
+- [ ] **Step 6 : `update.rs`** — mise à jour de modèles/config : « updated … » → `ok` ; « nothing to update » → `muted` ; erreurs → `err`.
+- [ ] **Step 7 : Vérif + Gate** (même bloc que Task 1 Step 6, sur les 6 fichiers de cette tâche).
+- [ ] **Step 8 : Commit**
+```bash
+git add src/cli/new.rs src/cli/init.rs src/cli/link.rs src/cli/unlink.rs src/cli/setup.rs src/cli/update.rs
+git commit -m "feat(cli): design-system accents for project-setup commands (new/init/link/unlink/setup/update)"
+```
+
+---
+
+### Task 3: Registry / skills — `registry`, `skills`
+
+**Files:** Modify `src/cli/{registry.rs, skills.rs}`.
+
+**Interfaces:** Consumes `crate::cli::style::*` + `anstream::{println,eprintln}`.
+
+- [ ] **Step 1 : `registry.rs`** (50 prints) — sync/search/convert du catalogue awesome-copilot : en-têtes de section / titres de résultats → `header` ; noms d'entrées/agents → `accent` ; « synced N »/« installed » → `ok` ; compteurs/URLs/chemins → `muted` ; hints (« registry may be outdated… ») → `warn`/`muted` ; erreurs → `err`. Les éventuelles sorties destinées au parsing restent brutes.
+- [ ] **Step 2 : `skills.rs`** (46 prints) — sync/search/install de skills GitHub : même logique (titres `header`, noms de skills/repos `accent`, succès `ok`, secondaire `muted`, hints `warn`, erreurs `err`).
+- [ ] **Step 3 : Vérif + Gate** (même bloc, sur registry.rs + skills.rs).
+- [ ] **Step 4 : Commit**
+```bash
+git add src/cli/registry.rs src/cli/skills.rs
+git commit -m "feat(cli): design-system accents for registry/skills commands"
+```
+
+---
+
+### Task 4: Config / divers — `config`, `audit`, `extract`
+
+**Files:** Modify `src/cli/{config.rs, audit.rs, extract.rs}`.
+
+**Interfaces:** Consumes `crate::cli::style::*` + `anstream::{println,eprintln}`.
+
+- [ ] **Step 1 : `config.rs`** (37 prints) — affichage/édition de config : clés/labels → `muted` ou `header` (titre de section = header, clés = muted, valeurs = défaut) ; « set »/« saved » → `ok` ; erreurs de validation → `err` ; hints → `warn`/`muted`.
+- [ ] **Step 2 : `audit.rs`** (10 prints) — sortie de l'audit agentique : titres/sections → `header` ; findings selon sévérité → `err` (critique) / `warn` (avertissement) / `ok` (rien à signaler) ; compteurs/chemins → `muted`.
+- [ ] **Step 3 : `extract.rs`** (`print_summary`, 2 prints) — résumé d'extraction : titre → `header`, chemin de sortie → `muted`, « extracted N » → `ok`. **Attention** : si `extract` imprime une liste de noms destinée au pipe, la laisser BRUTE.
+- [ ] **Step 4 : Vérif finale + Gate complet (fin de lot)** :
+```bash
+grep -rn "anstream::" src/cli/ | wc -l    # cohérence globale
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui 2>&1 | tail -5
+cargo test --test e2e --no-default-features --features tui,storage 2>&1 | tail -5
+```
+Expected : tout vert ; e2e inchangé (anstream strippe en non-TTY → octets identiques). Vérifier qu'il ne reste plus de `#[allow(dead_code)]` sur un helper de `style.rs` désormais utilisé.
+- [ ] **Step 5 : Commit**
+```bash
+git add src/cli/config.rs src/cli/audit.rs src/cli/extract.rs src/cli/style.rs
+git commit -m "feat(cli): design-system accents for config/audit/extract commands"
+```
+
+**➡️ Fin du lot CLI-2. PR + revue indépendante + validation visuelle Dimitri : lancer chaque commande en TTY (accents), et vérifier `| cat` / `NO_COLOR=1` → aucune couleur, `--json` inchangé.**
+
+---
+
+## Self-Review
+- **Spec coverage** : le design (module `style.rs` + accent-only + anstream) est celui de la spec CLI-1 ; CLI-2 l'applique aux commandes restantes → couvert par Tasks 1-4 (les 16 commandes réparties, aucune oubliée : list/models/inspect/prompts/validate + new/init/link/unlink/setup/update + registry/skills + config/audit/extract). ✓
+- **Placeholder scan** : pas de TODO ; c'est un sweep pattern-based **délibéré** (le pattern + un exemple entièrement travaillé `list.rs` + le mapping sémantique + la référence CLI-1 `run.rs` fournissent le « comment » ; pré-écrire les 331 prints verbatim serait irréaliste et fragile). Chaque Step nomme le fichier + les types de lignes → helper. Les cas ambigus (sorties scriptables) sont explicitement « rester brutes ».
+- **Type consistency** : helpers `style::{header,accent,ok,warn,err,running,muted,agent}` (définis en CLI-1) consommés partout ; `anstream::println!`/`eprintln!` fully-qualified ; retrait `allow(dead_code)` sur `err`/`agent` cohérent (Task 1 ou plus tard selon premier usage — vérifié au gate). Aucune nouvelle API introduite.
+- **Risque** : le CONTENU/données doit rester non coloré (accent-only) et les sorties scriptables intactes — rappelé dans les Global Constraints ET le worked example ET les Steps ambigus ; la revue de tâche + la validation visuelle Dimitri sont le filet.

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -49,6 +49,15 @@ impl AuditReport {
         }
     }
 
+    /// Accent style for a severity level (terminal output only).
+    fn severity_style(s: Severity) -> anstyle::Style {
+        match s {
+            Severity::Critical => crate::cli::style::err(),
+            Severity::Warning => crate::cli::style::warn(),
+            Severity::Info => crate::cli::style::ok(),
+        }
+    }
+
     /// Per-rule counts, e.g. `A01×2  A06×1(+3)  A08×1(+23)`.
     fn breakdown_line(&self) -> String {
         let mut per_rule: std::collections::BTreeMap<&str, (usize, usize)> =
@@ -100,9 +109,12 @@ impl AuditReport {
     /// `anyhow::bail!` on critical findings is what signals errors on
     /// stderr, so this only ever writes to stdout.
     pub fn print_terminal(&self, min_severity: Severity) {
-        println!("armadai audit - {}", self.root.display());
-        println!(
-            "  Detected: {} ({} agent(s), {} skill(s))",
+        let h = crate::cli::style::header();
+        anstream::println!("{h}armadai audit - {}{h:#}", self.root.display());
+        let m = crate::cli::style::muted();
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {m}Detected:{m:#} {a}{}{a:#} {m}({} agent(s), {} skill(s)){m:#}",
             self.detected.join(", "),
             self.agent_count,
             self.skill_count
@@ -119,23 +131,30 @@ impl AuditReport {
             if group.is_empty() {
                 continue;
             }
-            println!();
-            println!("  {} ({})", Self::severity_title(severity), group.len());
+            anstream::println!();
+            let s = Self::severity_style(severity);
+            anstream::println!(
+                "  {s}{} ({}){s:#}",
+                Self::severity_title(severity),
+                group.len()
+            );
             for f in group {
                 let related = if f.related.is_empty() {
                     String::new()
                 } else {
                     format!(" (+{} others)", f.related.len())
                 };
-                println!(
-                    "    {:<4} {}{}  {}",
+                let a = crate::cli::style::accent();
+                let m = crate::cli::style::muted();
+                anstream::println!(
+                    "    {a}{:<4}{a:#} {m}{}{related}{m:#}  {}",
                     f.rule,
                     self.rel(&f.file),
-                    related,
                     f.message
                 );
                 if let Some(s) = &f.suggestion {
-                    println!("         -> {s}");
+                    let m = crate::cli::style::muted();
+                    anstream::println!("         {m}-> {s}{m:#}");
                 }
             }
         }
@@ -144,28 +163,36 @@ impl AuditReport {
             .iter()
             .filter(|f| f.severity > min_severity)
             .count();
-        println!();
-        println!("  Summary: {}", self.summary_line());
+        anstream::println!();
+        let h = crate::cli::style::header();
+        anstream::println!("  {h}Summary:{h:#} {}", self.summary_line());
         if !self.findings.is_empty() {
-            println!("  Breakdown: {}", self.breakdown_line());
+            anstream::println!("  {h}Breakdown:{h:#} {}", self.breakdown_line());
         }
         if hidden > 0 {
-            println!("  ({hidden} finding(s) hidden below the severity threshold)");
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "  {m}({hidden} finding(s) hidden below the severity threshold){m:#}"
+            );
         }
         let funnel = self.funnel_lines();
         if !funnel.is_empty() {
-            println!();
-            println!("  What ArmadAI would give you:");
+            anstream::println!();
+            let h = crate::cli::style::header();
+            anstream::println!("  {h}What ArmadAI would give you:{h:#}");
+            let m = crate::cli::style::muted();
             for l in funnel {
-                println!("    - {l}");
+                anstream::println!("    {m}- {l}{m:#}");
             }
-            println!("    Run `armadai audit --propose` to generate the config.");
+            let a = crate::cli::style::accent();
+            anstream::println!("    {a}Run `armadai audit --propose` to generate the config.{a:#}");
         }
         if let Some(raw) = &self.deep_raw {
-            println!();
-            println!("  Deep analysis (unstructured):");
+            anstream::println!();
+            let h = crate::cli::style::header();
+            anstream::println!("  {h}Deep analysis (unstructured):{h:#}");
             for line in raw.lines() {
-                println!("    {line}");
+                anstream::println!("    {line}");
             }
         }
     }

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -101,7 +101,10 @@ async fn apply_deep_pass(
     let (_, config) = import_surfaces(root);
     let agent = build_deep_auditor(cli);
     let run = |prompt: &str| call_deep_auditor(&agent, prompt);
-    eprintln!("  Note: --deep sends (secret-redacted) prompt excerpts to the '{cli}' CLI.");
+    let w = crate::cli::style::warn();
+    anstream::eprintln!(
+        "{w}  Note: --deep sends (secret-redacted) prompt excerpts to the '{cli}' CLI.{w:#}"
+    );
     match run_deep(
         &config,
         &audit.findings,
@@ -139,8 +142,9 @@ pub async fn execute(
     let settings = AuditSettings::from_project(&root);
     let mut audit = run_audit(&root, &settings);
     if audit.detected.is_empty() {
-        println!(
-            "No native agentic configuration detected in {}.",
+        let o = crate::cli::style::ok();
+        anstream::println!(
+            "{o}No native agentic configuration detected in {}.{o:#}",
             root.display()
         );
         return Ok(());
@@ -157,31 +161,50 @@ pub async fn execute(
             .unwrap_or(false);
         if is_html {
             std::fs::write(&out, audit.to_html())?;
-            println!("\n  HTML report written to {}", out.display());
+            let o = crate::cli::style::ok();
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "\n  {o}HTML report written to{o:#} {m}{}{m:#}",
+                out.display()
+            );
         } else {
             std::fs::write(&out, audit.to_markdown())?;
-            println!("\n  Markdown report written to {}", out.display());
+            let o = crate::cli::style::ok();
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "\n  {o}Markdown report written to{o:#} {m}{}{m:#}",
+                out.display()
+            );
         }
     }
     if propose {
         let (_, config) = import_surfaces(&root);
         let summary = generate_proposal(&root, &config)?;
-        println!();
-        println!("  Proposal written to {}/", summary.out_dir.display());
-        println!(
-            "    {} agent(s), {} shared prompt(s), {} skill(s) ({} fixed)",
-            summary.agents, summary.prompts, summary.skills, summary.skill_fixes
+        anstream::println!();
+        let o = crate::cli::style::ok();
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "  {o}Proposal written to{o:#} {m}{}/{m:#}",
+            summary.out_dir.display()
+        );
+        anstream::println!(
+            "{m}    {} agent(s), {} shared prompt(s), {} skill(s) ({} fixed){m:#}",
+            summary.agents,
+            summary.prompts,
+            summary.skills,
+            summary.skill_fixes
         );
         if !summary.skipped_agents.is_empty() {
-            println!(
-                "    {} agent(s) skipped (unreadable): {}",
+            let w = crate::cli::style::warn();
+            anstream::println!(
+                "{w}    {} agent(s) skipped (unreadable): {}{w:#}",
                 summary.skipped_agents.len(),
                 summary.skipped_agents.join(", ")
             );
         }
-        println!("  Install it with:");
-        println!(
-            "    armadai init --pack {} --project",
+        anstream::println!("{m}  Install it with:{m:#}");
+        anstream::println!(
+            "{m}    armadai init --pack {} --project{m:#}",
             summary.out_dir.display()
         );
     }

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -143,8 +143,9 @@ pub async fn execute(
     let mut audit = run_audit(&root, &settings);
     if audit.detected.is_empty() {
         let o = crate::cli::style::ok();
+        let m = crate::cli::style::muted();
         anstream::println!(
-            "{o}No native agentic configuration detected in {}.{o:#}",
+            "{o}No native agentic configuration detected in{o:#} {m}{}.{m:#}",
             root.display()
         );
         return Ok(());

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -72,8 +72,9 @@ async fn show_providers() -> anyhow::Result<()> {
     if config_path.exists() {
         let content = std::fs::read_to_string(&config_path)?;
         let h = crate::cli::style::header();
+        let m = crate::cli::style::muted();
         anstream::println!(
-            "{h}Provider configuration ({}):{h:#}\n",
+            "{h}Provider configuration{h:#} {m}({}):{m:#}\n",
             config_path.display()
         );
         anstream::println!("{content}");

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -71,29 +71,40 @@ async fn show_providers() -> anyhow::Result<()> {
     let config_path = config_dir.join("providers.yaml");
     if config_path.exists() {
         let content = std::fs::read_to_string(&config_path)?;
-        println!("Provider configuration ({}):\n", config_path.display());
-        println!("{content}");
+        let h = crate::cli::style::header();
+        anstream::println!(
+            "{h}Provider configuration ({}):{h:#}\n",
+            config_path.display()
+        );
+        anstream::println!("{content}");
     } else {
-        println!(
-            "No provider configuration found at {}",
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}No provider configuration found at {}{m:#}",
             config_path.display()
         );
     }
 
-    println!("---");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}---{m:#}");
 
     // Show secrets status
     let sops_path = config_dir.join("providers.sops.yaml");
     let plain_path = config_dir.join("providers.secret.yaml");
 
     if sops_path.exists() {
-        println!("Secrets: encrypted (SOPS) at {}", sops_path.display());
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}Secrets: encrypted (SOPS) at {}{m:#}",
+            sops_path.display()
+        );
         // Try to list provider names from decrypted content
         match crate::secrets::load_secrets(&config_dir) {
             Ok(secrets) => {
                 let names: Vec<&String> = secrets.providers.keys().collect();
-                println!(
-                    "  Configured API keys: {}",
+                let m = crate::cli::style::muted();
+                anstream::println!(
+                    "{m}  Configured API keys:{m:#} {}",
                     names
                         .iter()
                         .map(|s| s.as_str())
@@ -102,19 +113,22 @@ async fn show_providers() -> anyhow::Result<()> {
                 );
             }
             Err(e) => {
-                println!("  (could not decrypt: {e})");
+                let e_style = crate::cli::style::err();
+                anstream::println!("{e_style}  (could not decrypt: {e}){e_style:#}");
             }
         }
     } else if plain_path.exists() {
-        println!(
-            "Secrets: unencrypted at {} (consider running: armadai config secrets init)",
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}Secrets: unencrypted at {} (consider running: armadai config secrets init){m:#}",
             plain_path.display()
         );
         match crate::secrets::load_secrets(&config_dir) {
             Ok(secrets) => {
                 let names: Vec<&String> = secrets.providers.keys().collect();
-                println!(
-                    "  Configured API keys: {}",
+                let m = crate::cli::style::muted();
+                anstream::println!(
+                    "{m}  Configured API keys:{m:#} {}",
                     names
                         .iter()
                         .map(|s| s.as_str())
@@ -123,28 +137,38 @@ async fn show_providers() -> anyhow::Result<()> {
                 );
             }
             Err(e) => {
-                println!("  (could not read: {e})");
+                let e_style = crate::cli::style::err();
+                anstream::println!("{e_style}  (could not read: {e}){e_style:#}");
             }
         }
     } else {
-        println!("No secrets file found. Create one:");
-        println!("  Option A: armadai config secrets init  (encrypted with SOPS + age)");
-        println!("  Option B: Create config/providers.secret.yaml manually (unencrypted)");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No secrets file found. Create one:{m:#}");
+        anstream::println!(
+            "{m}  Option A: armadai config secrets init  (encrypted with SOPS + age){m:#}"
+        );
+        anstream::println!(
+            "{m}  Option B: Create config/providers.secret.yaml manually (unencrypted){m:#}"
+        );
     }
 
     // Check environment variables
-    println!("\n--- Environment variables ---");
+    let h = crate::cli::style::header();
+    anstream::println!("\n{h}--- Environment variables ---{h:#}");
     for (name, var) in [
         ("Anthropic", "ANTHROPIC_API_KEY"),
         ("OpenAI", "OPENAI_API_KEY"),
         ("Google", "GOOGLE_API_KEY"),
     ] {
-        let status = if std::env::var(var).is_ok_and(|v| !v.is_empty()) {
-            "set"
+        let is_set = std::env::var(var).is_ok_and(|v| !v.is_empty());
+        let status = if is_set { "set" } else { "not set" };
+        if is_set {
+            let o = crate::cli::style::ok();
+            anstream::println!("  {name}: ${var} = {o}{status}{o:#}");
         } else {
-            "not set"
-        };
-        println!("  {name}: ${var} = {status}");
+            let m = crate::cli::style::muted();
+            anstream::println!("  {name}: ${var} = {m}{status}{m:#}");
+        }
     }
 
     Ok(())
@@ -172,7 +196,8 @@ providers:
     api_key: "AIza-your-key-here"
 "#;
         std::fs::write(&sops_path, template)?;
-        println!("Template created at: {}", sops_path.display());
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Template created at: {}{m:#}", sops_path.display());
 
         // Try to encrypt it with sops
         let encrypt = std::process::Command::new("sops")
@@ -181,28 +206,36 @@ providers:
 
         match encrypt {
             Ok(output) if output.status.success() => {
-                println!("File encrypted successfully.");
-                println!("\nEdit your secrets with:");
-                println!("  sops config/providers.sops.yaml");
+                let o = crate::cli::style::ok();
+                anstream::println!("{o}File encrypted successfully.{o:#}");
+                let m = crate::cli::style::muted();
+                anstream::println!("{m}\nEdit your secrets with:{m:#}");
+                anstream::println!("{m}  sops config/providers.sops.yaml{m:#}");
             }
             Ok(output) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                println!(
-                    "\nWarning: could not encrypt file: {stderr}\n\
+                let w = crate::cli::style::warn();
+                anstream::println!(
+                    "{w}\nWarning: could not encrypt file: {stderr}\n\
                      Make sure SOPS_AGE_KEY_FILE is set, then encrypt manually:\n  \
-                     sops --encrypt --in-place config/providers.sops.yaml"
+                     sops --encrypt --in-place config/providers.sops.yaml{w:#}"
                 );
             }
             Err(_) => {
-                println!(
-                    "\nWarning: sops not found. Install it and encrypt manually:\n  \
-                     sops --encrypt --in-place config/providers.sops.yaml"
+                let w = crate::cli::style::warn();
+                anstream::println!(
+                    "{w}\nWarning: sops not found. Install it and encrypt manually:\n  \
+                     sops --encrypt --in-place config/providers.sops.yaml{w:#}"
                 );
             }
         }
     } else {
-        println!("Secrets file already exists at: {}", sops_path.display());
-        println!("Edit with: sops config/providers.sops.yaml");
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}Secrets file already exists at: {}{m:#}",
+            sops_path.display()
+        );
+        anstream::println!("{m}Edit with: sops config/providers.sops.yaml{m:#}");
     }
 
     Ok(())
@@ -229,13 +262,15 @@ async fn secrets_rotate() -> anyhow::Result<()> {
     }
 
     // 1. Decrypt current secrets
-    println!("Decrypting current secrets...");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}Decrypting current secrets...{m:#}");
     let secrets = crate::secrets::sops::decrypt_file(&sops_path)?;
 
     // 2. Backup old key
     let backup_path = config_dir.join("age-key.txt.bak");
     std::fs::copy(&key_path, &backup_path)?;
-    println!("Old key backed up to: {}", backup_path.display());
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}Old key backed up to: {}{m:#}", backup_path.display());
 
     // 3. Generate new key
     std::fs::remove_file(&key_path)?;
@@ -251,7 +286,8 @@ async fn secrets_rotate() -> anyhow::Result<()> {
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    println!("New age key generated.");
+    let o = crate::cli::style::ok();
+    anstream::println!("{o}New age key generated.{o:#}");
 
     // 4. Update .sops.yaml with new public key
     let key_content = std::fs::read_to_string(&key_path)?;
@@ -269,7 +305,8 @@ async fn secrets_rotate() -> anyhow::Result<()> {
     );
     let sops_config_path = Path::new(".sops.yaml");
     std::fs::write(sops_config_path, sops_config)?;
-    println!("Updated .sops.yaml with new public key.");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}Updated .sops.yaml with new public key.{m:#}");
 
     // 5. Re-encrypt secrets with new key
     let yaml = serde_yaml_ng::to_string(&secrets)?;
@@ -286,10 +323,12 @@ async fn secrets_rotate() -> anyhow::Result<()> {
         );
     }
 
-    println!("Secrets re-encrypted with new key.");
-    println!("\nDon't forget to update SOPS_AGE_KEY_FILE if needed.");
-    println!(
-        "You can delete the backup when confirmed: rm {}",
+    let o = crate::cli::style::ok();
+    anstream::println!("{o}Secrets re-encrypted with new key.{o:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}\nDon't forget to update SOPS_AGE_KEY_FILE if needed.{m:#}");
+    anstream::println!(
+        "{m}You can delete the backup when confirmed: rm {}{m:#}",
         backup_path.display()
     );
 
@@ -333,7 +372,8 @@ async fn starters_dir_list() -> anyhow::Result<()> {
         } else {
             "unknown"
         };
-        println!("  [{source}] {}", dir.display());
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  [{source}]{m:#} {}", dir.display());
     }
 
     Ok(())
@@ -344,14 +384,20 @@ async fn starters_dir_add(path: &str) -> anyhow::Result<()> {
     let mut config = app_config::load_user_config();
 
     if config.starters_dirs.contains(&path.to_string()) {
-        println!("Directory already in config: {path}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Directory already in config: {path}{m:#}");
         return Ok(());
     }
 
     config.starters_dirs.push(path.to_string());
     app_config::save_user_config(&config)?;
-    println!("Added starter directory: {path}");
-    println!("  Saved to {}", app_config::config_file_path().display());
+    let o = crate::cli::style::ok();
+    anstream::println!("{o}Added starter directory: {path}{o:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  Saved to {}{m:#}",
+        app_config::config_file_path().display()
+    );
 
     Ok(())
 }
@@ -364,13 +410,19 @@ async fn starters_dir_remove(path: &str) -> anyhow::Result<()> {
     config.starters_dirs.retain(|d| d != path);
 
     if config.starters_dirs.len() == before {
-        println!("Directory not found in config: {path}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Directory not found in config: {path}{m:#}");
         return Ok(());
     }
 
     app_config::save_user_config(&config)?;
-    println!("Removed starter directory: {path}");
-    println!("  Saved to {}", app_config::config_file_path().display());
+    let o = crate::cli::style::ok();
+    anstream::println!("{o}Removed starter directory: {path}{o:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  Saved to {}{m:#}",
+        app_config::config_file_path().display()
+    );
 
     Ok(())
 }

--- a/src/cli/extract.rs
+++ b/src/cli/extract.rs
@@ -429,15 +429,22 @@ fn run_wizard(mut args: ExtractArgs) -> anyhow::Result<ExtractArgs> {
 // ---------------------------------------------------------------------------
 
 fn print_summary(out: &Path, selected: &Selection, as_pack: bool) {
-    println!(
-        "\nExtracted {} agent(s), {} prompt(s), {} skill(s) -> {}",
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "\n{o}Extracted {} agent(s), {} prompt(s), {} skill(s){o:#} {m}-> {}{m:#}",
         selected.agents.len(),
         selected.prompts.len(),
         selected.skills.len(),
         out.display()
     );
     if as_pack {
-        println!("Generated pack.yaml at {}", out.join("pack.yaml").display());
+        let o = crate::cli::style::ok();
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{o}Generated pack.yaml at{o:#} {m}{}{m:#}",
+            out.join("pack.yaml").display()
+        );
     }
 }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -35,7 +35,12 @@ fn init_global(force: bool) -> anyhow::Result<()> {
 
     // Create directory tree
     config::ensure_config_dirs()?;
-    println!("Created config directory: {}", dir.display());
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{o}Created config directory:{o:#} {m}{}{m:#}",
+        dir.display()
+    );
 
     // Write config.yaml
     let config_path = config::config_file_path();
@@ -48,15 +53,30 @@ fn init_global(force: bool) -> anyhow::Result<()> {
     // Install built-in skills
     let skills_installed = crate::core::skill::install_embedded_skills(force)?;
 
-    println!("\nArmadAI initialized at {}", dir.display());
-    println!("  config:    {}", config_path.display());
-    println!("  providers: {}", providers_path.display());
-    println!("  agents:    {}", config::user_agents_dir().display());
-    println!("  prompts:   {}", config::user_prompts_dir().display());
-    println!("  skills:    {}", config::user_skills_dir().display());
-    println!("  registry:  {}", config::registry_cache_dir().display());
+    anstream::println!("\n{o}ArmadAI initialized at{o:#} {m}{}{m:#}", dir.display());
+    anstream::println!("{m}  config:    {}{m:#}", config_path.display());
+    anstream::println!("{m}  providers: {}{m:#}", providers_path.display());
+    anstream::println!(
+        "{m}  agents:    {}{m:#}",
+        config::user_agents_dir().display()
+    );
+    anstream::println!(
+        "{m}  prompts:   {}{m:#}",
+        config::user_prompts_dir().display()
+    );
+    anstream::println!(
+        "{m}  skills:    {}{m:#}",
+        config::user_skills_dir().display()
+    );
+    anstream::println!(
+        "{m}  registry:  {}{m:#}",
+        config::registry_cache_dir().display()
+    );
     if skills_installed > 0 {
-        println!("  built-in:  {} skill(s) installed", skills_installed);
+        anstream::println!(
+            "{o}  built-in:  {} skill(s) installed{o:#}",
+            skills_installed
+        );
     }
 
     Ok(())
@@ -83,7 +103,10 @@ pub(crate) fn resolve_pack_dir(name: &str) -> Option<std::path::PathBuf> {
     if sources.is_empty() {
         return None;
     }
-    eprintln!("Pack '{name}' not found locally — syncing remote starter registries...");
+    let r = crate::cli::style::running();
+    anstream::eprintln!(
+        "{r}Pack '{name}' not found locally — syncing remote starter registries...{r:#}"
+    );
     let _ = crate::starters_registry::sync_starters(&sources);
     find_pack_dir(name)
 }
@@ -106,15 +129,23 @@ fn install_pack(name: &str, force: bool) -> anyhow::Result<StarterPack> {
     };
 
     let pack = StarterPack::load(&pack_dir)?;
-    println!(
-        "\nInstalling starter pack: {} — {}",
-        pack.name, pack.description
+    let r = crate::cli::style::running();
+    let a = crate::cli::style::accent();
+    anstream::println!(
+        "\n{r}Installing starter pack:{r:#} {a}{}{a:#} — {}",
+        pack.name,
+        pack.description
     );
 
     let (agents, prompts, skills) = pack.install(&pack_dir, force)?;
-    println!(
-        "\nPack '{}' installed: {} agent(s), {} prompt(s), {} skill(s)",
-        pack.name, agents, prompts, skills
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "\n{o}Pack{o:#} {a}'{}'{a:#} {o}installed:{o:#} {m}{} agent(s), {} prompt(s), {} skill(s){m:#}",
+        pack.name,
+        agents,
+        prompts,
+        skills
     );
 
     Ok(pack)
@@ -182,13 +213,17 @@ fn init_project() -> anyhow::Result<()> {
 
     let content = generate_empty_project_yaml();
     std::fs::write(&dotarmadai_config, content)?;
-    println!("Created .armadai/ project structure:");
-    println!("  .armadai/config.yaml");
-    println!("  .armadai/agents/");
-    println!("  .armadai/prompts/");
-    println!("  .armadai/skills/");
-    println!("  .armadai/starters/");
-    println!("\n  Edit .armadai/config.yaml to declare agents, prompts, skills and link targets.");
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    anstream::println!("{o}Created .armadai/ project structure:{o:#}");
+    anstream::println!("{m}  .armadai/config.yaml{m:#}");
+    anstream::println!("{m}  .armadai/agents/{m:#}");
+    anstream::println!("{m}  .armadai/prompts/{m:#}");
+    anstream::println!("{m}  .armadai/skills/{m:#}");
+    anstream::println!("{m}  .armadai/starters/{m:#}");
+    anstream::println!(
+        "\n{m}  Edit .armadai/config.yaml to declare agents, prompts, skills and link targets.{m:#}"
+    );
 
     // Check for deprecated models in newly created project
     if let Some((root, _)) = crate::core::project::find_project_config() {
@@ -299,11 +334,14 @@ fn init_project_with_pack(pack: &StarterPack, pack_name: &str) -> anyhow::Result
 
     let content = generate_project_yaml(pack, pack_name);
     std::fs::write(&dotarmadai_config, &content)?;
-    println!(
-        "\nCreated .armadai/config.yaml with pack '{}' agents",
+    let o = crate::cli::style::ok();
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "\n{o}Created .armadai/config.yaml with pack{o:#} {a}'{}'{a:#} {o}agents{o:#}",
         pack.name
     );
-    println!("  Run `armadai link` to generate target config files.");
+    anstream::println!("{m}  Run `armadai link` to generate target config files.{m:#}");
 
     // Check for deprecated models in newly created project
     if let Some((root, _)) = crate::core::project::find_project_config() {
@@ -378,14 +416,17 @@ fn write_if_missing_or_force(
     force: bool,
 ) -> anyhow::Result<()> {
     if path.exists() && !force {
-        println!("  skip (exists): {}", path.display());
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  skip (exists): {}{m:#}", path.display());
         return Ok(());
     }
     std::fs::write(path, content)?;
     if force && path.exists() {
-        println!("  overwritten:   {}", path.display());
+        let w = crate::cli::style::warn();
+        anstream::println!("{w}  overwritten:   {}{w:#}", path.display());
     } else {
-        println!("  created:       {}", path.display());
+        let o = crate::cli::style::ok();
+        anstream::println!("{o}  created:       {}{o:#}", path.display());
     }
     Ok(())
 }

--- a/src/cli/inspect.rs
+++ b/src/cli/inspect.rs
@@ -8,60 +8,88 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
     let agent = parse_agent_file(&path)?;
 
     // Header
-    println!("Agent: {}", agent.name);
-    println!("Source: {}", agent.source.display());
+    let h = crate::cli::style::header();
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    anstream::println!("{h}Agent:{h:#} {a}{}{a:#}", agent.name);
+    anstream::println!("{m}Source: {}{m:#}", agent.source.display());
     println!();
 
     // Metadata table
-    println!("## Metadata");
-    println!("  Provider:       {}", agent.metadata.provider);
+    let h = crate::cli::style::header();
+    anstream::println!("{h}## Metadata{h:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}  Provider:      {m:#} {}", agent.metadata.provider);
 
     if let Some(ref model) = agent.metadata.model {
-        println!("  Model:          {model}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Model:         {m:#} {model}");
     }
     if let Some(ref command) = agent.metadata.command {
-        println!("  Command:        {command}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Command:       {m:#} {command}");
     }
     if !agent.metadata.model_fallback.is_empty() {
-        println!(
-            "  Fallbacks:      [{}]",
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}  Fallbacks:     {m:#} [{}]",
             agent.metadata.model_fallback.join(", ")
         );
     }
     if let Some(ref args) = agent.metadata.args {
-        println!("  Args:           [{}]", args.join(", "));
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Args:          {m:#} [{}]", args.join(", "));
     }
 
-    println!("  Temperature:    {}", agent.metadata.temperature);
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}  Temperature:   {m:#} {}", agent.metadata.temperature);
 
     if let Some(max) = agent.metadata.max_tokens {
-        println!("  Max tokens:     {max}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Max tokens:    {m:#} {max}");
     }
     if let Some(timeout) = agent.metadata.timeout {
-        println!("  Timeout:        {timeout}s");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Timeout:       {m:#} {timeout}s");
     }
     if !agent.metadata.tags.is_empty() {
-        println!("  Tags:           [{}]", agent.metadata.tags.join(", "));
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}  Tags:          {m:#} [{}]",
+            agent.metadata.tags.join(", ")
+        );
     }
     if !agent.metadata.stacks.is_empty() {
-        println!("  Stacks:         [{}]", agent.metadata.stacks.join(", "));
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}  Stacks:        {m:#} [{}]",
+            agent.metadata.stacks.join(", ")
+        );
     }
     if !agent.metadata.scope.is_empty() {
-        println!("  Scope:          [{}]", agent.metadata.scope.join(", "));
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{m}  Scope:         {m:#} [{}]",
+            agent.metadata.scope.join(", ")
+        );
     }
     if let Some(cost) = agent.metadata.cost_limit {
-        println!("  Cost limit:     ${cost:.2}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Cost limit:    {m:#} ${cost:.2}");
     }
     if let Some(ref rate) = agent.metadata.rate_limit {
-        println!("  Rate limit:     {rate}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Rate limit:    {m:#} {rate}");
     }
     if let Some(ctx) = agent.metadata.context_window {
-        println!("  Context window: {ctx}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  Context window:{m:#} {ctx}");
     }
 
     // System prompt
     println!();
-    println!("## System Prompt");
+    let h = crate::cli::style::header();
+    anstream::println!("{h}## System Prompt{h:#}");
     for line in agent.system_prompt.lines() {
         println!("  {line}");
     }
@@ -69,7 +97,8 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
     // Instructions
     if let Some(ref instructions) = agent.instructions {
         println!();
-        println!("## Instructions");
+        let h = crate::cli::style::header();
+        anstream::println!("{h}## Instructions{h:#}");
         for line in instructions.lines() {
             println!("  {line}");
         }
@@ -78,7 +107,8 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
     // Output format
     if let Some(ref format) = agent.output_format {
         println!();
-        println!("## Output Format");
+        let h = crate::cli::style::header();
+        anstream::println!("{h}## Output Format{h:#}");
         for line in format.lines() {
             println!("  {line}");
         }
@@ -87,16 +117,20 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
     // Pipeline
     if let Some(ref pipeline) = agent.pipeline {
         println!();
-        println!("## Pipeline");
+        let h = crate::cli::style::header();
+        anstream::println!("{h}## Pipeline{h:#}");
         for next in &pipeline.next {
-            println!("  -> {next}");
+            let a = crate::cli::style::accent();
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  ->{m:#} {a}{next}{a:#}");
         }
     }
 
     // Context
     if let Some(ref context) = agent.context {
         println!();
-        println!("## Context");
+        let h = crate::cli::style::header();
+        anstream::println!("{h}## Context{h:#}");
         for line in context.lines() {
             println!("  {line}");
         }

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -37,9 +37,10 @@ pub async fn execute(
         && orch.enabled
         && let Err(errors) = crate::core::orchestration::validate_config(orch)
     {
-        eprintln!("Orchestration validation failed:\n");
+        let e = crate::cli::style::err();
+        anstream::eprintln!("{e}Orchestration validation failed:{e:#}\n");
         for error in &errors {
-            eprintln!("  - {}", error);
+            anstream::eprintln!("{e}  - {}{e:#}", error);
         }
         anyhow::bail!(
             "Cannot link with invalid orchestration config. {} error(s) found.",
@@ -50,14 +51,18 @@ pub async fn execute(
     // 2. Resolve and parse agents
     let (paths, errors) = project::resolve_all_agents(&config, &root);
     for err in &errors {
-        eprintln!("  warn: {err}");
+        let w = crate::cli::style::warn();
+        anstream::eprintln!("{w}  warn: {err}{w:#}");
     }
 
     let mut link_agents: Vec<LinkAgent> = Vec::new();
     for path in &paths {
         match parser::parse_agent_file(path) {
             Ok(agent) => link_agents.push(LinkAgent::from(&agent)),
-            Err(e) => eprintln!("  warn: failed to parse {}: {e}", path.display()),
+            Err(e) => {
+                let w = crate::cli::style::warn();
+                anstream::eprintln!("{w}  warn: failed to parse {}: {e}{w:#}", path.display());
+            }
         }
     }
 
@@ -182,7 +187,8 @@ pub async fn execute(
     let files = linker.generate(&link_agents, coordinator.as_ref(), sources);
 
     if files.is_empty() {
-        println!("No files to generate.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No files to generate.{m:#}");
         return Ok(());
     }
 
@@ -201,7 +207,8 @@ pub async fn execute(
     // 8b. Resolve and collect skill files
     let (skill_dirs, skill_errors) = project::resolve_all_skills(&config, &root);
     for err in &skill_errors {
-        eprintln!("  warn: {err}");
+        let w = crate::cli::style::warn();
+        anstream::eprintln!("{w}  warn: {err}{w:#}");
     }
 
     let mut extra_files: Vec<(PathBuf, String)> = Vec::new();
@@ -227,7 +234,8 @@ pub async fn execute(
     // 8c. Resolve and collect prompt files
     let (prompt_paths, prompt_errors) = project::resolve_all_prompts(&config, &root);
     for err in &prompt_errors {
-        eprintln!("  warn: {err}");
+        let w = crate::cli::style::warn();
+        anstream::eprintln!("{w}  warn: {err}{w:#}");
     }
 
     let mut prompt_count = 0;
@@ -245,18 +253,21 @@ pub async fn execute(
 
     // 9. Dry run or write
     if dry_run {
-        println!(
-            "Dry run — files that would be generated for '{}':\n",
+        let h = crate::cli::style::header();
+        let a = crate::cli::style::accent();
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{h}Dry run{h:#} — files that would be generated for {a}'{}'{a:#}:\n",
             target_name
         );
         for (path, _) in &output_files {
-            println!("  {}", path.display());
+            anstream::println!("{m}  {}{m:#}", path.display());
         }
         for (path, _) in &extra_files {
-            println!("  {}", path.display());
+            anstream::println!("{m}  {}{m:#}", path.display());
         }
-        println!(
-            "\n  {} file(s) total.",
+        anstream::println!(
+            "\n{m}  {} file(s) total.{m:#}",
             output_files.len() + extra_files.len()
         );
         return Ok(());
@@ -267,8 +278,9 @@ pub async fn execute(
 
     for (path, content) in output_files.iter().chain(extra_files.iter()) {
         if path.exists() && !force {
-            eprintln!(
-                "  skip: {} already exists (use --force to overwrite)",
+            let w = crate::cli::style::warn();
+            anstream::eprintln!(
+                "{w}  skip: {} already exists (use --force to overwrite){w:#}",
                 path.display()
             );
             skipped += 1;
@@ -279,7 +291,8 @@ pub async fn execute(
             std::fs::create_dir_all(parent)?;
         }
         std::fs::write(path, content)?;
-        println!("  wrote {}", path.display());
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  wrote {}{m:#}", path.display());
         written += 1;
     }
 
@@ -290,9 +303,15 @@ pub async fn execute(
     if prompt_count > 0 {
         summary.push_str(&format!(", {} prompt(s)", prompt_count));
     }
-    println!(
-        "\n{} to '{}': {} written, {} skipped.",
-        summary, target_name, written, skipped
+    let o = crate::cli::style::ok();
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "\n{o}{}{o:#} to {a}'{}'{a:#}: {m}{} written, {} skipped.{m:#}",
+        summary,
+        target_name,
+        written,
+        skipped
     );
 
     Ok(())

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -7,8 +7,9 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
     let mut agents = load_agents()?;
 
     if agents.is_empty() {
-        println!("No agents found.");
-        println!("Create one with: armadai new --template basic <name>");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No agents found.{m:#}");
+        anstream::println!("{m}Create one with: armadai new --template basic <name>{m:#}");
         return Ok(());
     }
 
@@ -21,7 +22,8 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
     }
 
     if agents.is_empty() {
-        println!("No agents match the given filters.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No agents match the given filters.{m:#}");
         return Ok(());
     }
 
@@ -46,12 +48,16 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
         .max(5);
 
     // Header
-    println!(
-        "  {:<name_w$}  {:<provider_w$}  {:<model_w$}  TAGS  STACKS",
-        "NAME", "PROVIDER", "MODEL",
+    let h = crate::cli::style::header();
+    anstream::println!(
+        "{h}  {:<name_w$}  {:<provider_w$}  {:<model_w$}  TAGS  STACKS{h:#}",
+        "NAME",
+        "PROVIDER",
+        "MODEL",
     );
-    println!(
-        "  {:<name_w$}  {:<provider_w$}  {:<model_w$}  ----  ------",
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  {:<name_w$}  {:<provider_w$}  {:<model_w$}  ----  ------{m:#}",
         "-".repeat(name_w),
         "-".repeat(provider_w),
         "-".repeat(model_w),
@@ -70,8 +76,9 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
             agent.metadata.stacks.join(", ")
         };
 
-        println!(
-            "  {:<name_w$}  {:<provider_w$}  {:<model_w$}  {}  {}",
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {a}{:<name_w$}{a:#}  {:<provider_w$}  {:<model_w$}  {}  {}",
             agent.name,
             agent.metadata.provider,
             agent.model_display(),
@@ -80,7 +87,8 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
         );
     }
 
-    println!("\n  {} agent(s) found.", agents.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}  {} agent(s) found.{m:#}", agents.len());
     Ok(())
 }
 
@@ -94,13 +102,17 @@ fn load_agents() -> anyhow::Result<Vec<Agent>> {
     {
         let (paths, errors) = project::resolve_all_agents(&config, &root);
         for err in &errors {
-            eprintln!("  warn: {err}");
+            let w = crate::cli::style::warn();
+            anstream::eprintln!("{w}  warn: {err}{w:#}");
         }
         let mut agents = Vec::new();
         for path in &paths {
             match parser::parse_agent_file(path) {
                 Ok(agent) => agents.push(agent),
-                Err(e) => eprintln!("  warn: failed to parse {}: {e}", path.display()),
+                Err(e) => {
+                    let w = crate::cli::style::warn();
+                    anstream::eprintln!("{w}  warn: failed to parse {}: {e}{w:#}", path.display());
+                }
             }
         }
         return Ok(agents);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,7 +16,7 @@ mod run;
 mod run_es_record;
 pub(crate) mod setup;
 mod skills;
-mod style;
+pub(crate) mod style;
 mod unlink;
 mod up;
 mod update;

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -40,18 +40,21 @@ fn check(all: bool, prune: bool) -> anyhow::Result<()> {
         if prune {
             let pruned = project_registry::prune_stale(&mut registry);
             if !pruned.is_empty() {
-                println!("Pruned {} stale project(s):", pruned.len());
+                let m = crate::cli::style::muted();
+                anstream::println!("{m}Pruned {} stale project(s):{m:#}", pruned.len());
+                let a = crate::cli::style::accent();
                 for p in &pruned {
-                    println!("  - {p}");
+                    anstream::println!("  {a}- {p}{a:#}");
                 }
                 project_registry::save(&registry)?;
-                println!();
+                anstream::println!();
             }
         }
 
         if registry.projects.is_empty() {
-            println!(
-                "No registered projects. Run `armadai run` or `armadai link` in a project first."
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "{m}No registered projects. Run `armadai run` or `armadai link` in a project first.{m:#}"
             );
             return Ok(());
         }
@@ -61,25 +64,29 @@ fn check(all: bool, prune: bool) -> anyhow::Result<()> {
             let findings = match model_updater::check_project(std::path::Path::new(&entry.path)) {
                 Ok(f) => f,
                 Err(e) => {
-                    eprintln!("  warn: {}: {e}", entry.path);
+                    let w = crate::cli::style::warn();
+                    anstream::eprintln!("{w}  warn: {}: {e}{w:#}", entry.path);
                     continue;
                 }
             };
             if !findings.is_empty() {
-                println!("{}:", entry.path);
+                let h = crate::cli::style::header();
+                anstream::println!("{h}{}:{h:#}", entry.path);
                 print_findings(&findings);
                 total += findings.len();
             }
         }
 
         if total == 0 {
-            println!(
-                "All models are up to date across {} project(s).",
+            let o = crate::cli::style::ok();
+            anstream::println!(
+                "{o}All models are up to date across {} project(s).{o:#}",
                 registry.projects.len()
             );
         } else {
-            println!(
-                "\n{total} deprecated model(s) found. Run `armadai models update --all` to fix."
+            let w = crate::cli::style::warn();
+            anstream::println!(
+                "\n{w}{total} deprecated model(s) found. Run `armadai models update --all` to fix.{w:#}"
             );
         }
     } else {
@@ -89,11 +96,13 @@ fn check(all: bool, prune: bool) -> anyhow::Result<()> {
 
         let findings = model_updater::check_project(&root)?;
         if findings.is_empty() {
-            println!("All models are up to date.");
+            let o = crate::cli::style::ok();
+            anstream::println!("{o}All models are up to date.{o:#}");
         } else {
             print_findings(&findings);
-            println!(
-                "\n{} deprecated model(s) found. Run `armadai models update` to fix.",
+            let w = crate::cli::style::warn();
+            anstream::println!(
+                "\n{w}{} deprecated model(s) found. Run `armadai models update` to fix.{w:#}",
                 findings.len()
             );
         }
@@ -106,7 +115,8 @@ fn update(all: bool) -> anyhow::Result<()> {
     if all {
         let registry = project_registry::load();
         if registry.projects.is_empty() {
-            println!("No registered projects.");
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}No registered projects.{m:#}");
             return Ok(());
         }
 
@@ -116,7 +126,8 @@ fn update(all: bool) -> anyhow::Result<()> {
             let findings = match model_updater::check_project(root) {
                 Ok(f) => f,
                 Err(e) => {
-                    eprintln!("  warn: {}: {e}", entry.path);
+                    let w = crate::cli::style::warn();
+                    anstream::eprintln!("{w}  warn: {}: {e}{w:#}", entry.path);
                     continue;
                 }
             };
@@ -148,16 +159,24 @@ fn update(all: bool) -> anyhow::Result<()> {
                 match model_updater::update_agent_file(path, &owned) {
                     Ok(n) => {
                         if n > 0 {
-                            println!("  updated {}: {n} replacement(s)", path.display());
+                            let o = crate::cli::style::ok();
+                            anstream::println!(
+                                "{o}  updated {}: {n} replacement(s){o:#}",
+                                path.display()
+                            );
                             total_updated += n;
                         }
                     }
-                    Err(e) => eprintln!("  error: {}: {e}", path.display()),
+                    Err(e) => {
+                        let er = crate::cli::style::err();
+                        anstream::eprintln!("{er}  error: {}: {e}{er:#}", path.display());
+                    }
                 }
             }
         }
 
-        println!("\n{total_updated} model(s) updated across all projects.");
+        let o = crate::cli::style::ok();
+        anstream::println!("{o}\n{total_updated} model(s) updated across all projects.{o:#}");
     } else {
         let (root, _config) = project::find_project_config().ok_or_else(|| {
             anyhow::anyhow!("No project config found. Run from a project directory or use --all.")
@@ -165,7 +184,8 @@ fn update(all: bool) -> anyhow::Result<()> {
 
         let findings = model_updater::check_project(&root)?;
         if findings.is_empty() {
-            println!("All models are up to date.");
+            let o = crate::cli::style::ok();
+            anstream::println!("{o}All models are up to date.{o:#}");
             return Ok(());
         }
 
@@ -193,15 +213,23 @@ fn update(all: bool) -> anyhow::Result<()> {
             match model_updater::update_agent_file(path, &owned) {
                 Ok(n) => {
                     if n > 0 {
-                        println!("  updated {}: {n} replacement(s)", path.display());
+                        let o = crate::cli::style::ok();
+                        anstream::println!(
+                            "{o}  updated {}: {n} replacement(s){o:#}",
+                            path.display()
+                        );
                         total += n;
                     }
                 }
-                Err(e) => eprintln!("  error: {}: {e}", path.display()),
+                Err(e) => {
+                    let er = crate::cli::style::err();
+                    anstream::eprintln!("{er}  error: {}: {e}{er:#}", path.display());
+                }
             }
         }
 
-        println!("\n{total} model(s) updated.");
+        let o = crate::cli::style::ok();
+        anstream::println!("{o}\n{total} model(s) updated.{o:#}");
     }
 
     Ok(())
@@ -211,25 +239,43 @@ fn list() -> anyhow::Result<()> {
     let registry = project_registry::load();
 
     if registry.projects.is_empty() {
-        println!("No registered projects.");
-        println!("Projects are auto-registered when you run `armadai run` or `armadai link`.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No registered projects.{m:#}");
+        anstream::println!(
+            "{m}Projects are auto-registered when you run `armadai run` or `armadai link`.{m:#}"
+        );
         return Ok(());
     }
 
-    println!("Registered projects:\n");
+    let h = crate::cli::style::header();
+    anstream::println!("{h}Registered projects:{h:#}\n");
     for entry in &registry.projects {
-        println!("  {}  (last seen: {})", entry.path, entry.last_seen);
+        let a = crate::cli::style::accent();
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "  {a}{}{a:#}  {m}(last seen: {}){m:#}",
+            entry.path,
+            entry.last_seen
+        );
     }
-    println!("\n{} project(s) total.", registry.projects.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}{} project(s) total.{m:#}", registry.projects.len());
 
     Ok(())
 }
 
 fn print_findings(findings: &[model_updater::DeprecationFinding]) {
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    let w = crate::cli::style::warn();
+    let o = crate::cli::style::ok();
     for f in findings {
-        println!(
-            "  {} [{}]: {} -> {}",
-            f.agent_name, f.field, f.current, f.replacement
+        anstream::println!(
+            "  {a}{}{a:#} {m}[{}]{m:#}: {w}{}{w:#} -> {o}{}{o:#}",
+            f.agent_name,
+            f.field,
+            f.current,
+            f.replacement
         );
     }
 }

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -35,7 +35,8 @@ fn template_create(
     // Load template
     let template_path = templates_dir.join(format!("{template}.md"));
     if !template_path.exists() {
-        eprintln!("Template '{template}' not found.\n");
+        let e = crate::cli::style::err();
+        anstream::eprintln!("{e}Template '{template}' not found.{e:#}\n");
         list_templates(templates_dir)?;
         anyhow::bail!("Use --template <name> with one of the templates above");
     }
@@ -82,18 +83,24 @@ fn template_create(
     // Write the agent file
     std::fs::write(&output_path, &content)?;
 
-    println!("Agent created: {}", output_path.display());
-    println!("  Template: {template}");
-    println!("  Name: {title}");
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    let a = crate::cli::style::accent();
+    anstream::println!("{o}Agent created:{o:#} {m}{}{m:#}", output_path.display());
+    anstream::println!("{m}  Template: {template}{m:#}");
+    anstream::println!("{m}  Name:{m:#} {a}{title}{a:#}");
 
     if !remaining.is_empty() {
         let unique: Vec<&str> = {
             let mut seen = std::collections::HashSet::new();
             remaining.into_iter().filter(|p| seen.insert(*p)).collect()
         };
-        println!("\n  Note: the following placeholders need to be filled in manually:");
+        let w = crate::cli::style::warn();
+        anstream::println!(
+            "\n{w}  Note: the following placeholders need to be filled in manually:{w:#}"
+        );
         for p in &unique {
-            println!("    - {p}");
+            anstream::println!("{w}    - {p}{w:#}");
         }
     }
 
@@ -106,7 +113,8 @@ async fn interactive_create() -> anyhow::Result<()> {
     let templates_dir = &paths.templates_dir;
     let agents_dir = &paths.agents_dir;
 
-    println!("🧙 ArmadAI Agent Creation Wizard\n");
+    let h = crate::cli::style::header();
+    anstream::println!("{h}🧙 ArmadAI Agent Creation Wizard{h:#}\n");
 
     // 1. Agent name
     let name: String = Input::new()
@@ -299,11 +307,14 @@ async fn interactive_create() -> anyhow::Result<()> {
     std::fs::create_dir_all(agents_dir)?;
     std::fs::write(&output_path, &content)?;
 
-    println!("\nAgent created: {}", output_path.display());
-    println!("  Name: {}", slug_to_title(&name));
-    println!("  Provider: {provider}");
-    if let Some(ref m) = model {
-        println!("  Model: {m}");
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    let a = crate::cli::style::accent();
+    anstream::println!("\n{o}Agent created:{o:#} {m}{}{m:#}", output_path.display());
+    anstream::println!("{m}  Name:{m:#} {a}{}{a:#}", slug_to_title(&name));
+    anstream::println!("{m}  Provider: {provider}{m:#}");
+    if let Some(ref model_name) = model {
+        anstream::println!("{m}  Model: {model_name}{m:#}");
     }
 
     Ok(())
@@ -564,9 +575,11 @@ fn collect_template_names(templates_dir: &Path) -> Vec<String> {
 }
 
 fn list_templates(templates_dir: &Path) -> anyhow::Result<()> {
-    println!("Available templates:");
+    let h = crate::cli::style::header();
+    let m = crate::cli::style::muted();
+    anstream::println!("{h}Available templates:{h:#}");
     if !templates_dir.exists() {
-        println!("  (no templates directory found)");
+        anstream::println!("{m}  (no templates directory found){m:#}");
         return Ok(());
     }
 
@@ -577,13 +590,14 @@ fn list_templates(templates_dir: &Path) -> anyhow::Result<()> {
         if path.extension().is_some_and(|e| e == "md")
             && let Some(stem) = path.file_stem()
         {
-            println!("  - {}", stem.to_string_lossy());
+            let a = crate::cli::style::accent();
+            anstream::println!("  - {a}{}{a:#}", stem.to_string_lossy());
             found = true;
         }
     }
 
     if !found {
-        println!("  (no templates found)");
+        anstream::println!("{m}  (no templates found){m:#}");
     }
 
     Ok(())

--- a/src/cli/prompts.rs
+++ b/src/cli/prompts.rs
@@ -26,8 +26,9 @@ async fn list() -> anyhow::Result<()> {
     let prompts = collect_prompts();
 
     if prompts.is_empty() {
-        println!("No prompts found.");
-        println!("Add .md files in prompts/ or ~/.config/armadai/prompts/");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No prompts found.{m:#}");
+        anstream::println!("{m}Add .md files in prompts/ or ~/.config/armadai/prompts/{m:#}");
         return Ok(());
     }
 
@@ -46,12 +47,15 @@ async fn list() -> anyhow::Result<()> {
         .max(11);
 
     // Header
-    println!(
-        "  {:<name_w$}  {:<desc_w$}  APPLY_TO",
-        "NAME", "DESCRIPTION",
+    let h = crate::cli::style::header();
+    anstream::println!(
+        "{h}  {:<name_w$}  {:<desc_w$}  APPLY_TO{h:#}",
+        "NAME",
+        "DESCRIPTION",
     );
-    println!(
-        "  {:<name_w$}  {:<desc_w$}  --------",
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  {:<name_w$}  {:<desc_w$}  --------{m:#}",
         "-".repeat(name_w),
         "-".repeat(desc_w),
     );
@@ -64,10 +68,17 @@ async fn list() -> anyhow::Result<()> {
         } else {
             prompt.apply_to.join(", ")
         };
-        println!("  {:<name_w$}  {:<desc_w$}  {}", prompt.name, desc, apply);
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {a}{:<name_w$}{a:#}  {:<desc_w$}  {}",
+            prompt.name,
+            desc,
+            apply
+        );
     }
 
-    println!("\n  {} prompt(s) found.", prompts.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}  {} prompt(s) found.{m:#}", prompts.len());
     Ok(())
 }
 
@@ -78,18 +89,24 @@ async fn show(name: &str) -> anyhow::Result<()> {
         .find(|p| p.name == name)
         .ok_or_else(|| anyhow::anyhow!("Prompt '{name}' not found"))?;
 
-    println!("Prompt: {}", prompt.name);
-    println!("Source: {}", prompt.source.display());
+    let h = crate::cli::style::header();
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    anstream::println!("{h}Prompt:{h:#} {a}{}{a:#}", prompt.name);
+    anstream::println!("{m}Source: {}{m:#}", prompt.source.display());
 
     if let Some(ref desc) = prompt.description {
-        println!("Description: {desc}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Description:{m:#} {desc}");
     }
     if !prompt.apply_to.is_empty() {
-        println!("Apply to: [{}]", prompt.apply_to.join(", "));
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Apply to:{m:#} [{}]", prompt.apply_to.join(", "));
     }
 
     println!();
-    println!("## Body");
+    let h = crate::cli::style::header();
+    anstream::println!("{h}## Body{h:#}");
     for line in prompt.body.lines() {
         println!("  {line}");
     }
@@ -105,12 +122,19 @@ fn collect_prompts() -> Vec<Prompt> {
     if let Some((root, config)) = project::find_project_config() {
         let (paths, errors) = project::resolve_all_prompts(&config, &root);
         for err in &errors {
-            eprintln!("  warn: {err}");
+            let w = crate::cli::style::warn();
+            anstream::eprintln!("{w}  warn: {err}{w:#}");
         }
         for path in &paths {
             match Prompt::load(path) {
                 Ok(p) => prompts.push(p),
-                Err(e) => eprintln!("  warn: failed to load prompt {}: {e}", path.display()),
+                Err(e) => {
+                    let w = crate::cli::style::warn();
+                    anstream::eprintln!(
+                        "{w}  warn: failed to load prompt {}: {e}{w:#}",
+                        path.display()
+                    );
+                }
             }
         }
 

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -107,14 +107,24 @@ pub async fn execute(action: RegistryAction) -> anyhow::Result<()> {
 
 async fn cmd_sync() -> anyhow::Result<()> {
     let sources = sync::effective_sources();
-    println!("Syncing {} agent registry source(s)...", sources.len());
+    let r = crate::cli::style::running();
+    anstream::println!(
+        "{r}Syncing {} agent registry source(s)...{r:#}",
+        sources.len()
+    );
     sync::registry_sync(&sources)?;
-    println!("Building search index...");
+    let r = crate::cli::style::running();
+    anstream::println!("{r}Building search index...{r:#}");
     let index = cache::build_index(&sources)?;
-    println!("Indexed {} agent(s).", index.entries.len());
+    let o = crate::cli::style::ok();
+    anstream::println!("{o}Indexed {} agent(s).{o:#}", index.entries.len());
 
     let starter_sources = effective_starter_sources();
-    println!("Syncing {} starter source(s)...", starter_sources.len());
+    let r = crate::cli::style::running();
+    anstream::println!(
+        "{r}Syncing {} starter source(s)...{r:#}",
+        starter_sources.len()
+    );
     if !starter_sources.is_empty() {
         crate::starters_registry::sync_starters(&starter_sources);
     }
@@ -160,7 +170,8 @@ async fn cmd_search(query: &str, category: Option<&str>) -> anyhow::Result<()> {
     let results = search::search(&entries, query);
 
     if results.is_empty() {
-        println!("No agents matching '{query}'.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No agents matching '{query}'.{m:#}");
         return Ok(());
     }
 
@@ -172,15 +183,27 @@ async fn cmd_search(query: &str, category: Option<&str>) -> anyhow::Result<()> {
         .unwrap_or(4)
         .max(4);
 
-    println!("  {:<name_w$}  SCORE  DESCRIPTION", "NAME",);
-    println!("  {:<name_w$}  -----  -----------", "-".repeat(name_w),);
+    let h = crate::cli::style::header();
+    anstream::println!("{h}  {:<name_w$}  SCORE  DESCRIPTION{h:#}", "NAME",);
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  {:<name_w$}  -----  -----------{m:#}",
+        "-".repeat(name_w),
+    );
 
     for r in &results {
         let desc = r.entry.description.as_deref().unwrap_or("-");
-        println!("  {:<name_w$}  {:>5}  {}", r.entry.name, r.score, desc);
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {a}{:<name_w$}{a:#}  {:>5}  {}",
+            r.entry.name,
+            r.score,
+            desc
+        );
     }
 
-    println!("\n  {} result(s).", results.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}  {} result(s).{m:#}", results.len());
     Ok(())
 }
 
@@ -195,9 +218,11 @@ async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
     };
 
     if entries.is_empty() {
-        println!("No agents in registry.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No agents in registry.{m:#}");
         if !sync::sources_dir().is_dir() {
-            println!("Run `armadai registry sync` to fetch the registry.");
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}Run `armadai registry sync` to fetch the registry.{m:#}");
         }
         return Ok(());
     }
@@ -216,9 +241,15 @@ async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
         .unwrap_or(8)
         .max(8);
 
-    println!("  {:<name_w$}  {:<cat_w$}  DESCRIPTION", "NAME", "CATEGORY",);
-    println!(
-        "  {:<name_w$}  {:<cat_w$}  -----------",
+    let h = crate::cli::style::header();
+    anstream::println!(
+        "{h}  {:<name_w$}  {:<cat_w$}  DESCRIPTION{h:#}",
+        "NAME",
+        "CATEGORY",
+    );
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  {:<name_w$}  {:<cat_w$}  -----------{m:#}",
         "-".repeat(name_w),
         "-".repeat(cat_w),
     );
@@ -232,13 +263,17 @@ async fn cmd_list(category: Option<&str>) -> anyhow::Result<()> {
         } else {
             desc.to_string()
         };
-        println!(
-            "  {:<name_w$}  {:<cat_w$}  {}",
-            entry.name, cat, desc_display
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {a}{:<name_w$}{a:#}  {:<cat_w$}  {}",
+            entry.name,
+            cat,
+            desc_display
         );
     }
 
-    println!("\n  {} agent(s) in registry.", entries.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}  {} agent(s) in registry.{m:#}", entries.len());
     Ok(())
 }
 
@@ -254,10 +289,17 @@ async fn cmd_add(agent: &str, force: bool) -> anyhow::Result<()> {
         .find(|e| e.name == agent || e.path == agent)
         .ok_or_else(|| not_found_error(agent, &index))?;
 
-    println!("Converting {} ...", entry.name);
+    let r = crate::cli::style::running();
+    let a = crate::cli::style::accent();
+    anstream::println!("{r}Converting {r:#}{a}{}{a:#} ...", entry.name);
     let dst = convert::import_to_library(&entry.source, &entry.path, force)?;
-    println!("Installed: {}", dst.display());
-    println!("\nAgent '{}' added to your library.", entry.name);
+    let o = crate::cli::style::ok();
+    let m = crate::cli::style::muted();
+    anstream::println!("{o}Installed:{o:#} {m}{}{m:#}", dst.display());
+    anstream::println!(
+        "\n{o}Agent{o:#} {a}'{}'{a:#} {o}added to your library.{o:#}",
+        entry.name
+    );
     Ok(())
 }
 
@@ -272,32 +314,36 @@ async fn cmd_info(agent: &str) -> anyhow::Result<()> {
         .find(|e| e.name == agent || e.path == agent)
         .ok_or_else(|| not_found_error(agent, &index))?;
 
-    println!("Name:        {}", entry.name);
-    println!("Path:        {}", entry.path);
+    let m = crate::cli::style::muted();
+    let a = crate::cli::style::accent();
+    anstream::println!("{m}Name:        {m:#}{a}{}{a:#}", entry.name);
+    anstream::println!("{m}Path:        {m:#}{}", entry.path);
     if !entry.source.is_empty() {
-        println!("Source:      {}", entry.source);
+        anstream::println!("{m}Source:      {m:#}{}", entry.source);
     }
     if let Some(ref cat) = entry.category {
-        println!("Category:    {cat}");
+        anstream::println!("{m}Category:    {m:#}{cat}");
     }
     if let Some(ref desc) = entry.description {
-        println!("Description: {desc}");
+        anstream::println!("{m}Description: {m:#}{desc}");
     }
     if !entry.tags.is_empty() {
-        println!("Tags:        [{}]", entry.tags.join(", "));
+        anstream::println!("{m}Tags:        {m:#}[{}]", entry.tags.join(", "));
     }
 
     // Show the raw content
     let repo = sync::dir_for_key(&entry.source);
     let src = repo.join(&entry.path);
     if src.is_file() {
-        println!("\n--- Content ---");
+        let h = crate::cli::style::header();
+        anstream::println!("\n{h}--- Content ---{h:#}");
         let content = std::fs::read_to_string(&src)?;
         // Print first 40 lines max
         for (i, line) in content.lines().enumerate() {
             if i >= 40 {
-                println!(
-                    "  ... (truncated, {} more lines)",
+                let m = crate::cli::style::muted();
+                anstream::println!(
+                    "{m}  ... (truncated, {} more lines){m:#}",
                     content.lines().count() - 40
                 );
                 break;
@@ -333,14 +379,18 @@ fn not_found_error(agent: &str, index: &cache::Index) -> anyhow::Error {
 /// version.
 fn check_staleness() {
     if cache::has_legacy_cache() {
-        eprintln!(
-            "hint: registry cache is from an older ArmadAI version and will be ignored. Run `armadai registry sync` to refresh."
+        let w = crate::cli::style::warn();
+        anstream::eprintln!(
+            "{w}hint: registry cache is from an older ArmadAI version and will be ignored. Run `armadai registry sync` to refresh.{w:#}"
         );
         return;
     }
 
     if sync::is_stale(7) && sync::sources_dir().is_dir() {
-        eprintln!("hint: registry may be outdated. Run `armadai registry sync` to refresh.");
+        let w = crate::cli::style::warn();
+        anstream::eprintln!(
+            "{w}hint: registry may be outdated. Run `armadai registry sync` to refresh.{w:#}"
+        );
     }
 }
 
@@ -352,54 +402,69 @@ async fn sources_list() -> anyhow::Result<()> {
         .and_then(|cfg| cfg.registries);
 
     // Agents
-    println!("Agents:");
-    println!("  [default] {}", sync::DEFAULT_REGISTRY_URL);
+    let h = crate::cli::style::header();
+    anstream::println!("{h}Agents:{h:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}  [default] {}{m:#}", sync::DEFAULT_REGISTRY_URL);
     for source in &user.agents {
-        println!("  [user]    {}", source.url);
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  [user]    {}{m:#}", source.url);
     }
     if let Some(ref proj) = project {
         for source in &proj.agents {
-            println!("  [project] {}", source.url);
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  [project] {}{m:#}", source.url);
         }
     }
 
     // Skills
-    println!("\nSkills:");
+    let h = crate::cli::style::header();
+    anstream::println!("\n{h}Skills:{h:#}");
     for default_url in crate::skills_registry::sync::default_sources() {
-        println!("  [default] {}", default_url);
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  [default] {}{m:#}", default_url);
     }
     for source in &user.skills {
-        println!("  [user]    {}", source.url);
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  [user]    {}{m:#}", source.url);
     }
     if let Some(ref proj) = project {
         for source in &proj.skills {
-            println!("  [project] {}", source.url);
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  [project] {}{m:#}", source.url);
         }
     }
 
     // Models
-    println!("\nModels:");
-    println!(
-        "  [default] {}",
+    let h = crate::cli::style::header();
+    anstream::println!("\n{h}Models:{h:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  [default] {}{m:#}",
         crate::model_registry::fetch::MODELS_DEV_URL
     );
     for source in &user.models {
-        println!("  [user]    {}", source.url);
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  [user]    {}{m:#}", source.url);
     }
     if let Some(ref proj) = project {
         for source in &proj.models {
-            println!("  [project] {}", source.url);
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  [project] {}{m:#}", source.url);
         }
     }
 
     // Starters (no built-in default registry — user/project sources only)
-    println!("\nStarters:");
+    let h = crate::cli::style::header();
+    anstream::println!("\n{h}Starters:{h:#}");
     for source in &user.starters {
-        println!("  [user]    {}", source.url);
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}  [user]    {}{m:#}", source.url);
     }
     if let Some(ref proj) = project {
         for source in &proj.starters {
-            println!("  [project] {}", source.url);
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  [project] {}{m:#}", source.url);
         }
     }
 
@@ -420,7 +485,8 @@ async fn sources_add(kind: SourceKind, url: &str) -> anyhow::Result<()> {
 
     // Check if already present (idempotent)
     if sources.iter().any(|s| s.url == url) {
-        println!("Source already registered: {url}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Source already registered: {url}{m:#}");
         return Ok(());
     }
 
@@ -430,8 +496,13 @@ async fn sources_add(kind: SourceKind, url: &str) -> anyhow::Result<()> {
     });
 
     save_registries_config(&config)?;
-    println!("Added {} registry source: {url}", kind_name(registry_kind));
-    println!("  Saved to {}", registries_config_path().display());
+    let o = crate::cli::style::ok();
+    anstream::println!(
+        "{o}Added {} registry source: {url}{o:#}",
+        kind_name(registry_kind)
+    );
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}  Saved to {}{m:#}", registries_config_path().display());
 
     Ok(())
 }
@@ -452,16 +523,19 @@ async fn sources_remove(kind: SourceKind, url: &str) -> anyhow::Result<()> {
     sources.retain(|s| s.url != url);
 
     if sources.len() == before {
-        println!("Source not found in config: {url}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Source not found in config: {url}{m:#}");
         return Ok(());
     }
 
     save_registries_config(&config)?;
-    println!(
-        "Removed {} registry source: {url}",
+    let o = crate::cli::style::ok();
+    anstream::println!(
+        "{o}Removed {} registry source: {url}{o:#}",
         kind_name(registry_kind)
     );
-    println!("  Saved to {}", registries_config_path().display());
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}  Saved to {}{m:#}", registries_config_path().display());
 
     Ok(())
 }

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -34,7 +34,10 @@ pub fn prompt_shell_setup() {
             }
         }
         Ok(false) => {
-            println!("Shell integration skipped. Run `armadai init` again to set it up later.");
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "{m}Shell integration skipped. Run `armadai init` again to set it up later.{m:#}"
+            );
         }
         Err(_) => {
             // Non-interactive or error — skip silently
@@ -121,17 +124,23 @@ fn home_dir() -> Option<PathBuf> {
 /// Create `~/.local/bin/armadai` symlink pointing to the current executable.
 fn setup_path() {
     let Ok(current_exe) = std::env::current_exe() else {
-        eprintln!("  [PATH] Could not determine current executable path.");
+        let e = crate::cli::style::err();
+        anstream::eprintln!("{e}  [PATH] Could not determine current executable path.{e:#}");
         return;
     };
     let Some(home) = home_dir() else {
-        eprintln!("  [PATH] Could not determine home directory.");
+        let e = crate::cli::style::err();
+        anstream::eprintln!("{e}  [PATH] Could not determine home directory.{e:#}");
         return;
     };
 
     let local_bin = home.join(".local").join("bin");
     if let Err(e) = std::fs::create_dir_all(&local_bin) {
-        eprintln!("  [PATH] Failed to create {}: {e}", local_bin.display());
+        let err_style = crate::cli::style::err();
+        anstream::eprintln!(
+            "{err_style}  [PATH] Failed to create {}: {e}{err_style:#}",
+            local_bin.display()
+        );
         return;
     }
 
@@ -148,8 +157,9 @@ fn setup_path() {
                 tracing::debug!("Failed to remove existing symlink: {:?}", e);
             }
         } else {
-            eprintln!(
-                "  [PATH] {} already exists and is not a symlink — skipping.",
+            let w = crate::cli::style::warn();
+            anstream::eprintln!(
+                "{w}  [PATH] {} already exists and is not a symlink — skipping.{w:#}",
                 link_path.display()
             );
             return;
@@ -161,14 +171,19 @@ fn setup_path() {
         use std::os::unix::fs::symlink;
         match symlink(&current_exe, &link_path) {
             Ok(()) => {
-                println!(
-                    "  [PATH] Symlink created: {} -> {}",
+                let o = crate::cli::style::ok();
+                let m = crate::cli::style::muted();
+                anstream::println!(
+                    "{o}  [PATH] Symlink created:{o:#} {m}{} -> {}{m:#}",
                     link_path.display(),
                     current_exe.display()
                 );
             }
             Err(e) => {
-                eprintln!("  [PATH] Failed to create symlink: {e}");
+                let err_style = crate::cli::style::err();
+                anstream::eprintln!(
+                    "{err_style}  [PATH] Failed to create symlink: {e}{err_style:#}"
+                );
                 return;
             }
         }
@@ -176,10 +191,12 @@ fn setup_path() {
 
     #[cfg(not(unix))]
     {
-        println!("  [PATH] Symlink creation is not supported on this platform.");
-        println!("         Add the following directory to your PATH manually:");
-        println!(
-            "         {}",
+        let w = crate::cli::style::warn();
+        let m = crate::cli::style::muted();
+        anstream::println!("{w}  [PATH] Symlink creation is not supported on this platform.{w:#}");
+        anstream::println!("{m}         Add the following directory to your PATH manually:{m:#}");
+        anstream::println!(
+            "{m}         {}{m:#}",
             current_exe.parent().unwrap_or(&current_exe).display()
         );
         return;
@@ -193,16 +210,19 @@ fn setup_path() {
 
     if !in_path {
         let rc_hint = shell_rc_file();
-        println!("  [PATH] ~/.local/bin is not in your PATH.");
-        println!("         Add this line to {}:", rc_hint);
-        println!("           export PATH=\"$HOME/.local/bin:$PATH\"");
+        let w = crate::cli::style::warn();
+        let m = crate::cli::style::muted();
+        anstream::println!("{w}  [PATH] ~/.local/bin is not in your PATH.{w:#}");
+        anstream::println!("{m}         Add this line to {}:{m:#}", rc_hint);
+        anstream::println!("{m}           export PATH=\"$HOME/.local/bin:$PATH\"{m:#}");
     }
 }
 
 /// Generate shell completions and write them to the appropriate file.
 fn setup_completions() {
     let Some(shell_name) = detect_shell() else {
-        eprintln!("  [Completions] Could not detect shell from $SHELL.");
+        let e = crate::cli::style::err();
+        anstream::eprintln!("{e}  [Completions] Could not detect shell from $SHELL.{e:#}");
         return;
     };
 
@@ -211,9 +231,13 @@ fn setup_completions() {
         "bash" => clap_complete::Shell::Bash,
         "fish" => clap_complete::Shell::Fish,
         other => {
-            println!("  [Completions] Shell '{other}' is not supported for auto-install.");
-            println!(
-                "               Run `armadai completion <shell>` to generate completions manually."
+            let w = crate::cli::style::warn();
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "{w}  [Completions] Shell '{other}' is not supported for auto-install.{w:#}"
+            );
+            anstream::println!(
+                "{m}               Run `armadai completion <shell>` to generate completions manually.{m:#}"
             );
             return;
         }
@@ -226,8 +250,9 @@ fn setup_completions() {
     if let Some(parent) = completion_path.parent()
         && let Err(e) = std::fs::create_dir_all(parent)
     {
-        eprintln!(
-            "  [Completions] Failed to create directory {}: {e}",
+        let err_style = crate::cli::style::err();
+        anstream::eprintln!(
+            "{err_style}  [Completions] Failed to create directory {}: {e}{err_style:#}",
             parent.display()
         );
         return;
@@ -238,12 +263,18 @@ fn setup_completions() {
 
     match std::fs::File::create(&completion_path).and_then(|mut f| f.write_all(&buf)) {
         Ok(()) => {
-            println!("  [Completions] Written to {}", completion_path.display());
+            let o = crate::cli::style::ok();
+            let m = crate::cli::style::muted();
+            anstream::println!(
+                "{o}  [Completions] Written to:{o:#} {m}{}{m:#}",
+                completion_path.display()
+            );
             print_completion_hint(&shell_name, &completion_path);
         }
         Err(e) => {
-            eprintln!(
-                "  [Completions] Failed to write {}: {e}",
+            let err_style = crate::cli::style::err();
+            anstream::eprintln!(
+                "{err_style}  [Completions] Failed to write {}: {e}{err_style:#}",
                 completion_path.display()
             );
         }
@@ -252,18 +283,30 @@ fn setup_completions() {
 
 /// Print shell-specific hints for activating completions.
 fn print_completion_hint(shell: &str, path: &Path) {
+    let h = crate::cli::style::header();
+    let m = crate::cli::style::muted();
+    let o = crate::cli::style::ok();
     match shell {
         "zsh" => {
-            println!("  [Completions] To enable zsh completions, add to ~/.zshrc:");
-            println!("                  fpath=(~/.zfunc $fpath)");
-            println!("                  autoload -Uz compinit && compinit");
+            anstream::println!(
+                "{h}  [Completions] To enable zsh completions, add to ~/.zshrc:{h:#}"
+            );
+            anstream::println!("{m}                  fpath=(~/.zfunc $fpath){m:#}");
+            anstream::println!("{m}                  autoload -Uz compinit && compinit{m:#}");
         }
         "bash" => {
-            println!("  [Completions] Completions will be auto-loaded on next bash session.");
-            println!("               If not, source {} manually.", path.display());
+            anstream::println!(
+                "{o}  [Completions] Completions will be auto-loaded on next bash session.{o:#}"
+            );
+            anstream::println!(
+                "{m}               If not, source {} manually.{m:#}",
+                path.display()
+            );
         }
         "fish" => {
-            println!("  [Completions] Fish completions are active immediately in new sessions.");
+            anstream::println!(
+                "{o}  [Completions] Fish completions are active immediately in new sessions.{o:#}"
+            );
         }
         _ => {}
     }

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -51,12 +51,13 @@ async fn list() -> anyhow::Result<()> {
     let skills = collect_skills();
 
     if skills.is_empty() {
-        println!("No skills found.");
-        println!(
-            "Add skill directories (containing SKILL.md) in skills/ or ~/.config/armadai/skills/"
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No skills found.{m:#}");
+        anstream::println!(
+            "{m}Add skill directories (containing SKILL.md) in skills/ or ~/.config/armadai/skills/{m:#}"
         );
-        println!(
-            "Or run `armadai skills sync` then `armadai skills search <query>` to discover remote skills."
+        anstream::println!(
+            "{m}Or run `armadai skills sync` then `armadai skills search <query>` to discover remote skills.{m:#}"
         );
         return Ok(());
     }
@@ -82,12 +83,16 @@ async fn list() -> anyhow::Result<()> {
         .max(7);
 
     // Header
-    println!(
-        "  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  TOOLS",
-        "NAME", "DESCRIPTION", "VERSION",
+    let h = crate::cli::style::header();
+    anstream::println!(
+        "{h}  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  TOOLS{h:#}",
+        "NAME",
+        "DESCRIPTION",
+        "VERSION",
     );
-    println!(
-        "  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  -----",
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  -----{m:#}",
         "-".repeat(name_w),
         "-".repeat(desc_w),
         "-".repeat(ver_w),
@@ -102,13 +107,18 @@ async fn list() -> anyhow::Result<()> {
         } else {
             skill.tools.join(", ")
         };
-        println!(
-            "  {:<name_w$}  {:<desc_w$}  {:<ver_w$}  {}",
-            skill.name, desc, ver, tools,
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {a}{:<name_w$}{a:#}  {:<desc_w$}  {:<ver_w$}  {}",
+            skill.name,
+            desc,
+            ver,
+            tools,
         );
     }
 
-    println!("\n  {} skill(s) found.", skills.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}  {} skill(s) found.{m:#}", skills.len());
     Ok(())
 }
 
@@ -119,40 +129,53 @@ async fn show(name: &str) -> anyhow::Result<()> {
         .find(|s| s.name == name)
         .ok_or_else(|| anyhow::anyhow!("Skill '{name}' not found"))?;
 
-    println!("Skill: {}", skill.name);
-    println!("Source: {}", skill.source.display());
+    let h = crate::cli::style::header();
+    let a = crate::cli::style::accent();
+    anstream::println!("{h}Skill:{h:#} {a}{}{a:#}", skill.name);
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}Source: {}{m:#}", skill.source.display());
 
     if let Some(ref desc) = skill.description {
-        println!("Description: {desc}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Description:{m:#} {desc}");
     }
     if let Some(ref ver) = skill.version {
-        println!("Version: {ver}");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Version:{m:#} {ver}");
     }
     if !skill.tools.is_empty() {
-        println!("Tools: [{}]", skill.tools.join(", "));
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Tools:{m:#} [{}]", skill.tools.join(", "));
     }
 
     if !skill.scripts.is_empty() {
-        println!("\nScripts:");
+        let h = crate::cli::style::header();
+        anstream::println!("\n{h}Scripts:{h:#}");
         for s in &skill.scripts {
-            println!("  - {}", s.display());
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  - {}{m:#}", s.display());
         }
     }
     if !skill.references.is_empty() {
-        println!("\nReferences:");
+        let h = crate::cli::style::header();
+        anstream::println!("\n{h}References:{h:#}");
         for r in &skill.references {
-            println!("  - {}", r.display());
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  - {}{m:#}", r.display());
         }
     }
     if !skill.assets.is_empty() {
-        println!("\nAssets:");
+        let h = crate::cli::style::header();
+        anstream::println!("\n{h}Assets:{h:#}");
         for a in &skill.assets {
-            println!("  - {}", a.display());
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  - {}{m:#}", a.display());
         }
     }
 
     println!();
-    println!("## Body");
+    let h = crate::cli::style::header();
+    anstream::println!("{h}## Body{h:#}");
     for line in skill.body.lines() {
         println!("  {line}");
     }
@@ -166,11 +189,14 @@ async fn show(name: &str) -> anyhow::Result<()> {
 
 async fn cmd_sync() -> anyhow::Result<()> {
     let sources = cache::effective_sources();
-    println!("Syncing {} skill source(s)...", sources.len());
+    let r = crate::cli::style::running();
+    anstream::println!("{r}Syncing {} skill source(s)...{r:#}", sources.len());
     sync::sync_all(&sources)?;
-    println!("Building search index...");
+    let r = crate::cli::style::running();
+    anstream::println!("{r}Building search index...{r:#}");
     let index = cache::build_index(&sources)?;
-    println!("Indexed {} skill(s).", index.entries.len());
+    let o = crate::cli::style::ok();
+    anstream::println!("{o}Indexed {} skill(s).{o:#}", index.entries.len());
     Ok(())
 }
 
@@ -180,14 +206,16 @@ async fn cmd_search(query: &str) -> anyhow::Result<()> {
     let index = cache::load_or_build_index(&sources)?;
 
     if index.entries.is_empty() {
-        println!("No skills indexed. Run `armadai skills sync` first.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No skills indexed. Run `armadai skills sync` first.{m:#}");
         return Ok(());
     }
 
     let results = search::search(&index.entries, query);
 
     if results.is_empty() {
-        println!("No skills matching '{query}'.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No skills matching '{query}'.{m:#}");
         return Ok(());
     }
 
@@ -205,12 +233,16 @@ async fn cmd_search(query: &str) -> anyhow::Result<()> {
         .unwrap_or(6)
         .max(6);
 
-    println!(
-        "  {:<name_w$}  {:>5}  {:<repo_w$}  DESCRIPTION",
-        "NAME", "SCORE", "SOURCE",
+    let h = crate::cli::style::header();
+    anstream::println!(
+        "{h}  {:<name_w$}  {:>5}  {:<repo_w$}  DESCRIPTION{h:#}",
+        "NAME",
+        "SCORE",
+        "SOURCE",
     );
-    println!(
-        "  {:<name_w$}  {:>5}  {:<repo_w$}  -----------",
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{m}  {:<name_w$}  {:>5}  {:<repo_w$}  -----------{m:#}",
         "-".repeat(name_w),
         "-----",
         "-".repeat(repo_w),
@@ -223,13 +255,18 @@ async fn cmd_search(query: &str) -> anyhow::Result<()> {
         } else {
             desc.to_string()
         };
-        println!(
-            "  {:<name_w$}  {:>5}  {:<repo_w$}  {}",
-            r.entry.name, r.score, r.entry.source_repo, desc_display,
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "  {a}{:<name_w$}{a:#}  {:>5}  {:<repo_w$}  {}",
+            r.entry.name,
+            r.score,
+            r.entry.source_repo,
+            desc_display,
         );
     }
 
-    println!("\n  {} result(s).", results.len());
+    let m = crate::cli::style::muted();
+    anstream::println!("\n{m}  {} result(s).{m:#}", results.len());
     Ok(())
 }
 
@@ -244,7 +281,8 @@ async fn cmd_add(source: &str, force: bool) -> anyhow::Result<()> {
 
     // Clone/pull the repo
     let repo_slug = format!("{owner}/{repo}");
-    println!("Syncing {repo_slug}...");
+    let r = crate::cli::style::running();
+    anstream::println!("{r}Syncing {repo_slug}...{r:#}");
     let repo_path = sync::sync_repo(&repo_slug)?;
 
     // Scan for skills in the repo
@@ -279,10 +317,12 @@ async fn cmd_add(source: &str, force: bool) -> anyhow::Result<()> {
     } else if skill_dirs.len() == 1 {
         skill_dirs[0].clone()
     } else {
-        println!("Multiple skills found in {repo_slug}:");
+        let h = crate::cli::style::header();
+        anstream::println!("{h}Multiple skills found in {repo_slug}:{h:#}");
         for (i, d) in skill_dirs.iter().enumerate() {
             let name = d.file_name().and_then(|s| s.to_str()).unwrap_or("?");
-            println!("  {}. {}", i + 1, name);
+            let a = crate::cli::style::accent();
+            anstream::println!("  {}. {a}{}{a:#}", i + 1, name);
         }
         anyhow::bail!(
             "Specify which skill to install: armadai skills add {repo_slug}/<skill-name>"
@@ -304,7 +344,14 @@ async fn cmd_add(source: &str, force: bool) -> anyhow::Result<()> {
     // Copy entire skill directory
     copy_dir_recursive(&skill_dir, &dest)?;
 
-    println!("Installed skill '{}' to {}", skill.name, dest.display());
+    let o = crate::cli::style::ok();
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "{o}Installed skill{o:#} {a}'{}'{a:#} {o}to{o:#} {m}{}{m:#}",
+        skill.name,
+        dest.display()
+    );
     Ok(())
 }
 
@@ -323,14 +370,16 @@ async fn cmd_info(name: &str) -> anyhow::Result<()> {
             )
         })?;
 
-    println!("Name:        {}", entry.name);
-    println!("Source:      {}", entry.source_repo);
-    println!("Path:        {}", entry.path);
+    let m = crate::cli::style::muted();
+    let a = crate::cli::style::accent();
+    anstream::println!("{m}Name:        {m:#}{a}{}{a:#}", entry.name);
+    anstream::println!("{m}Source:      {m:#}{}", entry.source_repo);
+    anstream::println!("{m}Path:        {m:#}{}", entry.path);
     if let Some(ref desc) = entry.description {
-        println!("Description: {desc}");
+        anstream::println!("{m}Description: {m:#}{desc}");
     }
     if !entry.tags.is_empty() {
-        println!("Tags:        [{}]", entry.tags.join(", "));
+        anstream::println!("{m}Tags:        {m:#}[{}]", entry.tags.join(", "));
     }
 
     // Try to show SKILL.md content from cloned repo
@@ -339,12 +388,14 @@ async fn cmd_info(name: &str) -> anyhow::Result<()> {
             .join(&entry.path)
             .join("SKILL.md");
         if skill_file.is_file() {
-            println!("\n--- SKILL.md ---");
+            let h = crate::cli::style::header();
+            anstream::println!("\n{h}--- SKILL.md ---{h:#}");
             let content = std::fs::read_to_string(&skill_file)?;
             for (i, line) in content.lines().enumerate() {
                 if i >= 40 {
-                    println!(
-                        "  ... (truncated, {} more lines)",
+                    let m = crate::cli::style::muted();
+                    anstream::println!(
+                        "{m}  ... (truncated, {} more lines){m:#}",
                         content.lines().count() - 40
                     );
                     break;
@@ -354,9 +405,11 @@ async fn cmd_info(name: &str) -> anyhow::Result<()> {
         }
     }
 
-    println!(
-        "\nInstall with: armadai skills add {}/{}",
-        entry.source_repo, entry.name
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "\n{m}Install with: armadai skills add {}/{}{m:#}",
+        entry.source_repo,
+        entry.name
     );
     Ok(())
 }
@@ -413,7 +466,10 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> anyhow::R
 /// Print a hint if the skills registry is stale.
 fn check_staleness() {
     if sync::is_stale(7) && sync::repos_dir().is_dir() {
-        eprintln!("hint: skills registry may be outdated. Run `armadai skills sync` to refresh.");
+        let w = crate::cli::style::warn();
+        anstream::eprintln!(
+            "{w}hint: skills registry may be outdated. Run `armadai skills sync` to refresh.{w:#}"
+        );
     }
 }
 
@@ -425,12 +481,19 @@ fn collect_skills() -> Vec<Skill> {
     if let Some((root, config)) = project::find_project_config() {
         let (paths, errors) = project::resolve_all_skills(&config, &root);
         for err in &errors {
-            eprintln!("  warn: {err}");
+            let w = crate::cli::style::warn();
+            anstream::eprintln!("{w}  warn: {err}{w:#}");
         }
         for path in &paths {
             match Skill::load(path) {
                 Ok(s) => skills.push(s),
-                Err(e) => eprintln!("  warn: failed to load skill {}: {e}", path.display()),
+                Err(e) => {
+                    let w = crate::cli::style::warn();
+                    anstream::eprintln!(
+                        "{w}  warn: failed to load skill {}: {e}{w:#}",
+                        path.display()
+                    );
+                }
             }
         }
 

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -10,13 +10,13 @@
 use anstyle::{AnsiColor, Color, RgbColor, Style};
 
 // Design-system accents (assets/terminal-palette.json).
-// `#[allow(dead_code)]` on the remaining unwired items below: this lot only
-// wires `cli/run.rs`; other call sites (and `err()`/`agent()`) land in a
+// `#[allow(dead_code)]` on the remaining unwired items below: CLI-1 wired
+// `cli/run.rs`, CLI-2 (this lot) wires the discovery/read commands (`err()`
+// now used by `models.rs`/`validate.rs`); `agent()` still lands in a
 // follow-up lot (same convention as `crate::theme`).
 const BRASS: Color = Color::Rgb(RgbColor(0xc7, 0x9a, 0x4a));
 const SIGNAL_OK: Color = Color::Rgb(RgbColor(0x5c, 0xbf, 0x87));
 const SIGNAL_WARNING: Color = Color::Rgb(RgbColor(0xe2, 0xb2, 0x4c));
-#[allow(dead_code)]
 const SIGNAL_CRITICAL: Color = Color::Rgb(RgbColor(0xd7, 0x5f, 0x4d));
 const SIGNAL_RUNNING: Color = Color::Rgb(RgbColor(0x57, 0xa9, 0xcc));
 
@@ -37,7 +37,6 @@ pub fn warn() -> Style {
     Style::new().fg_color(Some(SIGNAL_WARNING))
 }
 /// Error / critical status.
-#[allow(dead_code)]
 pub fn err() -> Style {
     Style::new().fg_color(Some(SIGNAL_CRITICAL))
 }

--- a/src/cli/unlink.rs
+++ b/src/cli/unlink.rs
@@ -27,14 +27,18 @@ pub async fn execute(
     // 2. Resolve and parse agents
     let (paths, errors) = project::resolve_all_agents(&config, &root);
     for err in &errors {
-        eprintln!("  warn: {err}");
+        let w = crate::cli::style::warn();
+        anstream::eprintln!("{w}  warn: {err}{w:#}");
     }
 
     let mut link_agents: Vec<LinkAgent> = Vec::new();
     for path in &paths {
         match parser::parse_agent_file(path) {
             Ok(agent) => link_agents.push(LinkAgent::from(&agent)),
-            Err(e) => eprintln!("  warn: failed to parse {}: {e}", path.display()),
+            Err(e) => {
+                let w = crate::cli::style::warn();
+                anstream::eprintln!("{w}  warn: failed to parse {}: {e}{w:#}", path.display());
+            }
         }
     }
 
@@ -92,7 +96,8 @@ pub async fn execute(
     let files = linker.generate(&link_agents, coordinator.as_ref(), sources);
 
     if files.is_empty() {
-        println!("No files to remove.");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}No files to remove.{m:#}");
         return Ok(());
     }
 
@@ -150,21 +155,24 @@ pub async fn execute(
 
     // 10. Dry run
     if dry_run {
-        println!(
-            "Dry run — files that would be removed for '{}':\n",
+        let h = crate::cli::style::header();
+        let a = crate::cli::style::accent();
+        let m = crate::cli::style::muted();
+        anstream::println!(
+            "{h}Dry run{h:#} — files that would be removed for {a}'{}'{a:#}:\n",
             target_name
         );
         let mut existing = 0;
         for path in &targets {
             if path.exists() {
-                println!("  {}", path.display());
+                anstream::println!("{m}  {}{m:#}", path.display());
                 existing += 1;
             } else {
-                println!("  {} (already absent)", path.display());
+                anstream::println!("{m}  {} (already absent){m:#}", path.display());
             }
         }
-        println!(
-            "\n  {} existing, {} already absent.",
+        anstream::println!(
+            "\n{m}  {} existing, {} already absent.{m:#}",
             existing,
             targets.len() - existing
         );
@@ -178,7 +186,8 @@ pub async fn execute(
     for path in &targets {
         if path.exists() {
             std::fs::remove_file(path)?;
-            println!("  deleted {}", path.display());
+            let m = crate::cli::style::muted();
+            anstream::println!("{m}  deleted {}{m:#}", path.display());
             deleted += 1;
         } else {
             absent += 1;
@@ -193,9 +202,14 @@ pub async fn execute(
         }
     }
 
-    println!(
-        "\nUnlinked '{}': {} deleted, {} already absent.",
-        target_name, deleted, absent
+    let o = crate::cli::style::ok();
+    let a = crate::cli::style::accent();
+    let m = crate::cli::style::muted();
+    anstream::println!(
+        "\n{o}Unlinked{o:#} {a}'{}'{a:#}: {m}{} deleted, {} already absent.{m:#}",
+        target_name,
+        deleted,
+        absent
     );
 
     Ok(())

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -15,8 +15,10 @@ pub async fn execute() -> anyhow::Result<()> {
 
     let repo = "Dr0drigues/swarm-festai";
     let current_version = env!("CARGO_PKG_VERSION");
-    println!("Current version: v{current_version}");
-    println!("Checking for updates...");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}Current version: v{current_version}{m:#}");
+    let r = crate::cli::style::running();
+    anstream::println!("{r}Checking for updates...{r:#}");
 
     // Get latest release tag
     let output = ProcessCommand::new("curl")
@@ -45,11 +47,14 @@ pub async fn execute() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Could not parse latest version from GitHub API"))?;
 
     if latest_version == current_version {
-        println!("Already up to date (v{current_version}).");
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}Already up to date (v{current_version}).{m:#}");
         return Ok(());
     }
 
-    println!("New version available: v{latest_version}");
+    let w = crate::cli::style::warn();
+    let a = crate::cli::style::accent();
+    anstream::println!("{w}New version available:{w:#} {a}v{latest_version}{a:#}");
 
     // Find where the current binary is installed
     let current_exe = std::env::current_exe()?;
@@ -61,7 +66,9 @@ pub async fn execute() -> anyhow::Result<()> {
     let download_url =
         format!("https://github.com/{repo}/releases/download/v{latest_version}/{artifact}");
 
-    println!("Downloading v{latest_version} for {platform}...");
+    let r = crate::cli::style::running();
+    let a = crate::cli::style::accent();
+    anstream::println!("{r}Downloading{r:#} {a}v{latest_version}{a:#} for {a}{platform}{a:#}...");
 
     // Download to temp file
     let tmp_path = install_dir.join(".armadai-update-tmp");
@@ -96,8 +103,11 @@ pub async fn execute() -> anyhow::Result<()> {
     let target_path = install_dir.join("armadai");
     std::fs::rename(&tmp_path, &target_path)?;
 
-    println!("Updated to v{latest_version}!");
-    println!("Run 'armadai --version' to verify.");
+    let o = crate::cli::style::ok();
+    let a = crate::cli::style::accent();
+    anstream::println!("{o}Updated to{o:#} {a}v{latest_version}{a:#}{o}!{o:#}");
+    let m = crate::cli::style::muted();
+    anstream::println!("{m}Run 'armadai --version' to verify.{m:#}");
 
     super::setup::prompt_shell_setup();
 

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -17,12 +17,22 @@ pub async fn execute(path: Option<PathBuf>) -> anyhow::Result<()> {
 
     let (mode, issues) = if pack_yaml.is_file() {
         // Pack mode
-        println!("Validating starter pack at: {}", target_path.display());
+        let h = crate::cli::style::header();
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "{h}Validating starter pack at:{h:#} {a}{}{a:#}",
+            target_path.display()
+        );
         println!();
         ("pack", validate_pack(&target_path))
     } else if armadai_config_yaml.is_file() || armadai_yaml.is_file() || armadai_yml.is_file() {
         // Project mode
-        println!("Validating project config at: {}", target_path.display());
+        let h = crate::cli::style::header();
+        let a = crate::cli::style::accent();
+        anstream::println!(
+            "{h}Validating project config at:{h:#} {a}{}{a:#}",
+            target_path.display()
+        );
         println!();
         ("project", validate_project_config(&target_path))
     } else {
@@ -38,26 +48,39 @@ pub async fn execute(path: Option<PathBuf>) -> anyhow::Result<()> {
     let mut warning_count = 0;
 
     for issue in &issues {
-        let (color, prefix) = match issue.severity {
+        let (style, prefix) = match issue.severity {
             Severity::Error => {
                 error_count += 1;
-                ("\x1b[31m", "ERROR")
+                (crate::cli::style::err(), "ERROR")
             }
             Severity::Warning => {
                 warning_count += 1;
-                ("\x1b[33m", "WARN ")
+                (crate::cli::style::warn(), "WARN ")
             }
         };
 
-        println!(
-            "{}{}\x1b[0m {}: {}",
-            color, prefix, issue.location, issue.message
+        anstream::println!(
+            "{style}{}{style:#} {}: {}",
+            prefix,
+            issue.location,
+            issue.message
         );
     }
 
     // Footer
     println!();
-    println!("{} error(s), {} warning(s)", error_count, warning_count);
+    let footer_style = if error_count > 0 {
+        crate::cli::style::err()
+    } else if warning_count > 0 {
+        crate::cli::style::warn()
+    } else {
+        crate::cli::style::ok()
+    };
+    anstream::println!(
+        "{footer_style}{} error(s), {} warning(s){footer_style:#}",
+        error_count,
+        warning_count
+    );
 
     // Exit code logic
     if error_count > 0 {
@@ -65,8 +88,9 @@ pub async fn execute(path: Option<PathBuf>) -> anyhow::Result<()> {
     }
 
     println!();
-    println!(
-        "Validation passed for {} at {}",
+    let o = crate::cli::style::ok();
+    anstream::println!(
+        "{o}Validation passed for {} at {}{o:#}",
         mode,
         target_path.display()
     );


### PR DESCRIPTION
## Contexte

Lot **CLI-2** du chantier Design System → CLI (3ᵉ surface après Web Svelte et TUI T3a-d). Applique le module `src/cli/style.rs` (livré en CLI-1 #246) à la **sortie humaine de toutes les commandes restantes**. Accent-only, ANSI via `anstream` (strip auto NO_COLOR/CLICOLOR/non-TTY), aucun chemin machine touché.

## Périmètre (16 commandes)

- **Discovery** : `list`, `models`, `inspect`, `prompts`, `validate`
- **Setup projet** : `new`, `init`, `link`, `unlink`, `setup`, `update`
- **Registry/skills** : `registry`, `skills`
- **Config/divers** : `config`, `audit`, `extract`
- `src/audit/report.rs::print_terminal` (le vrai rendu riche d'`armadai audit`, hors `cli/audit.rs`) stylé par sévérité ; `mod style` passé `pub(crate)`.

## Garanties

- **Accent-only** : données/valeurs en couleur terminal par défaut ; seuls titres/entités/statuts/secondaire accentués.
- **Aucune contamination machine** : `--json`, `sink.emit`, listes scriptables (pipe), `tracing::` intacts.
- **Bug latent corrigé** : `validate.rs` émettait des escapes ANSI codés en dur (ignoraient NO_COLOR) → passe par anstream, strippé hors TTY.

## Gate

fmt clean · clippy 3 modes (`tui` / `tui,providers-api` / `tui,web,storage`) `-D warnings` clean · `cargo test --features tui` 954 passed · `cargo test --test e2e --features tui,storage` 30 passed.

## Revue

Revue finale whole-branch indépendante (opus) : **READY TO MERGE**, 0 Critical / 0 Important. Minors cosmétiques déférés : chemin `pruned` en accent (models.rs), `\n` dans un span de style (models/update), nom de template `muted` vs `accent` (new.rs). Sans impact fonctionnel ni perte de texte.

## Validation visuelle (Dimitri)

Chaque commande en TTY montre les accents ; `| cat` et `NO_COLOR=1` sans couleur ; `--json` inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
