### PR TITLE
feat(run): OH1 Lot 6 — run --resume/--replay (event-sourced) (#249)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-oh1-lot6-resume-replay.md
+++ b/docs/superpowers/plans/2026-07-24-oh1-lot6-resume-replay.md
@@ -1,0 +1,186 @@
+# OH1 Lot 6 — resume/replay CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `armadai run --replay <run_id>` (deterministic re-emission of a finished run to the display, no effects) and `armadai run --resume <run_id>` (reconstruct state from the event log and continue an interrupted run), closing OH1 Lot 6.
+
+**Architecture:** The event log is already the source of truth (`execution_events` table, `SqliteLog`). `replay(run_id, log)` folds it to an `ExecutionState` without effects. Replay = fold + emit each event to the `EventSink`. Resume = seed a fresh loop from the replayed state (skipping re-append of existing events) and continue. A new core primitive `resume_event_sourced` provides the seeded loop; the 4 pattern dispatchers gain a resume entry. `run_id` (today a fresh uuid never shown) becomes visible so users can target it.
+
+**Tech Stack:** Rust edition 2024, `core/orchestration/es/`, `cli/run.rs`, `storage` (rusqlite), clap.
+
+## Global Constraints
+
+- Design source: `docs/superpowers/specs/2026-07-21-oh1-event-sourcing-design.md` §8 (Reprise C7 & audit/replay) + Lot 6. Verbatim semantics:
+  - `--resume <run_id>`: load `execution_events[run_id]`, fold → `ExecutionState`, **resume the pattern loop from that state** (only if status is non-terminal). **No effect re-executed** (observations are in the log).
+  - `--replay <run_id>`: fold + **replay events to the display sink without executing effects** (deterministic visualization).
+- **Persistence is gated `storage`.** Without `storage` (or if the DB is unavailable) the log is `InMemoryLog` (ephemeral) → resume/replay are impossible and MUST fail with a clear error, never silently no-op.
+- **Never duplicate log events on resume**: `run_event_sourced` re-appends everything in its `initial` arg (`engine.rs:124` `append_and_apply` in the `for event in initial` loop). Resume MUST seed state via `replay()` (pure fold, no append) and continue — do NOT pass existing events as `initial`.
+- `RunStatus` (`es/state.rs:14`): `Running` (resumable) | `Completed` | `Halted` (terminal). Resume of a terminal run is an error.
+- Conventional Commits, single type per commit. Trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- rust-analyzer unreliable — verify at the compiler. Gate every task: `cargo fmt --all` + clippy 3 modes (`tui` / `tui,providers-api` / `tui,web,storage`) `-D warnings` + `cargo test --no-default-features --features tui` + `cargo test --no-default-features --features tui,storage`.
+
+---
+
+## File Structure
+
+- `src/cli/mod.rs` — `Run` variant: `agent` becomes optional; add `--resume`/`--replay` flags (clap `ArgGroup`, mutually exclusive, and exclusive with `agent`).
+- `src/cli/run.rs` — `execute(...)`/`run_inner(...)`: two new `Option<String>` params (`resume`, `replay`); dispatch to replay/resume paths; surface `run_id`.
+- `src/core/events.rs` — surface `run_id`: add a `RunStart.run_id` field (or a new `RunEvent::Meta { run_id }` emitted first). Chosen: add `run_id: String` to `RunStart`.
+- `src/core/orchestration/es/engine.rs` — new `resume_event_sourced(...)`; extract the shared loop body so `run_event_sourced` and `resume_event_sourced` share it.
+- `src/core/orchestration/es/{direct,blackboard,ring,hierarchical}.rs` — a resume entry per pattern (seed from replayed state, continue).
+- `src/storage/queries.rs` — reuse `all_event_log_run_ids`; add a helper to fetch a run's stored pattern (from `orchestration_runs`) so resume picks the right engine.
+- `docs/wiki/orchestration-guide.md` — document `--resume`/`--replay`.
+
+---
+
+## Task 1: Surface `run_id` + CLI flag plumbing
+
+**Files:**
+- Modify: `src/core/events.rs` (RunStart gains `run_id`)
+- Modify: `src/cli/mod.rs` (Run variant + handler)
+- Modify: `src/cli/run.rs` (`execute`/`run_inner` params; emit run_id; the 4 dispatch sites pass their generated run_id into the emitted `RunStart`)
+- Test: `src/core/events.rs` unit test (RunStart serializes run_id in `--json`)
+
+**Interfaces:**
+- Produces: `execute(..., resume: Option<String>, replay: Option<String>)` and `run_inner(..., resume: Option<String>, replay: Option<String>)`. `RunStart { run_id, v, agents, prov, model, in_chars }`.
+
+- [ ] **Step 1: Add `run_id` to `RunStart`**
+
+In `src/core/events.rs`, add `run_id: String` as the first field of the `RunStart` variant. Update every constructor/emitter of `RunStart` (grep `RunStart {`) — the 4 dispatch sites in `run.rs` already own a `run_id` local; pass it. For any non-orchestrated/simple path that emits `RunStart`, generate/propagate a run_id.
+
+- [ ] **Step 2: Test run_id in JSON**
+
+Add a unit test asserting a `RunStart { run_id: "abc", .. }` serializes with `"run_id":"abc"` (serde tag `t`). Run it; expect PASS.
+
+- [ ] **Step 3: Human-surface the run_id**
+
+On the human path (non-json), print one muted line at run start via `anstream` + `crate::cli::style::muted()`: `run <run_id>` (so users can copy it for `--resume`). Not on `--json`/`--quiet` (json carries it in `RunStart`).
+
+- [ ] **Step 4: Make `agent` optional + add flags (clap)**
+
+In `src/cli/mod.rs` `Run` variant: change `agent: String` → `agent: Option<String>`; add `#[arg(long, value_name="RUN_ID")] resume: Option<String>` and `replay: Option<String>`. Add a clap `ArgGroup` (e.g. `group(ArgGroup::new("mode").args(["agent","resume","replay"]).required(true))`) so exactly one of agent/resume/replay is given and resume⊕replay are mutually exclusive. Update the `Command::Run { .. }` handler to pass `resume`/`replay` into `run::execute`.
+
+- [ ] **Step 5: Thread params + validate**
+
+In `run.rs::execute` and `run_inner`, add `resume`/`replay` params. At the top of `execute`, branch: if `replay.is_some()` → call the replay path (Task 2, stub returning `anyhow::bail!("--replay not yet wired")` for now); if `resume.is_some()` → resume path (Task 3 stub); else the existing agent path (unwrap `agent`, which the ArgGroup guarantees is present). Compile-time: `agent_name` is now `Option<String>` — unwrap only in the normal branch.
+
+- [ ] **Step 6: Gate**
+
+Run the full gate. Expect green. Commit: `feat(run): surface run_id and add --resume/--replay flag scaffolding (OH1 Lot 6)`.
+
+---
+
+## Task 2: `--replay <run_id>` (deterministic re-emission)
+
+**Files:**
+- Modify: `src/cli/run.rs` (replay path)
+- Create: `src/cli/run_replay.rs` (or a fn in run.rs) — `async fn replay_run(run_id, sink, human_output) -> Result<()>`
+- Test: integration test — run a pattern to a log, then replay reproduces the same `RunEvent` sequence.
+
+**Interfaces:**
+- Consumes: `crate::core::orchestration::es::replay`, `SqliteLog`, the existing event→`RunEvent` projection used by the live path.
+
+- [ ] **Step 1: Failing test**
+
+In an ES integration test (mirror `es/blackboard.rs:2137` harness), build a `SqliteLog` on a temp DB, run a short pattern (run_id `r1`), collect the live `RunEvent`s into a `Vec` via a capturing sink; then call the new replay path for `r1` with a second capturing sink and assert the replayed `RunEvent` sequence equals the live one (modulo timing fields). Expect FAIL (replay path unimplemented).
+
+- [ ] **Step 2: Implement `replay_run`**
+
+Load events: `#[cfg(feature="storage")]` open `SqliteLog` via `crate::storage::init_db()`; `let events = log.events(run_id)?;`. If empty → `anyhow::bail!("no run found for id {run_id}")`. Map each `ExecutionEvent` to the display `RunEvent` using the SAME projection the live engine uses (find it — grep where `ExecutionEvent` → `RunEvent`/`sink.emit` mapping lives; reuse it, do not fork). Emit to `sink`. Execute NO effects (no provider calls). `#[cfg(not(feature="storage"))]` → `anyhow::bail!("--replay requires the 'storage' feature (event log persistence)")`.
+
+- [ ] **Step 3: Wire + error cases**
+
+Replace the Task 1 replay stub with `replay_run`. Add tests: unknown run_id → error; (storage-off compile path returns the storage error — covered by the `tui` (no storage) test mode compiling the bail arm).
+
+- [ ] **Step 4: Gate + commit**
+
+`feat(run): --replay reconstructs a finished run to the display without effects (OH1 Lot 6)`.
+
+---
+
+## Task 3: `--resume <run_id>` (continue an interrupted run)
+
+**Files:**
+- Modify: `src/core/orchestration/es/engine.rs` (extract shared loop; add `resume_event_sourced`)
+- Modify: `src/core/orchestration/es/{direct,blackboard,ring,hierarchical}.rs` (resume entry per pattern)
+- Modify: `src/cli/run.rs` (resume path: pick pattern, guard status, dispatch)
+- Modify: `src/storage/queries.rs` (helper: fetch stored pattern for a run_id from `orchestration_runs`)
+- Test: integration — a run interrupted before completion resumes to completion without re-invoking already-observed agents.
+
+**Interfaces:**
+- Produces: `pub async fn resume_event_sourced<D,R,L>(run_id: &str, decider: &D, effects: &R, log: &mut L) -> Result<ExecutionState>` — seeds `state = replay(run_id, log)?` (NO re-append), then runs the shared loop.
+
+- [ ] **Step 1: Extract the shared loop**
+
+In `engine.rs`, factor the `while state.status == RunStatus::Running { … }` body (lines ~128-185) into `async fn run_loop<D,R,L>(run_id, state: &mut ExecutionState, decider, effects, log) -> Result<()>`. `run_event_sourced` becomes: default state → append+apply `initial` → `run_loop`. Verify existing engine tests still pass (behavior identical).
+
+- [ ] **Step 2: Add `resume_event_sourced`**
+
+```rust
+pub async fn resume_event_sourced<D, R, L>(run_id: &str, decider: &D, effects: &R, log: &mut L) -> anyhow::Result<ExecutionState>
+where D: Decider, R: EffectRunner, L: EventLog {
+    let mut state = replay(run_id, log)?;      // pure fold, NO re-append
+    if state.status != RunStatus::Running {
+        anyhow::bail!("run {run_id} is not resumable (status: {:?})", state.status);
+    }
+    run_loop(run_id, &mut state, decider, effects, log).await?;
+    Ok(state)
+}
+```
+Export it from `es/mod.rs` next to `run_event_sourced`/`replay`.
+
+- [ ] **Step 3: Failing test (core)**
+
+In `engine.rs` (or per-pattern) tests: build a log, run a decider that would take N steps but stop the process after step 1 by using a log pre-seeded with only the first events (simulate a crash: append `RunStarted` + one `AgentInvoked`/`AgentObserved` manually, leaving status `Running`). Call `resume_event_sourced` with the real decider/effects; assert it completes (`status == Completed`) and that the already-observed agent is NOT re-invoked (effects runner records invocations; assert the pre-observed one absent). Expect FAIL until wired. Also assert resuming a `Completed` log bails.
+
+- [ ] **Step 4: Per-pattern resume entry**
+
+Each `run_*_es` builds its decider+effects from config then calls `run_event_sourced`. Add a sibling `resume_*_es(run_id, <config/agents>, log, sink)` that builds the SAME decider+effects and calls `resume_event_sourced`. The config needed to rebuild decider/effects comes from the `ConfigSnapshot` event already in the log (Lot 5b) — reconstruct config from the replayed state/events, so resume needs no external args beyond run_id. Verify `ConfigSnapshot` carries what each pattern's decider/effects need; if a pattern needs more, note it.
+
+- [ ] **Step 5: CLI resume path**
+
+In `run.rs`, the resume branch: require storage (else bail as in Task 2). Open `SqliteLog`; fetch the run's pattern via the new `queries` helper (from `orchestration_runs.pattern`); `replay` to check it exists + is `Running` (else clear error); dispatch to the matching `resume_*_es`; drive the same sink/TUI as a normal orchestrated run.
+
+- [ ] **Step 6: Gate + commit**
+
+`feat(run): --resume continues an interrupted event-sourced run from the log (OH1 Lot 6)`.
+
+---
+
+## Task 4: End-to-end resume test + docs
+
+**Files:**
+- Create/modify: an integration test simulating crash→resume at the CLI level (bespoke, since the declarative `tests/e2e` harness can't inject a mid-run crash — see spec note).
+- Modify: `docs/wiki/orchestration-guide.md`
+
+**Interfaces:** consumes Tasks 1-3.
+
+- [ ] **Step 1: Crash→resume integration test**
+
+Bespoke Rust integration test (not the declarative yaml harness): using a temp DB + `fake-claude`, drive a hierarchical/blackboard run whose fake spec makes the process stop after partial progress (e.g. a decider/effects seam that returns early once), leaving the log with status `Running`; then invoke the resume path on the same run_id and assert it reaches `Completed` with the full expected event set, and that no already-observed agent was re-invoked. Reuse the `es/*.rs` test harness style (temp `SqliteLog`).
+
+- [ ] **Step 2: Replay determinism test**
+
+Assert `--replay` of a completed run emits a `RunEvent` sequence byte-identical (modulo timestamps) to the original live run (already drafted in Task 2 Step 1 — consolidate here if needed).
+
+- [ ] **Step 3: Docs**
+
+In `docs/wiki/orchestration-guide.md`, add a "Resume & replay" subsection: how run_id is shown, `armadai run --resume <run_id>` / `--replay <run_id>`, the `storage`-required caveat, and that no LLM effect is re-run.
+
+- [ ] **Step 4: Gate + commit**
+
+`test(run): crash→resume and replay-determinism integration tests + docs (OH1 Lot 6)`.
+
+---
+
+## Self-Review
+
+**Spec coverage (§8 + Lot 6):** `--resume` (fold→state→continue, no effects, terminal-guard) → Task 3. `--replay` (fold→sink, no effects) → Task 2. Storage-gated with clear failure when absent → Global Constraints + Task 2/3 bail arms. run_id surfacing (prereq, not in spec but required for the feature to be usable) → Task 1. Crash→resume e2e (Lot 6 "tests bout-en-bout") → Task 4. ✅
+
+**No-duplication invariant** (the subtle one): called out in Global Constraints and enforced by `resume_event_sourced` seeding via `replay` (pure fold) — Task 3 Step 2. The shared-loop extraction (Step 1) is behavior-preserving for the normal path (verified by existing engine tests).
+
+**Placeholder scan:** Task 1 intentionally stubs the replay/resume branches with explicit `bail!` that Tasks 2/3 replace — each task still ends green and independently reviewable. Two items require the implementer to *locate then reuse* an existing thing rather than invent: (a) the `ExecutionEvent`→`RunEvent` display projection (Task 2 Step 2) — reuse the live one; (b) whether `ConfigSnapshot` carries enough to rebuild each pattern's decider/effects (Task 3 Step 4) — verify, and if a pattern needs more, surface it as a blocker rather than guessing. These are "find the real API" directives, not vague placeholders.
+
+**Type consistency:** `resume`/`replay: Option<String>` threaded identically through `execute`→`run_inner`. `resume_event_sourced` mirrors `run_event_sourced`'s generics `<D,R,L>`. `RunStart.run_id: String` added once and populated at every emit site.
+
+**Open risk flagged for execution:** Task 3 Step 4 hinges on `ConfigSnapshot` sufficiency — if a pattern's decider/effects need runtime config not in the snapshot, that pattern's resume needs the snapshot extended (a Lot-5b touch-up) before it can resume; the implementer must report this rather than silently narrow scope.

--- a/docs/wiki/orchestration-guide.md
+++ b/docs/wiki/orchestration-guide.md
@@ -423,6 +423,36 @@ When a budget or cost limit is hit:
 
 **Best practice:** The default token budget (500k) is a generous safety cap meant to catch a runaway, not a tight limit — normal multi-round/multi-lap runs with verbose agents stay well under it. Lower it only if you want a tighter ceiling for a specific run, and monitor costs via `armadai costs`.
 
+## Resume & Replay
+
+Every run (Direct or orchestrated) prints its `run_id` as it starts:
+
+```
+run 3f2a1c9e-...
+```
+
+Keep that id — it lets you come back to the run later with either flag below. Both require the `storage` feature (they read from the persisted event log, which doesn't exist without it) and fail with an explicit `requires the 'storage' feature` error rather than doing nothing silently.
+
+### `--resume <run_id>`
+
+Continues a run that's still `Running` — typically because the process was killed or crashed mid-orchestration. Resume seeds its state by replaying the persisted event log (no LLM calls), then hands off to the same decider/effects loop the pattern would normally drive, picking up exactly where it left off: agents already invoked and observed before the interruption are **not** re-invoked, only the remaining work runs.
+
+```bash
+armadai run --resume 3f2a1c9e-...
+```
+
+Fails with a clear error if `run_id` is unknown, or if the run already reached a terminal state (`Completed`/`Halted` — nothing left to resume; use `--replay` instead).
+
+### `--replay <run_id>`
+
+Deterministically re-displays a run that has already finished, reconstructing the exact same `RunEvent` sequence the live run emitted — purely by folding the persisted event log. No agent is re-invoked and no LLM effect runs. Useful for re-inspecting a completed run's output/trace (a new terminal, cleared scrollback, `--json` post-processing, …) without spending tokens again.
+
+```bash
+armadai run --replay 3f2a1c9e-...
+```
+
+Fails with a clear error if `run_id` is unknown.
+
 ## Tips and Gotchas
 
 ### 1. Start Simple, Add Orchestration When Needed

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@ mod prompts;
 mod registry;
 mod run;
 mod run_es_record;
+mod run_replay;
 pub(crate) mod setup;
 mod skills;
 pub(crate) mod style;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,7 +22,7 @@ mod up;
 mod update;
 mod validate;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{ArgGroup, CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
@@ -53,15 +53,23 @@ pub enum Command {
         long_about = "Run an agent with the given input.\n\n\
             Loads the agent definition from agents/<name>.md, sends the input to the \
             configured provider, and prints the response. Use --pipe to chain multiple \
-            agents sequentially (output of one becomes input of the next).",
+            agents sequentially (output of one becomes input of the next).\n\n\
+            Exactly one of <AGENT>, --resume, or --replay must be given.",
         after_help = "Examples:\n  \
             armadai run code-reviewer \"Review this function\"\n  \
             armadai run summarizer @long-document.txt\n  \
-            armadai run --pipe reviewer writer src/main.rs"
+            armadai run --pipe reviewer writer src/main.rs\n  \
+            armadai run --resume <RUN_ID>\n  \
+            armadai run --replay <RUN_ID>",
+        group(
+            ArgGroup::new("run_mode")
+                .args(["agent", "resume", "replay"])
+                .required(true)
+        )
     )]
     Run {
         /// Agent name (filename without .md)
-        agent: String,
+        agent: Option<String>,
         /// Input text or file path (use @file.txt for files)
         input: Option<String>,
         /// Pipeline mode: chain agents sequentially
@@ -94,6 +102,12 @@ pub enum Command {
         /// Disable the live orchestration TUI (force plain headless output)
         #[arg(long = "no-tui")]
         no_tui: bool,
+        /// Resume a previously interrupted run by its run_id (OH1 Lot 6)
+        #[arg(long, value_name = "RUN_ID")]
+        resume: Option<String>,
+        /// Replay a previously recorded run by its run_id (OH1 Lot 6)
+        #[arg(long, value_name = "RUN_ID")]
+        replay: Option<String>,
     },
     /// Create a new agent from a template
     #[command(
@@ -492,6 +506,8 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
             tags,
             dry_run,
             no_tui,
+            resume,
+            replay,
         } => {
             run::execute(
                 agent,
@@ -506,6 +522,8 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
                 tags,
                 dry_run,
                 no_tui,
+                resume,
+                replay,
             )
             .await
         }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -364,13 +364,19 @@ async fn resume_run(
     max_content: Option<usize>,
     human_output: bool,
 ) -> anyhow::Result<()> {
-    use crate::core::orchestration::es::engine::replay;
+    use crate::core::orchestration::es::bridge::synthetic_run_start;
     use crate::core::orchestration::es::log::SqliteLog;
-    use crate::core::orchestration::es::state::RunStatus;
+    use crate::core::orchestration::es::state::{RunStatus, fold};
 
     let db = crate::storage::init_db()?;
     let log = SqliteLog::new(db.clone());
-    let state = replay(run_id, &log)?;
+    // Read the raw log back once, up front: `fold` gives the roster/status
+    // needed to validate + dispatch the resume below, and the SAME raw
+    // `pre_resume_events` also feeds `synthetic_run_start`'s `in_chars`
+    // recovery (the original `RunStarted.input`, discarded by `apply` but
+    // still present verbatim in the event list) — see that fn's doc comment.
+    let pre_resume_events = log.events(run_id)?;
+    let state = fold(&pre_resume_events);
     if state.pattern.is_empty() {
         anyhow::bail!("no run found for id {run_id}");
     }
@@ -391,6 +397,38 @@ async fn resume_run(
         let m = crate::cli::style::muted();
         anstream::eprintln!("{m}resume {run_id}{m:#}");
     }
+
+    // I3 (whole-branch review, light must-fix): the roster below is reloaded
+    // from the CURRENT directory's project, not the original run's
+    // (`RunStarted.project` is logged but never read back — full
+    // project-pinning is backlog, not attempted here). Warn once, concisely,
+    // so resuming from a different directory than the original run doesn't
+    // silently execute the remaining steps against different agent
+    // definitions.
+    if !json && !quiet && human_output {
+        let w = crate::cli::style::warn();
+        anstream::eprintln!(
+            "{w}resuming {run_id} — agents reloaded from the current project; \
+             not-yet-run steps use current definitions{w:#}"
+        );
+    }
+
+    // HEAD bookend (whole-branch review, I2): a live orchestrated run's
+    // `RunStart` is what seeds the Workroom's agent roster
+    // (`Workroom::on_run_event_at`'s `RunStart { agents, .. }` arm —
+    // `AgentStart` only mutates an already-present agent, it never inserts
+    // one). `resume_run` never emitted one, so an interactive `--resume`
+    // showed an empty Workroom even though `execute_resume` already routes
+    // orchestrated resumes through `run_orchestration_tui` (mirroring
+    // `execute`'s own `use_tui` gate). Emitting it here, from the folded
+    // roster, before the engine resumes fixes that for both the TUI and
+    // `--json`/headless consumers (the bookend is harmless/expected on json
+    // too — it matches what a live run emits).
+    sink.emit(&synthetic_run_start(
+        run_id,
+        &state.agents,
+        &pre_resume_events,
+    ));
 
     // Reload the agent roster from the project on disk — the log carries no
     // `Agent` definitions (system prompt/model/temperature/…), only the
@@ -3980,11 +4018,89 @@ mod es_switch_tests {
             .collect();
 
         assert!(!live.is_empty(), "sanity: the live run must emit events");
+
+        // `run_direct_against_sqlite_log` drives the bare ES engine
+        // (`run_direct_es`) directly, NOT the CLI's `run_inner` — so `live`
+        // here is the engine-level mid-stream slice only, with no
+        // `RunStart`/`Result` bookends (those are built by `run.rs`, never by
+        // the engine projection — see `run_replay.rs`'s module doc).
+        // `replayed` DOES carry both (that's `replay_from_log`'s job, OH1
+        // Lot 6 whole-branch review I1). Assert their presence/shape
+        // explicitly here, then strip them before the mid-stream comparison
+        // below — this doesn't weaken that comparison, it just scopes it to
+        // what `live` actually contains; `replay_full_stream_starts_with_run_start_and_ends_with_result`
+        // below is the dedicated test for the bookends themselves.
         assert_eq!(
-            live, replayed,
-            "replay must reproduce the same RunEvent sequence (modulo the \
+            replayed.first().unwrap()["t"],
+            "run_start",
+            "replay must lead with a synthetic RunStart bookend, got: {replayed:?}"
+        );
+        assert_eq!(replayed.first().unwrap()["run_id"], run_id);
+        assert_eq!(
+            replayed.last().unwrap()["t"],
+            "result",
+            "replay must end with a Result bookend, got: {replayed:?}"
+        );
+
+        let replayed_mid_stream: Vec<_> = replayed[1..replayed.len() - 1].to_vec();
+        assert_eq!(
+            live, replayed_mid_stream,
+            "replay must reproduce the same mid-stream RunEvent sequence (modulo the \
              non-reconstructable AgentStart.prov/model gap, already stripped above)"
         );
+    }
+
+    /// OH1 Lot 6 whole-branch review, I1: dedicated coverage for the
+    /// `RunStart`/`Result` bookends — this is the test that would have
+    /// caught their absence (the sibling
+    /// `replay_reproduces_the_live_run_event_sequence` test's "live"
+    /// baseline is engine-level only and never had them to compare
+    /// against). Asserts the FULL replayed stream, as a `--json` consumer
+    /// would see it, starts with `run_start` and ends with `result`, with
+    /// the fields `synthetic_run_start`/`to_orchestration_result` are
+    /// documented to fill.
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn replay_full_stream_starts_with_run_start_and_ends_with_result() {
+        use crate::storage::init_embedded;
+
+        let db = init_embedded().unwrap();
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        let (_live_capture, live_sink) = capture_sink();
+        run_direct_against_sqlite_log(db.clone(), &run_id, &live_sink).await;
+
+        let replay_log = crate::core::orchestration::es::log::SqliteLog::new(db);
+        let (replay_capture, replay_sink) = capture_sink();
+        crate::cli::run_replay::replay_from_log(&replay_log, &run_id, &replay_sink, false).unwrap();
+
+        let tags = replay_capture.tags();
+        assert_eq!(
+            tags.first().map(String::as_str),
+            Some("run_start"),
+            "replayed stream must start with run_start, got: {tags:?}"
+        );
+        assert_eq!(
+            tags.last().map(String::as_str),
+            Some("result"),
+            "replayed stream must end with result, got: {tags:?}"
+        );
+
+        let events = replay_capture.events.lock().unwrap();
+        let head = events.first().unwrap();
+        assert_eq!(head["run_id"], run_id);
+        assert_eq!(head["v"], 1);
+        assert_eq!(head["agents"], serde_json::json!(["solo"]));
+        assert_eq!(head["prov"], "");
+        assert_eq!(head["model"], "");
+        assert_eq!(
+            head["in_chars"],
+            serde_json::json!("do the thing".chars().count())
+        );
+
+        let tail = events.last().unwrap();
+        assert_eq!(tail["content"], "the answer");
+        assert_eq!(tail["agents"], serde_json::json!(1));
     }
 
     #[cfg(feature = "storage")]
@@ -4014,5 +4130,120 @@ mod es_switch_tests {
             err.to_string().contains("storage"),
             "expected the storage-feature-required message, got: {err}"
         );
+    }
+
+    // ── OH1 Lot 6 whole-branch review, I2: `--resume` RunStart bookend ──
+    //
+    // `resume_run` (the CLI wrapper) reloads its roster from real agent
+    // files on disk via `resolve_agents_dir`/`resolve_agent_path` — driving
+    // it directly in a hermetic unit test would mean mutating the process
+    // CWD/project resolution, racing every other test in this file that
+    // also touches `crate::storage::init_db()`/project resolution (same
+    // reasoning as the big comment above the `--replay` determinism tests).
+    // This test instead drives the EXACT sequence `resume_run` performs on
+    // an injected `SqliteLog`: fold the log, emit `synthetic_run_start` from
+    // the folded roster, dispatch `resume_direct_es` through a
+    // `SinkProjectingLog`, then emit the terminal `Result` via
+    // `to_orchestration_result` — the same idiom
+    // `run_direct_against_sqlite_log` above uses for the `--replay` tests.
+    //
+    // This is what would have caught the Workroom-population regression:
+    // before the fix, nothing in `resume_run` ever emitted a `RunStart`, so
+    // `Workroom::on_run_event_at`'s `RunStart { agents, .. }` arm — the ONLY
+    // arm that inserts a new tracked agent, `AgentStart` only mutates one
+    // already present — never ran, and an interactive `--resume` showed an
+    // empty live Workroom.
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn resume_emits_run_start_bookend_before_the_mid_stream_events() {
+        use crate::core::orchestration::es::bridge::synthetic_run_start;
+        use crate::core::orchestration::es::direct::resume_direct_es;
+        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::core::orchestration::es::state::fold;
+        use crate::storage::init_embedded;
+
+        let db = init_embedded().unwrap();
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        // Simulate a crashed run: only `RunStarted` was ever persisted (the
+        // process died before the single agent was invoked) — this folds to
+        // `RunStatus::Running`, exactly what `resume_run` requires to
+        // proceed with a resume.
+        let mut log = SqliteLog::new(db);
+        log.append(
+            &run_id,
+            &ExecutionEvent::RunStarted {
+                run_id: run_id.clone(),
+                pattern: "direct".to_string(),
+                agents: vec!["solo".to_string()],
+                input: "do the thing".to_string(),
+                project: None,
+            },
+        )
+        .unwrap();
+
+        let pre_resume_events = log.events(&run_id).unwrap();
+        let state = fold(&pre_resume_events);
+        assert_eq!(state.status, RunStatus::Running, "sanity: resumable");
+
+        let (capture, sink) = capture_sink();
+
+        // HEAD bookend — same call `resume_run` makes, from the same folded
+        // roster/events, before the engine resumes.
+        sink.emit(&synthetic_run_start(
+            &run_id,
+            &state.agents,
+            &pre_resume_events,
+        ));
+
+        let mut agents = BTreeMap::new();
+        agents.insert("solo".to_string(), test_agent("solo"));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert(
+            "solo".to_string(),
+            Arc::new(ScriptedProvider::new(&["resumed answer"])) as Arc<dyn Provider>,
+        );
+
+        let mut proj_log = SinkProjectingLog::with_meta(log, sink.as_ref(), BTreeMap::new());
+        let final_state = resume_direct_es(
+            &run_id,
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut proj_log,
+        )
+        .await
+        .unwrap();
+
+        // TERMINAL bookend — same call `resume_run` makes after the engine
+        // resumes.
+        let events = proj_log.events(&run_id).unwrap();
+        let result = to_orchestration_result(&final_state, &events);
+        sink.emit(&RunEvent::Result {
+            content: result.content.clone(),
+            tin: result.total_tokens_in,
+            tout: result.total_tokens_out,
+            cost: result.total_cost,
+            agents: final_state.agents.len(),
+        });
+
+        let tags = capture.tags();
+        assert_eq!(
+            tags.first().map(String::as_str),
+            Some("run_start"),
+            "resume must emit a RunStart bookend at the head, got: {tags:?}"
+        );
+        assert_eq!(
+            tags.last().map(String::as_str),
+            Some("result"),
+            "resume must still end with the terminal Result, got: {tags:?}"
+        );
+
+        let captured = capture.events.lock().unwrap();
+        let head = captured.first().unwrap();
+        assert_eq!(head["run_id"], run_id);
+        assert_eq!(head["agents"], serde_json::json!(["solo"]));
+        let tail = captured.last().unwrap();
+        assert_eq!(tail["content"], "resumed answer");
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,14 +45,14 @@ pub async fn execute(
     // `replay`) guarantees exactly one of the three is present, so these
     // branches are exhaustive — the `else` below is the pre-existing agent
     // path, safe to `expect()` since `resume`/`replay` are both `None` there.
-    // Task 3 will replace the `--resume` stub with the actual resume logic;
-    // `--replay` (Task 2) is fully wired below, ahead of any agent/TUI
-    // concern (replay never has an `agent_name` to route through them).
+    // `--replay` (Task 2) and `--resume` (Task 3) are both fully wired below,
+    // ahead of any agent/TUI concern (neither has an `agent_name` to route
+    // through them).
     if let Some(run_id) = replay {
         return execute_replay(&run_id, json, quiet, headless).await;
     }
-    if resume.is_some() {
-        anyhow::bail!("--resume not yet wired");
+    if let Some(run_id) = resume {
+        return execute_resume(&run_id, json, quiet, headless, max_content, no_tui).await;
     }
     let agent_name =
         agent_name.expect("clap ArgGroup guarantees agent is present when resume/replay are not");
@@ -216,6 +216,301 @@ async fn execute_replay(
         }
         return Err(e);
     }
+
+    Ok(())
+}
+
+/// `--resume <run_id>` entry point (OH1 Lot 6, Task 3): continues a
+/// previously interrupted event-sourced run (one whose process died/was
+/// killed mid-run, leaving `RunStatus::Running` in the persisted log) from
+/// where it left off, executing REAL effects (provider calls) for whatever
+/// work remains — unlike `--replay`, which only re-emits the past.
+///
+/// Requires the `storage` feature (the event log this reads/appends to only
+/// persists under it); without it, funnels a clear bail through the same
+/// headless error-event/exit-code handling [`execute_replay`] uses, rather
+/// than a bare panic.
+///
+/// The live Workroom TUI is offered the same way the normal agent path does
+/// (`use_tui` gate in [`execute`]) — except the pattern (which layout to
+/// render) isn't known from a CLI flag here, only from the log itself, so
+/// this peeks the run's pattern/status via a synchronous [`replay`] BEFORE
+/// deciding `use_tui` and building the `explicit_pattern` hint. `direct`
+/// pattern runs never use the TUI, mirroring the live path (a single-agent
+/// run never sets `orchestrate`, so it never reaches the TUI branch either).
+async fn execute_resume(
+    run_id: &str,
+    json: bool,
+    quiet: bool,
+    headless: bool,
+    max_content: Option<usize>,
+    no_tui: bool,
+) -> anyhow::Result<()> {
+    #[cfg(not(feature = "storage"))]
+    {
+        let _ = (run_id, json, quiet, headless, max_content, no_tui);
+        anyhow::bail!("--resume requires the 'storage' feature (event log persistence)")
+    }
+
+    #[cfg(feature = "storage")]
+    {
+        use crate::core::orchestration::es::engine::replay;
+        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::core::orchestration::es::state::RunStatus;
+
+        let headless = headless || json;
+
+        // Peek the run's pattern/status before deciding on the live TUI —
+        // mirrors the agent path's own `use_tui` gate in `execute`, which
+        // needs to know the pattern is "orchestrated" before offering it.
+        let peek = {
+            let db = crate::storage::init_db()?;
+            let log = SqliteLog::new(db);
+            replay(run_id, &log)?
+        };
+        if peek.pattern.is_empty() {
+            anyhow::bail!("no run found for id {run_id}");
+        }
+        if peek.status != RunStatus::Running {
+            anyhow::bail!("run {run_id} is not resumable (status: {:?})", peek.status);
+        }
+
+        let use_tui = peek.pattern != "direct"
+            && !json
+            && !quiet
+            && !no_tui
+            && std::io::IsTerminal::is_terminal(&std::io::stdout());
+
+        #[cfg(feature = "tui")]
+        if use_tui {
+            let explicit_pattern = match peek.pattern.as_str() {
+                "blackboard" => Some(crate::core::orchestration::OrchestrationPattern::Blackboard),
+                "ring" => Some(crate::core::orchestration::OrchestrationPattern::Ring),
+                _ => None,
+            };
+            let run_id_owned = run_id.to_string();
+            let printed = crate::shell::run_view::run_orchestration_tui(
+                move |sink| async move {
+                    // `false, false` for json/quiet: guaranteed by the
+                    // `use_tui` gate above (mirrors `execute`'s own TUI
+                    // closure, which hardcodes the same for `run_inner`).
+                    resume_run(&run_id_owned, &sink, false, false, max_content, false).await
+                },
+                None,
+                explicit_pattern,
+            )
+            .await;
+            return match printed {
+                Ok(Some(content)) => {
+                    println!("{content}");
+                    Ok(())
+                }
+                Ok(None) => Ok(()),
+                Err(e) => Err(e),
+            };
+        }
+        #[cfg(not(feature = "tui"))]
+        let _ = use_tui;
+
+        let sink = crate::core::events::make_sink(json);
+
+        // `human_output = true` here (unconditional, like the live
+        // orchestrated path's non-TUI branch): `resume_run` gates its own
+        // `--json`/`--quiet` suppression at each print site instead, since
+        // `human_output` here means "not the TUI's alternate screen", not
+        // "not machine output" (see `run_orchestrated_inner`'s identical
+        // convention).
+        let result = resume_run(run_id, &sink, json, quiet, max_content, true).await;
+
+        if let Err(e) = result {
+            if headless {
+                let code = exit_code_for(&e);
+                sink.emit(&RunEvent::Error {
+                    code: match code {
+                        3 => "budget_exceeded",
+                        4 => "provider_unavailable",
+                        _ => "agent_failed",
+                    }
+                    .into(),
+                    msg: e.to_string(),
+                });
+                std::process::exit(code);
+            }
+            return Err(e);
+        }
+
+        Ok(())
+    }
+}
+
+/// Core of `--resume`: reload the roster from the project on disk (keyed by
+/// the run's own `ExecutionState::agents`, folded from the log's
+/// `RunStarted`), dispatch to the pattern-matching `resume_*_es` engine entry
+/// point wrapped in the same [`SinkProjectingLog`]/[`QuietMaxContentSink`]
+/// observability every live `dispatch_*_es` uses, then project/print/emit
+/// the result exactly like a live orchestrated run's terminal steps.
+///
+/// Requires `run_id` to name a `Running` run recorded in the persisted event
+/// log — checked again here (not just by the `execute_resume` peek above,
+/// which only gates the TUI decision) since this is also the function real
+/// tests would call directly.
+#[allow(clippy::too_many_arguments)]
+#[cfg(feature = "storage")]
+async fn resume_run(
+    run_id: &str,
+    sink: &Arc<dyn EventSink>,
+    json: bool,
+    quiet: bool,
+    max_content: Option<usize>,
+    human_output: bool,
+) -> anyhow::Result<()> {
+    use crate::core::orchestration::es::engine::replay;
+    use crate::core::orchestration::es::log::SqliteLog;
+    use crate::core::orchestration::es::state::RunStatus;
+
+    let db = crate::storage::init_db()?;
+    let log = SqliteLog::new(db.clone());
+    let state = replay(run_id, &log)?;
+    if state.pattern.is_empty() {
+        anyhow::bail!("no run found for id {run_id}");
+    }
+    if state.status != RunStatus::Running {
+        anyhow::bail!("run {run_id} is not resumable (status: {:?})", state.status);
+    }
+
+    // Prefer the stored `orchestration_runs.pattern` when present, falling
+    // back to the log-folded `state.pattern` — the ONLY source available for
+    // `direct` runs, which never get an `orchestration_runs` row (see
+    // `queries::get_run_pattern`'s doc comment).
+    let pattern = crate::storage::queries::get_run_pattern(&db, run_id)
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| state.pattern.clone());
+
+    if !json && !quiet && human_output {
+        let m = crate::cli::style::muted();
+        anstream::eprintln!("{m}resume {run_id}{m:#}");
+    }
+
+    // Reload the agent roster from the project on disk — the log carries no
+    // `Agent` definitions (system prompt/model/temperature/…), only the
+    // roster's KEYS (`state.agents`, folded from `RunStarted`) and the
+    // pattern's config (`ConfigSnapshot`). `headless = true` here: a resume
+    // is a non-interactive continuation, so it must never block on the
+    // model-updater's interactive prompt the way a fresh `armadai run` might.
+    let resolution = resolve_agents_dir(true);
+    let routing_rules = match &resolution {
+        AgentResolution::Project { config, .. } => config.routing.clone().unwrap_or_default(),
+        _ => crate::core::routing::RoutingRules::default(),
+    };
+    let cost_limit = orchestration_cost_limit(&resolution);
+
+    let mut agents_map: std::collections::BTreeMap<String, Agent> =
+        std::collections::BTreeMap::new();
+    let mut providers_map: std::collections::BTreeMap<
+        String,
+        Arc<dyn crate::providers::traits::Provider>,
+    > = std::collections::BTreeMap::new();
+    for name in &state.agents {
+        let agent_path = resolve_agent_path(&resolution, name)?;
+        let mut agent = crate::parser::parse_agent_file(&agent_path)?;
+        crate::linker::model_aliases::resolve_model_deprecations(
+            &mut agent.metadata.model,
+            &mut agent.metadata.model_fallback,
+        );
+        let provider = create_provider(&agent)?;
+        providers_map.insert(name.clone(), Arc::from(provider));
+        agents_map.insert(name.clone(), agent);
+    }
+
+    let filtered_sink = quiet_max_content_sink(sink, quiet, max_content);
+    let agent_meta = agent_meta_from_roster(&agents_map);
+    let mut proj_log = SinkProjectingLog::with_meta(log, &filtered_sink, agent_meta);
+
+    let final_state = match pattern.as_str() {
+        "direct" => {
+            use crate::core::orchestration::es::direct::resume_direct_es;
+            resume_direct_es(
+                run_id,
+                agents_map,
+                providers_map,
+                routing_rules,
+                &mut proj_log,
+            )
+            .await?
+        }
+        "blackboard" => {
+            use crate::core::orchestration::es::blackboard::resume_blackboard_es;
+            resume_blackboard_es(
+                run_id,
+                agents_map,
+                providers_map,
+                routing_rules,
+                cost_limit,
+                &mut proj_log,
+            )
+            .await?
+        }
+        "ring" => {
+            use crate::core::orchestration::es::ring::resume_ring_es;
+            resume_ring_es(
+                run_id,
+                agents_map,
+                providers_map,
+                routing_rules,
+                cost_limit,
+                &mut proj_log,
+            )
+            .await?
+        }
+        "hierarchical" => {
+            use crate::core::orchestration::es::hierarchical::resume_hierarchical_es;
+            resume_hierarchical_es(
+                run_id,
+                agents_map,
+                providers_map,
+                routing_rules,
+                &mut proj_log,
+            )
+            .await?
+        }
+        other => anyhow::bail!("unknown orchestration pattern '{other}' for run {run_id}"),
+    };
+
+    let events = proj_log.events(run_id)?;
+
+    match crate::storage::init_db() {
+        Ok(db2) => {
+            if let Err(e) = crate::cli::run_es_record::project_run(&db2, run_id) {
+                tracing::warn!("failed to project resumed run {}: {}", run_id, e);
+            }
+        }
+        Err(e) => {
+            tracing::warn!("event log storage unavailable, run not projected: {}", e);
+        }
+    }
+
+    let content = match pattern.as_str() {
+        "blackboard" => super::run_es_record::blackboard_display(&final_state),
+        "ring" => super::run_es_record::ring_display(&final_state, &events),
+        _ => to_orchestration_result(&final_state, &events).content,
+    };
+
+    if human_output {
+        let s = status_style(&final_state.status);
+        anstream::eprintln!("{s}resume {}: {:?}{s:#}", run_id, final_state.status);
+    }
+    if !json && human_output {
+        println!("{content}");
+    }
+
+    sink.emit(&RunEvent::Result {
+        content,
+        tin: u32::try_from(final_state.budget_tokens_in).unwrap_or(u32::MAX),
+        tout: u32::try_from(final_state.budget_tokens_out).unwrap_or(u32::MAX),
+        cost: final_state.budget_cost,
+        agents: final_state.agents.len(),
+    });
 
     Ok(())
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -123,11 +123,10 @@ pub async fn execute(
         )
         .await;
         return match printed {
-            Ok(Some(content)) => {
-                println!("{content}");
+            Ok((run_id, content)) => {
+                print_tui_run_outcome(run_id, content);
                 Ok(())
             }
-            Ok(None) => Ok(()),
             Err(e) => Err(e),
         };
     }
@@ -301,11 +300,10 @@ async fn execute_resume(
             )
             .await;
             return match printed {
-                Ok(Some(content)) => {
-                    println!("{content}");
+                Ok((run_id, content)) => {
+                    print_tui_run_outcome(run_id, content);
                     Ok(())
                 }
-                Ok(None) => Ok(()),
                 Err(e) => Err(e),
             };
         }
@@ -553,6 +551,26 @@ async fn resume_run(
     });
 
     Ok(())
+}
+
+/// Print the `(run_id, content)` pair returned by
+/// [`crate::shell::run_view::run_orchestration_tui`] once the terminal has
+/// been restored (OH1 Lot 6): the alternate screen clears everything on
+/// exit, so this muted `run <id>` banner — mirroring the non-TUI orchestrated
+/// path's own banner in `run_orchestrated_inner` — is the only way the id
+/// survives in scrollback for a later `--resume`/`--replay` on the TUI path.
+/// `run_id` prints whenever a `RunStart` was observed by the Workroom (even
+/// on an early Ctrl+C abort, since the id is generated before the run's first
+/// effect); `content` prints only when the run produced a final answer.
+#[cfg(feature = "tui")]
+fn print_tui_run_outcome(run_id: Option<String>, content: Option<String>) {
+    if let Some(id) = run_id {
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}run {id}{m:#}");
+    }
+    if let Some(content) = content {
+        println!("{content}");
+    }
 }
 
 /// Map a run error to a CI-friendly exit code.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -426,6 +426,7 @@ async fn resume_run(
     // too — it matches what a live run emits).
     sink.emit(&synthetic_run_start(
         run_id,
+        &pattern,
         &state.agents,
         &pre_resume_events,
     ));
@@ -528,11 +529,12 @@ async fn resume_run(
         }
     }
 
-    let content = match pattern.as_str() {
-        "blackboard" => super::run_es_record::blackboard_display(&final_state),
-        "ring" => super::run_es_record::ring_display(&final_state, &events),
-        _ => to_orchestration_result(&final_state, &events).content,
-    };
+    // Re-review fix: routed through the shared `final_content` helper (used
+    // identically by `--replay`'s `replay_from_log`) instead of inlining the
+    // pattern branch here a second time — see that fn's doc for why (a
+    // second, drifted copy of this branch is exactly what let `--replay`'s
+    // `ring` output silently lose its vote tally).
+    let content = super::run_es_record::final_content(&final_state, &events);
 
     if human_output {
         let s = status_style(&final_state.status);
@@ -4103,6 +4105,92 @@ mod es_switch_tests {
         assert_eq!(tail["agents"], serde_json::json!(1));
     }
 
+    /// Re-review fix, regression lock: `--replay` of a `ring` run with
+    /// non-empty `state.ring.votes` must include the `[votes] …` tally in
+    /// the terminal `Result.content`, exactly like the live path and
+    /// `--resume` already do via `run_es_record::ring_display` — before the
+    /// fix, `replay_from_log` called `to_orchestration_result`
+    /// unconditionally, which has no notion of votes at all, so the tally
+    /// silently vanished on replay for the one pattern whose whole point is
+    /// the vote. Builds a minimal ring event log directly (bypassing the
+    /// live ring engine entirely — same idiom as `run_es_record.rs`'s own
+    /// `sample_blackboard_events` test helper: only what `fold` +
+    /// `ring_display` need), persists it through a real (embedded)
+    /// `SqliteLog`, then drives `replay_from_log` against it — the same
+    /// injectable-log harness every other test in this module uses, no
+    /// global env/config mutation.
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn replay_of_completed_ring_run_with_votes_includes_vote_tally() {
+        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::init_embedded;
+
+        let db = init_embedded().unwrap();
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        let mut log = SqliteLog::new(db.clone());
+        let events = [
+            ExecutionEvent::RunStarted {
+                run_id: run_id.clone(),
+                pattern: "ring".to_string(),
+                agents: vec!["a".to_string(), "b".to_string()],
+                input: "review the design".to_string(),
+                project: None,
+            },
+            ExecutionEvent::LapStarted { lap: 1 },
+            ExecutionEvent::ContributionAdded {
+                agent: "a".to_string(),
+                lap: 1,
+                position: 0,
+                action: "propose".to_string(),
+                content: "initial proposal".to_string(),
+                tokens_in: 10,
+                tokens_out: 20,
+                cost: 0.01,
+            },
+            ExecutionEvent::VoteCast {
+                agent: "a".to_string(),
+                position: "approve".to_string(),
+                confidence: 0.9,
+                supports: vec![0],
+                concerns: vec![],
+            },
+            ExecutionEvent::VoteCast {
+                agent: "b".to_string(),
+                position: "approve".to_string(),
+                confidence: 0.8,
+                supports: vec![0],
+                concerns: vec![],
+            },
+            ExecutionEvent::OutcomeResolved {
+                outcome: "consensus reached".to_string(),
+            },
+            ExecutionEvent::Completed {
+                content: "consensus reached".to_string(),
+            },
+        ];
+        for event in &events {
+            log.append(&run_id, event).unwrap();
+        }
+
+        let replay_log = SqliteLog::new(db);
+        let (capture, sink) = capture_sink();
+        crate::cli::run_replay::replay_from_log(&replay_log, &run_id, &sink, false).unwrap();
+
+        let tags = capture.tags();
+        assert_eq!(tags.last().map(String::as_str), Some("result"));
+
+        let captured = capture.events.lock().unwrap();
+        let tail = captured.last().unwrap();
+        let content = tail["content"].as_str().unwrap();
+        assert!(
+            content.contains("[votes]"),
+            "replayed ring Result.content must include the vote tally like the \
+             live/--resume path, got: {content}"
+        );
+        assert!(content.starts_with("consensus reached"));
+    }
+
     #[cfg(feature = "storage")]
     #[test]
     fn replay_unknown_run_id_errors() {
@@ -4192,6 +4280,7 @@ mod es_switch_tests {
         // roster/events, before the engine resumes.
         sink.emit(&synthetic_run_start(
             &run_id,
+            &state.pattern,
             &state.agents,
             &pre_resume_events,
         ));

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,9 +45,11 @@ pub async fn execute(
     // `replay`) guarantees exactly one of the three is present, so these
     // branches are exhaustive — the `else` below is the pre-existing agent
     // path, safe to `expect()` since `resume`/`replay` are both `None` there.
-    // Tasks 2/3 replace these stubs with the actual resume/replay logic.
-    if replay.is_some() {
-        anyhow::bail!("--replay not yet wired");
+    // Task 3 will replace the `--resume` stub with the actual resume logic;
+    // `--replay` (Task 2) is fully wired below, ahead of any agent/TUI
+    // concern (replay never has an `agent_name` to route through them).
+    if let Some(run_id) = replay {
+        return execute_replay(&run_id, json, quiet, headless).await;
     }
     if resume.is_some() {
         anyhow::bail!("--resume not yet wired");
@@ -152,6 +154,51 @@ pub async fn execute(
         &sink,
     )
     .await;
+
+    if let Err(e) = result {
+        if headless {
+            let code = exit_code_for(&e);
+            sink.emit(&RunEvent::Error {
+                code: match code {
+                    3 => "budget_exceeded",
+                    4 => "provider_unavailable",
+                    _ => "agent_failed",
+                }
+                .into(),
+                msg: e.to_string(),
+            });
+            std::process::exit(code);
+        }
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// `--replay <run_id>` entry point (OH1 Lot 6, Task 2): builds the sink the
+/// same way the normal path does (`make_sink(json)`), delegates to
+/// [`crate::cli::run_replay::replay_run`] — which reads the persisted
+/// `ExecutionEvent` log back and re-emits it as `RunEvent`s, executing no
+/// effects — and funnels any error through the SAME headless
+/// error-event/exit-code handler [`execute`] uses for the normal run path, so
+/// `--replay --json` on an unknown/errored id behaves like any other failed
+/// headless run (an `error` JSONL line + a CI-friendly exit code) rather than
+/// a bare panic or a silent non-zero exit.
+async fn execute_replay(
+    run_id: &str,
+    json: bool,
+    quiet: bool,
+    headless: bool,
+) -> anyhow::Result<()> {
+    let headless = headless || json;
+    let sink = crate::core::events::make_sink(json);
+    // No TUI concern here (unlike the agent path in `execute`): replay has no
+    // `orchestrate`/config-driven auto-detect to check and no `agent_name` to
+    // route through the live Workroom, so `human_output` collapses to the
+    // same `!json && !quiet` gate the agent path's `RunStart` banner uses.
+    let human_output = !json && !quiet;
+
+    let result = crate::cli::run_replay::replay_run(run_id, &sink, human_output).await;
 
     if let Err(e) = result {
         if headless {
@@ -3525,5 +3572,152 @@ mod es_switch_tests {
     fn scripted_provider_call_count_tracks_calls() {
         let p = ScriptedProvider::new(&["one", "two"]);
         assert_eq!(p.call_count(), 0);
+    }
+
+    // ── OH1 Lot 6, Task 2: `--replay` determinism ─────────────────────
+    //
+    // These tests drive `run_replay::replay_from_log` — the `pub(crate)`,
+    // generic-over-`EventLog` core `replay_run` wraps around its own
+    // `crate::storage::init_db()` call — directly against an in-memory
+    // `SqliteLog` (`init_embedded()`), the SAME idiom
+    // `blackboard_es_run_persists_event_log`/`ring_es_run_persists_event_log`
+    // already use above. This deliberately avoids exercising `init_db()`
+    // itself (which resolves the real, global, config-dependent DB path):
+    // an earlier version of this test mutated `ARMADAI_CONFIG_DIR`/
+    // `XDG_DATA_HOME` process-wide to sandbox `init_db()`, which raced with
+    // OTHER tests in this same file (`dispatch_ring_es` et al.) that also
+    // call `crate::storage::init_db()` internally under `storage` but hold
+    // no such guard — those tests intermittently failed to open their own
+    // (unrelated) DB while this test's temp dirs existed/were torn down
+    // concurrently. Testing the generic core instead sidesteps that
+    // entirely: no env mutation, no cross-test interference, and it's the
+    // same read-back+projection logic `replay_run` itself runs.
+
+    /// Drive the event-sourced `direct` engine directly against an injected
+    /// `SqliteLog` (mirroring `blackboard_es_run_persists_event_log`'s
+    /// pattern) so the "live" side of the determinism test below persists
+    /// through the exact same `SqliteLog`/`SinkProjectingLog` machinery a
+    /// real `--storage` run does, without going through `dispatch_direct_es`
+    /// (which would call the real `crate::storage::init_db()`).
+    #[cfg(feature = "storage")]
+    async fn run_direct_against_sqlite_log(
+        db: crate::storage::Database,
+        run_id: &str,
+        sink: &Arc<dyn EventSink>,
+    ) {
+        use std::collections::BTreeMap;
+
+        use crate::core::orchestration::es::direct::run_direct_es;
+        use crate::core::orchestration::es::log::SqliteLog;
+
+        let mut agent_meta = BTreeMap::new();
+        agent_meta.insert(
+            "solo".to_string(),
+            ("anthropic".to_string(), "concrete-model".to_string()),
+        );
+        let mut log = SinkProjectingLog::with_meta(SqliteLog::new(db), sink.as_ref(), agent_meta);
+
+        let mut agents = BTreeMap::new();
+        agents.insert("solo".to_string(), test_agent("solo"));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert(
+            "solo".to_string(),
+            Arc::new(ScriptedProvider::new(&["the answer"])) as Arc<dyn Provider>,
+        );
+
+        run_direct_es(
+            run_id,
+            "solo",
+            "do the thing",
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Strip the fields `replay_run` cannot reconstruct from the persisted
+    /// event log alone (see `run_replay.rs`'s module doc: `AgentStart`'s
+    /// `prov`/`model` need the pre-run roster, which the log never carries)
+    /// before comparing a live vs. replayed `RunEvent` sequence. Every other
+    /// field of every other event must still match exactly.
+    #[cfg(feature = "storage")]
+    fn normalize_for_replay_comparison(mut v: serde_json::Value) -> serde_json::Value {
+        if v["t"] == "agent_start" {
+            v["prov"] = serde_json::Value::String(String::new());
+            v["model"] = serde_json::Value::String(String::new());
+        }
+        v
+    }
+
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn replay_reproduces_the_live_run_event_sequence() {
+        use crate::storage::init_embedded;
+
+        let db = init_embedded().unwrap();
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        let (live_capture, live_sink) = capture_sink();
+        run_direct_against_sqlite_log(db.clone(), &run_id, &live_sink).await;
+
+        let replay_log = crate::core::orchestration::es::log::SqliteLog::new(db);
+        let (replay_capture, replay_sink) = capture_sink();
+        crate::cli::run_replay::replay_from_log(&replay_log, &run_id, &replay_sink, false).unwrap();
+
+        let live: Vec<_> = live_capture
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .map(normalize_for_replay_comparison)
+            .collect();
+        let replayed: Vec<_> = replay_capture
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .map(normalize_for_replay_comparison)
+            .collect();
+
+        assert!(!live.is_empty(), "sanity: the live run must emit events");
+        assert_eq!(
+            live, replayed,
+            "replay must reproduce the same RunEvent sequence (modulo the \
+             non-reconstructable AgentStart.prov/model gap, already stripped above)"
+        );
+    }
+
+    #[cfg(feature = "storage")]
+    #[test]
+    fn replay_unknown_run_id_errors() {
+        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::init_embedded;
+
+        let log = SqliteLog::new(init_embedded().unwrap());
+        let (_capture, sink) = capture_sink();
+        let err = crate::cli::run_replay::replay_from_log(&log, "does-not-exist", &sink, false)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("does-not-exist"),
+            "expected the unknown run_id in the error message, got: {err}"
+        );
+    }
+
+    #[cfg(not(feature = "storage"))]
+    #[tokio::test]
+    async fn replay_requires_storage_feature() {
+        let (_capture, sink) = capture_sink();
+        let err = crate::cli::run_replay::replay_run("any-id", &sink, false)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("storage"),
+            "expected the storage-feature-required message, got: {err}"
+        );
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -26,7 +26,7 @@ accurate, relevant output.";
 /// configuration flags; grouping into a struct would obscure the caller's argument binding.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute(
-    agent_name: String,
+    agent_name: Option<String>,
     input: Option<String>,
     pipe: Option<Vec<String>>,
     orchestrate: Option<String>,
@@ -38,7 +38,23 @@ pub async fn execute(
     tags: Option<Vec<String>>,
     dry_run: bool,
     no_tui: bool,
+    resume: Option<String>,
+    replay: Option<String>,
 ) -> anyhow::Result<()> {
+    // OH1 Lot 6: the clap `ArgGroup` on `Command::Run` (`agent`/`resume`/
+    // `replay`) guarantees exactly one of the three is present, so these
+    // branches are exhaustive — the `else` below is the pre-existing agent
+    // path, safe to `expect()` since `resume`/`replay` are both `None` there.
+    // Tasks 2/3 replace these stubs with the actual resume/replay logic.
+    if replay.is_some() {
+        anyhow::bail!("--replay not yet wired");
+    }
+    if resume.is_some() {
+        anyhow::bail!("--resume not yet wired");
+    }
+    let agent_name =
+        agent_name.expect("clap ArgGroup guarantees agent is present when resume/replay are not");
+
     // headless is implied by json (machine output cannot be interrupted by a prompt)
     let headless = headless || json;
 
@@ -94,6 +110,8 @@ pub async fn execute(
                     route,
                     tags,
                     dry_run,
+                    resume,
+                    replay,
                     &sink,
                 )
                 .await
@@ -129,6 +147,8 @@ pub async fn execute(
         route,
         tags,
         dry_run,
+        resume,
+        replay,
         &sink,
     )
     .await;
@@ -188,8 +208,15 @@ async fn run_inner(
     route: Option<String>,
     tags: Option<Vec<String>>,
     dry_run: bool,
+    // OH1 Lot 6: threaded through for signature stability across Tasks 2/3
+    // (resume/replay execution). `execute` already bails before calling
+    // `run_inner` when either is `Some`, so this function never branches on
+    // them yet.
+    resume: Option<String>,
+    replay: Option<String>,
     sink: &Arc<dyn EventSink>,
 ) -> anyhow::Result<()> {
+    let _ = (&resume, &replay);
     let resolution = resolve_agents_dir(headless);
     let tags = tags.unwrap_or_default();
 
@@ -275,13 +302,29 @@ async fn run_inner(
     // `armadai.yaml` was found (still useful to distinguish ad-hoc runs).
     let project = project_display_string(&resolution);
 
+    // Generated once, up front, so the emitted `RunStart` (surfaced to the
+    // user for a future `--resume`/`--replay`) carries the SAME run_id the
+    // single-agent ES dispatch below (`dispatch_direct_es`) persists the ES
+    // log under.
+    let run_id = uuid::Uuid::new_v4().to_string();
+
     sink.emit(&RunEvent::RunStart {
+        run_id: run_id.clone(),
         v: 1,
         agents: chain.clone(),
         prov: String::new(), // filled per-agent in agent_start; kept minimal here
         model: String::new(),
         in_chars: current_input.chars().count(),
     });
+
+    // Surface the run_id on the human path (OH1 Lot 6, Task 1) so it can be
+    // copied for a future `--resume`/`--replay`. Not on `--json` (the id
+    // already travels in `RunStart`) or `--quiet`, and gated on
+    // `human_output` too, mirroring the orchestrated path below.
+    if !json && !quiet && human_output {
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}run {run_id}{m:#}");
+    }
 
     // Single-agent direct execution (OH1 Lot 5, T5a): switched onto the
     // event-sourced `direct` engine (`run_direct_es`), wrapped in a
@@ -293,6 +336,7 @@ async fn run_inner(
         let name = &chain[0];
         let agent_path = resolve_agent_path(&resolution, name)?;
         let (content, tin, tout, cost) = run_single_agent_es(
+            &run_id,
             &agent_path,
             name,
             &current_input,
@@ -714,6 +758,7 @@ fn quiet_max_content_sink(
 /// the log (the `record_*_es` will disappear).
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_direct_es(
+    run_id: &str,
     agent_key: &str,
     agent: Agent,
     provider: Arc<dyn crate::providers::traits::Provider>,
@@ -744,7 +789,6 @@ async fn dispatch_direct_es(
     let mut providers = BTreeMap::new();
     providers.insert(agent_key.to_string(), provider);
 
-    let run_id = uuid::Uuid::new_v4().to_string();
     let filtered_sink = quiet_max_content_sink(sink, quiet, max_content);
 
     // Deduplication macro (Fix 2): single definition of the run_direct_es call,
@@ -753,7 +797,7 @@ async fn dispatch_direct_es(
         ($log:expr) => {{
             let mut log = SinkProjectingLog::with_meta($log, &filtered_sink, agent_meta);
             let state = run_direct_es(
-                &run_id,
+                run_id,
                 agent_key,
                 input,
                 agents,
@@ -762,7 +806,7 @@ async fn dispatch_direct_es(
                 &mut log,
             )
             .await?;
-            let events = log.events(&run_id)?;
+            let events = log.events(run_id)?;
             (state, events)
         }};
     }
@@ -810,6 +854,7 @@ async fn dispatch_direct_es(
 /// `run_single_agent`'s step 6.
 #[allow(clippy::too_many_arguments)]
 async fn run_single_agent_es(
+    run_id: &str,
     agent_path: &Path,
     agent_key: &str,
     input: &str,
@@ -867,6 +912,7 @@ async fn run_single_agent_es(
     // AgentStart/AgentEnd observability, the actual provider call).
     let start = Instant::now();
     let dispatch = dispatch_direct_es(
+        run_id,
         agent_key,
         agent,
         provider,
@@ -1251,13 +1297,31 @@ async fn run_orchestrated_inner(
         _ => crate::core::routing::RoutingRules::default(),
     };
 
+    // Generated once, up front, so the emitted `RunStart` (surfaced to the
+    // user for a future `--resume`/`--replay`) carries the SAME run_id the
+    // `dispatch_*_es` pattern dispatch below persists the ES log under —
+    // otherwise the human-visible id and the one actually usable for replay
+    // would silently diverge.
+    let run_id = uuid::Uuid::new_v4().to_string();
+
     sink.emit(&RunEvent::RunStart {
+        run_id: run_id.clone(),
         v: 1,
         agents: agent_names.to_vec(),
         prov: String::new(),
         model: pattern.to_string(),
         in_chars: input.chars().count(),
     });
+
+    // Surface the run_id on the human path (OH1 Lot 6, Task 1) so it can be
+    // copied for a future `--resume`/`--replay`. Not on `--json` (the id
+    // already travels in `RunStart`) or `--quiet`, and gated on
+    // `human_output` too — `false` on the live Workroom TUI path, where a
+    // direct stdout write would corrupt the alternate-screen display.
+    if !json && !quiet && human_output {
+        let m = crate::cli::style::muted();
+        anstream::println!("{m}run {run_id}{m:#}");
+    }
 
     // Replay deprecation warnings collected during roster load, right after
     // `RunStart` (same order as the pre-split load loop emitted them).
@@ -1377,6 +1441,7 @@ async fn run_orchestrated_inner(
             }
 
             let (state, _run_id) = dispatch_blackboard_es(
+                &run_id,
                 input,
                 agent_map,
                 provider_map,
@@ -1459,6 +1524,7 @@ async fn run_orchestrated_inner(
             }
 
             let (state, events, _run_id) = dispatch_ring_es(
+                &run_id,
                 input,
                 agent_map,
                 agent_names.to_vec(),
@@ -1554,6 +1620,7 @@ async fn run_orchestrated_inner(
             }
 
             let (state, events, _run_id) = dispatch_hierarchical_es(
+                &run_id,
                 &coordinator_name,
                 input,
                 orch_config,
@@ -1678,6 +1745,7 @@ fn agent_meta_from_roster(
 /// `tests::blackboard_es`).
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_blackboard_es(
+    run_id: &str,
     input: &str,
     agents: std::collections::BTreeMap<String, Agent>,
     providers: std::collections::BTreeMap<String, Arc<dyn crate::providers::traits::Provider>>,
@@ -1690,7 +1758,6 @@ async fn dispatch_blackboard_es(
 ) -> anyhow::Result<(ExecutionState, String)> {
     use crate::core::orchestration::es::blackboard::run_blackboard_es;
 
-    let run_id = uuid::Uuid::new_v4().to_string();
     let filtered_sink = quiet_max_content_sink(sink, quiet, max_content);
 
     // Deduplication macro (Fix 2): single definition of the run_blackboard_es call.
@@ -1699,7 +1766,7 @@ async fn dispatch_blackboard_es(
             let mut log =
                 SinkProjectingLog::with_meta($log, &filtered_sink, agent_meta_from_roster(&agents));
             run_blackboard_es(
-                &run_id,
+                run_id,
                 input,
                 agents,
                 providers,
@@ -1725,7 +1792,7 @@ async fn dispatch_blackboard_es(
     };
     #[cfg(not(feature = "storage"))]
     let state = run_with_log!(InMemoryLog::default());
-    Ok((state, run_id))
+    Ok((state, run_id.to_string()))
 }
 
 /// Drive the event-sourced `ring` engine end-to-end for an already-loaded
@@ -1737,6 +1804,7 @@ async fn dispatch_blackboard_es(
 /// reconciliation Task 5).
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_ring_es(
+    run_id: &str,
     input: &str,
     agents: std::collections::BTreeMap<String, Agent>,
     agent_order: Vec<String>,
@@ -1750,7 +1818,6 @@ async fn dispatch_ring_es(
 ) -> anyhow::Result<(ExecutionState, Vec<ExecutionEvent>, String)> {
     use crate::core::orchestration::es::ring::run_ring_es;
 
-    let run_id = uuid::Uuid::new_v4().to_string();
     let filtered_sink = quiet_max_content_sink(sink, quiet, max_content);
 
     // Deduplication macro (Fix 2): single definition of the run_ring_es call.
@@ -1759,7 +1826,7 @@ async fn dispatch_ring_es(
             let mut log =
                 SinkProjectingLog::with_meta($log, &filtered_sink, agent_meta_from_roster(&agents));
             let state = run_ring_es(
-                &run_id,
+                run_id,
                 input,
                 agents,
                 agent_order,
@@ -1770,7 +1837,7 @@ async fn dispatch_ring_es(
                 &mut log,
             )
             .await?;
-            let events = log.events(&run_id)?;
+            let events = log.events(run_id)?;
             (state, events)
         }};
     }
@@ -1788,7 +1855,7 @@ async fn dispatch_ring_es(
     };
     #[cfg(not(feature = "storage"))]
     let (state, events) = run_with_log!(InMemoryLog::default());
-    Ok((state, events, run_id))
+    Ok((state, events, run_id.to_string()))
 }
 
 /// Drive the event-sourced `hierarchical` engine end-to-end for an
@@ -1802,6 +1869,7 @@ async fn dispatch_ring_es(
 /// reconciliation Task 5).
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_hierarchical_es(
+    run_id: &str,
     coordinator: &str,
     input: &str,
     config: crate::core::orchestration::OrchestrationConfig,
@@ -1814,7 +1882,6 @@ async fn dispatch_hierarchical_es(
 ) -> anyhow::Result<(ExecutionState, Vec<ExecutionEvent>, String)> {
     use crate::core::orchestration::es::hierarchical::run_hierarchical_es;
 
-    let run_id = uuid::Uuid::new_v4().to_string();
     let filtered_sink = quiet_max_content_sink(sink, quiet, max_content);
 
     // Deduplication macro (Fix 2): single definition of the run_hierarchical_es call.
@@ -1823,7 +1890,7 @@ async fn dispatch_hierarchical_es(
             let mut log =
                 SinkProjectingLog::with_meta($log, &filtered_sink, agent_meta_from_roster(&agents));
             let state = run_hierarchical_es(
-                &run_id,
+                run_id,
                 coordinator,
                 input,
                 config,
@@ -1833,7 +1900,7 @@ async fn dispatch_hierarchical_es(
                 &mut log,
             )
             .await?;
-            let events = log.events(&run_id)?;
+            let events = log.events(run_id)?;
             (state, events)
         }};
     }
@@ -1851,7 +1918,7 @@ async fn dispatch_hierarchical_es(
     };
     #[cfg(not(feature = "storage"))]
     let (state, events) = run_with_log!(InMemoryLog::default());
-    Ok((state, events, run_id))
+    Ok((state, events, run_id.to_string()))
 }
 
 /// Apply project-level orchestration overrides to a BlackboardConfig.
@@ -2507,6 +2574,7 @@ mod es_switch_tests {
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the answer"]));
 
         let dispatch = dispatch_direct_es(
+            &uuid::Uuid::new_v4().to_string(),
             "solo",
             test_agent("solo"),
             provider,
@@ -2550,6 +2618,7 @@ mod es_switch_tests {
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the answer"]));
 
         let dispatch = dispatch_direct_es(
+            &uuid::Uuid::new_v4().to_string(),
             "solo",
             test_agent("solo"),
             provider,
@@ -2581,6 +2650,7 @@ mod es_switch_tests {
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the full answer"]));
 
         let dispatch = dispatch_direct_es(
+            &uuid::Uuid::new_v4().to_string(),
             "solo",
             test_agent("solo"),
             provider,
@@ -2614,6 +2684,7 @@ mod es_switch_tests {
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the answer"]));
 
         dispatch_direct_es(
+            &uuid::Uuid::new_v4().to_string(),
             "solo",
             test_agent("solo"),
             provider,
@@ -2688,6 +2759,7 @@ mod es_switch_tests {
         let (agents, providers) = hierarchical_roster();
 
         let (state, events, _run_id) = dispatch_hierarchical_es(
+            &uuid::Uuid::new_v4().to_string(),
             "dev-lead",
             "build X",
             flat_config("dev-lead", &["core-specialist"]),
@@ -2732,6 +2804,7 @@ mod es_switch_tests {
         let config = flat_config("dev-lead", &["core-specialist"]);
 
         let (state, events, _dispatch_run_id) = dispatch_hierarchical_es(
+            &uuid::Uuid::new_v4().to_string(),
             "dev-lead",
             "build X",
             config.clone(),
@@ -2801,6 +2874,7 @@ mod es_switch_tests {
         let (agents, providers) = blackboard_roster();
 
         let (state, _run_id) = dispatch_blackboard_es(
+            &uuid::Uuid::new_v4().to_string(),
             "task",
             agents,
             providers,
@@ -2850,6 +2924,7 @@ mod es_switch_tests {
         let config = BlackboardConfig::default();
 
         let (state, _dispatch_run_id) = dispatch_blackboard_es(
+            &uuid::Uuid::new_v4().to_string(),
             "task",
             agents,
             providers,
@@ -3143,6 +3218,7 @@ mod es_switch_tests {
         };
 
         let (state, events, _run_id) = dispatch_ring_es(
+            &uuid::Uuid::new_v4().to_string(),
             "task",
             agents,
             vec!["a".to_string(), "b".to_string()],
@@ -3197,6 +3273,7 @@ mod es_switch_tests {
         };
 
         let (state, _events, _dispatch_run_id) = dispatch_ring_es(
+            &uuid::Uuid::new_v4().to_string(),
             "task",
             agents,
             vec!["a".to_string(), "b".to_string()],

--- a/src/cli/run_es_record.rs
+++ b/src/cli/run_es_record.rs
@@ -109,6 +109,38 @@ pub fn ring_display(state: &ExecutionState, events: &[ExecutionEvent]) -> String
     format!("{outcome}\n[votes] {votes}")
 }
 
+/// Single source of truth for a run's terminal `RunEvent::Result.content`,
+/// branching on the folded `state.pattern` exactly the way `resume_run`
+/// (`src/cli/run.rs`) used to inline it: `blackboard` and `ring` need their
+/// own display helpers (the ring vote tally in particular has no equivalent
+/// in the generic `OrchestrationResult` shape), everything else — `direct`,
+/// `hierarchical`, and any unexpected pattern — falls back to
+/// `to_orchestration_result`.
+///
+/// Factored out (re-review fix) so `resume_run` and `--replay`
+/// (`crate::cli::run_replay::replay_from_log`) call the SAME branch instead
+/// of each hand-rolling it: before this, `replay_from_log` used
+/// `to_orchestration_result` unconditionally for every pattern, so a
+/// replayed `ring` run silently dropped the `[votes] …` tally that live/
+/// `--resume` both include — replay diverged from live for exactly the
+/// pattern whose whole point is the vote. Routing both call sites through
+/// one function makes that drift structurally impossible to reintroduce.
+///
+/// Both current callers (`resume_run`, `replay_from_log`) only exist under
+/// `#[cfg(feature = "storage")]` (the event log this whole read-back/resume
+/// story depends on is only persisted with that feature), so this is gated
+/// the same way — unlike `blackboard_display`/`ring_display` above, which
+/// stay ungated because the LIVE orchestrated path also calls them
+/// unconditionally.
+#[cfg(feature = "storage")]
+pub(crate) fn final_content(state: &ExecutionState, events: &[ExecutionEvent]) -> String {
+    match state.pattern.as_str() {
+        "blackboard" => blackboard_display(state),
+        "ring" => ring_display(state, events),
+        _ => crate::core::orchestration::es::bridge::to_orchestration_result(state, events).content,
+    }
+}
+
 /// Plain-text summary of ring contributions (`[agent] action: content`, in
 /// insertion order). Used as the `runs.output` diagnostic column in
 /// [`record_ring_es_into`] — unlike [`ring_display`], it needs no `events`
@@ -803,5 +835,64 @@ mod storage_tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].agent, "a");
         assert_eq!(entries[0].kind, "finding");
+    }
+
+    // ── final_content: the shared resume/replay branch (storage-gated,
+    // same as the function itself — see its doc comment) ────────────
+
+    #[test]
+    fn final_content_uses_ring_display_for_ring_pattern() {
+        let mut state = ExecutionState {
+            pattern: "ring".to_string(),
+            ..Default::default()
+        };
+        state.ring.votes.insert(
+            "b".to_string(),
+            VoteRec {
+                agent: "b".to_string(),
+                position: "approve".to_string(),
+                confidence: 0.8,
+                supports: vec![0],
+                concerns: vec![],
+            },
+        );
+        let events = [ExecutionEvent::OutcomeResolved {
+            outcome: "consensus reached".to_string(),
+        }];
+        let content = final_content(&state, &events);
+        assert!(content.starts_with("consensus reached"));
+        assert!(
+            content.contains("[votes]"),
+            "ring's final_content must include the vote tally, got: {content}"
+        );
+    }
+
+    #[test]
+    fn final_content_uses_blackboard_display_for_blackboard_pattern() {
+        let mut state = ExecutionState {
+            pattern: "blackboard".to_string(),
+            ..Default::default()
+        };
+        state.board.entries.push(BoardEntryRec {
+            agent: "a".to_string(),
+            round: 1,
+            kind: "finding".to_string(),
+            content: "first finding".to_string(),
+            refs: vec![],
+            confidence: 0.9,
+        });
+        assert_eq!(final_content(&state, &[]), "[a] first finding");
+    }
+
+    #[test]
+    fn final_content_falls_back_to_orchestration_result_for_other_patterns() {
+        let state = ExecutionState {
+            pattern: "hierarchical".to_string(),
+            ..Default::default()
+        };
+        let events = [ExecutionEvent::Completed {
+            content: "final answer".to_string(),
+        }];
+        assert_eq!(final_content(&state, &events), "final answer");
     }
 }

--- a/src/cli/run_replay.rs
+++ b/src/cli/run_replay.rs
@@ -21,8 +21,12 @@
 //! either CLI-shaped event needs context the per-event projection doesn't
 //! have. `replay_from_log` therefore synthesizes both itself —
 //! [`crate::core::orchestration::es::bridge::synthetic_run_start`] for the
-//! head, `to_orchestration_result` (same fn the live hierarchical/direct path
-//! uses) for the terminal `Result` — so `--replay --json` produces the SAME
+//! head, [`crate::cli::run_es_record::final_content`] (the SAME helper
+//! `resume_run` in `run.rs` calls, and the fix for a re-review fidelity gap:
+//! this module used to call `to_orchestration_result` unconditionally here,
+//! which has no notion of a `ring` run's vote tally — a replayed `ring` run
+//! would silently drop the `[votes] …` line live/`--resume` both include)
+//! for the terminal `Result` — so `--replay --json` produces the SAME
 //! complete `RunEvent` stream a live run did, not just its mid-stream slice.
 //!
 //! Split in two on purpose:
@@ -123,6 +127,7 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
     sink: &Arc<dyn EventSink>,
     human_output: bool,
 ) -> anyhow::Result<()> {
+    use crate::cli::run_es_record::final_content;
     use crate::core::orchestration::es::bridge::{
         map_execution_to_run_events, synthetic_run_start, to_orchestration_result,
     };
@@ -149,7 +154,12 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
     // ES engine (`RunStarted` maps to `[]` in `map_execution_to_run_events`)
     // — replay must synthesize it so `--replay --json` produces the SAME
     // complete stream a live run does (see `synthetic_run_start`'s doc).
-    sink.emit(&synthetic_run_start(run_id, &state.agents, &events));
+    sink.emit(&synthetic_run_start(
+        run_id,
+        &state.pattern,
+        &state.agents,
+        &events,
+    ));
 
     // No roster is available on this read-only path (see module docs): every
     // `AgentInvoked` replays through the empty-`agent_meta` fallback, so its
@@ -162,13 +172,20 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
     }
 
     // TERMINAL bookend: same reasoning as the head `RunStart` above — a live
-    // run's `Result` is built by `run.rs` from `to_orchestration_result`,
-    // never by the engine projection (`Completed` also maps to `[]`), so
-    // replay must build and emit it itself for the stream to end the same
-    // way a live run's does.
+    // run's `Result` is built by `run.rs`, never by the engine projection
+    // (`Completed` also maps to `[]`), so replay must build and emit it
+    // itself for the stream to end the same way a live run's does.
+    //
+    // `content` goes through `final_content` (the SAME pattern-branching
+    // helper `resume_run` uses) rather than `to_orchestration_result`
+    // directly — that fixed a fidelity gap where a replayed `ring` run
+    // dropped its vote tally (see module doc). `tin`/`tout`/`cost` stay
+    // pattern-agnostic (always `state.budget_*`), so `to_orchestration_result`
+    // is still the right source for those.
     let result = to_orchestration_result(&state, &events);
+    let content = final_content(&state, &events);
     sink.emit(&RunEvent::Result {
-        content: result.content.clone(),
+        content: content.clone(),
         tin: result.total_tokens_in,
         tout: result.total_tokens_out,
         cost: result.total_cost,
@@ -176,11 +193,11 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
     });
 
     // Human-mode convenience: print the run's final answer, same as a live
-    // run's `println!(content)` — reuses `result.content` above instead of
+    // run's `println!(content)` — reuses `content` above instead of
     // recomputing it. This is a plain stdout print, independent of the
     // `RunEvent` stream above/`sink`.
     if human_output {
-        println!("{}", result.content);
+        println!("{content}");
     }
 
     Ok(())

--- a/src/cli/run_replay.rs
+++ b/src/cli/run_replay.rs
@@ -1,0 +1,150 @@
+//! `armadai run --replay <run_id>` (OH1 Lot 6, Task 2): reconstruct a
+//! finished run's `RunEvent` stream purely from the persisted `execution_events`
+//! log, without executing any effect (no provider calls).
+//!
+//! This is deliberately the read-only counterpart of the ES engines'
+//! `run_direct_es`/`run_blackboard_es`/`run_ring_es`/`run_hierarchical_es`,
+//! which append to the log AND drive the live provider calls. Replay only
+//! ever reads: `EventLog::events(run_id)` back, then projects each
+//! `ExecutionEvent` onto zero-or-more `RunEvent`s via
+//! [`crate::core::orchestration::es::bridge::map_execution_to_run_events`] —
+//! the SAME function `SinkProjectingLog` (the live path's bridge, see
+//! `bridge.rs`) uses for every ES run. Reusing it here (rather than forking a
+//! second `ExecutionEvent -> RunEvent` mapping) is what guarantees replay
+//! emits the same shape of events a live run did for the same log content.
+//!
+//! Split in two on purpose:
+//! - [`replay_run`] is the CLI-facing entry point: opens the real
+//!   `SqliteLog` via `crate::storage::init_db()` (the actual, global,
+//!   config-resolved DB — same one every other storage-gated run path
+//!   opens) and hands off to...
+//! - [`replay_from_log`], generic over any [`EventLog`], which does the
+//!   actual read-back + projection + emit. Generic so tests can drive it
+//!   against a throwaway in-memory `SqliteLog`/`InMemoryLog` without ever
+//!   touching `ARMADAI_CONFIG_DIR`/`XDG_DATA_HOME` or the developer's real
+//!   database — see `run.rs`'s
+//!   `replay_reproduces_the_live_run_event_sequence` test.
+//!
+//! ## Known fidelity gap: `AgentStart.prov`/`model`
+//!
+//! `map_execution_to_run_events` fills `AgentStart.prov`/`model` from an
+//! `agent_meta` side table (roster key -> `(provider, configured model)`)
+//! that the LIVE path builds from the run's `Agent` definitions *before*
+//! invoking anything (see `dispatch_direct_es`/`agent_meta_from_roster` in
+//! `run.rs`). `ExecutionEvent` never records an agent's provider name at
+//! all, and the model configured for an agent's *first* invocation (which is
+//! what `AgentStart` shows, not the resolved tier) isn't reconstructable
+//! from the log alone either — only `AgentObserved.model` is logged, and
+//! only after the call already happened. Replay therefore calls
+//! `map_execution_to_run_events` with an **empty** `agent_meta`, which is
+//! the function's documented "no roster available" fallback (see
+//! `bridge.rs`'s `agent_invoked_maps_to_agent_start_with_empty_prov_model_when_meta_absent`
+//! test): every replayed `AgentStart` carries `prov: ""`, `model: ""`,
+//! whatever the live run's actually were. Every other field of every other
+//! event (content/tokens/cost/agent names, `AgentEnd`/`Route`/`Board`/`Vote`/
+//! `Delegate`/`Warning`/...) round-trips through the log exactly, since it's
+//! carried verbatim by the `ExecutionEvent` that produced it.
+//!
+//! `human_output` gates the two pieces of direct terminal output this
+//! module performs (a muted `replay <run_id>` banner and, on success, the
+//! run's final answer) — mirroring the `!json && !quiet` gate `run.rs`'s
+//! live paths use for their own `run <run_id>` banner. It is independent
+//! from `sink`: JSONL consumers (`--json`) get the full replayed `RunEvent`
+//! stream from `sink` regardless of `human_output`.
+
+#[cfg(feature = "storage")]
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::core::events::EventSink;
+
+/// Replay a finished run: open the real, config-resolved event log
+/// (`crate::storage::init_db()` + `SqliteLog`) and re-emit the same
+/// `RunEvent` sequence a live run produced for it, executing no effects.
+/// Returns an error if `run_id` has no persisted events (unknown id) or if
+/// the `storage` feature isn't compiled in (the event log only persists
+/// under `storage`).
+#[cfg(feature = "storage")]
+pub async fn replay_run(
+    run_id: &str,
+    sink: &Arc<dyn EventSink>,
+    human_output: bool,
+) -> anyhow::Result<()> {
+    use crate::core::orchestration::es::log::SqliteLog;
+
+    let db = crate::storage::init_db()?;
+    let log = SqliteLog::new(db);
+    replay_from_log(&log, run_id, sink, human_output)
+}
+
+/// Without the `storage` feature there is no event log to read back from —
+/// `--replay` cannot be honored at all (it needs the persisted
+/// `execution_events` table).
+#[cfg(not(feature = "storage"))]
+pub async fn replay_run(
+    _run_id: &str,
+    _sink: &Arc<dyn EventSink>,
+    _human_output: bool,
+) -> anyhow::Result<()> {
+    anyhow::bail!("--replay requires the 'storage' feature (event log persistence)")
+}
+
+/// Core of `--replay`, generic over any [`EventLog`] — no I/O beyond the log
+/// itself (no `init_db()`, no env/config resolution), which is what makes it
+/// directly unit-testable against an in-memory log without touching global
+/// env/config state (see `run.rs`'s
+/// `es_switch_tests::replay_reproduces_the_live_run_event_sequence`, which
+/// calls this via `crate::cli::run_replay::replay_from_log` — `pub(crate)`
+/// for exactly that cross-module test access; not part of the CLI's public
+/// surface, [`replay_run`] is).
+///
+/// Bails with `"no run found for id {run_id}"` when `log.events(run_id)` is
+/// empty — [`EventLog::events`] returns an empty vec (not an error) for an
+/// unknown id, so this is the only place that turns "nothing recorded"
+/// into a user-facing error.
+#[cfg(feature = "storage")]
+pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
+    log: &L,
+    run_id: &str,
+    sink: &Arc<dyn EventSink>,
+    human_output: bool,
+) -> anyhow::Result<()> {
+    use crate::core::orchestration::es::bridge::{
+        map_execution_to_run_events, to_orchestration_result,
+    };
+    use crate::core::orchestration::es::state::fold;
+
+    let events = log.events(run_id)?;
+
+    if events.is_empty() {
+        anyhow::bail!("no run found for id {run_id}");
+    }
+
+    if human_output {
+        let m = crate::cli::style::muted();
+        anstream::eprintln!("{m}replay {run_id}{m:#}");
+    }
+
+    // No roster is available on this read-only path (see module docs): every
+    // `AgentInvoked` replays through the empty-`agent_meta` fallback, so its
+    // `AgentStart` carries empty `prov`/`model` rather than the live run's.
+    let agent_meta: BTreeMap<String, (String, String)> = BTreeMap::new();
+    for event in &events {
+        for re in map_execution_to_run_events(event, &agent_meta) {
+            sink.emit(&re);
+        }
+    }
+
+    // Human-mode convenience: print the run's final answer, same as a live
+    // run's `println!(content)` — reuses the same `to_orchestration_result`
+    // content extraction the live hierarchical/blackboard/ring paths already
+    // rely on (last `Completed`, else last `AgentObserved`). This is a plain
+    // stdout print, independent of the `RunEvent` stream above/`sink`.
+    if human_output {
+        let state = fold(&events);
+        let result = to_orchestration_result(&state, &events);
+        println!("{}", result.content);
+    }
+
+    Ok(())
+}

--- a/src/cli/run_replay.rs
+++ b/src/cli/run_replay.rs
@@ -13,6 +13,18 @@
 //! second `ExecutionEvent -> RunEvent` mapping) is what guarantees replay
 //! emits the same shape of events a live run did for the same log content.
 //!
+//! ## `RunStart`/`Result` bookends
+//!
+//! A live run's `RunEvent::RunStart` (head) and `RunEvent::Result` (terminal)
+//! are emitted by `run.rs`, NOT by the ES engine: `map_execution_to_run_events`
+//! maps `RunStarted`/`Completed` to `[]` (see its doc comment), since building
+//! either CLI-shaped event needs context the per-event projection doesn't
+//! have. `replay_from_log` therefore synthesizes both itself —
+//! [`crate::core::orchestration::es::bridge::synthetic_run_start`] for the
+//! head, `to_orchestration_result` (same fn the live hierarchical/direct path
+//! uses) for the terminal `Result` — so `--replay --json` produces the SAME
+//! complete `RunEvent` stream a live run did, not just its mid-stream slice.
+//!
 //! Split in two on purpose:
 //! - [`replay_run`] is the CLI-facing entry point: opens the real
 //!   `SqliteLog` via `crate::storage::init_db()` (the actual, global,
@@ -57,6 +69,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::core::events::EventSink;
+#[cfg(feature = "storage")]
+use crate::core::events::RunEvent;
 
 /// Replay a finished run: open the real, config-resolved event log
 /// (`crate::storage::init_db()` + `SqliteLog`) and re-emit the same
@@ -110,7 +124,7 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
     human_output: bool,
 ) -> anyhow::Result<()> {
     use crate::core::orchestration::es::bridge::{
-        map_execution_to_run_events, to_orchestration_result,
+        map_execution_to_run_events, synthetic_run_start, to_orchestration_result,
     };
     use crate::core::orchestration::es::state::fold;
 
@@ -125,6 +139,18 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
         anstream::eprintln!("{m}replay {run_id}{m:#}");
     }
 
+    // Folded once up front: the roster (`state.agents`) seeds the synthetic
+    // `RunStart` bookend below, and the same `state` feeds
+    // `to_orchestration_result` for the terminal `Result` bookend after the
+    // mid-stream loop.
+    let state = fold(&events);
+
+    // HEAD bookend: a live run's `RunStart` is emitted by `run.rs`, not the
+    // ES engine (`RunStarted` maps to `[]` in `map_execution_to_run_events`)
+    // — replay must synthesize it so `--replay --json` produces the SAME
+    // complete stream a live run does (see `synthetic_run_start`'s doc).
+    sink.emit(&synthetic_run_start(run_id, &state.agents, &events));
+
     // No roster is available on this read-only path (see module docs): every
     // `AgentInvoked` replays through the empty-`agent_meta` fallback, so its
     // `AgentStart` carries empty `prov`/`model` rather than the live run's.
@@ -135,14 +161,25 @@ pub(crate) fn replay_from_log<L: crate::core::orchestration::es::log::EventLog>(
         }
     }
 
+    // TERMINAL bookend: same reasoning as the head `RunStart` above — a live
+    // run's `Result` is built by `run.rs` from `to_orchestration_result`,
+    // never by the engine projection (`Completed` also maps to `[]`), so
+    // replay must build and emit it itself for the stream to end the same
+    // way a live run's does.
+    let result = to_orchestration_result(&state, &events);
+    sink.emit(&RunEvent::Result {
+        content: result.content.clone(),
+        tin: result.total_tokens_in,
+        tout: result.total_tokens_out,
+        cost: result.total_cost,
+        agents: state.agents.len(),
+    });
+
     // Human-mode convenience: print the run's final answer, same as a live
-    // run's `println!(content)` — reuses the same `to_orchestration_result`
-    // content extraction the live hierarchical/blackboard/ring paths already
-    // rely on (last `Completed`, else last `AgentObserved`). This is a plain
-    // stdout print, independent of the `RunEvent` stream above/`sink`.
+    // run's `println!(content)` — reuses `result.content` above instead of
+    // recomputing it. This is a plain stdout print, independent of the
+    // `RunEvent` stream above/`sink`.
     if human_output {
-        let state = fold(&events);
-        let result = to_orchestration_result(&state, &events);
         println!("{}", result.content);
     }
 

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 #[serde(tag = "t", rename_all = "snake_case")]
 pub enum RunEvent {
     RunStart {
+        run_id: String,
         v: u32,
         agents: Vec<String>,
         prov: String,
@@ -121,6 +122,7 @@ mod tests {
     #[test]
     fn run_start_serializes_with_short_keys() {
         let ev = RunEvent::RunStart {
+            run_id: "r1".into(),
             v: 1,
             agents: vec!["dev-lead".into()],
             prov: "claude".into(),
@@ -130,7 +132,27 @@ mod tests {
         let s = serde_json::to_string(&ev).unwrap();
         assert_eq!(
             s,
-            r#"{"t":"run_start","v":1,"agents":["dev-lead"],"prov":"claude","model":"claude-x","in_chars":412}"#
+            r#"{"t":"run_start","run_id":"r1","v":1,"agents":["dev-lead"],"prov":"claude","model":"claude-x","in_chars":412}"#
+        );
+    }
+
+    #[test]
+    fn run_start_serializes_run_id() {
+        // OH1 Lot 6, Task 1: `run_id` must round-trip through the JSONL
+        // contract so `--json` consumers (and a future `--resume <run_id>`)
+        // can identify the run.
+        let ev = RunEvent::RunStart {
+            run_id: "abc".into(),
+            v: 1,
+            agents: vec!["a".into()],
+            prov: "p".into(),
+            model: "m".into(),
+            in_chars: 1,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(
+            s.contains(r#""run_id":"abc""#),
+            "expected run_id in serialized event, got: {s}"
         );
     }
 
@@ -197,6 +219,7 @@ mod tests {
             out: Mutex::new(Box::new(SharedBuf(buf.clone()))),
         };
         sink.emit(&RunEvent::RunStart {
+            run_id: "r1".into(),
             v: 1,
             agents: vec!["a".into()],
             prov: "p".into(),

--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -789,6 +789,60 @@ pub async fn run_blackboard_es(
     run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
 
+/// Resume a previously interrupted `blackboard` run (OH1 Lot 6, Task 3):
+/// recovers the run's original `input` and the pattern's `BlackboardConfig`
+/// from the log (`RunStarted`/`ConfigSnapshot` — see
+/// [`super::engine::run_started_roster_and_input`]/[`super::engine::config_snapshot`]),
+/// rebuilds the SAME [`BlackboardDecider`]/[`BlackboardEffectRunner`] pair
+/// [`run_blackboard_es`] would (including `agent_order` derived from
+/// `agents.keys()`, exactly like the live path — deterministic given the
+/// same roster, so it needs no log-recovered ordering), and drives
+/// [`super::engine::resume_event_sourced`] instead of appending a fresh
+/// `RunStarted`/`ConfigSnapshot`.
+///
+/// `agents`/`providers` must be the roster reloaded from the project on disk
+/// (keyed by the same roster keys the original run used — see
+/// `ExecutionState::agents`, folded from `RunStarted`); `cost_limit` is
+/// re-derived from the project's top-level `orchestration.cost_limit`
+/// exactly as [`run_blackboard_es`]'s caller does, since it lives outside
+/// `BlackboardConfig` and is never captured by `ConfigSnapshot`.
+///
+/// Bails if `run_id` has no recorded `RunStarted` (unknown run) or isn't
+/// currently `Running` (see `resume_event_sourced`).
+pub async fn resume_blackboard_es(
+    run_id: &str,
+    agents: BTreeMap<String, Agent>,
+    providers: BTreeMap<String, Arc<dyn Provider>>,
+    routing_rules: RoutingRules,
+    cost_limit: Option<f64>,
+    log: &mut impl EventLog,
+) -> anyhow::Result<ExecutionState> {
+    use super::engine::{config_snapshot, resume_event_sourced, run_started_roster_and_input};
+
+    let events = log.events(run_id)?;
+    let (_roster, input) = run_started_roster_and_input(&events)
+        .ok_or_else(|| anyhow::anyhow!("no run found for id {run_id}"))?;
+    let config: BlackboardConfig = config_snapshot(&events);
+
+    let agent_order: Vec<String> = agents.keys().cloned().collect();
+    let max_rounds = config.max_rounds;
+    let token_budget = Some(u32::try_from(config.token_budget).unwrap_or(u32::MAX));
+
+    let decider = BlackboardDecider::new(
+        agents.clone(),
+        agent_order,
+        input,
+        config.clone(),
+        routing_rules,
+        max_rounds,
+        token_budget,
+        cost_limit,
+    );
+    let effects = BlackboardEffectRunner::new(agents, providers, config);
+
+    resume_event_sourced(run_id, &decider, &effects, log).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2001,6 +2055,112 @@ mod tests {
                 !final_content(&log, "run-converge").trim().is_empty(),
                 "expected a non-empty final board digest"
             );
+        }
+
+        /// OH1 Lot 6, Task 3: `resume_blackboard_es` reconstructs the same
+        /// `BlackboardDecider`/`BlackboardEffectRunner` a fresh
+        /// `run_blackboard_es` would from a log that only has `RunStarted` +
+        /// `ConfigSnapshot` recorded (simulating a crash immediately after
+        /// config capture, before any round started) — proving
+        /// `BlackboardConfig` round-trips through `ConfigSnapshot` correctly
+        /// (the ConfigSnapshot-sufficiency finding this task investigates).
+        /// Same scripted scenario as `es_blackboard_converges_and_completes`
+        /// above, seeded by hand instead of via `run_blackboard_es`.
+        #[tokio::test]
+        async fn resume_blackboard_es_converges_from_a_config_snapshot_only_log() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:tout est cohérent",
+                ])),
+            );
+            providers.insert(
+                "b".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION:CONFIRMATION\nTARGET:0\nCONFIDENCE:0.9\nCONTENT:confirmé",
+                ])),
+            );
+
+            let config = BlackboardConfig::default();
+            let agent_order: Vec<String> = agents.keys().cloned().collect();
+
+            let mut log = InMemoryLog::default();
+            log.append(
+                "run-resume-bb",
+                &ExecutionEvent::RunStarted {
+                    run_id: "run-resume-bb".to_string(),
+                    pattern: "blackboard".to_string(),
+                    agents: agent_order,
+                    input: "task".to_string(),
+                    project: None,
+                },
+            )
+            .unwrap();
+            log.append(
+                "run-resume-bb",
+                &ExecutionEvent::ConfigSnapshot {
+                    config_json: serde_json::to_string(&config).unwrap(),
+                },
+            )
+            .unwrap();
+
+            let st = resume_blackboard_es(
+                "run-resume-bb",
+                agents,
+                providers,
+                RoutingRules::default(),
+                None,
+                &mut log,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(st.status, RunStatus::Completed);
+            assert!(
+                st.board.entries.iter().all(|e| e.kind == "confirmation"),
+                "expected only confirmation entries, got {:?}",
+                st.board.entries
+            );
+            assert!(!final_content(&log, "run-resume-bb").trim().is_empty());
+        }
+
+        #[tokio::test]
+        async fn resume_blackboard_es_bails_on_completed_run() {
+            let mut log = InMemoryLog::default();
+            log.append(
+                "run-resume-bb",
+                &ExecutionEvent::RunStarted {
+                    run_id: "run-resume-bb".to_string(),
+                    pattern: "blackboard".to_string(),
+                    agents: vec!["a".to_string()],
+                    input: "task".to_string(),
+                    project: None,
+                },
+            )
+            .unwrap();
+            log.append(
+                "run-resume-bb",
+                &ExecutionEvent::Completed {
+                    content: "done".to_string(),
+                },
+            )
+            .unwrap();
+
+            let err = resume_blackboard_es(
+                "run-resume-bb",
+                BTreeMap::new(),
+                BTreeMap::new(),
+                RoutingRules::default(),
+                None,
+                &mut log,
+            )
+            .await
+            .unwrap_err();
+            assert!(err.to_string().contains("not resumable"));
         }
 
         // Scenario 2: both agents post plain `FINDING`s every round — never

--- a/src/core/orchestration/es/bridge.rs
+++ b/src/core/orchestration/es/bridge.rs
@@ -321,6 +321,49 @@ pub fn to_orchestration_result(
     }
 }
 
+/// Build the synthetic `RunEvent::RunStart` bookend for a run reconstructed
+/// purely from its persisted `ExecutionEvent` log (`--replay`/`--resume`).
+///
+/// Neither path gets a `RunStart` "for free" the way a live run does: a live
+/// run's `RunStart` is emitted by `run.rs` itself (`run_inner`/
+/// `run_orchestrated`), not by the ES engine — `RunStarted` maps to `[]` in
+/// [`map_execution_to_run_events`] (see its doc comment) since building the
+/// CLI-shaped bookend needs context (the pre-run roster) the per-event
+/// projection doesn't have. `--replay`/`--resume` read the log back with no
+/// such live context either, so both synthesize it here from what IS
+/// reconstructable:
+///
+/// - `run_id`: the id being replayed/resumed, verbatim.
+/// - `v`: `1`, matching every live `RunStart`.
+/// - `agents`: the folded roster (`ExecutionState::agents`, from
+///   `RunStarted`).
+/// - `prov`/`model`: empty strings — not reconstructable from the log alone
+///   (same documented gap as replayed `AgentStart`s, see `run_replay.rs`'s
+///   module doc).
+/// - `in_chars`: recovered from the FIRST `ExecutionEvent::RunStarted.input`
+///   found in `events` (`0` if somehow absent). Unlike `prov`/`model`, the
+///   original input IS logged verbatim — `ExecutionState::apply` just
+///   discards it (keeping only `agents`/`pattern` from `RunStarted`) — so
+///   scanning the raw event list recovers it exactly instead of stubbing it.
+pub fn synthetic_run_start(run_id: &str, agents: &[String], events: &[ExecutionEvent]) -> RunEvent {
+    let in_chars = events
+        .iter()
+        .find_map(|e| match e {
+            ExecutionEvent::RunStarted { input, .. } => Some(input.chars().count()),
+            _ => None,
+        })
+        .unwrap_or(0);
+
+    RunEvent::RunStart {
+        run_id: run_id.to_string(),
+        v: 1,
+        agents: agents.to_vec(),
+        prov: String::new(),
+        model: String::new(),
+        in_chars,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;

--- a/src/core/orchestration/es/bridge.rs
+++ b/src/core/orchestration/es/bridge.rs
@@ -337,15 +337,29 @@ pub fn to_orchestration_result(
 /// - `v`: `1`, matching every live `RunStart`.
 /// - `agents`: the folded roster (`ExecutionState::agents`, from
 ///   `RunStarted`).
-/// - `prov`/`model`: empty strings — not reconstructable from the log alone
-///   (same documented gap as replayed `AgentStart`s, see `run_replay.rs`'s
-///   module doc).
+/// - `prov`: empty string — not reconstructable from the log alone (same
+///   documented gap as replayed `AgentStart`s, see `run_replay.rs`'s module
+///   doc).
+/// - `model`: matches what the live `RunStart` puts there for `pattern`
+///   (re-review fix — this used to be unconditionally empty here, diverging
+///   from live): `run.rs`'s live orchestrated `RunStart`
+///   (`run_orchestrated`) sets `model: pattern.to_string()`, while its live
+///   `direct`/sequential `RunStart` (`run_single_agent`) leaves it empty. So
+///   `pattern` (the SAME folded `ExecutionState::pattern` the caller already
+///   has) selects between the two: `""` for `"direct"`, the pattern name
+///   itself otherwise. `--json`/Workroom fidelity only — the Workroom itself
+///   only reads `agents` off this event.
 /// - `in_chars`: recovered from the FIRST `ExecutionEvent::RunStarted.input`
 ///   found in `events` (`0` if somehow absent). Unlike `prov`/`model`, the
 ///   original input IS logged verbatim — `ExecutionState::apply` just
 ///   discards it (keeping only `agents`/`pattern` from `RunStarted`) — so
 ///   scanning the raw event list recovers it exactly instead of stubbing it.
-pub fn synthetic_run_start(run_id: &str, agents: &[String], events: &[ExecutionEvent]) -> RunEvent {
+pub fn synthetic_run_start(
+    run_id: &str,
+    pattern: &str,
+    agents: &[String],
+    events: &[ExecutionEvent],
+) -> RunEvent {
     let in_chars = events
         .iter()
         .find_map(|e| match e {
@@ -354,12 +368,18 @@ pub fn synthetic_run_start(run_id: &str, agents: &[String], events: &[ExecutionE
         })
         .unwrap_or(0);
 
+    let model = if pattern == "direct" {
+        String::new()
+    } else {
+        pattern.to_string()
+    };
+
     RunEvent::RunStart {
         run_id: run_id.to_string(),
         v: 1,
         agents: agents.to_vec(),
         prov: String::new(),
-        model: String::new(),
+        model,
         in_chars,
     }
 }

--- a/src/core/orchestration/es/direct.rs
+++ b/src/core/orchestration/es/direct.rs
@@ -278,6 +278,43 @@ pub async fn run_direct_es(
     run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
 
+/// Resume a previously interrupted `direct` run (OH1 Lot 6, Task 3): recovers
+/// the invoked agent's name and the run's original `input` from the log's
+/// `RunStarted` event (see [`super::engine::run_started_roster_and_input`] —
+/// `direct`'s `RunStarted.agents` is always a single-element roster, the
+/// invoked agent), rebuilds the SAME [`DirectDecider`]/[`DirectEffectRunner`]
+/// pair [`run_direct_es`] would have from a fresh `agents`/`providers`
+/// reload (the caller is expected to have re-parsed the agent from the
+/// project on disk, exactly as a live run does — the log carries no `Agent`
+/// definitions, only the roster's key), and drives
+/// [`super::engine::resume_event_sourced`] instead of appending a fresh
+/// `RunStarted`.
+///
+/// Bails if `run_id` has no recorded `RunStarted` (unknown run) or isn't
+/// currently `Running` (see `resume_event_sourced`).
+pub async fn resume_direct_es(
+    run_id: &str,
+    agents: BTreeMap<String, Agent>,
+    providers: BTreeMap<String, Arc<dyn Provider>>,
+    routing_rules: RoutingRules,
+    log: &mut impl EventLog,
+) -> anyhow::Result<ExecutionState> {
+    use super::engine::{resume_event_sourced, run_started_roster_and_input};
+
+    let events = log.events(run_id)?;
+    let (roster, input) = run_started_roster_and_input(&events)
+        .ok_or_else(|| anyhow::anyhow!("no run found for id {run_id}"))?;
+    let agent = roster
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("run {run_id} has an empty agent roster"))?;
+
+    let decider = DirectDecider::new(&agent, &input, agents.clone(), routing_rules);
+    let effects = DirectEffectRunner::new(agents, providers);
+
+    resume_event_sourced(run_id, &decider, &effects, log).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,6 +481,177 @@ mod tests {
         // Replay reconstructs the same state purely from the log.
         let replayed = super::super::engine::replay("run-direct", &log).unwrap();
         assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
+    }
+
+    /// OH1 Lot 6, Task 3: a `direct` run interrupted right after
+    /// `RunStarted` (crashed before ever invoking the agent) resumes to
+    /// completion via `resume_direct_es`, invoking the provider exactly
+    /// once — same end-to-end shape `run_direct_es` produces, but starting
+    /// from a log that already has a `RunStarted` recorded.
+    #[tokio::test]
+    async fn resume_direct_es_completes_a_run_interrupted_before_any_invoke() {
+        let mut agents = BTreeMap::new();
+        agents.insert("solo".to_string(), test_agent("solo", "concrete-model"));
+        let capturing = Arc::new(CapturingProvider::new("the answer"));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert("solo".to_string(), capturing.clone() as Arc<dyn Provider>);
+
+        let mut log = InMemoryLog::default();
+        // Simulate a crash: only `RunStarted` was persisted before the
+        // process died — the agent was never invoked.
+        log.append(
+            "run-direct",
+            &ExecutionEvent::RunStarted {
+                run_id: "run-direct".to_string(),
+                pattern: "direct".to_string(),
+                agents: vec!["solo".to_string()],
+                input: "do the thing".to_string(),
+                project: None,
+            },
+        )
+        .unwrap();
+
+        let st = resume_direct_es(
+            "run-direct",
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(st.status, RunStatus::Completed);
+        assert_eq!(capturing.requests().len(), 1);
+        assert_eq!(
+            event_kinds(&log, "run-direct"),
+            vec![
+                "run_started",
+                "agent_invoked",
+                "agent_observed",
+                "completed"
+            ]
+        );
+    }
+
+    /// OH1 Lot 6, Task 3: a `direct` run interrupted AFTER the agent
+    /// answered (crashed between `AgentObserved` and `Completed`) resumes to
+    /// completion WITHOUT calling the provider again — the already-observed
+    /// response from the log is reused, proving `resume_direct_es` doesn't
+    /// re-invoke.
+    #[tokio::test]
+    async fn resume_direct_es_does_not_reinvoke_an_already_observed_agent() {
+        let mut agents = BTreeMap::new();
+        agents.insert("solo".to_string(), test_agent("solo", "concrete-model"));
+        let capturing = Arc::new(CapturingProvider::new("should never be sent"));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert("solo".to_string(), capturing.clone() as Arc<dyn Provider>);
+
+        let mut log = InMemoryLog::default();
+        log.append(
+            "run-direct",
+            &ExecutionEvent::RunStarted {
+                run_id: "run-direct".to_string(),
+                pattern: "direct".to_string(),
+                agents: vec!["solo".to_string()],
+                input: "do the thing".to_string(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "run-direct",
+            &ExecutionEvent::AgentInvoked {
+                agent: "solo".to_string(),
+                input: "do the thing".to_string(),
+            },
+        )
+        .unwrap();
+        log.append(
+            "run-direct",
+            &ExecutionEvent::AgentObserved {
+                agent: "solo".to_string(),
+                content: "already answered".to_string(),
+                tokens_in: 3,
+                tokens_out: 4,
+                cost: 0.02,
+                model: "concrete-model".to_string(),
+            },
+        )
+        .unwrap();
+
+        let st = resume_direct_es(
+            "run-direct",
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(st.status, RunStatus::Completed);
+        // The provider was never called: the response came from the log.
+        assert!(capturing.requests().is_empty());
+        let final_content = log
+            .events("run-direct")
+            .unwrap()
+            .into_iter()
+            .find_map(|e| match e {
+                ExecutionEvent::Completed { content } => Some(content),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(final_content, "already answered");
+    }
+
+    #[tokio::test]
+    async fn resume_direct_es_bails_on_completed_run() {
+        let mut log = InMemoryLog::default();
+        log.append(
+            "run-direct",
+            &ExecutionEvent::RunStarted {
+                run_id: "run-direct".to_string(),
+                pattern: "direct".to_string(),
+                agents: vec!["solo".to_string()],
+                input: "do the thing".to_string(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "run-direct",
+            &ExecutionEvent::Completed {
+                content: "done".to_string(),
+            },
+        )
+        .unwrap();
+
+        let err = resume_direct_es(
+            "run-direct",
+            BTreeMap::new(),
+            BTreeMap::new(),
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("not resumable"));
+    }
+
+    #[tokio::test]
+    async fn resume_direct_es_bails_on_unknown_run() {
+        let mut log = InMemoryLog::default();
+        let err = resume_direct_es(
+            "nope",
+            BTreeMap::new(),
+            BTreeMap::new(),
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("no run found"));
     }
 
     // `latest:auto` must route: a `ModelRouted` event is emitted before the

--- a/src/core/orchestration/es/engine.rs
+++ b/src/core/orchestration/es/engine.rs
@@ -125,13 +125,38 @@ where
         append_and_apply(log, run_id, &mut state, event)?;
     }
 
+    run_loop(run_id, &mut state, decider, effects, log).await?;
+
+    Ok(state)
+}
+
+/// Drive the generic event-sourced loop body for `run_id`, given an
+/// already-seeded `state` — the part of [`run_event_sourced`] that runs
+/// `while state.status == RunStatus::Running`, factored out so
+/// [`resume_event_sourced`] can seed `state` via [`replay`] (no re-append of
+/// `initial`) instead of `ExecutionState::default()`, while sharing the
+/// exact same decide/act/append/fold sequence — see [`run_event_sourced`]'s
+/// own doc comment for the full behavior this implements (iteration cap,
+/// per-`Action` handling, etc.), which is unchanged by this extraction.
+async fn run_loop<D, R, L>(
+    run_id: &str,
+    state: &mut ExecutionState,
+    decider: &D,
+    effects: &R,
+    log: &mut L,
+) -> anyhow::Result<()>
+where
+    D: Decider,
+    R: EffectRunner,
+    L: EventLog,
+{
     let mut iterations = 0usize;
     while state.status == RunStatus::Running {
         if iterations >= MAX_ITERATIONS {
             append_and_apply(
                 log,
                 run_id,
-                &mut state,
+                state,
                 ExecutionEvent::Halted {
                     reason: "iteration_cap".to_string(),
                 },
@@ -140,7 +165,7 @@ where
         }
         iterations += 1;
 
-        let actions = decider.decide(&state);
+        let actions = decider.decide(state);
         if actions.is_empty() {
             break;
         }
@@ -154,34 +179,105 @@ where
                     append_and_apply(
                         log,
                         run_id,
-                        &mut state,
+                        state,
                         ExecutionEvent::AgentInvoked {
                             agent: agent.clone(),
                             input: input.clone(),
                         },
                     )?;
-                    let observed = effects.run_invoke(&agent, &input, &state).await?;
-                    append_and_apply(log, run_id, &mut state, observed)?;
+                    let observed = effects.run_invoke(&agent, &input, state).await?;
+                    append_and_apply(log, run_id, state, observed)?;
                 }
                 Action::Emit(event) => {
-                    append_and_apply(log, run_id, &mut state, event)?;
+                    append_and_apply(log, run_id, state, event)?;
                 }
                 Action::Halt { reason } => {
-                    append_and_apply(log, run_id, &mut state, ExecutionEvent::Halted { reason })?;
+                    append_and_apply(log, run_id, state, ExecutionEvent::Halted { reason })?;
                 }
                 Action::Complete { content } => {
-                    append_and_apply(
-                        log,
-                        run_id,
-                        &mut state,
-                        ExecutionEvent::Completed { content },
-                    )?;
+                    append_and_apply(log, run_id, state, ExecutionEvent::Completed { content })?;
                 }
             }
         }
     }
 
+    Ok(())
+}
+
+/// Resume a previously interrupted event-sourced run: seed `state` by
+/// [`replay`]ing `run_id` from `log` (a pure fold — NO re-append of the
+/// events already recorded), then drive the same [`run_loop`] a fresh run
+/// would use, appending only the NEW events resuming produces.
+///
+/// Bails if `run_id` has no recorded events at all (unknown run — `replay`
+/// alone can't distinguish "unknown id" from "a real, empty-by-construction
+/// state", since both fold to `ExecutionState::default()`), or if the
+/// replayed run's status isn't [`RunStatus::Running`] (already
+/// `Completed`/`Halted` — nothing to resume).
+///
+/// `decider`/`effects` must be reconstructed by the caller (see the
+/// `resume_*_es` entry points in `es::direct`/`blackboard`/`ring`/
+/// `hierarchical`) from data recoverable at resume time: the roster/input
+/// carried by the log's `RunStarted` event, the pattern config carried by
+/// `ConfigSnapshot`, and the agents/providers reloaded from the project on
+/// disk — never from anything the caller must have kept around since the
+/// original run started.
+pub async fn resume_event_sourced<D, R, L>(
+    run_id: &str,
+    decider: &D,
+    effects: &R,
+    log: &mut L,
+) -> anyhow::Result<ExecutionState>
+where
+    D: Decider,
+    R: EffectRunner,
+    L: EventLog,
+{
+    if log.events(run_id)?.is_empty() {
+        anyhow::bail!("no run found for id {run_id}");
+    }
+
+    let mut state = replay(run_id, log)?;
+    if state.status != RunStatus::Running {
+        anyhow::bail!("run {run_id} is not resumable (status: {:?})", state.status);
+    }
+
+    run_loop(run_id, &mut state, decider, effects, log).await?;
+
     Ok(state)
+}
+
+/// Recover the roster (`RunStarted.agents`, in original order) and original
+/// user `input` from the first `RunStarted` event in `events`. Returns
+/// `None` if no `RunStarted` is present (an unknown/empty log) — the only
+/// piece of `RunStarted` not preserved by the pure `ExecutionState`
+/// projection (`apply` deliberately discards `input`, see `state.rs`), so
+/// every `resume_*_es` entry point needs this raw-event scan (mirroring
+/// `run_es_record::project_run`'s own `RunStarted` extraction) to rebuild a
+/// `Decider` that needs the run's original input text.
+pub fn run_started_roster_and_input(events: &[ExecutionEvent]) -> Option<(Vec<String>, String)> {
+    events.iter().find_map(|e| match e {
+        ExecutionEvent::RunStarted { agents, input, .. } => Some((agents.clone(), input.clone())),
+        _ => None,
+    })
+}
+
+/// Recover a pattern's orchestration config (`BlackboardConfig`/`RingConfig`/
+/// `OrchestrationConfig`) from the log's `ConfigSnapshot` event, deserializing
+/// its `config_json`. Falls back to `C::default()` when no `ConfigSnapshot`
+/// is present (direct runs never emit one) or it fails to deserialize —
+/// same fallback `run_es_record::project_run` already relies on via
+/// `ExecutionState::config_json`.
+pub fn config_snapshot<C: serde::de::DeserializeOwned + Default>(events: &[ExecutionEvent]) -> C {
+    events
+        .iter()
+        .find_map(|e| match e {
+            ExecutionEvent::ConfigSnapshot { config_json } => {
+                serde_json::from_str(config_json).ok()
+            }
+            _ => None,
+        })
+        .unwrap_or_default()
 }
 
 /// Reconstruct an `ExecutionState` for `run_id` purely from `log`, executing
@@ -260,5 +356,195 @@ mod tests {
         assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
         // log contains RunStarted, AgentInvoked, AgentObserved, Completed
         assert!(log.events("r").unwrap().len() >= 4);
+    }
+
+    // ── `resume_event_sourced` (OH1 Lot 6, Task 3) ──────────────────────
+
+    /// Two-step decider: invoke "a", then "b", then complete — needed
+    /// (unlike the single-step `D` above) to prove a resume genuinely
+    /// *continues* mid-sequence rather than trivially completing on its
+    /// first `decide` call.
+    struct TwoStep;
+    impl Decider for TwoStep {
+        fn decide(&self, s: &ExecutionState) -> Vec<Action> {
+            let observed = |agent: &str| {
+                s.conversations
+                    .get(agent)
+                    .map(|c| c.iter().any(|m| m.role == "assistant"))
+                    .unwrap_or(false)
+            };
+            if !observed("a") {
+                vec![Action::Invoke {
+                    agent: "a".into(),
+                    input: "go".into(),
+                }]
+            } else if !observed("b") {
+                vec![Action::Invoke {
+                    agent: "b".into(),
+                    input: "go".into(),
+                }]
+            } else {
+                vec![Action::Complete {
+                    content: "final".into(),
+                }]
+            }
+        }
+    }
+
+    /// Effect runner that records every agent it's asked to invoke, so tests
+    /// can assert an already-observed agent (replayed from the log, not
+    /// re-invoked) never appears in the recorded list.
+    #[derive(Default)]
+    struct TrackingEff {
+        invoked: std::sync::Mutex<Vec<String>>,
+    }
+    #[async_trait]
+    impl EffectRunner for TrackingEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            self.invoked.lock().unwrap().push(agent.to_string());
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: "resp".into(),
+                tokens_in: 1,
+                tokens_out: 1,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn resume_event_sourced_continues_without_reinvoking_observed_agent() {
+        let mut log = InMemoryLog::default();
+        // Simulate a crash: the process recorded `RunStarted` + invoked/
+        // observed "a", then died before deciding on "b" — status is still
+        // `Running` (no terminal event recorded).
+        log.append(
+            "r",
+            &E::RunStarted {
+                run_id: "r".into(),
+                pattern: "direct".into(),
+                agents: vec!["a".into(), "b".into()],
+                input: "go".into(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "r",
+            &E::AgentInvoked {
+                agent: "a".into(),
+                input: "go".into(),
+            },
+        )
+        .unwrap();
+        log.append(
+            "r",
+            &E::AgentObserved {
+                agent: "a".into(),
+                content: "resp-a".into(),
+                tokens_in: 1,
+                tokens_out: 1,
+                cost: 0.0,
+                model: "m".into(),
+            },
+        )
+        .unwrap();
+
+        let eff = TrackingEff::default();
+        let state = resume_event_sourced("r", &TwoStep, &eff, &mut log)
+            .await
+            .unwrap();
+
+        assert_eq!(state.status, RunStatus::Completed);
+        // Only "b" was invoked by the resumed run — "a" (already observed
+        // before the crash) was never re-invoked.
+        assert_eq!(*eff.invoked.lock().unwrap(), vec!["b".to_string()]);
+        // The log now also contains the pre-crash events, unchanged.
+        let events = log.events("r").unwrap();
+        assert!(matches!(events[0], E::RunStarted { .. }));
+        assert!(
+            events
+                .iter()
+                .filter(|e| matches!(e, E::AgentInvoked { agent, .. } if agent == "a"))
+                .count()
+                == 1,
+            "\"a\" must appear invoked exactly once across the whole log"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_event_sourced_bails_on_completed_run() {
+        let mut log = InMemoryLog::default();
+        log.append(
+            "r",
+            &E::RunStarted {
+                run_id: "r".into(),
+                pattern: "direct".into(),
+                agents: vec!["a".into()],
+                input: "go".into(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "r",
+            &E::Completed {
+                content: "done".into(),
+            },
+        )
+        .unwrap();
+
+        let eff = TrackingEff::default();
+        let err = resume_event_sourced("r", &D, &eff, &mut log)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not resumable"));
+        // No effect should have been run against an already-terminal log.
+        assert!(eff.invoked.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resume_event_sourced_bails_on_halted_run() {
+        let mut log = InMemoryLog::default();
+        log.append(
+            "r",
+            &E::RunStarted {
+                run_id: "r".into(),
+                pattern: "direct".into(),
+                agents: vec!["a".into()],
+                input: "go".into(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "r",
+            &E::Halted {
+                reason: "budget".into(),
+            },
+        )
+        .unwrap();
+
+        let eff = TrackingEff::default();
+        let err = resume_event_sourced("r", &D, &eff, &mut log)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not resumable"));
+    }
+
+    #[tokio::test]
+    async fn resume_event_sourced_bails_on_unknown_run() {
+        let mut log = InMemoryLog::default();
+        let eff = TrackingEff::default();
+        let err = resume_event_sourced("nope", &D, &eff, &mut log)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no run found"));
     }
 }

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -3495,6 +3495,168 @@ mod tests {
         assert!(!final_content(&log, "run-resume-hier").trim().is_empty());
     }
 
+    /// OH1 Lot 6, Task 4: crash→resume test for `hierarchical` where the
+    /// "crash" happens AFTER an agent has already been invoked and observed
+    /// — unlike `resume_hierarchical_es_completes_from_a_config_snapshot_only_log`
+    /// above (which crashes before any delegation at all), this is the exact
+    /// scenario the task brief calls out: an already-`AgentObserved` agent
+    /// must NOT be re-invoked on resume.
+    ///
+    /// Strategy: run the same scripted scenario as `es_single_delegation_completes`
+    /// once, straight through to completion, to obtain the canonical event
+    /// sequence a crash-free run produces. Then simulate a crash by
+    /// truncating that sequence right after core-specialist's
+    /// `AgentObserved` (dev-lead has delegated and gotten its answer back,
+    /// but hasn't yet been asked to synthesize) — the truncated log's folded
+    /// state is still `Running` (no terminal event recorded, verified below).
+    /// Resuming from there, with a FRESH `ScriptedProvider` per agent
+    /// (core-specialist's has NOTHING scripted, so any call to it would be a
+    /// bug this test must catch), must reach `Completed` without ever
+    /// calling core-specialist's provider again, and the resulting log must
+    /// be identical event-for-event (`Debug`-format comparison, the same
+    /// technique `run_event_sourced`'s own generic test and
+    /// `es_replay_reconstructs_state` above use) to the canonical
+    /// straight-through run — proving resume genuinely *continues* the same
+    /// deterministic sequence rather than merely reaching `Completed` by
+    /// some other, divergent path.
+    #[tokio::test]
+    async fn resume_hierarchical_es_does_not_reinvoke_an_already_observed_agent() {
+        let run_id = "run-crash";
+        let config = es_flat_config("dev-lead", &["core-specialist"]);
+
+        // 1. Canonical straight-through run (never interrupted) — the
+        // source of both the "pre-crash" prefix and the expected final
+        // event shape.
+        let mut canonical_agents = BTreeMap::new();
+        canonical_agents.insert(
+            "dev-lead".to_string(),
+            es_test_agent("dev-lead", "concrete-model"),
+        );
+        canonical_agents.insert(
+            "core-specialist".to_string(),
+            es_test_agent("core-specialist", "concrete-model"),
+        );
+        let mut canonical_providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        canonical_providers.insert(
+            "dev-lead".to_string(),
+            Arc::new(ScriptedProvider::new(&[
+                "@core-specialist: fais X",
+                "Synthèse : tout est prêt.",
+            ])),
+        );
+        canonical_providers.insert(
+            "core-specialist".to_string(),
+            Arc::new(ScriptedProvider::new(&["X est fait."])),
+        );
+        let mut canonical_log = InMemoryLog::default();
+        run_hierarchical_es(
+            run_id,
+            "dev-lead",
+            "build X",
+            config.clone(),
+            canonical_agents,
+            canonical_providers,
+            RoutingRules::default(),
+            &mut canonical_log,
+        )
+        .await
+        .unwrap();
+        let canonical_events = canonical_log.events(run_id).unwrap();
+
+        // 2. Truncate right after core-specialist's `AgentObserved` — the
+        // "crash point": core-specialist has already answered, dev-lead
+        // hasn't been asked to synthesize yet.
+        let cut = canonical_events
+            .iter()
+            .position(
+                |e| matches!(e, ExecutionEvent::AgentObserved { agent, .. } if agent == "core-specialist"),
+            )
+            .expect("expected core-specialist to be observed in the canonical run")
+            + 1;
+        let prefix = &canonical_events[..cut];
+        assert!(
+            prefix.iter().any(
+                |e| matches!(e, ExecutionEvent::AgentInvoked { agent, .. } if agent == "core-specialist")
+            ),
+            "sanity: the crash prefix must include core-specialist's AgentInvoked"
+        );
+        assert!(
+            cut < canonical_events.len(),
+            "sanity: the crash prefix must be a strict, non-trivial prefix of the canonical run \
+             (there must be remaining work — dev-lead's synthesis — for resume to do)"
+        );
+
+        let mut crashed_log = InMemoryLog::default();
+        for event in prefix {
+            crashed_log.append(run_id, event).unwrap();
+        }
+        assert_eq!(
+            replay(run_id, &crashed_log).unwrap().status,
+            RunStatus::Running,
+            "sanity: the truncated log must still be mid-run (no terminal event recorded)"
+        );
+
+        // 3. Resume with FRESH providers: dev-lead's has only the synthesis
+        // response left (it already answered the delegation question before
+        // the "crash"); core-specialist's has NOTHING scripted.
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "dev-lead".to_string(),
+            es_test_agent("dev-lead", "concrete-model"),
+        );
+        agents.insert(
+            "core-specialist".to_string(),
+            es_test_agent("core-specialist", "concrete-model"),
+        );
+        let dev_lead_provider = Arc::new(ScriptedProvider::new(&["Synthèse : tout est prêt."]));
+        let core_specialist_provider = Arc::new(ScriptedProvider::new(&[]));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert(
+            "dev-lead".to_string(),
+            dev_lead_provider.clone() as Arc<dyn Provider>,
+        );
+        providers.insert(
+            "core-specialist".to_string(),
+            core_specialist_provider.clone() as Arc<dyn Provider>,
+        );
+
+        let st = resume_hierarchical_es(
+            run_id,
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut crashed_log,
+        )
+        .await
+        .unwrap();
+
+        // (a) reaches Completed.
+        assert_eq!(st.status, RunStatus::Completed);
+        // (c) core-specialist (already observed before the crash) is never
+        // re-invoked; dev-lead's only NEW call is the synthesis one.
+        assert_eq!(
+            core_specialist_provider.call_count(),
+            0,
+            "core-specialist already answered before the crash and must not be re-invoked"
+        );
+        assert_eq!(
+            dev_lead_provider.call_count(),
+            1,
+            "dev-lead's synthesis call is the only new work resume should perform"
+        );
+
+        // (b) the full expected event set is present: resuming from the
+        // crash point reconstructs a log event-for-event identical to the
+        // canonical straight-through run.
+        let resumed_events = crashed_log.events(run_id).unwrap();
+        assert_eq!(
+            format!("{canonical_events:?}"),
+            format!("{resumed_events:?}"),
+            "resume must reconstruct the exact same event log a crash-free run would have produced"
+        );
+        assert!(!final_content(&crashed_log, run_id).trim().is_empty());
+    }
+
     #[tokio::test]
     async fn resume_hierarchical_es_bails_on_completed_run() {
         let mut log = InMemoryLog::default();

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -1398,6 +1398,72 @@ pub async fn run_hierarchical_es(
     run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
 
+/// Resume a previously interrupted `hierarchical` run (OH1 Lot 6, Task 3):
+/// recovers the run's original `input` and the roster (for the coordinator
+/// fallback below) from `RunStarted`, and the run's `OrchestrationConfig`
+/// from `ConfigSnapshot` (see
+/// [`super::engine::run_started_roster_and_input`]/[`super::engine::config_snapshot`]).
+/// The coordinator name is `config.coordinator` when set, else the first
+/// roster entry — the SAME fallback [`run_hierarchical_es`]'s caller
+/// (`run_orchestrated_inner` in `cli::run`) applies, just read from the
+/// log's roster instead of the CLI's freshly-resolved `agent_names`. Rebuilds
+/// the SAME [`HierarchicalDecider`]/[`HierarchicalEffectRunner`] pair
+/// [`run_hierarchical_es`] would, and drives
+/// [`super::engine::resume_event_sourced`] instead of appending a fresh
+/// `RunStarted`/`ConfigSnapshot`.
+///
+/// `agents`/`providers` must be the roster reloaded from the project on disk
+/// (keyed by the same roster keys the original run used —
+/// `ExecutionState::agents`, folded from `RunStarted`). Unlike
+/// blackboard/ring, `hierarchical`'s `cost_limit` and `token_budget` both
+/// live directly on `OrchestrationConfig`, so — unlike those two patterns —
+/// nothing here needs re-deriving from the project's config on disk beyond
+/// the roster/providers themselves.
+///
+/// Bails if `run_id` has no recorded `RunStarted` (unknown run) or isn't
+/// currently `Running` (see `resume_event_sourced`).
+pub async fn resume_hierarchical_es(
+    run_id: &str,
+    agents: BTreeMap<String, Agent>,
+    providers: BTreeMap<String, Arc<dyn Provider>>,
+    routing_rules: RoutingRules,
+    log: &mut impl EventLog,
+) -> anyhow::Result<ExecutionState> {
+    use super::engine::{config_snapshot, resume_event_sourced, run_started_roster_and_input};
+
+    let events = log.events(run_id)?;
+    let (roster, input) = run_started_roster_and_input(&events)
+        .ok_or_else(|| anyhow::anyhow!("no run found for id {run_id}"))?;
+    let config: OrchestrationConfig = config_snapshot(&events);
+
+    let coordinator = config
+        .coordinator
+        .clone()
+        .unwrap_or_else(|| roster.first().cloned().unwrap_or_default());
+    let max_depth = config.max_depth();
+    let max_iterations = config.max_iterations();
+    let token_budget = config
+        .token_budget
+        .map(|b| u32::try_from(b).unwrap_or(u32::MAX));
+    let cost_limit = config.cost_limit;
+
+    let decider = HierarchicalDecider::new(
+        coordinator,
+        input,
+        config.clone(),
+        agents.clone(),
+        routing_rules.clone(),
+        max_depth,
+        max_iterations,
+        token_budget,
+        cost_limit,
+    );
+    let effects =
+        HierarchicalEffectRunner::new(agents, providers, config).with_routing_rules(routing_rules);
+
+    resume_event_sourced(run_id, &decider, &effects, log).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3347,6 +3413,120 @@ mod tests {
 
         let replayed = replay("run-single", &log).unwrap();
         assert_eq!(format!("{st:?}"), format!("{replayed:?}"));
+    }
+
+    /// OH1 Lot 6, Task 3: `resume_hierarchical_es` reconstructs the same
+    /// `HierarchicalDecider`/`HierarchicalEffectRunner` a fresh
+    /// `run_hierarchical_es` would from a log that only has `RunStarted` +
+    /// `ConfigSnapshot` recorded (simulating a crash immediately after
+    /// config capture, before any delegation happened) — proving
+    /// `OrchestrationConfig` (including its `coordinator` field, which
+    /// `resume_hierarchical_es` falls back to the roster's first entry for
+    /// when absent) round-trips through `ConfigSnapshot` correctly. Same
+    /// scripted scenario as `es_single_delegation_completes` above, seeded
+    /// by hand instead of via `run_hierarchical_es`.
+    #[tokio::test]
+    async fn resume_hierarchical_es_completes_from_a_config_snapshot_only_log() {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "dev-lead".to_string(),
+            es_test_agent("dev-lead", "concrete-model"),
+        );
+        agents.insert(
+            "core-specialist".to_string(),
+            es_test_agent("core-specialist", "concrete-model"),
+        );
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert(
+            "dev-lead".to_string(),
+            Arc::new(ScriptedProvider::new(&[
+                "@core-specialist: fais X",
+                "Synthèse : tout est prêt.",
+            ])),
+        );
+        providers.insert(
+            "core-specialist".to_string(),
+            Arc::new(ScriptedProvider::new(&["X est fait."])),
+        );
+
+        let config = es_flat_config("dev-lead", &["core-specialist"]);
+        let agent_names: Vec<String> = agents.keys().cloned().collect();
+
+        let mut log = InMemoryLog::default();
+        log.append(
+            "run-resume-hier",
+            &ExecutionEvent::RunStarted {
+                run_id: "run-resume-hier".to_string(),
+                pattern: "hierarchical".to_string(),
+                agents: agent_names,
+                input: "build X".to_string(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "run-resume-hier",
+            &ExecutionEvent::ConfigSnapshot {
+                config_json: serde_json::to_string(&config).unwrap(),
+            },
+        )
+        .unwrap();
+
+        let st = resume_hierarchical_es(
+            "run-resume-hier",
+            agents,
+            providers,
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(st.status, RunStatus::Completed);
+        assert!(!st.hier.trace.is_empty(), "expected a recorded delegation");
+        assert!(
+            st.hier
+                .trace
+                .iter()
+                .any(|(from, to, _, _)| from == "dev-lead" && to == "core-specialist"),
+            "expected dev-lead -> core-specialist in the trace, got {:?}",
+            st.hier.trace
+        );
+        assert!(!final_content(&log, "run-resume-hier").trim().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resume_hierarchical_es_bails_on_completed_run() {
+        let mut log = InMemoryLog::default();
+        log.append(
+            "run-resume-hier",
+            &ExecutionEvent::RunStarted {
+                run_id: "run-resume-hier".to_string(),
+                pattern: "hierarchical".to_string(),
+                agents: vec!["dev-lead".to_string()],
+                input: "build X".to_string(),
+                project: None,
+            },
+        )
+        .unwrap();
+        log.append(
+            "run-resume-hier",
+            &ExecutionEvent::Completed {
+                content: "done".to_string(),
+            },
+        )
+        .unwrap();
+
+        let err = resume_hierarchical_es(
+            "run-resume-hier",
+            BTreeMap::new(),
+            BTreeMap::new(),
+            RoutingRules::default(),
+            &mut log,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("not resumable"));
     }
 
     // Scenario 2: coordinator delegates to two sibling agents in the same

--- a/src/core/orchestration/es/mod.rs
+++ b/src/core/orchestration/es/mod.rs
@@ -22,7 +22,10 @@ pub mod state;
 #[allow(unused_imports)]
 pub use bridge::{SinkProjectingLog, map_execution_to_run_events, to_orchestration_result};
 #[allow(unused_imports)]
-pub use engine::{Action, Decider, EffectRunner, replay, run_event_sourced};
+pub use engine::{
+    Action, Decider, EffectRunner, config_snapshot, replay, resume_event_sourced,
+    run_event_sourced, run_started_roster_and_input,
+};
 #[allow(unused_imports)]
 pub use event::ExecutionEvent;
 #[cfg(feature = "storage")]

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -1068,6 +1068,64 @@ pub async fn run_ring_es(
     run_event_sourced(run_id, initial, &decider, &effects, log).await
 }
 
+/// Resume a previously interrupted `ring` run (OH1 Lot 6, Task 3): recovers
+/// the run's original `input` AND its circulation `agent_order` from the
+/// log's `RunStarted` event (see
+/// [`super::engine::run_started_roster_and_input`]) — unlike blackboard's
+/// alphabetical `agents.keys()` derivation, ring's circulation order is
+/// caller-supplied and NOT reconstructable from the `agents` `BTreeMap`
+/// alone, so it must come from the log, where `RunStarted.agents` preserves
+/// it verbatim (see `run_ring_es`'s own `agents: agent_order.clone()`). Also
+/// recovers the pattern's `RingConfig` from `ConfigSnapshot` (see
+/// [`super::engine::config_snapshot`]), rebuilds the SAME
+/// [`RingDecider`]/[`RingEffectRunner`] pair [`run_ring_es`] would (including
+/// `vote_weights`, recomputed from `agents` — pure function of the reloaded
+/// roster), and drives [`super::engine::resume_event_sourced`] instead of
+/// appending a fresh `RunStarted`/`ConfigSnapshot`.
+///
+/// `agents`/`providers` must be the roster reloaded from the project on disk
+/// (keyed by the same roster keys the original run used); `cost_limit` is
+/// re-derived from the project's top-level `orchestration.cost_limit`
+/// exactly as [`run_ring_es`]'s caller does, since it lives outside
+/// `RingConfig` and is never captured by `ConfigSnapshot`.
+///
+/// Bails if `run_id` has no recorded `RunStarted` (unknown run) or isn't
+/// currently `Running` (see `resume_event_sourced`).
+pub async fn resume_ring_es(
+    run_id: &str,
+    agents: BTreeMap<String, Agent>,
+    providers: BTreeMap<String, Arc<dyn Provider>>,
+    routing_rules: RoutingRules,
+    cost_limit: Option<f64>,
+    log: &mut impl EventLog,
+) -> anyhow::Result<ExecutionState> {
+    use super::engine::{config_snapshot, resume_event_sourced, run_started_roster_and_input};
+
+    let events = log.events(run_id)?;
+    let (agent_order, input) = run_started_roster_and_input(&events)
+        .ok_or_else(|| anyhow::anyhow!("no run found for id {run_id}"))?;
+    let config: RingConfig = config_snapshot(&events);
+
+    let vote_weights = vote_weights_from_agents(&agents);
+    let max_laps = config.max_laps;
+    let token_budget = Some(u32::try_from(config.token_budget).unwrap_or(u32::MAX));
+
+    let decider = RingDecider::new(
+        agents.clone(),
+        agent_order,
+        input,
+        config.clone(),
+        routing_rules,
+        max_laps,
+        vote_weights.clone(),
+        token_budget,
+        cost_limit,
+    );
+    let effects = RingEffectRunner::new(agents, providers, config, vote_weights);
+
+    resume_event_sourced(run_id, &decider, &effects, log).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2331,6 +2389,116 @@ mod tests {
                 "expected a non-empty resolved outcome"
             );
             assert_eq!(content, "Use Rust with Axum");
+        }
+
+        /// OH1 Lot 6, Task 3: `resume_ring_es` reconstructs the same
+        /// `RingDecider`/`RingEffectRunner` a fresh `run_ring_es` would from
+        /// a log that only has `RunStarted` + `ConfigSnapshot` recorded
+        /// (simulating a crash immediately after config capture, before any
+        /// lap started) — proving `RingConfig` round-trips through
+        /// `ConfigSnapshot` correctly AND that the circulation `agent_order`
+        /// (which, unlike blackboard, is NOT derivable from the `agents`
+        /// `BTreeMap` alone — see `resume_ring_es`'s own doc comment) is
+        /// correctly recovered from the log's `RunStarted.agents`. Same
+        /// scripted scenario as `es_ring_circulates_votes_and_resolves`
+        /// above, seeded by hand instead of via `run_ring_es`.
+        #[tokio::test]
+        async fn resume_ring_es_resolves_from_a_config_snapshot_only_log() {
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), es_test_agent("a", "concrete-model"));
+            agents.insert("b".to_string(), es_test_agent("b", "concrete-model"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert(
+                "a".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION: PROPOSE\nCONTENT: use Rust with Axum",
+                    "CONFIDENCE: 0.9\nUse Rust with Axum",
+                ])),
+            );
+            providers.insert(
+                "b".to_string(),
+                Arc::new(ScriptedProvider::new(&[
+                    "ACTION: PROPOSE\nCONTENT: agreed, Rust and Axum",
+                    "CONFIDENCE: 0.8\nUse Rust with Axum",
+                ])),
+            );
+
+            let config = RingConfig {
+                max_laps: 1,
+                ..RingConfig::default()
+            };
+
+            let mut log = InMemoryLog::default();
+            log.append(
+                "run-resume-ring",
+                &E::RunStarted {
+                    run_id: "run-resume-ring".to_string(),
+                    pattern: "ring".to_string(),
+                    agents: vec!["a".to_string(), "b".to_string()],
+                    input: "task".to_string(),
+                    project: None,
+                },
+            )
+            .unwrap();
+            log.append(
+                "run-resume-ring",
+                &E::ConfigSnapshot {
+                    config_json: serde_json::to_string(&config).unwrap(),
+                },
+            )
+            .unwrap();
+
+            let st = resume_ring_es(
+                "run-resume-ring",
+                agents,
+                providers,
+                RoutingRules::default(),
+                None,
+                &mut log,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(st.status, RunStatus::Completed);
+            assert_eq!(st.ring.contributions.len(), 2);
+            assert_eq!(st.ring.votes.len(), 2);
+            assert!(log_has_outcome_resolved(&log, "run-resume-ring"));
+            assert_eq!(final_content(&log, "run-resume-ring"), "Use Rust with Axum");
+        }
+
+        #[tokio::test]
+        async fn resume_ring_es_bails_on_completed_run() {
+            let mut log = InMemoryLog::default();
+            log.append(
+                "run-resume-ring",
+                &E::RunStarted {
+                    run_id: "run-resume-ring".to_string(),
+                    pattern: "ring".to_string(),
+                    agents: vec!["a".to_string()],
+                    input: "task".to_string(),
+                    project: None,
+                },
+            )
+            .unwrap();
+            log.append(
+                "run-resume-ring",
+                &E::Completed {
+                    content: "done".to_string(),
+                },
+            )
+            .unwrap();
+
+            let err = resume_ring_es(
+                "run-resume-ring",
+                BTreeMap::new(),
+                BTreeMap::new(),
+                RoutingRules::default(),
+                None,
+                &mut log,
+            )
+            .await
+            .unwrap_err();
+            assert!(err.to_string().contains("not resumable"));
         }
 
         // Scenario 2: two agents contribute a substantive (non-pass)

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -62,13 +62,17 @@ fn restore_terminal() {
 
 /// Run an orchestration (`run`) while showing a live Workroom TUI fed by its
 /// event stream. Restores the terminal on exit (including on error or panic),
-/// and returns the final answer (if the run produced one) for the caller to
-/// print *after* the terminal has been restored.
+/// and returns `(run_id, content)` for the caller to print *after* the
+/// terminal has been restored: `run_id` is `Some` once a `RunStart` has been
+/// observed (independent of whether the run produced a final answer), so a
+/// caller can still surface it — for a later `--resume`/`--replay` — even on
+/// an early abort. The alternate screen clears everything on exit, so this is
+/// the only way the id survives in scrollback for the TUI path (OH1 Lot 6).
 pub async fn run_orchestration_tui<F>(
     run: impl FnOnce(Arc<dyn EventSink>) -> F,
     config_yaml: Option<String>,
     explicit_pattern: Option<OrchestrationPattern>,
-) -> anyhow::Result<Option<String>>
+) -> anyhow::Result<(Option<String>, Option<String>)>
 where
     F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
 {
@@ -144,10 +148,15 @@ where
 
     let render_result = run_loop(&mut terminal, &mut workroom, &mut rx, handle).await;
 
+    // Captured before `restore_terminal()` merely for clarity — the workroom
+    // itself is untouched by the terminal teardown; read here so it's beside
+    // the `render_result` it's paired with below.
+    let run_id = workroom.run_id().map(str::to_string);
+
     // Always restore the terminal, even if the loop errored.
     restore_terminal();
 
-    render_result
+    render_result.map(|content| (run_id, content))
 }
 
 /// Minimum sensible Workroom panel width (columns) — narrower than this and

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -325,6 +325,7 @@ mod tests {
     fn sink_forwards_events_to_projection() {
         let (sink, mut rx) = WorkroomSink::new();
         sink.emit(&RunEvent::RunStart {
+            run_id: "r1".into(),
             v: 1,
             agents: vec!["a".into(), "b".into()],
             prov: "f".into(),

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -1479,6 +1479,7 @@ orchestration:
         let t = Instant::now();
         wr.on_run_event_at(
             &RunEvent::RunStart {
+                run_id: "r1".into(),
                 v: 1,
                 agents: vec!["alpha".into(), "beta".into()],
                 prov: "fake".into(),
@@ -1524,6 +1525,7 @@ orchestration:
 
     fn rs(agents: &[&str]) -> RunEvent {
         RunEvent::RunStart {
+            run_id: "r1".into(),
             v: 1,
             agents: agents.iter().map(|s| s.to_string()).collect(),
             prov: "fake".into(),

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -86,6 +86,12 @@ pub struct Workroom {
     /// final frame for the user to dismiss (Dimitri's visual-validation
     /// request: fast providers used to make the workroom flash and vanish).
     completed: bool,
+    /// The run's id, captured from `RunEvent::RunStart` (OH1 Lot 6). Rendered
+    /// on the completion screen so the user can copy it for a later
+    /// `--resume`/`--replay` — the live TUI is the only path where it was
+    /// previously surfaced nowhere at all (the alternate screen hides
+    /// anything printed to stdout while it's active).
+    run_id: Option<String>,
 }
 
 impl Workroom {
@@ -100,7 +106,14 @@ impl Workroom {
             focused: false,
             pattern: OrchestrationPattern::Hierarchical,
             completed: false,
+            run_id: None,
         }
+    }
+
+    /// The captured run id (if a `RunStart` has been observed yet), for a
+    /// caller to print after the TUI exits (see `run_view::run_orchestration_tui`).
+    pub fn run_id(&self) -> Option<&str> {
+        self.run_id.as_deref()
     }
 
     /// Set whether the workroom has keyboard focus (drill-down mode).
@@ -460,7 +473,8 @@ impl Workroom {
     /// the live renderer passes `Instant::now()`.
     pub fn on_run_event_at(&mut self, ev: &RunEvent, now: Instant) {
         match ev {
-            RunEvent::RunStart { agents, .. } => {
+            RunEvent::RunStart { agents, run_id, .. } => {
+                self.run_id = Some(run_id.clone());
                 for name in agents {
                     if !self.agents.iter().any(|a| a.name == *name) {
                         self.agents.push(TrackedAgent {
@@ -851,6 +865,15 @@ impl Workroom {
                 format!("{check} run complete · press q or Esc to exit"),
                 theme::muted(),
             )));
+            // Last chance to copy the run_id before the alternate screen
+            // clears on exit (OH1 Lot 6): shown in full, on its own line, so
+            // it survives even at narrow widths without truncation logic.
+            if let Some(id) = &self.run_id {
+                lines.push(Line::from(Span::styled(
+                    format!("run {id}"),
+                    theme::muted(),
+                )));
+            }
         }
     }
 
@@ -1383,6 +1406,49 @@ orchestration:
             !lines
                 .iter()
                 .any(|l| l.spans.iter().any(|s| s.content.contains("run complete")))
+        );
+    }
+
+    #[test]
+    fn run_id_captured_from_run_start_and_shown_on_completion() {
+        // OH1 Lot 6 gap: an orchestrated run in the live Workroom TUI never
+        // surfaced its run_id anywhere (the non-TUI path prints it to
+        // stdout, but `human_output` is false for the TUI path to avoid
+        // corrupting the alt-screen). The Workroom itself must capture it
+        // from `RunStart` and render it on the hold-on-completion screen —
+        // the user's last chance to copy it before the alt-screen clears.
+        let mut wr = Workroom::new();
+        let t = Instant::now();
+        wr.on_run_event_at(
+            &RunEvent::RunStart {
+                run_id: "abc123".into(),
+                v: 1,
+                agents: vec!["alpha".into()],
+                prov: "fake".into(),
+                model: "m".into(),
+                in_chars: 0,
+            },
+            t,
+        );
+        assert_eq!(wr.run_id(), Some("abc123"));
+
+        // Not shown before completion — only on the hold-on-completion screen.
+        let mut lines = Vec::new();
+        wr.push_footer(&mut lines);
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.spans.iter().any(|s| s.content.contains("abc123")))
+        );
+
+        wr.set_completed(true);
+        let mut lines = Vec::new();
+        wr.push_footer(&mut lines);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.spans.iter().any(|s| s.content.contains("abc123"))),
+            "completion footer should render the run_id for a later --resume/--replay"
         );
     }
 

--- a/src/storage/queries.rs
+++ b/src/storage/queries.rs
@@ -646,6 +646,31 @@ pub fn delete_projection_for_run(db: &Database, run_id: &str) -> anyhow::Result<
     Ok(total_deleted)
 }
 
+/// Fetch the stored `pattern` (`"direct"`/`"blackboard"`/`"ring"`/
+/// `"hierarchical"`) for `run_id` from `orchestration_runs`, or `None` if no
+/// row exists there.
+///
+/// **Known gap**: `"direct"` runs never get an `orchestration_runs` row (see
+/// `cli::run_es_record::project_run`'s own `"direct" => {}` no-op arm —
+/// direct runs have no orchestration metadata to project), so this returns
+/// `None` for them even though the run itself is real and present in the
+/// event log. Callers that need the pattern for EVERY run (e.g.
+/// `armadai run --resume`) must fall back to the event-sourced
+/// `ExecutionState::pattern` (folded from the log's own `RunStarted` event
+/// via [`crate::core::orchestration::es::engine::replay`]), which is always
+/// populated regardless of pattern.
+pub fn get_run_pattern(db: &Database, run_id: &str) -> anyhow::Result<Option<String>> {
+    let conn = db
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+    let mut stmt = conn.prepare("SELECT pattern FROM orchestration_runs WHERE run_id = ?1")?;
+    let mut rows = stmt.query_map(params![run_id], |row| row.get::<_, String>(0))?;
+    match rows.next() {
+        Some(row) => Ok(Some(row?)),
+        None => Ok(None),
+    }
+}
+
 /// Get all distinct run_ids present in the execution_events log.
 ///
 /// Returns run IDs in sorted order. Used by `armadai projections rebuild --all`
@@ -759,6 +784,44 @@ mod tests {
         let r = result.unwrap();
         assert_eq!(r.pattern, "blackboard");
         assert_eq!(r.rounds, 3);
+    }
+
+    #[test]
+    fn test_get_run_pattern_returns_stored_pattern() {
+        let db = init_embedded().unwrap();
+        // `orchestration_runs.run_id` is a FK into `runs.id` — insert the
+        // parent row first, exactly like `test_insert_and_get_orchestration_run`.
+        insert_run_with_id(
+            &db,
+            "run-hier-1",
+            sample_run("orchestration:hierarchical", 0.0),
+        )
+        .unwrap();
+        let orch = OrchestrationRunRecord {
+            run_id: "run-hier-1".to_string(),
+            pattern: "hierarchical".to_string(),
+            config_json: "{}".to_string(),
+            outcome_json: None,
+            rounds: 0,
+            halt_reason: None,
+            parent_run_id: None,
+        };
+        insert_orchestration_run(&db, orch).unwrap();
+
+        assert_eq!(
+            get_run_pattern(&db, "run-hier-1").unwrap(),
+            Some("hierarchical".to_string())
+        );
+    }
+
+    /// `"direct"` runs never get an `orchestration_runs` row (see
+    /// `get_run_pattern`'s doc comment) — `--resume` must fall back to the
+    /// event-sourced `ExecutionState::pattern` for them, not treat this
+    /// `None` as "unknown run".
+    #[test]
+    fn test_get_run_pattern_none_for_unknown_run() {
+        let db = init_embedded().unwrap();
+        assert_eq!(get_run_pattern(&db, "no-such-run").unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #249.

## Contexte
**OH1 Lot 6** — clôt l'épic event-sourcing : `armadai run --resume <run_id>` (reprend un run interrompu depuis le log, aucun effet LLM rejoué) et `--replay <run_id>` (ré-affichage déterministe, sans effet). Spec §8 de `2026-07-21-oh1-event-sourcing-design.md`. Subagent-driven, 4 tâches + revue par tâche + **revue finale whole-branch (opus)** + fixes re-relus.

## Contenu
- **T1** — `run_id` surfacé (ajouté à `RunStart`, généré en amont pour que affiché == persisté) + scaffolding CLI (`agent` optionnel, flags `--resume`/`--replay` en clap `ArgGroup`).
- **T2** — `--replay` : `run_replay.rs`, réutilise la projection live `map_execution_to_run_events`, zéro effet, gated `storage`.
- **T3** — `--resume` : primitive cœur `resume_event_sourced` (seed via `replay()`, **jamais de ré-append**), boucle partagée `run_loop` extraite, entrée resume pour les 4 patterns, chemin CLI + lookup pattern.
- **T4** — test d'intégration crash→resume (prouve la non-réinvocation d'un agent déjà observé) + docs wiki.
- **Fixes revue finale** : bookends `RunStart`/`Result` synthétiques pour `--replay`/`--resume` (contrat JSONL complet + Workroom peuplée au resume) ; warning I3 (roster rechargé du projet courant) ; helper partagé `final_content` unifiant le contenu terminal live/resume/replay (corrige le tally de votes `ring` manquant) ; `model=pattern` sur le RunStart synthétique.

## Invariants vérifiés (revue + tests)
Zéro duplication d'events au resume · aucun effet ré-exécuté (replay & resume) · run_id affiché == persisté · extraction `run_loop` byte-équivalente · gating `storage` propre (erreurs claires sans storage / run inconnu / terminal).

## Gate
clippy 3 modes clean · fmt clean · test `tui` 1000 · `tui,storage` 1044 (incl. e2e 30). Revue finale opus + re-revues des fixes : **READY** après corrections.

## Follow-ups backlog (non bloquants, notés pour la suite)
- **Pin du projet d'origine au resume** (`RunStarted.project` loggé mais None/non lu → reload roster cwd-dépendant ; warning ajouté en attendant).
- `RunStarted` ne porte pas de roster prov/model → `AgentStart` replay a prov/model vides ; role `Coordinator` non re-seedé dans la Workroom au resume hiérarchique.
- Mineurs : input positionnel ignoré avec `--resume/--replay` ; dry-run/`--pipe` surfacent un run_id non-resumable ; pas de cas e2e yaml resume/replay ; recalcul `to_orchestration_result` redondant.

## Smoke test (Dimitri)
```
cd /Users/bl209054/work/misc/armadai
# run orchestré, note le "run <id>" affiché
cargo run --bin armadai -- run --orchestrate blackboard <input>   # ou un run projet
# replay déterministe (stream --json complet, se termine par t=result)
cargo run --bin armadai -- run --replay <run_id> --json | tail
# resume d'un run non terminal
cargo run --bin armadai -- run --resume <run_id>
```
`--replay`/`--resume` nécessitent la feature `storage` (défaut). Erreurs claires si run introuvable / déjà terminé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
