### PR TITLE
fix: Phase 1 debts — flaky test, zip-slip, TUI quit/scroll/Costs (#259)

### DIFF
--- a/src/shell/config.rs
+++ b/src/shell/config.rs
@@ -125,12 +125,39 @@ mod tests {
 
     #[test]
     fn test_resolve_shell_model_aliases() {
+        // Hermetic: force an empty, private `ARMADAI_CONFIG_DIR` so this test
+        // never sees the ambient/machine-local models.dev cache. Without this,
+        // `resolve_shell_model` → `resolve_model_for_tier` reads the shared,
+        // mutable cache file via `load_models_cached`; under the parallel test
+        // suite other tests populate/clear/refresh that cache between the two
+        // calls below, so the two resolutions could observe different cache
+        // states and diverge — flaky (passes in isolation / on a clean CI
+        // runner, fails under `--test-threads>1`). With no cache reachable,
+        // resolution always takes the deterministic hardcoded-fallback path
+        // (`fallback_model_for_tier`), while still exercising the real
+        // low/fast → Fast tier and high/max → Max tier collapsing invariant
+        // this test is meant to guard. Mirrors
+        // `linker::model_resolution::test_preview_resolution_with_latest`.
+        let _guard = crate::core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: env mutation is serialised via ENV_MUTEX for the duration
+        // of this test, and the original value is restored before returning.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path());
+        }
+
         let low = resolve_shell_model("claude", "latest:low");
         let fast = resolve_shell_model("claude", "latest:fast");
-        assert_eq!(low, fast);
-
         let high = resolve_shell_model("claude", "latest:high");
         let max = resolve_shell_model("claude", "latest:max");
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+        }
+
+        assert_eq!(low, fast);
         assert_eq!(high, max);
     }
 

--- a/src/starters_registry/mod.rs
+++ b/src/starters_registry/mod.rs
@@ -75,15 +75,93 @@ fn run_git(args: &[&str]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Check whether an archive entry's path is safe to extract under a fixed
+/// `dest` directory (zip-slip guard).
+///
+/// Rejects:
+/// - an absolute path (leading `/`, i.e. a `RootDir` path component),
+/// - any `..` (`ParentDir`) path component, at any depth,
+/// - Windows-style separators (`\`) or a drive-absolute prefix (`C:\...`,
+///   `C:/...`) — we only expect POSIX-style entries from `tar -tzf`/
+///   `unzip -Z1`, so anything shaped like this is already suspicious and
+///   `Path` on a non-Windows host wouldn't otherwise recognize it as
+///   absolute.
+///
+/// Pure and testable in isolation from the actual shell-out extraction.
+fn archive_entry_is_safe(name: &str) -> bool {
+    if name.is_empty() || name.contains('\\') {
+        return false;
+    }
+    let mut chars = name.chars();
+    if let (Some(letter), Some(':')) = (chars.next(), chars.next())
+        && letter.is_ascii_alphabetic()
+    {
+        // Drive-absolute, e.g. `C:/foo` — not a `RootDir` component on a
+        // non-Windows host, so it must be checked explicitly.
+        return false;
+    }
+    !Path::new(name).components().any(|c| {
+        matches!(
+            c,
+            std::path::Component::RootDir | std::path::Component::ParentDir
+        )
+    })
+}
+
+/// List entry paths inside an archive without extracting it, so they can be
+/// validated by [`archive_entry_is_safe`] before anything is written to disk.
+// Only called by `extract_archive`, itself only called by `ArchiveFetcher`
+// (gated `providers-api`); without that feature this helper is unused (still
+// exercised indirectly through `extract_archive`'s own tests).
+#[cfg_attr(not(feature = "providers-api"), allow(dead_code))]
+fn list_archive_entries(archive: &Path, is_zip: bool) -> anyhow::Result<Vec<String>> {
+    let out = if is_zip {
+        std::process::Command::new("unzip")
+            .args(["-Z1", archive.to_str().unwrap_or("")])
+            .output()?
+    } else {
+        std::process::Command::new("tar")
+            .args(["-tzf", archive.to_str().unwrap_or("")])
+            .output()?
+    };
+    if !out.status.success() {
+        anyhow::bail!(
+            "failed to list archive entries for {}: {}",
+            archive.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
 /// Extract a downloaded archive (.tar.gz/.tgz or .zip) into `dest` by shelling
 /// out to system `tar`/`unzip` (no extra crate). `dest` is created.
+///
+/// Before extracting, every entry is listed and validated with
+/// [`archive_entry_is_safe`]: a malicious archive with a `../../etc/x` or
+/// absolute-path entry (zip-slip) is rejected up front rather than allowed to
+/// write outside `dest`.
 // Only called by `ArchiveFetcher`, which is gated `providers-api`; without
 // that feature this helper is unused (still exercised directly by tests).
 #[cfg_attr(not(feature = "providers-api"), allow(dead_code))]
 fn extract_archive(archive: &Path, dest: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(dest)?;
     let name = archive.to_string_lossy().to_lowercase();
-    let status = if name.ends_with(".zip") {
+    let is_zip = name.ends_with(".zip");
+
+    let entries = list_archive_entries(archive, is_zip)?;
+    if let Some(unsafe_entry) = entries.iter().find(|e| !archive_entry_is_safe(e)) {
+        anyhow::bail!(
+            "refusing to extract archive {}: unsafe entry path '{unsafe_entry}' (zip-slip guard)",
+            archive.display()
+        );
+    }
+
+    let status = if is_zip {
         std::process::Command::new("unzip")
             .args([
                 "-q",
@@ -310,6 +388,47 @@ mod tests {
             kind: None,
         };
         assert!(fetch_starter_source(&src).is_err());
+    }
+
+    #[test]
+    fn archive_entry_is_safe_accepts_normal_nested_path() {
+        assert!(archive_entry_is_safe("dir/sub/file.txt"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_accepts_flat_path() {
+        assert!(archive_entry_is_safe("a/b/c"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_rejects_leading_parent_dir() {
+        assert!(!archive_entry_is_safe("../escape"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_rejects_embedded_parent_dir() {
+        assert!(!archive_entry_is_safe("a/../../b"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_rejects_absolute_path() {
+        assert!(!archive_entry_is_safe("/abs"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_rejects_windows_separator() {
+        assert!(!archive_entry_is_safe("a\\..\\b"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_rejects_windows_drive_absolute() {
+        assert!(!archive_entry_is_safe("C:/windows/system32"));
+        assert!(!archive_entry_is_safe("C:\\windows\\system32"));
+    }
+
+    #[test]
+    fn archive_entry_is_safe_rejects_empty() {
+        assert!(!archive_entry_is_safe(""));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -250,6 +250,11 @@ pub enum SortMode {
     NameDesc,
 }
 
+/// How many lines a single PageUp/PageDown jumps in a scrollable detail
+/// view. Mirrors the shell TUI's popup page-scroll step
+/// (`src/shell/tui.rs`'s `popup_scroll` PageUp/PageDown handling).
+const DETAIL_PAGE_SIZE: u16 = 10;
+
 pub struct App {
     pub current_tab: Tab,
     pub tab_index: usize,
@@ -289,6 +294,16 @@ pub struct App {
     pub sort_mode: SortMode,
     // Detail view scroll offset (reset on tab switch / selection change).
     pub detail_scroll: u16,
+    // Upper bound for `detail_scroll`, recomputed each render pass by the
+    // active detail view from its actual content + panel size (see
+    // `tui::wrap::wrapped_line_count`). Zero when content fits without
+    // scrolling, or no detail view is active.
+    pub detail_scroll_max: u16,
+    // "Press Esc again to quit" arming (top-level safety net — mirrors
+    // `src/shell/tui.rs`'s `esc_armed`). Set when Esc is pressed on a
+    // top-level list view (no popup/search/detail active); a second,
+    // consecutive Esc then confirms the quit. Any other key disarms it.
+    pub esc_armed: bool,
 }
 
 impl App {
@@ -320,6 +335,8 @@ impl App {
             search_query: String::new(),
             sort_mode: SortMode::Default,
             detail_scroll: 0,
+            detail_scroll_max: 0,
+            esc_armed: false,
         }
     }
 
@@ -327,6 +344,7 @@ impl App {
         self.tab_index = (self.tab_index + 1) % Tab::ALL.len();
         self.current_tab = Tab::ALL[self.tab_index];
         self.detail_scroll = 0;
+        self.detail_scroll_max = 0;
     }
 
     pub fn prev_tab(&mut self) {
@@ -337,24 +355,54 @@ impl App {
         };
         self.current_tab = Tab::ALL[self.tab_index];
         self.detail_scroll = 0;
+        self.detail_scroll_max = 0;
     }
 
     pub fn switch_tab(&mut self, tab: Tab) {
         self.current_tab = tab;
         self.tab_index = tab.index();
         self.detail_scroll = 0;
+        self.detail_scroll_max = 0;
     }
 
-    /// Scroll a detail view down by one line (saturating at the content's end
-    /// is handled by ratatui simply rendering nothing past it — no need to
-    /// track content length here).
+    /// Scroll a detail view down by one line, bounds-checked against
+    /// `detail_scroll_max` (computed from the panel's actual content on the
+    /// last render pass) so it never scrolls past the content's end.
     pub fn scroll_detail_down(&mut self) {
-        self.detail_scroll = self.detail_scroll.saturating_add(1);
+        self.detail_scroll = self
+            .detail_scroll
+            .saturating_add(1)
+            .min(self.detail_scroll_max);
     }
 
-    /// Scroll a detail view up by one line.
+    /// Scroll a detail view up by one line (saturates at 0).
     pub fn scroll_detail_up(&mut self) {
         self.detail_scroll = self.detail_scroll.saturating_sub(1);
+    }
+
+    /// Scroll a detail view down by one page, bounds-checked.
+    pub fn scroll_detail_page_down(&mut self) {
+        self.detail_scroll = self
+            .detail_scroll
+            .saturating_add(DETAIL_PAGE_SIZE)
+            .min(self.detail_scroll_max);
+    }
+
+    /// Scroll a detail view up by one page (saturates at 0).
+    pub fn scroll_detail_page_up(&mut self) {
+        self.detail_scroll = self.detail_scroll.saturating_sub(DETAIL_PAGE_SIZE);
+    }
+
+    /// Update the active detail view's scroll bound. Called once per render
+    /// pass by whichever detail view is currently on screen, from its
+    /// actual content + panel size — also clamps the stored offset in case
+    /// a terminal resize (or switching to shorter content) shrank the
+    /// scrollable range out from under it.
+    pub fn set_detail_scroll_max(&mut self, max: u16) {
+        self.detail_scroll_max = max;
+        if self.detail_scroll > max {
+            self.detail_scroll = max;
+        }
     }
 
     pub fn load_agents(&mut self) {
@@ -793,5 +841,81 @@ impl App {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod detail_scroll_tests {
+    use super::*;
+
+    #[test]
+    fn scroll_down_is_bounds_checked_against_max() {
+        let mut app = App::new();
+        app.set_detail_scroll_max(3);
+        for _ in 0..10 {
+            app.scroll_detail_down();
+        }
+        assert_eq!(
+            app.detail_scroll, 3,
+            "scrolling down must never exceed the content's end"
+        );
+    }
+
+    #[test]
+    fn scroll_up_never_goes_negative() {
+        let mut app = App::new();
+        app.set_detail_scroll_max(5);
+        app.detail_scroll = 1;
+        app.scroll_detail_up();
+        app.scroll_detail_up();
+        assert_eq!(
+            app.detail_scroll, 0,
+            "scrolling up must never go past the content's start"
+        );
+    }
+
+    #[test]
+    fn page_down_is_bounds_checked_against_max() {
+        let mut app = App::new();
+        app.set_detail_scroll_max(3);
+        app.scroll_detail_page_down();
+        assert_eq!(
+            app.detail_scroll, 3,
+            "a page jump larger than the remaining content must clamp to the end"
+        );
+    }
+
+    #[test]
+    fn shrinking_max_clamps_an_out_of_range_offset() {
+        let mut app = App::new();
+        app.set_detail_scroll_max(20);
+        app.detail_scroll = 15;
+        // Simulates a render pass discovering the panel/content got
+        // smaller (e.g. terminal resize) — the stored offset must not be
+        // left pointing past the new end.
+        app.set_detail_scroll_max(5);
+        assert_eq!(app.detail_scroll, 5);
+        assert_eq!(app.detail_scroll_max, 5);
+    }
+
+    #[test]
+    fn switching_tab_resets_scroll_and_bound() {
+        let mut app = App::new();
+        app.detail_scroll = 7;
+        app.set_detail_scroll_max(12);
+        app.switch_tab(Tab::AgentDetail);
+        assert_eq!(app.detail_scroll, 0);
+        assert_eq!(app.detail_scroll_max, 0);
+    }
+}
+
+#[cfg(test)]
+mod esc_armed_tests {
+    use super::*;
+
+    #[test]
+    fn esc_armed_starts_disarmed() {
+        let app = App::new();
+        assert!(!app.esc_armed);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,6 +3,7 @@ pub mod filter;
 pub mod format;
 pub mod views;
 pub mod widgets;
+mod wrap;
 
 use anyhow::Result;
 use crossterm::{
@@ -35,7 +36,7 @@ pub async fn run(ascii: bool) -> Result<()> {
 
     loop {
         terminal.draw(|frame| {
-            views::dashboard::render(frame, &app);
+            views::dashboard::render(frame, &mut app);
             // Overlay command palette if visible
             views::palette::render(frame, &app);
         })?;
@@ -52,6 +53,12 @@ pub async fn run(ascii: bool) -> Result<()> {
             if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
                 break;
             }
+
+            // Disarm "press Esc again to quit" (see `handle_top_level_esc`
+            // below) on any key that isn't Esc — the double-Esc confirmation
+            // must be consecutive, mirroring `src/shell/tui.rs`'s
+            // `esc_armed` semantics.
+            disarm_esc_on_other_key(&mut app, key.code);
 
             // Command palette mode
             if app.palette.visible {
@@ -143,7 +150,17 @@ pub async fn run(ascii: bool) -> Result<()> {
                         app.switch_tab(app::Tab::Orchestration);
                         continue;
                     }
-                    _ => break, // Quit on Esc from top-level tabs
+                    // Top-level list view: Esc no longer quits instantly.
+                    // First press arms a "press Esc again to quit" safety
+                    // net (shown in the shortcuts bar); a second,
+                    // consecutive Esc confirms. Mirrors the shell TUI's
+                    // `esc_armed` (`src/shell/tui.rs`).
+                    _ => {
+                        if handle_top_level_esc(&mut app) {
+                            break;
+                        }
+                        continue;
+                    }
                 }
             }
 
@@ -224,13 +241,19 @@ pub async fn run(ascii: bool) -> Result<()> {
                         app.select_prev();
                     }
                 }
+                KeyCode::PageDown if is_scrollable_detail(app.current_tab) => {
+                    app.scroll_detail_page_down();
+                }
+                KeyCode::PageUp if is_scrollable_detail(app.current_tab) => {
+                    app.scroll_detail_page_up();
+                }
                 KeyCode::Char('R')
                     if matches!(app.current_tab, app::Tab::Models | app::Tab::ModelDetail) =>
                 {
                     app.status_msg = Some("Syncing models from models.dev…".to_string());
                     // Force redraw to show status message
                     terminal.draw(|frame| {
-                        views::dashboard::render(frame, &app);
+                        views::dashboard::render(frame, &mut app);
                         views::palette::render(frame, &app);
                     })?;
                     match sync_models_online().await {
@@ -357,6 +380,29 @@ fn is_scrollable_detail(tab: app::Tab) -> bool {
     )
 }
 
+/// Disarm the top-level "press Esc again to quit" safety net (see
+/// `handle_top_level_esc`) on any key that isn't Esc. The double-Esc
+/// confirmation must be consecutive — mirrors `src/shell/tui.rs`'s
+/// `esc_armed` semantics.
+fn disarm_esc_on_other_key(app: &mut app::App, code: KeyCode) {
+    if code != KeyCode::Esc {
+        app.esc_armed = false;
+    }
+}
+
+/// Handle Esc pressed on a top-level list view (no popup/search/detail
+/// active). First press arms `esc_armed` (surfaced in the shortcuts bar,
+/// see `views::shortcuts::render`) instead of quitting outright; a second,
+/// consecutive Esc confirms. Returns `true` if the caller should quit.
+fn handle_top_level_esc(app: &mut app::App) -> bool {
+    if app.esc_armed {
+        true
+    } else {
+        app.esc_armed = true;
+        false
+    }
+}
+
 #[cfg(feature = "storage")]
 fn load_storage_data(app: &mut app::App) {
     use crate::storage::{init_db, queries};
@@ -418,4 +464,39 @@ async fn sync_models_online() -> anyhow::Result<usize> {
 #[cfg(not(feature = "providers-api"))]
 async fn sync_models_online() -> anyhow::Result<usize> {
     anyhow::bail!("Model sync requires providers-api feature")
+}
+
+#[cfg(test)]
+mod esc_quit_tests {
+    use super::*;
+
+    #[test]
+    fn first_top_level_esc_arms_without_quitting() {
+        let mut app = app::App::new();
+        assert!(!handle_top_level_esc(&mut app));
+        assert!(app.esc_armed);
+    }
+
+    #[test]
+    fn second_consecutive_top_level_esc_quits() {
+        let mut app = app::App::new();
+        handle_top_level_esc(&mut app);
+        assert!(handle_top_level_esc(&mut app));
+    }
+
+    #[test]
+    fn any_other_key_disarms_the_pending_quit() {
+        let mut app = app::App::new();
+        app.esc_armed = true;
+        disarm_esc_on_other_key(&mut app, KeyCode::Char('q'));
+        assert!(!app.esc_armed);
+    }
+
+    #[test]
+    fn esc_itself_does_not_disarm() {
+        let mut app = app::App::new();
+        app.esc_armed = true;
+        disarm_esc_on_other_key(&mut app, KeyCode::Esc);
+        assert!(app.esc_armed);
+    }
 }

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -245,7 +245,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner_height = prompt_area.height.saturating_sub(2);
     let total_lines = wrapped_line_count(&prompt_text, inner_width);
     let overflow = total_lines > inner_height as usize;
-    app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+    app.set_detail_scroll_max(
+        total_lines
+            .saturating_sub(inner_height as usize)
+            .min(u16::MAX as usize) as u16,
+    );
     let scroll = app.detail_scroll;
 
     let mut prompt_block = Block::default()

--- a/src/tui/views/agent_detail.rs
+++ b/src/tui/views/agent_detail.rs
@@ -8,11 +8,13 @@ use ratatui::{
 
 use crate::theme;
 use crate::tui::app::App;
+use crate::tui::wrap::wrapped_line_count;
 
-pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let agent = match app.selected_agent() {
         Some(a) => a,
         None => {
+            app.set_detail_scroll_max(0);
             let msg = Paragraph::new("No agent selected. Go to Agents tab and select one.").block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -223,28 +225,52 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         .wrap(Wrap { trim: false });
     frame.render_widget(res_widget, chunks[2 + orch_offset]);
 
-    // System Prompt section
+    // System Prompt section. Both bodies are pulled out as owned `String`s
+    // up front (rather than kept as `&agent.*` borrows) so `agent` (which
+    // borrows `app` via `selected_agent()`) is no longer live once we need
+    // `app` mutably below to record the scroll bound.
     let prompt_text = if agent.system_prompt.is_empty() {
         "(no system prompt)".to_string()
     } else {
         agent.system_prompt.clone()
     };
+    let instr_text = agent
+        .instructions
+        .as_deref()
+        .unwrap_or("(no instructions)")
+        .to_string();
+
+    let prompt_area = chunks[3 + orch_offset];
+    let inner_width = prompt_area.width.saturating_sub(2);
+    let inner_height = prompt_area.height.saturating_sub(2);
+    let total_lines = wrapped_line_count(&prompt_text, inner_width);
+    let overflow = total_lines > inner_height as usize;
+    app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+    let scroll = app.detail_scroll;
+
+    let mut prompt_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" System Prompt ")
+        .title_style(Style::default().add_modifier(Modifier::BOLD))
+        .style(theme::border_style());
+    if overflow {
+        // Scroll position indicator (only shown when content overflows the
+        // panel), right-aligned on the same border line as the title.
+        prompt_block = prompt_block.title(
+            Line::from(format!(" {}/{} ", scroll + 1, total_lines))
+                .right_aligned()
+                .style(theme::muted()),
+        );
+    }
     let prompt_widget = Paragraph::new(prompt_text)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" System Prompt ")
-                .title_style(Style::default().add_modifier(Modifier::BOLD))
-                .style(theme::border_style()),
-        )
+        .block(prompt_block)
         // Was `fg(Color::White)` — white-on-white on a light terminal.
         .style(Style::default())
         .wrap(Wrap { trim: false })
-        .scroll((app.detail_scroll, 0));
-    frame.render_widget(prompt_widget, chunks[3 + orch_offset]);
+        .scroll((scroll, 0));
+    frame.render_widget(prompt_widget, prompt_area);
 
     // Instructions section
-    let instr_text = agent.instructions.as_deref().unwrap_or("(no instructions)");
     let instr_widget = Paragraph::new(instr_text)
         .block(
             Block::default()

--- a/src/tui/views/costs.rs
+++ b/src/tui/views/costs.rs
@@ -2,7 +2,8 @@ use ratatui::{
     Frame,
     layout::{Constraint, Rect},
     style::{Modifier, Style},
-    widgets::{Block, Borders, Paragraph, Row, Table},
+    text::Text,
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
 };
 
 use crate::theme;
@@ -10,6 +11,12 @@ use crate::tui::app::App;
 use crate::tui::filter;
 use crate::tui::format::format_cost;
 use crate::tui::widgets::search_bar;
+
+/// Right-align a cell's content (numeric columns), matching the convention
+/// that numbers line up on their least-significant digit.
+fn right(text: impl Into<Text<'static>>) -> Cell<'static> {
+    Cell::from(text.into().right_aligned())
+}
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if app.costs.is_empty() {
@@ -39,16 +46,26 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
+    // Column labels: right-aligned over the numeric columns (matching the
+    // values underneath) and muted, per the design-system convention that
+    // headers/labels use `theme::muted()`.
+    let header_style = theme::muted().add_modifier(Modifier::BOLD);
     let header = Row::new(vec![
-        "",
-        "AGENT",
-        "RUNS",
-        "COST (USD)",
-        "TOKENS IN",
-        "TOKENS OUT",
+        Cell::from(""),
+        Cell::from("AGENT"),
+        right("RUNS"),
+        right("COST (USD)"),
+        right("TOKENS IN"),
+        right("TOKENS OUT"),
     ])
-    .style(Style::default().add_modifier(Modifier::BOLD))
+    .style(header_style)
     .bottom_margin(1);
+
+    // Runs/tokens are secondary to the agent name and its cost (the point
+    // of this view), so they're muted to let AGENT/COST stand out — even
+    // on a selected row, where the row-level selection style still wins
+    // for foreground boldness but the muted fg keeps them de-emphasized.
+    let secondary_style = theme::muted();
 
     let mut rows: Vec<Row> = display_indices
         .iter()
@@ -66,12 +83,12 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Style::default()
             };
             Row::new(vec![
-                marker.to_string(),
-                c.agent.clone(),
-                c.total_runs.to_string(),
-                format_cost(c.total_cost),
-                c.total_tokens_in.to_string(),
-                c.total_tokens_out.to_string(),
+                Cell::from(marker),
+                Cell::from(c.agent.clone()),
+                right(c.total_runs.to_string()).style(secondary_style),
+                right(format_cost(c.total_cost)),
+                right(c.total_tokens_in.to_string()).style(secondary_style),
+                right(c.total_tokens_out.to_string()).style(secondary_style),
             ])
             .style(style)
         })
@@ -83,12 +100,12 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let total_cost: f64 = app.costs.iter().map(|c| c.total_cost).sum();
     rows.push(
         Row::new(vec![
-            String::new(),
-            "TOTAL".to_string(),
-            String::new(),
-            format_cost(total_cost),
-            String::new(),
-            String::new(),
+            Cell::from(""),
+            Cell::from("TOTAL"),
+            Cell::from(""),
+            right(format_cost(total_cost)),
+            Cell::from(""),
+            Cell::from(""),
         ])
         .style(Style::default().add_modifier(Modifier::BOLD))
         .top_margin(1),

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -11,7 +11,7 @@ use crate::tui::app::{App, Tab};
 use crate::tui::filter;
 use crate::tui::widgets::search_bar;
 
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -177,7 +177,11 @@ pub fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         let inner_height = area.height.saturating_sub(2);
         let total_lines = detail_content.lines().count().max(1);
         let overflow = total_lines > inner_height as usize;
-        app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+        app.set_detail_scroll_max(
+            total_lines
+                .saturating_sub(inner_height as usize)
+                .min(u16::MAX as usize) as u16,
+        );
         let scroll = app.detail_scroll;
 
         let mut block = Block::default()

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -4,6 +4,7 @@ use ratatui::{
     Frame,
     layout::{Constraint, Rect},
     style::{Modifier, Style},
+    text::Line,
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
@@ -112,7 +113,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-pub fn render_detail(frame: &mut Frame, app: &App, area: Rect) {
+pub fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(entry) = app.selected_orchestration_entry() {
         use crate::storage::{init_db, queries};
 
@@ -164,17 +165,40 @@ pub fn render_detail(frame: &mut Frame, app: &App, area: Rect) {
             Err(e) => format!("Database error: {}", e),
         };
 
+        // Owned now (rather than kept as a format! borrowing `entry`) so
+        // `entry`'s borrow of `app` ends here, freeing `app` for the
+        // mutable scroll-bound call below.
+        let run_title = format!(" Run {} ", entry.run_id);
+
+        // This view renders unwrapped (no `.wrap(...)`, to preserve the
+        // pretty-printed JSON's indentation) — so, unlike the other detail
+        // views, its line count is just the raw newline count, not a
+        // wrapped-line estimate.
+        let inner_height = area.height.saturating_sub(2);
+        let total_lines = detail_content.lines().count().max(1);
+        let overflow = total_lines > inner_height as usize;
+        app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+        let scroll = app.detail_scroll;
+
+        let mut block = Block::default()
+            .borders(Borders::ALL)
+            .title(run_title)
+            .style(theme::border_style());
+        if overflow {
+            block = block.title(
+                Line::from(format!(" {}/{} ", scroll + 1, total_lines))
+                    .right_aligned()
+                    .style(theme::muted()),
+            );
+        }
+
         let paragraph = Paragraph::new(detail_content)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(format!(" Run {} ", entry.run_id))
-                    .style(theme::border_style()),
-            )
-            .scroll((app.detail_scroll, 0));
+            .block(block)
+            .scroll((scroll, 0));
 
         frame.render_widget(paragraph, area);
     } else {
+        app.set_detail_scroll_max(0);
         let msg = Paragraph::new("No orchestration run selected").block(
             Block::default()
                 .borders(Borders::ALL)

--- a/src/tui/views/prompt_detail.rs
+++ b/src/tui/views/prompt_detail.rs
@@ -8,11 +8,13 @@ use ratatui::{
 
 use crate::theme;
 use crate::tui::app::App;
+use crate::tui::wrap::wrapped_line_count;
 
-pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let prompt = match app.selected_prompt() {
         Some(p) => p,
         None => {
+            app.set_detail_scroll_max(0);
             let msg = Paragraph::new("No prompt selected. Go to Prompts tab and select one.")
                 .block(
                     Block::default()
@@ -99,17 +101,32 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         prompt.body.clone()
     };
+
+    let body_area = chunks[2];
+    let inner_width = body_area.width.saturating_sub(2);
+    let inner_height = body_area.height.saturating_sub(2);
+    let total_lines = wrapped_line_count(&body_text, inner_width);
+    let overflow = total_lines > inner_height as usize;
+    app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+    let scroll = app.detail_scroll;
+
+    let mut body_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Content ")
+        .title_style(Style::default().add_modifier(Modifier::BOLD))
+        .style(theme::border_style());
+    if overflow {
+        body_block = body_block.title(
+            Line::from(format!(" {}/{} ", scroll + 1, total_lines))
+                .right_aligned()
+                .style(theme::muted()),
+        );
+    }
     let body_widget = Paragraph::new(body_text)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Content ")
-                .title_style(Style::default().add_modifier(Modifier::BOLD))
-                .style(theme::border_style()),
-        )
+        .block(body_block)
         // Was `fg(Color::White)` — white-on-white on a light terminal.
         .style(Style::default())
         .wrap(Wrap { trim: false })
-        .scroll((app.detail_scroll, 0));
-    frame.render_widget(body_widget, chunks[2]);
+        .scroll((scroll, 0));
+    frame.render_widget(body_widget, body_area);
 }

--- a/src/tui/views/prompt_detail.rs
+++ b/src/tui/views/prompt_detail.rs
@@ -107,7 +107,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner_height = body_area.height.saturating_sub(2);
     let total_lines = wrapped_line_count(&body_text, inner_width);
     let overflow = total_lines > inner_height as usize;
-    app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+    app.set_detail_scroll_max(
+        total_lines
+            .saturating_sub(inner_height as usize)
+            .min(u16::MAX as usize) as u16,
+    );
     let scroll = app.detail_scroll;
 
     let mut body_block = Block::default()

--- a/src/tui/views/shortcuts.rs
+++ b/src/tui/views/shortcuts.rs
@@ -6,13 +6,28 @@ use ratatui::{
     widgets::Paragraph,
 };
 
+use crate::theme;
 use crate::tui::app::{App, Tab};
 
 /// Render the keyboard shortcuts bar at the bottom of the screen.
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
-    // Quit and tab-jump are available from every tab (P1-4 / P2-5): document
-    // them once here instead of repeating the pair in each arm below.
-    const QUIT: (&str, &str) = ("q / ^C", "Quit");
+    // Top-level "press Esc again to quit" is armed (see
+    // `App::esc_armed` / `handle_top_level_esc` in `tui/mod.rs`): replace
+    // the whole bar with a prominent warning, mirroring the shell TUI's
+    // `render_hint_bar` (`src/shell/tui.rs`) — including its wording.
+    if app.esc_armed {
+        let bar = Paragraph::new("Press Esc again to quit").style(theme::warning());
+        frame.render_widget(bar, area);
+        return;
+    }
+
+    // Tab-jump is available from every tab (P2-5): document it once here
+    // instead of repeating it in each arm below. Quit has two flavors: at
+    // the top level `q`/Ctrl+C quit instantly and Esc arms a confirming
+    // second press; in a detail view Esc instead goes back (documented
+    // separately per arm), so only `q`/Ctrl+C quit there.
+    const QUIT_TOP_LEVEL: (&str, &str) = ("q / Esc×2 / ^C", "Quit");
+    const QUIT_DETAIL: (&str, &str) = ("q / ^C", "Quit");
     const JUMP: (&str, &str) = ("1-8", "Jump tab");
 
     let shortcuts = match app.current_tab {
@@ -25,22 +40,23 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         Tab::AgentDetail | Tab::PromptDetail | Tab::SkillDetail => vec![
             ("j/k", "Scroll"),
+            ("PgUp/PgDn", "Page"),
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
             JUMP,
             (":", "Commands"),
-            QUIT,
+            QUIT_DETAIL,
         ],
         Tab::ModelDetail => vec![
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
             JUMP,
             (":", "Commands"),
-            QUIT,
+            QUIT_DETAIL,
         ],
         Tab::StarterDetail => vec![
             ("Esc", "Back to list"),
@@ -48,7 +64,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             ("Tab", "Next tab"),
             JUMP,
             (":", "Commands"),
-            QUIT,
+            QUIT_DETAIL,
         ],
         Tab::Prompts | Tab::Skills => vec![
             ("j/k", "Navigate"),
@@ -59,7 +75,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         Tab::Starters => vec![
             ("j/k", "Navigate"),
@@ -71,7 +87,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         Tab::History => vec![
             ("j/k", "Navigate"),
@@ -81,7 +97,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         Tab::Costs => vec![
             ("j/k", "Navigate"),
@@ -91,7 +107,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         Tab::Models => vec![
             ("j/k", "Navigate"),
@@ -103,7 +119,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         #[cfg(feature = "storage")]
         Tab::Orchestration => vec![
@@ -115,20 +131,21 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             JUMP,
             (":", "Commands"),
             ("r", "Refresh"),
-            QUIT,
+            QUIT_TOP_LEVEL,
         ],
         #[cfg(feature = "storage")]
         Tab::OrchestrationDetail => vec![
             ("j/k", "Scroll"),
+            ("PgUp/PgDn", "Page"),
             ("Esc", "Back to list"),
             ("Tab", "Next tab"),
             JUMP,
             (":", "Commands"),
-            QUIT,
+            QUIT_DETAIL,
         ],
         #[cfg(not(feature = "storage"))]
         Tab::Orchestration | Tab::OrchestrationDetail => {
-            vec![("Tab", "Next tab"), JUMP, (":", "Commands"), QUIT]
+            vec![("Tab", "Next tab"), JUMP, (":", "Commands"), QUIT_TOP_LEVEL]
         }
     };
 
@@ -160,4 +177,48 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     let bar = Paragraph::new(Line::from(spans));
     frame.render_widget(bar, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    /// Render the shortcuts bar into a small offscreen buffer and return its
+    /// content as a single string, for substring assertions. Wide enough
+    /// that the longest tab's full shortcut list isn't clipped (the bar
+    /// itself doesn't wrap, matching how it actually renders).
+    fn rendered_text(app: &App) -> String {
+        let backend = TestBackend::new(200, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn armed_esc_replaces_the_bar_with_the_quit_warning() {
+        let mut app = App::new();
+        app.esc_armed = true;
+        let text = rendered_text(&app);
+        assert!(
+            text.contains("Press Esc again to quit"),
+            "armed bar should show the quit warning, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn unarmed_bar_shows_the_normal_shortcuts_not_the_warning() {
+        let app = App::new();
+        let text = rendered_text(&app);
+        assert!(!text.contains("Press Esc again to quit"));
+        assert!(text.contains("Quit"), "normal bar should list Quit");
+    }
 }

--- a/src/tui/views/skill_detail.rs
+++ b/src/tui/views/skill_detail.rs
@@ -160,7 +160,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner_height = body_area.height.saturating_sub(2);
     let total_lines = wrapped_line_count(&body_text, inner_width);
     let overflow = total_lines > inner_height as usize;
-    app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+    app.set_detail_scroll_max(
+        total_lines
+            .saturating_sub(inner_height as usize)
+            .min(u16::MAX as usize) as u16,
+    );
     let scroll = app.detail_scroll;
 
     let mut body_block = Block::default()

--- a/src/tui/views/skill_detail.rs
+++ b/src/tui/views/skill_detail.rs
@@ -9,11 +9,13 @@ use ratatui::{
 use crate::core::skill::read_text_file;
 use crate::theme;
 use crate::tui::app::App;
+use crate::tui::wrap::wrapped_line_count;
 
-pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let skill = match app.selected_skill() {
         Some(s) => s,
         None => {
+            app.set_detail_scroll_max(0);
             let msg = Paragraph::new("No skill selected. Go to Skills tab and select one.").block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -38,7 +40,25 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
 
-    let has_other_files = !skill.scripts.is_empty() || !skill.assets.is_empty();
+    // Scripts/Assets summary line, extracted as owned data now (rather than
+    // read from `skill` further down, after the scrollable body section)
+    // so `skill`'s borrow of `app` ends here — freeing `app` for the
+    // mutable scroll-bound call the body section needs below.
+    let file_name = |p: &std::path::Path| -> String {
+        p.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default()
+    };
+    let mut file_parts: Vec<String> = Vec::new();
+    if !skill.scripts.is_empty() {
+        let names: Vec<String> = skill.scripts.iter().map(|p| file_name(p)).collect();
+        file_parts.push(format!("scripts: {}", names.join(", ")));
+    }
+    if !skill.assets.is_empty() {
+        let names: Vec<String> = skill.assets.iter().map(|p| file_name(p)).collect();
+        file_parts.push(format!("assets: {}", names.join(", ")));
+    }
+    let has_other_files = !file_parts.is_empty();
 
     // Build layout constraints dynamically
     let mut constraints = vec![
@@ -134,19 +154,34 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         skill.body.clone()
     };
+
+    let body_area = chunks[2];
+    let inner_width = body_area.width.saturating_sub(2);
+    let inner_height = body_area.height.saturating_sub(2);
+    let total_lines = wrapped_line_count(&body_text, inner_width);
+    let overflow = total_lines > inner_height as usize;
+    app.set_detail_scroll_max(total_lines.saturating_sub(inner_height as usize) as u16);
+    let scroll = app.detail_scroll;
+
+    let mut body_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" SKILL.md ")
+        .title_style(Style::default().add_modifier(Modifier::BOLD))
+        .style(theme::border_style());
+    if overflow {
+        body_block = body_block.title(
+            Line::from(format!(" {}/{} ", scroll + 1, total_lines))
+                .right_aligned()
+                .style(theme::muted()),
+        );
+    }
     let body_widget = Paragraph::new(body_text)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" SKILL.md ")
-                .title_style(Style::default().add_modifier(Modifier::BOLD))
-                .style(theme::border_style()),
-        )
+        .block(body_block)
         // Was `fg(Color::White)` — white-on-white on a light terminal.
         .style(Style::default())
         .wrap(Wrap { trim: false })
-        .scroll((app.detail_scroll, 0));
-    frame.render_widget(body_widget, chunks[2]);
+        .scroll((scroll, 0));
+    frame.render_widget(body_widget, body_area);
 
     // Reference file content blocks
     for (i, (name, content)) in ref_contents.iter().enumerate() {
@@ -169,21 +204,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // Scripts/Assets summary (compact)
     if has_other_files {
-        let file_name = |p: &std::path::Path| -> String {
-            p.file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default()
-        };
-        let mut file_parts: Vec<String> = Vec::new();
-        if !skill.scripts.is_empty() {
-            let names: Vec<String> = skill.scripts.iter().map(|p| file_name(p)).collect();
-            file_parts.push(format!("scripts: {}", names.join(", ")));
-        }
-        if !skill.assets.is_empty() {
-            let names: Vec<String> = skill.assets.iter().map(|p| file_name(p)).collect();
-            file_parts.push(format!("assets: {}", names.join(", ")));
-        }
-
         let files_widget = Paragraph::new(file_parts.join("  |  "))
             .block(
                 Block::default()

--- a/src/tui/wrap.rs
+++ b/src/tui/wrap.rs
@@ -10,7 +10,14 @@
 //! packed onto a line until the next word would overflow `width`, then a
 //! new line starts. It doesn't need to match ratatui's wrapping character
 //! for character, only closely enough that the computed bound never lets
-//! the user scroll past real content.
+//! the user scroll past real content — so this counts leading/indentation
+//! whitespace toward line width (ratatui's `trim: false` keeps it, it isn't
+//! dropped) and, after a word gets hard-broken across multiple lines,
+//! carries the remaining width of its last physical chunk forward so
+//! following text can share that line, exactly as ratatui's own
+//! `WordWrapper` does. Both behaviors were verified against real ratatui
+//! 0.30.2 rendering (`Paragraph` + `Wrap { trim: false }` into a
+//! `TestBackend` buffer) — see the tests below.
 
 use unicode_width::UnicodeWidthStr;
 
@@ -35,9 +42,23 @@ fn wrapped_line_count_single(line: &str, width: usize) -> usize {
     for word in line.split(' ') {
         if word.is_empty() {
             // Collapsed/repeated whitespace: consume a column if there's
-            // room. Only cosmetic for our bound-checking purpose.
-            if has_content && current < width {
+            // room. This also covers *leading* whitespace (indentation),
+            // which `Wrap { trim: false }` renders and counts toward line
+            // width instead of dropping — a `split(' ')` run of N leading
+            // spaces yields N empty tokens before the first real word, so
+            // counting them unconditionally reproduces that width exactly.
+            //
+            // Deliberately not setting `has_content = true` here: a run of
+            // leading spaces has no preceding word to separate from, so the
+            // first real word that follows must not get a phantom extra
+            // separator column added on top of the spaces already counted.
+            if current < width {
                 current += 1;
+            } else {
+                // The line is already full of whitespace; ratatui starts a
+                // fresh (empty) line rather than carrying anything over.
+                lines += 1;
+                current = 0;
             }
             continue;
         }
@@ -46,13 +67,20 @@ fn wrapped_line_count_single(line: &str, width: usize) -> usize {
         if word_width > width {
             // A single word wider than the line will be hard-broken by the
             // real renderer. We don't reproduce the exact split point, only
-            // the resulting line count (see module doc).
+            // the resulting line count (see module doc) — except for the
+            // *last* hard-wrapped chunk, which matters for what follows: it
+            // isn't a fresh closed line, it's the still-open current line.
+            // Ratatui reuses whatever width remains on it for the text that
+            // comes next, instead of starting that text on a brand new
+            // line. Losing this remaining-width state is what caused the
+            // original undercount here.
             if has_content {
                 lines += 1;
             }
             lines += word_width.div_ceil(width).saturating_sub(1);
-            current = 0;
-            has_content = false;
+            let remainder = word_width % width;
+            current = if remainder == 0 { width } else { remainder };
+            has_content = true;
             continue;
         }
 
@@ -119,5 +147,48 @@ mod tests {
         // needs 3 lines because "aaaaaa bbbbbb" (13 cols) doesn't fit on
         // one width-10 line — undercounting would hide real content.
         assert_eq!(wrapped_line_count("aaaaaa bbbbbb cccccc", 10), 3);
+    }
+
+    #[test]
+    fn leading_indentation_counts_toward_line_width() {
+        // Regression guard for a confirmed undercount: `Wrap { trim: false
+        // }` renders leading whitespace (e.g. code-block/nested-list
+        // indentation) as real columns instead of dropping it, so "    let
+        // x = 5;" (4 leading spaces + 10 columns of text = 14 total) at
+        // width 10 needs 2 physical lines, not 1. Verified against real
+        // ratatui 0.30.2 (`Paragraph::new(text).wrap(Wrap { trim: false
+        // })` rendered into a `TestBackend`, counting non-blank rows):
+        // ratatui renders exactly 2 rows for this input at width 10. The
+        // pre-fix implementation returned 1 here (dropped the 4 leading
+        // spaces while `has_content` was still false), stranding scroll
+        // content.
+        assert!(
+            wrapped_line_count("    let x = 5;", 10) >= 2,
+            "must not undercount indented content (ratatui renders 2 lines here)"
+        );
+    }
+
+    #[test]
+    fn hard_break_remainder_shares_line_with_following_text() {
+        // Regression guard for a confirmed undercount: once a word too wide
+        // for the line gets hard-broken, ratatui's `WordWrapper` reuses the
+        // remaining width of that word's last physical chunk for whatever
+        // text follows, rather than starting that text on a fresh line.
+        // Verified against real ratatui 0.30.2 the same way as above: this
+        // 87-column unbreakable "URL" followed by " more text after", at
+        // width 20, renders exactly 6 rows (the 87-wide token hard-breaks
+        // into 4 full 20-wide rows plus a 7-wide remainder, and that
+        // remainder row absorbs " more" before "text after" wraps onward).
+        // The pre-fix implementation reset the running column count to 0
+        // after the hard break (as if a brand new empty line had started),
+        // which returned 5 here instead of 6 — an undercount that would
+        // strand the last visible line of content.
+        assert!(
+            wrapped_line_count(
+                "https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa more text after",
+                20
+            ) >= 6,
+            "must not undercount text following a hard-broken word (ratatui renders 6 lines here)"
+        );
     }
 }

--- a/src/tui/wrap.rs
+++ b/src/tui/wrap.rs
@@ -1,0 +1,123 @@
+//! Approximate word-wrap line counting, used only to bound detail-view
+//! scrolling (Up/Down/PageUp/PageDown must never scroll past the start or
+//! end of the rendered content — see `App::detail_scroll_max`).
+//!
+//! ratatui's own `Paragraph::line_count` would compute this exactly, but it
+//! is gated behind the `unstable-rendered-line-info` cargo feature (no
+//! stability guarantee — <https://github.com/ratatui/ratatui/issues/293>),
+//! which we don't enable. This reimplements just the greedy word-wrap
+//! ratatui uses for `Wrap { trim: false }`: whitespace-separated words are
+//! packed onto a line until the next word would overflow `width`, then a
+//! new line starts. It doesn't need to match ratatui's wrapping character
+//! for character, only closely enough that the computed bound never lets
+//! the user scroll past real content.
+
+use unicode_width::UnicodeWidthStr;
+
+/// Number of display lines `text` occupies when wrapped to `width` columns
+/// (mirrors `Wrap { trim: false }`). Returns 0 for `width == 0` (nothing
+/// can be rendered in a zero-width area).
+pub(crate) fn wrapped_line_count(text: &str, width: u16) -> usize {
+    if width == 0 {
+        return 0;
+    }
+    let width = width as usize;
+    text.split('\n')
+        .map(|line| wrapped_line_count_single(line, width))
+        .sum()
+}
+
+fn wrapped_line_count_single(line: &str, width: usize) -> usize {
+    let mut lines = 1usize;
+    let mut current = 0usize;
+    let mut has_content = false;
+
+    for word in line.split(' ') {
+        if word.is_empty() {
+            // Collapsed/repeated whitespace: consume a column if there's
+            // room. Only cosmetic for our bound-checking purpose.
+            if has_content && current < width {
+                current += 1;
+            }
+            continue;
+        }
+
+        let word_width = word.width();
+        if word_width > width {
+            // A single word wider than the line will be hard-broken by the
+            // real renderer. We don't reproduce the exact split point, only
+            // the resulting line count (see module doc).
+            if has_content {
+                lines += 1;
+            }
+            lines += word_width.div_ceil(width).saturating_sub(1);
+            current = 0;
+            has_content = false;
+            continue;
+        }
+
+        let sep = usize::from(has_content);
+        if current + sep + word_width > width {
+            lines += 1;
+            current = word_width;
+        } else {
+            current += sep + word_width;
+        }
+        has_content = true;
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_fits_one_line() {
+        assert_eq!(wrapped_line_count("hello world", 40), 1);
+    }
+
+    #[test]
+    fn two_words_wrap_when_they_dont_both_fit() {
+        // "aaaaaaaaaa" (10) + space + "bbbbbbbbbb" (10) can't share a
+        // width-10 line, so each word gets its own line.
+        assert_eq!(
+            wrapped_line_count("aaaaaaaaaa bbbbbbbbbb", 10),
+            2,
+            "greedy wrap must break at the word boundary, not mid-word"
+        );
+    }
+
+    #[test]
+    fn respects_explicit_newlines() {
+        assert_eq!(wrapped_line_count("line one\nline two\nline three", 40), 3);
+    }
+
+    #[test]
+    fn empty_text_is_one_line() {
+        assert_eq!(wrapped_line_count("", 40), 1);
+    }
+
+    #[test]
+    fn zero_width_has_no_lines() {
+        assert_eq!(wrapped_line_count("anything", 0), 0);
+    }
+
+    #[test]
+    fn word_wider_than_width_is_hard_broken_across_lines() {
+        // A 25-char unbroken token in a 10-col line needs 3 hard-wrapped
+        // lines (10 + 10 + 5).
+        assert_eq!(wrapped_line_count("aaaaaaaaaaaaaaaaaaaaaaaaa", 10), 3);
+    }
+
+    #[test]
+    fn moderate_word_width_does_not_undercount_lines() {
+        // Regression guard: a naive `ceil(total_display_width / width)`
+        // estimate undercounts here (predicts 2 lines for 20 display
+        // columns of content in width 10), but greedy word-wrap actually
+        // needs 3 lines because "aaaaaa bbbbbb" (13 cols) doesn't fit on
+        // one width-10 line — undercounting would hide real content.
+        assert_eq!(wrapped_line_count("aaaaaa bbbbbb cccccc", 10), 3);
+    }
+}


### PR DESCRIPTION
Closes #259.

## Contexte
Dettes de la Phase 1 v1.0.0 (`epic:docs`, item #259). Subagent-driven, lots relus indépendamment + revue finale whole-branch **READY TO MERGE**.

## Contenu
- **A — Test flaky hermétisé** (`test`) : `test_resolve_shell_model_aliases` racedait sur le cache models.dev partagé (muté par des tests parallèles). Isolé via `ENV_MUTEX` + cache temp (pattern existant du repo). Déterminisme vérifié sur runs répétés.
- **B — Zip-slip durci** (`fix`) : `extract_archive` (starters distants) liste les entrées et **rejette** `..`/absolu avant de shell-out `tar`/`unzip` (helper pur `archive_entry_is_safe` + tests). Échec fermé. Follow-up noté : cibles de symlink non couvertes (hors scope).
- **C1/C2 — Quit-keys unifiées + scroll détail** (`fix`) : `Ctrl+C` quitte inconditionnellement (TUI+shell) ; **Esc top-level arme « appuie encore sur Esc pour quitter »** (aligné sur le shell) au lieu de quitter direct ; `q` reste quit rapide TUI-only. Scroll vues détail : ↑/↓ + PageUp/Down bornés + indicateur, thème DS.
- **C3 — Costs aux conventions** (`fix`) : alignement colonnes + `theme::muted()` + `format_cost` réutilisé (présentation seule).
- **C-fix** (`fix`) : `wrap.rs::wrapped_line_count` sous-comptait (indentation + carry hard-break) → fin de contenu inaccessible ; corrigé et **vérifié contre ratatui 0.30.2 réel** (jamais de sous-comptage), `max_scroll` saturé u16.

## Gate
clippy 3 modes clean · fmt clean · test `tui` 983 / `tui,storage` 1018 · wrap:: 9. Revue finale re-exécute la gate indépendamment.

## Minors non bloquants
Trailer absent sur 2 commits (absorbé au squash) ; 2 tests wrap en `>=` vs `assert_eq!` (documenté) ; zip-slip symlink (follow-up).

## Validation visuelle (Dimitri) — TUI
`cargo run --bin armadai -- tui` : Esc au top-level → « Esc encore pour quitter » (pas de quit direct) ; `q`/`Ctrl+C` quittent ; vues détail (agent/prompt/skill) → ↑/↓ + PageUp/Down + indicateur de scroll ; onglet Costs aligné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
