### PR TITLE
feat(providers): real proactive rate-limiting via a Provider decorator (rate-limit Lot 1, #265)

### DIFF
--- a/docs/superpowers/plans/2026-07-27-rate-limiting-lot1.md
+++ b/docs/superpowers/plans/2026-07-27-rate-limiting-lot1.md
@@ -1,0 +1,574 @@
+# Rate-limiting Lot 1 (proactive throttling) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ArmadAI's exposed-but-inert provider rate-limiting real: a shared, durable per-process throttle applied to every provider call site (event-sourced engines included), driven by the two existing knobs (`config.rate_limits` per provider + agent frontmatter `rate_limit`), with the `/hour` panic fixed.
+
+**Architecture:** A `RateLimitedProvider` decorator (implements the `Provider` trait, wraps the real provider) installed in `factory.rs::create_provider`, so all call sites inherit throttling via the trait. A process-global registry shares one limiter per provider key across a run; an optional per-agent limiter (from frontmatter) tightens it. The token bucket is reworked to a `Rate { per_sec, burst }` representation to kill the integer-division panic.
+
+**Tech Stack:** Rust edition 2024, `src/providers/` (rate_limiter, factory, traits), `tokio`, `async_trait`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-27-rate-limiting-design.md`. Milestone item **#265** (P1). Scope = **Lot 1 (A) only**; 429/529/Retry-After/backoff = **Lot 2, OUT of scope**.
+- The `Provider` trait (`src/providers/traits.rs`) is **unchanged**; the decorator implements it.
+- No rate-limit section in `armadai.yaml`/`ProjectConfig`.
+- **Absence of a cap → unlimited** (no limiter, never blocks). A refill ≤ 0 or "unlimited" construction must make `acquire()` return immediately — **never** `Duration::from_secs_f64(inf)` (the current panic).
+- Throttling is **silent** + `tracing::debug!` when a wait actually happened. **No** `RunEvent`/Workroom signal (Lot 2).
+- `config.rate_limits` values are **requests per MINUTE** (`u32`; defaults anthropic:50, openai:60, google:60, proxy:100).
+- The `RateLimiter`/`Rate`/`RateLimitedProvider`/registry are **NOT feature-gated** (must compile in all 3 CI modes); only the concrete API providers are gated `providers-api`.
+- Gate every task: `cargo fmt --all` + clippy 3 modes (`tui` / `tui,providers-api` / `tui,web,storage`) `-D warnings` + `cargo test --no-default-features --features tui` + `cargo test --no-default-features --features tui,storage`.
+- rust-analyzer unreliable (ABI/inactive/stale) — verify at the compiler. Conventional Commits single type; trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. One PR (Lot 1) + independent review + Dimitri validation.
+
+---
+
+## File Structure
+
+- `src/providers/rate_limiter.rs` — `Rate` struct + reworked `RateLimiter` (Task 1) + `RateLimitedProvider` decorator + process-global registry (Task 2).
+- `src/providers/factory.rs` — wrap the constructed provider (Task 3).
+- `src/providers/mod.rs` — export the new items if needed (Task 2/3).
+- `src/cli/run.rs` — remove the two dead manual limiter blocks (Task 3).
+
+---
+
+## Task 1: Rework `RateLimiter` around a `Rate { per_sec, burst }` (kill the panic)
+
+**Files:**
+- Modify: `src/providers/rate_limiter.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub struct Rate { pub per_sec: f64, pub burst: f64 }`
+  - `impl Rate { pub fn from_per_minute(per_minute: f64) -> Rate; pub fn parse(s: &str) -> Option<Rate>; }`
+  - `impl RateLimiter { pub fn new(rate: Rate) -> Self; pub async fn acquire(&self); }`
+  - Semantics: `per_sec <= 0.0` or `burst <= 0.0` ⇒ "unlimited" ⇒ `acquire()` returns immediately.
+
+- [ ] **Step 1: Write failing tests for `Rate::parse` (precise, no truncation/panic)**
+
+Replace the existing `parse_rate_formats` test and add cases. In `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn rate_parse_is_precise_no_truncation() {
+    // per-minute canonical form
+    let r = Rate::parse("10/min").unwrap();
+    assert!((r.per_sec - 10.0 / 60.0).abs() < 1e-9);
+    assert_eq!(r.burst, 10.0);
+
+    // per-second
+    let r = Rate::parse("1/sec").unwrap();
+    assert!((r.per_sec - 1.0).abs() < 1e-9);
+    assert_eq!(r.burst, 1.0);
+
+    // per-hour: the OLD bug truncated 30/hour -> 0. Now precise.
+    let r = Rate::parse("30/hour").unwrap();
+    assert!((r.per_sec - 30.0 / 3600.0).abs() < 1e-9);
+    assert_eq!(r.burst, 30.0);
+
+    // sub-1/window still yields burst >= 1 (so a single request can pass)
+    let r = Rate::parse("1/hour").unwrap();
+    assert!((r.per_sec - 1.0 / 3600.0).abs() < 1e-12);
+    assert_eq!(r.burst, 1.0);
+
+    // aliases
+    assert!(Rate::parse("5/m").is_some());
+    assert!(Rate::parse("2/second").is_some());
+    assert!(Rate::parse("100/hr").is_some());
+
+    // invalid
+    assert!(Rate::parse("invalid").is_none());
+    assert!(Rate::parse("10/decade").is_none());
+    assert!(Rate::parse("abc/min").is_none());
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL (Rate not defined)**
+
+Run: `cargo test --no-default-features --features tui rate_parse_is_precise -- --nocapture`
+Expected: FAIL (`cannot find type Rate`).
+
+- [ ] **Step 3: Implement `Rate` + `parse`**
+
+Add near the top of `src/providers/rate_limiter.rs`:
+
+```rust
+/// A parsed rate: sustained refill (`per_sec`) plus bucket capacity (`burst`).
+/// `burst` is the window count, floored at 1.0 so a single request can always
+/// pass before throttling kicks in (a capacity < 1 would deadlock acquire).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rate {
+    pub per_sec: f64,
+    pub burst: f64,
+}
+
+impl Rate {
+    /// Build a rate from a requests-per-minute value (used by `config.rate_limits`).
+    pub fn from_per_minute(per_minute: f64) -> Rate {
+        Rate {
+            per_sec: per_minute / 60.0,
+            burst: per_minute.max(1.0),
+        }
+    }
+
+    /// Parse "N/sec", "N/min", "N/hour" (with aliases). Precise — no integer
+    /// truncation. Returns `None` on malformed input.
+    pub fn parse(s: &str) -> Option<Rate> {
+        let (count_str, unit) = s.split_once('/')?;
+        let count: f64 = count_str.trim().parse::<u32>().ok()? as f64;
+        let per_sec = match unit.trim() {
+            "s" | "sec" | "second" => count,
+            "m" | "min" | "minute" => count / 60.0,
+            "h" | "hr" | "hour" => count / 3600.0,
+            _ => return None,
+        };
+        Some(Rate {
+            per_sec,
+            burst: count.max(1.0),
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `cargo test --no-default-features --features tui rate_parse_is_precise`
+Expected: PASS.
+
+- [ ] **Step 5: Rework `RateLimiter` to take a `Rate` + unlimited guard**
+
+Replace `RateLimiter::new` and the `BucketState`/`acquire` refill so it uses `Rate`, and guard the unlimited case. New `new`:
+
+```rust
+impl RateLimiter {
+    /// Create a limiter from a `Rate`. A non-positive `per_sec`/`burst` means
+    /// "unlimited": `acquire()` never waits.
+    pub fn new(rate: Rate) -> Self {
+        Self {
+            state: Mutex::new(BucketState {
+                tokens: rate.burst,
+                max_tokens: rate.burst,
+                refill_rate: rate.per_sec,
+                last_refill: Instant::now(),
+            }),
+        }
+    }
+}
+```
+
+In `acquire`, add the guard at the top of the locked block (before computing any wait):
+
+```rust
+        // Unlimited: no throttle configured.
+        if state.refill_rate <= 0.0 || state.max_tokens <= 0.0 {
+            return; // (restructure: see note)
+        }
+```
+
+Note for the implementer: `acquire` currently computes `wait` inside a block then matches outside the lock. Restructure so the unlimited check short-circuits the whole `loop` (e.g. check `refill_rate <= 0.0 || max_tokens <= 0.0` once and `return`), guaranteeing `Duration::from_secs_f64(deficit / refill_rate)` is only reached when `refill_rate > 0.0` — so the `inf`/`NaN` panic is impossible. Keep the existing bucket math otherwise.
+
+- [ ] **Step 6: Update the existing limiter tests to the new API + add unlimited/panic-guard + throttle tests**
+
+Rewrite the `acquire_*` tests to use `Rate` and add coverage:
+
+```rust
+#[tokio::test]
+async fn acquire_unlimited_never_waits_and_never_panics() {
+    // per_sec 0 == unlimited; the OLD code panicked here (from_secs_f64(inf)).
+    let limiter = RateLimiter::new(Rate { per_sec: 0.0, burst: 0.0 });
+    let start = Instant::now();
+    for _ in 0..1000 {
+        limiter.acquire().await;
+    }
+    assert!(start.elapsed() < Duration::from_millis(200));
+}
+
+#[tokio::test]
+async fn acquire_within_burst_is_immediate() {
+    let limiter = RateLimiter::new(Rate::from_per_minute(60.0)); // burst 60
+    let start = Instant::now();
+    limiter.acquire().await;
+    limiter.acquire().await;
+    assert!(start.elapsed() < Duration::from_millis(100));
+}
+
+#[tokio::test]
+async fn acquire_waits_when_burst_exhausted() {
+    let limiter = RateLimiter::new(Rate::from_per_minute(60.0)); // 1/sec, burst 60
+    for _ in 0..60 {
+        limiter.acquire().await;
+    }
+    let start = Instant::now();
+    limiter.acquire().await;
+    // Refill is 1/sec, so the 61st waits ~1s. Generous margin (non-flaky).
+    assert!(start.elapsed() >= Duration::from_millis(800));
+}
+
+#[tokio::test]
+async fn low_hourly_rate_does_not_panic_and_passes_first_call() {
+    // 30/hour: OLD code -> new(0) -> panic on first acquire. Now: burst 30 -> passes.
+    let limiter = RateLimiter::new(Rate::parse("30/hour").unwrap());
+    let start = Instant::now();
+    limiter.acquire().await; // must not panic, must return promptly (burst available)
+    assert!(start.elapsed() < Duration::from_millis(100));
+}
+```
+
+- [ ] **Step 7: Run all limiter tests + gate**
+
+Run: `cargo test --no-default-features --features tui rate_limiter` then the full gate (fmt + clippy 3 modes + test 2 modes).
+Expected: PASS / clean. (No other file references `RateLimiter::new(u32)`/`parse_rate` yet except `cli/run.rs:906/1294` — those are removed in Task 3; if the crate doesn't compile because of them, this task may leave them; **verify**: Task 1 must keep the crate compiling. If `cli/run.rs` still calls the old `parse_rate`/`new(u32)`, update those two blocks minimally to the new API in THIS task OR remove them here — prefer removing them here since Task 3 also removes them; pick one and keep the build green. Recommended: remove the two blocks in Task 1's Step 5 commit so the crate compiles, and Task 3 only adds the factory wiring.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/providers/rate_limiter.rs src/cli/run.rs
+git commit -m "refactor(providers): Rate{per_sec,burst} limiter, fix /hour panic (rate-limit Lot 1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `RateLimitedProvider` decorator + process-global registry
+
+**Files:**
+- Modify: `src/providers/rate_limiter.rs` (add decorator + registry)
+- Modify: `src/providers/mod.rs` (export `RateLimitedProvider`, `provider_limiter` if needed by `factory.rs`)
+
+**Interfaces:**
+- Consumes: `Rate`, `RateLimiter` (Task 1); `Provider`/`CompletionRequest`/`CompletionResponse`/`TokenStream`/`ProviderMetadata` (`traits.rs`).
+- Produces:
+  - `pub struct RateLimitedProvider` wrapping `inner: Arc<dyn Provider>`, `provider_limiter: Option<Arc<RateLimiter>>`, `agent_limiter: Option<Arc<RateLimiter>>`.
+  - `pub fn new(inner: Arc<dyn Provider>, provider_limiter: Option<Arc<RateLimiter>>, agent_limiter: Option<Arc<RateLimiter>>) -> RateLimitedProvider`.
+  - `pub fn shared_provider_limiter(key: &str, rate: Option<Rate>) -> Option<Arc<RateLimiter>>` — process-global memoized limiter per provider key; `None` when `rate` is `None`.
+
+- [ ] **Step 1: Write failing test — a fake Provider counting calls, shared limiter throttles across two decorators**
+
+Add to the tests module (uses `async_trait`, already a dep):
+
+```rust
+use crate::providers::traits::{
+    ChatMessage, CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+struct CountingProvider {
+    calls: Arc<AtomicUsize>,
+}
+#[async_trait::async_trait]
+impl Provider for CountingProvider {
+    async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(CompletionResponse { content: "ok".into(), model: "m".into(), tokens_in: 0, tokens_out: 0, cost: 0.0 })
+    }
+    async fn stream(&self, _req: CompletionRequest) -> anyhow::Result<TokenStream> {
+        anyhow::bail!("unused")
+    }
+    fn metadata(&self) -> ProviderMetadata {
+        ProviderMetadata { name: "counting".into(), models: vec![], supports_streaming: false }
+    }
+}
+fn req() -> CompletionRequest {
+    CompletionRequest { model: "m".into(), system_prompt: String::new(), messages: vec![ChatMessage{role:"user".into(),content:"hi".into()}], temperature: 0.0, max_tokens: None }
+}
+
+#[tokio::test]
+async fn no_limiters_never_blocks() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let p = RateLimitedProvider::new(Arc::new(CountingProvider{calls: calls.clone()}), None, None);
+    let start = Instant::now();
+    for _ in 0..50 { p.complete(req()).await.unwrap(); }
+    assert_eq!(calls.load(Ordering::SeqCst), 50);
+    assert!(start.elapsed() < Duration::from_millis(200));
+}
+
+#[tokio::test]
+async fn shared_provider_limiter_throttles_across_decorators() {
+    // Two decorators sharing ONE provider limiter (burst 2, 1/sec refill).
+    let shared = Arc::new(RateLimiter::new(Rate { per_sec: 1.0, burst: 2.0 }));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let a = RateLimitedProvider::new(Arc::new(CountingProvider{calls: calls.clone()}), Some(shared.clone()), None);
+    let b = RateLimitedProvider::new(Arc::new(CountingProvider{calls: calls.clone()}), Some(shared.clone()), None);
+    // 2 immediate (burst), then the 3rd (via the OTHER decorator) must wait ~1s.
+    a.complete(req()).await.unwrap();
+    a.complete(req()).await.unwrap();
+    let start = Instant::now();
+    b.complete(req()).await.unwrap();
+    assert!(start.elapsed() >= Duration::from_millis(800));
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn agent_limiter_tightens_and_both_must_pass() {
+    // Loose provider limiter, tight per-agent limiter -> agent limiter governs.
+    let provider = Arc::new(RateLimiter::new(Rate::from_per_minute(600.0))); // basically loose
+    let agent = Arc::new(RateLimiter::new(Rate { per_sec: 1.0, burst: 1.0 })); // 1 then wait
+    let calls = Arc::new(AtomicUsize::new(0));
+    let p = RateLimitedProvider::new(Arc::new(CountingProvider{calls: calls.clone()}), Some(provider), Some(agent));
+    p.complete(req()).await.unwrap();
+    let start = Instant::now();
+    p.complete(req()).await.unwrap();
+    assert!(start.elapsed() >= Duration::from_millis(800));
+}
+
+#[test]
+fn shared_registry_memoizes_by_key() {
+    let a = shared_provider_limiter("anthropic", Some(Rate::from_per_minute(50.0))).unwrap();
+    let b = shared_provider_limiter("anthropic", Some(Rate::from_per_minute(50.0))).unwrap();
+    assert!(Arc::ptr_eq(&a, &b)); // same key -> same Arc
+    assert!(shared_provider_limiter("nokey", None).is_none());
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL (`RateLimitedProvider` / `shared_provider_limiter` undefined)**
+
+Run: `cargo test --no-default-features --features tui rate_limiter -- --nocapture`
+Expected: FAIL (unresolved names).
+
+- [ ] **Step 3: Implement the decorator**
+
+```rust
+use std::sync::Arc;
+use crate::providers::traits::{CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream};
+
+/// Wraps a `Provider` and awaits up to two limiters (shared-per-provider,
+/// then per-agent) before delegating. The tighter one effectively governs.
+pub struct RateLimitedProvider {
+    inner: Arc<dyn Provider>,
+    provider_limiter: Option<Arc<RateLimiter>>,
+    agent_limiter: Option<Arc<RateLimiter>>,
+}
+
+impl RateLimitedProvider {
+    pub fn new(
+        inner: Arc<dyn Provider>,
+        provider_limiter: Option<Arc<RateLimiter>>,
+        agent_limiter: Option<Arc<RateLimiter>>,
+    ) -> Self {
+        Self { inner, provider_limiter, agent_limiter }
+    }
+
+    async fn throttle(&self) {
+        if let Some(l) = &self.provider_limiter { l.acquire().await; }
+        if let Some(l) = &self.agent_limiter { l.acquire().await; }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for RateLimitedProvider {
+    async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        self.throttle().await;
+        self.inner.complete(request).await
+    }
+    async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
+        self.throttle().await;
+        self.inner.stream(request).await
+    }
+    fn metadata(&self) -> ProviderMetadata {
+        self.inner.metadata()
+    }
+}
+```
+
+Note: `acquire()` already `tracing::debug!`-style logging is out of scope in the limiter; add a `tracing::debug!("rate-limit: throttling provider call")` inside `throttle` guarded so it only logs when a limiter exists (the wait itself is inside `acquire`). Keep it minimal.
+
+- [ ] **Step 4: Implement the process-global registry**
+
+```rust
+use std::collections::HashMap;
+use std::sync::{Mutex as StdMutex, OnceLock};
+
+static PROVIDER_LIMITERS: OnceLock<StdMutex<HashMap<String, Arc<RateLimiter>>>> = OnceLock::new();
+
+/// Return (memoized, process-global) the shared limiter for `key`, creating it
+/// from `rate` on first use. `None` when no rate is configured for `key`.
+pub fn shared_provider_limiter(key: &str, rate: Option<Rate>) -> Option<Arc<RateLimiter>> {
+    let rate = rate?;
+    let map = PROVIDER_LIMITERS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let mut guard = map.lock().expect("provider limiter registry poisoned");
+    Some(guard.entry(key.to_string()).or_insert_with(|| Arc::new(RateLimiter::new(rate))).clone())
+}
+```
+
+- [ ] **Step 5: Export from `mod.rs`**
+
+In `src/providers/mod.rs`, ensure `rate_limiter` items are reachable by `factory.rs`: `pub use rate_limiter::{Rate, RateLimiter, RateLimitedProvider, shared_provider_limiter};` (adjust to the module's existing export style).
+
+- [ ] **Step 6: Run tests + gate**
+
+Run: `cargo test --no-default-features --features tui rate_limiter` then full gate. Confirm the decorator compiles in `tui` (no `providers-api`) — it must, since it only depends on the `Provider` trait (always compiled). Expected: PASS / clean in all 3 clippy modes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/providers/rate_limiter.rs src/providers/mod.rs
+git commit -m "feat(providers): RateLimitedProvider decorator + shared per-process limiter registry (rate-limit Lot 1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire the decorator into `create_provider` + retire the dead blocks
+
+**Files:**
+- Modify: `src/providers/factory.rs` (`create_provider` + a `rate_limit_key` helper)
+- Modify: `src/cli/run.rs` (remove the two dead manual limiter blocks — only if Task 1 didn't already)
+
+**Interfaces:**
+- Consumes: `RateLimitedProvider`, `shared_provider_limiter`, `Rate`, `RateLimiter` (Task 1/2); `load_user_config()` (`crate::core::config`), `Agent`/`AgentMetadata`.
+- Produces: `create_provider` returns a `RateLimitedProvider`-wrapped `Box<dyn Provider>` (same signature `-> anyhow::Result<Box<dyn Provider>>`).
+
+- [ ] **Step 1: Write the failing test — `create_provider` wraps with the right limiters**
+
+Because `create_provider` needs a real-ish `Agent`, test the `rate_limit_key` mapping + the wrapping decision at the helper level (avoid needing a live API). Add to `factory.rs` tests:
+
+```rust
+#[test]
+fn rate_limit_key_maps_providers() {
+    assert_eq!(rate_limit_key("anthropic"), Some("anthropic".to_string()));
+    assert_eq!(rate_limit_key("openai"), Some("openai".to_string()));
+    assert_eq!(rate_limit_key("google"), Some("google".to_string()));
+    assert_eq!(rate_limit_key("proxy"), Some("proxy".to_string()));
+    // unified names map to their API backend key
+    assert_eq!(rate_limit_key("claude"), Some("anthropic".to_string()));
+    assert_eq!(rate_limit_key("gemini"), Some("google".to_string()));
+    assert_eq!(rate_limit_key("gpt"), Some("openai".to_string()));
+    // pure CLI: no per-provider quota key
+    assert_eq!(rate_limit_key("cli"), None);
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL (`rate_limit_key` undefined)**
+
+Run: `cargo test --no-default-features --features tui,providers-api rate_limit_key`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `rate_limit_key` + the wrapping in `create_provider`**
+
+Add the helper:
+
+```rust
+/// Map an agent's `provider` string to the `config.rate_limits` key, or `None`
+/// for providers with no per-account API quota (pure CLI).
+fn rate_limit_key(provider: &str) -> Option<String> {
+    match provider {
+        "anthropic" | "openai" | "google" | "proxy" => Some(provider.to_string()),
+        "claude" => Some("anthropic".to_string()),
+        "gemini" => Some("google".to_string()),
+        "gpt" => Some("openai".to_string()),
+        _ => None, // "cli", unknown, or unified-resolving-to-cli
+    }
+}
+```
+
+Refactor `create_provider` so the existing branches build the inner provider, then wrap once before returning:
+
+```rust
+pub fn create_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
+    let provider = agent.metadata.provider.as_str();
+    let inner: Box<dyn Provider> = match provider {
+        "cli" => create_cli_provider(agent)?,
+        "anthropic" | "openai" | "google" | "proxy" => create_api_provider(provider, agent)?,
+        _ => {
+            if let Some(tool) = find_tool(provider) {
+                create_unified_provider(provider, tool, agent)?
+            } else {
+                anyhow::bail!("Unknown provider: '{provider}'. Known providers: cli, anthropic, openai, google, claude, gemini, gpt, aider");
+            }
+        }
+    };
+    Ok(wrap_rate_limited(agent, inner))
+}
+
+/// Wrap `inner` with the shared per-provider limiter (from `config.rate_limits`)
+/// and the optional per-agent limiter (from frontmatter `rate_limit`).
+fn wrap_rate_limited(agent: &Agent, inner: Box<dyn Provider>) -> Box<dyn Provider> {
+    use super::rate_limiter::{Rate, RateLimiter, RateLimitedProvider, shared_provider_limiter};
+    let inner: std::sync::Arc<dyn Provider> = std::sync::Arc::from(inner);
+
+    let provider_limiter = rate_limit_key(agent.metadata.provider.as_str()).and_then(|key| {
+        let rate = crate::core::config::load_user_config()
+            .rate_limits
+            .get(&key)
+            .map(|&per_min| Rate::from_per_minute(per_min as f64));
+        shared_provider_limiter(&key, rate)
+    });
+
+    let agent_limiter = agent
+        .metadata
+        .rate_limit
+        .as_deref()
+        .and_then(Rate::parse)
+        .map(|r| std::sync::Arc::new(RateLimiter::new(r)));
+
+    if provider_limiter.is_none() && agent_limiter.is_none() {
+        // No throttle configured: return the inner unchanged (no overhead).
+        return unarc(inner);
+    }
+    Box::new(RateLimitedProvider::new(inner, provider_limiter, agent_limiter))
+}
+```
+
+Note for the implementer: `Box<dyn Provider>` → `Arc<dyn Provider>` via `Arc::from(box)` works. The `unarc` helper is only needed if you want to return the bare inner when no limiter applies; simpler is to always wrap (the decorator with two `None` limiters is a zero-cost pass-through — `throttle()` awaits nothing). **Prefer always wrapping** (drop the `unarc` branch): it's simpler and the overhead is nil. Adjust the code to always return `Box::new(RateLimitedProvider::new(inner, provider_limiter, agent_limiter))`.
+
+- [ ] **Step 4: Run the mapping test — expect PASS**
+
+Run: `cargo test --no-default-features --features tui,providers-api rate_limit_key`
+Expected: PASS.
+
+- [ ] **Step 5: Remove the dead manual limiter blocks (if still present)**
+
+If Task 1 did not already remove them, delete these now-redundant blocks:
+- `src/cli/run.rs` in `run_single_agent` (~lines 906-912):
+  ```rust
+  // 3. Apply rate limiting if configured
+  if let Some(ref rate_str) = agent.metadata.rate_limit
+      && let Some(rpm) = RateLimiter::parse_rate(rate_str) { let limiter = RateLimiter::new(rpm); limiter.acquire().await; }
+  ```
+- `src/cli/run.rs` in `run_single_agent_es` (~lines 1294-1299):
+  ```rust
+  // 3. Rate limiting (step 3).
+  if let Some(ref rate_str) = agent.metadata.rate_limit
+      && let Some(rpm) = RateLimiter::parse_rate(rate_str) { RateLimiter::new(rpm).acquire().await; }
+  ```
+Remove the now-unused `use` of `RateLimiter` in `run.rs` if it becomes dead. The throttle now lives in the decorator, applied to ALL paths (including the 4 ES engines that call `provider.complete()` directly), because they all obtain their provider from `create_provider`.
+
+- [ ] **Step 6: Verify the ES path obtains its provider from `create_provider`**
+
+Confirm (read-only) that `src/core/orchestration/es/{direct,blackboard,ring,hierarchical}.rs` (and their `cli/run.rs` dispatchers) build providers via `create_provider`/the factory — so the decorator covers them. If any path constructs a provider by other means, note it in the report (it would need the same wrapping). Do not change behavior beyond wrapping.
+
+- [ ] **Step 7: Full gate**
+
+Run: fmt + clippy 3 modes + test 2 modes. Expected: clean / all pass. Confirm no remaining reference to the old `RateLimiter::parse_rate`/`RateLimiter::new(u32)` API.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/providers/factory.rs src/cli/run.rs
+git commit -m "feat(providers): wire rate-limit decorator into the factory, retire dead run.rs blocks (rate-limit Lot 1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Decorator at factory covering all call sites incl. ES → Task 3 (+ Step 6 verifies ES obtains provider via factory). ✅
+- Two-layer limiter (shared provider-key + per-agent) → Task 2 decorator + Task 3 wiring. ✅
+- Shared per-process registry keyed by provider → Task 2 `shared_provider_limiter`. ✅
+- `Rate{per_sec,burst}` f64, `/hour` precise, no-panic guard → Task 1. ✅
+- Revive `config.rate_limits` (req/min → Rate) + frontmatter `rate_limit` → Task 3 `wrap_rate_limited`. ✅
+- Remove dead `run.rs` blocks → Task 1 Step 7 note or Task 3 Step 5. ✅
+- Provider trait unchanged; no armadai.yaml section; unlimited when no cap; silent + tracing::debug → Global Constraints + Task 2/3. ✅
+- Not feature-gated (compiles all 3 modes) → Task 2 Step 6 verifies. ✅
+- 429/529 OUT of scope → not in any task. ✅
+
+**Placeholder scan:** No TBD/TODO. Two implementer decisions are bounded and resolved inline: (a) where to remove the dead `run.rs` blocks (Task 1 recommended, so the crate stays compiling; Task 3 Step 5 is the fallback) — pick Task 1; (b) always-wrap vs conditional (resolved: always wrap, drop `unarc`).
+
+**Type consistency:** `Rate { per_sec, burst }`, `RateLimiter::new(Rate)`, `Rate::parse`/`Rate::from_per_minute`, `RateLimitedProvider::new(Arc<dyn Provider>, Option<Arc<RateLimiter>>, Option<Arc<RateLimiter>>)`, `shared_provider_limiter(&str, Option<Rate>) -> Option<Arc<RateLimiter>>`, `rate_limit_key(&str) -> Option<String>` — consistent across Tasks 1→3. `config.rate_limits: HashMap<String,u32>` (req/min) → `Rate::from_per_minute(u32 as f64)`.
+
+**Resolved ambiguity:** The crate must stay compiling after Task 1 (it changes `RateLimiter`'s public API, breaking the two `run.rs` call sites). Therefore Task 1 Step 7 removes those two blocks in the same commit; Task 3 Step 5 becomes a no-op verification. This is called out in both tasks.

--- a/docs/superpowers/specs/2026-07-27-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-07-27-rate-limiting-design.md
@@ -1,0 +1,90 @@
+# Rate-limiting des providers API — Design
+
+## Contexte
+
+Le rate-limiting d'ArmadAI est **exposé mais inerte** (issue #265, constats vérifiés au code, tous CONFIRMÉS) :
+
+- `src/providers/rate_limiter.rs` : token-bucket correct en soi, mais `parse_rate("N/hour")` fait une **division entière** (`N.max(1)/60`) → tout `N<60` → `0` → `RateLimiter::new(0)` → `refill_rate=0` → `Duration::from_secs_f64(f64::INFINITY)` → **panique dès le 1ᵉʳ `acquire()`**.
+- **No-op** : `RateLimiter::new(rpm)` est reconstruit à chaque appel (`cli/run.rs:906` dans `run_single_agent`, `:1294` dans `run_single_agent_es`) → bucket toujours plein → ne bloque jamais. Et seulement sur ces deux chemins single-agent legacy.
+- Les 4 moteurs event-sourcés appellent `provider.complete()` **en direct** (`es/direct.rs:231`, `es/blackboard.rs:672`, `es/ring.rs:853/914`, `es/hierarchical.rs:1314`) → **aucun** limiteur en orchestration.
+- `UserConfig.rate_limits` (`core/config.rs`, défauts anthropic:50/openai:60/google:60/proxy:100) = **config morte** (jamais lue).
+- `AgentMetadata.rate_limit` (frontmatter `"10/min"`) : parsé, affiché (inspect/TUI/web), mais seulement câblé aux deux chemins cassés ci-dessus.
+- `ProjectConfig` (`armadai.yaml`) : **aucune** section rate-limit.
+- `factory.rs::create_provider(agent: &Agent) -> Result<Box<dyn Provider>>` renvoie un provider **nu**, aucun décorateur.
+- Zéro gestion 429/529 (traité au Lot 2).
+
+Item milestone : **#265** (P1, `epic:core`). Un produit 1.0 ne doit pas exposer un rate-limiting cassé.
+
+## Objectif (Lot 1 = A, throttling proactif)
+
+Rendre le throttling **réel** : un limiteur partagé et durable qui s'applique à **tous** les call-sites (moteurs ES inclus), branché sur les deux knobs déjà exposés (`config.rate_limits` par provider + frontmatter `rate_limit` par agent), sans panique. Le Lot 2 (résilience 429/529) est esquissé en fin de doc mais **hors périmètre** de cette spec.
+
+## Décisions validées (Dimitri, 2026-07-27)
+
+1. **Périmètre** : C (les deux) livré en 2 lots, **A d'abord** (throttling proactif), B ensuite (résilience 429).
+2. **Ancrage** : décorateur `Provider` posé dans `factory.rs` → couvre tous les call-sites via le trait, moteurs ES compris. Trait `Provider` **inchangé**.
+3. **Deux couches** : limiteur **partagé par clé provider** (= `config.rate_limits[provider]`, cap global du quota) **+** limiteur optionnel **par agent** (frontmatter `rate_limit`). `complete()`/`stream()` awaitent les deux → le plus strict gagne.
+4. **Partage** : registre **global au process** (un limiteur par clé provider partagé par tous les agents/tours d'un run). La coordination inter-process = rôle du Lot 2 (429).
+5. **Surface config** : `UserConfig.rate_limits` (par provider) + frontmatter (par agent) uniquement. **Pas** de section rate-limit dans `armadai.yaml` (YAGNI Lot 1).
+6. **Absence de cap** : si `config.rate_limits` ne contient pas de clé pour un provider **et** pas de frontmatter → **illimité** (aucun limiteur, pas de blocage).
+
+## Architecture
+
+### `RateLimiter` (remise à plat, `src/providers/rate_limiter.rs`)
+
+- Refill stocké en **tokens/seconde `f64`** (fini la division entière). Capacité (burst) = le compte de la fenêtre (ex. `50` pour `50/min`).
+- `parse_rate(&str) -> Option<Rate>` (ou `Option<f64>` tokens/sec) : `"N/sec"`→`N`, `"N/min"`→`N/60`, `"N/hour"`→`N/3600` ; unités et alias (`s/sec/second`, `m/min/minute`, `h/hr/hour`) conservés ; entrée invalide → `None`.
+- **Garde anti-panique** : un refill ≤ 0 (ou une construction « illimitée ») ⇒ `acquire()` retourne immédiatement, jamais de `Duration::from_secs_f64(inf)`.
+- `acquire(&self)` : logique bucket inchangée (refill proportionnel à l'`elapsed`, capé, consommation d'1 token), sur la nouvelle représentation f64.
+
+### `RateLimitedProvider` (nouveau décorateur)
+
+- Enveloppe `Arc<dyn Provider>` (l'inner réel) + jusqu'à 2 `Arc<RateLimiter>` : `provider_limiter: Option<Arc<RateLimiter>>` (partagé, depuis le registre) et `agent_limiter: Option<Arc<RateLimiter>>` (par agent, depuis le frontmatter).
+- `complete(req)` / `stream(req)` : `if let Some(l) = &provider_limiter { l.acquire().await }` puis `if let Some(l) = &agent_limiter { l.acquire().await }`, puis délègue à l'inner. `tracing::debug!` quand un `acquire` a réellement attendu. `metadata()` : pass-through.
+- (Le Lot 2 ajoutera la boucle 429/retry **dans ce même décorateur**.)
+
+### Registre partagé (par process)
+
+- `static PROVIDER_LIMITERS: OnceLock<Mutex<HashMap<String, Arc<RateLimiter>>>>` dans `rate_limiter.rs` (ou un module dédié). Une fonction `provider_limiter(provider_key: &str, rate: Option<Rate>) -> Option<Arc<RateLimiter>>` : renvoie/crée (memoize) le limiteur pour la clé si un `rate` est fourni, sinon `None`. Clé = nom de provider (`anthropic`/`google`/…).
+
+### Câblage factory (`src/providers/factory.rs`)
+
+- `create_provider(agent)` construit l'inner comme aujourd'hui, puis :
+  - clé provider dérivée du provider construit / des métadonnées d'agent ;
+  - `provider_rate` = `load_user_config().rate_limits.get(key)` (ranime la config morte) → `provider_limiter(key, rate)` ;
+  - `agent_rate` = `agent.metadata.rate_limit` via `parse_rate` → nouveau `RateLimiter` **par agent** (non partagé) ;
+  - renvoie `Box::new(RateLimitedProvider::new(inner, provider_limiter, agent_limiter))`.
+- **Nettoyage** : supprimer les blocs `RateLimiter::new(...).acquire()` de `cli/run.rs:906-912` et `:1294-1299` (désormais redondants ; le throttling vit dans le décorateur pour tous les chemins).
+
+## Impact par surface
+
+- **Trait `Provider`** : inchangé (le décorateur l'implémente).
+- **`core/config.rs`** : aucune nouvelle struct ; on **lit** enfin `rate_limits` (défauts conservés).
+- **`armadai.yaml`/`ProjectConfig`** : inchangé.
+- **CLI/TUI/Web** : aucune nouvelle UI ; le `rate_limit` d'agent déjà affiché (inspect/TUI/web) devient réel. Throttle silencieux + `tracing::debug` (signal Workroom « en attente de quota » = plus tard).
+- **Moteurs ES** : inchangés (héritent du décorateur via la factory).
+
+## Hors périmètre (Lot 2 = B, spec séparée)
+
+- Détection 429/529 dans le décorateur ; lecture `Retry-After` / `anthropic-ratelimit-*` / Google `RESOURCE_EXHAUSTED` ; backoff exponentiel + retry ; option de recalibrage du bucket depuis les en-têtes serveur.
+- Signal Workroom « en attente de quota » (`RunEvent` dédié).
+- Section rate-limit dans `armadai.yaml`.
+- Coordination inter-process (au-delà du best-effort 429 du Lot 2).
+
+## Tests
+
+- `parse_rate` : `"30/hour"` → taux précis non nul (plus de troncature) ; `"1/hour"` idem ; `"60/hour"`, `"10/min"`, `"1/sec"` corrects ; invalide → `None`.
+- `RateLimiter` : construit « illimité » / refill 0 → `acquire()` immédiat, **jamais de panique** ; throttle réel (deux `acquire` rapprochés sur un petit taux → le second attend).
+- `RateLimitedProvider` (avec un `Provider` factice comptant les appels + une horloge de test si besoin) : deux agents **partageant** la clé provider partagent le limiteur (taux soutenu throttlé) ; le limiteur par-agent resserre ; les deux doivent passer ; provider sans cap ni frontmatter → aucun blocage.
+- **Factory** : `create_provider` d'un agent avec `rate_limit` frontmatter et/ou `config.rate_limits[provider]` renvoie un `RateLimitedProvider` avec les bons limiteurs ; sans aucun des deux → provider non throttlé (ou décorateur inerte).
+- Non-régression : les chemins ES et single-agent compilent/passent après retrait des blocs manuels.
+
+## Gate
+
+`cargo fmt --all` + clippy 3 modes (`tui` / `tui,providers-api` / `tui,web,storage`) `-D warnings` + `cargo test --no-default-features --features tui` + `cargo test --no-default-features --features tui,storage`. Le rate-limiter/décorateur/factory sont sous `providers-api` (ou toujours compilés selon l'emplacement) — vérifier le gating. Une PR (Lot 1) + revue indé + validation Dimitri.
+
+## Risques
+
+- **Horloge dans les tests** : le token-bucket dépend d'`Instant::now()`. Pour un test déterministe du throttle, soit tolérer une petite attente réelle (`tokio::time`), soit injecter une horloge — décider à l'implémentation (préférer un test robuste non-flaky, pas d'assertion temporelle fragile).
+- **Clé provider** : bien dériver une clé stable et cohérente avec les clés de `config.rate_limits` (`anthropic`/`google`/`openai`/`proxy`) depuis le provider/agent — sinon le cap partagé ne s'applique pas. À vérifier au câblage.
+- **Gating features** : `RateLimitedProvider` doit compiler dans tous les modes CI (le rate_limiter est déjà non-gated ; garder le décorateur non-gated, seul l'inner API est gated `providers-api`).

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -11,7 +11,6 @@ use crate::core::orchestration::es::log::{EventLog, InMemoryLog};
 use crate::core::orchestration::es::state::ExecutionState;
 use crate::core::project::{self, AgentRef, ProjectConfig, ProjectDefaults};
 use crate::providers::factory::create_provider;
-use crate::providers::rate_limiter::RateLimiter;
 use crate::providers::traits::{ChatMessage, CompletionRequest};
 
 const GUIDED_MODE_INSTRUCTION: &str = "\
@@ -903,14 +902,6 @@ async fn run_single_agent(
     // 2. Create provider
     let provider = create_provider(&agent)?;
 
-    // 3. Apply rate limiting if configured
-    if let Some(ref rate_str) = agent.metadata.rate_limit
-        && let Some(rpm) = RateLimiter::parse_rate(rate_str)
-    {
-        let limiter = RateLimiter::new(rpm);
-        limiter.acquire().await;
-    }
-
     // 4. Resolve effective mode and build system prompt
     let effective_mode = agent
         .metadata
@@ -1290,13 +1281,6 @@ async fn run_single_agent_es(
     // 2. Create provider (step 2).
     let provider_name = agent.metadata.provider.clone();
     let provider: Arc<dyn crate::providers::traits::Provider> = Arc::from(create_provider(&agent)?);
-
-    // 3. Rate limiting (step 3).
-    if let Some(ref rate_str) = agent.metadata.rate_limit
-        && let Some(rpm) = RateLimiter::parse_rate(rate_str)
-    {
-        RateLimiter::new(rpm).acquire().await;
-    }
 
     // 4. Guided-mode system-prompt augmentation (step 4).
     let effective_mode = agent

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -95,17 +95,17 @@ fn cli_available(command: &str) -> bool {
 pub fn create_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
     let provider = agent.metadata.provider.as_str();
 
-    match provider {
+    let inner: Box<dyn Provider> = match provider {
         // Explicit CLI mode
-        "cli" => create_cli_provider(agent),
+        "cli" => create_cli_provider(agent)?,
 
         // Explicit API providers
-        "anthropic" | "openai" | "google" | "proxy" => create_api_provider(provider, agent),
+        "anthropic" | "openai" | "google" | "proxy" => create_api_provider(provider, agent)?,
 
         // Unified tool names — auto-detect CLI vs API
         _ => {
             if let Some(tool) = find_tool(provider) {
-                create_unified_provider(provider, tool, agent)
+                create_unified_provider(provider, tool, agent)?
             } else {
                 anyhow::bail!(
                     "Unknown provider: '{provider}'. \
@@ -113,7 +113,49 @@ pub fn create_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
                 )
             }
         }
+    };
+    Ok(wrap_rate_limited(agent, inner))
+}
+
+/// Map an agent's `provider` string to the `config.rate_limits` key, or `None`
+/// for providers with no per-account API quota (pure CLI).
+fn rate_limit_key(provider: &str) -> Option<String> {
+    match provider {
+        "anthropic" | "openai" | "google" | "proxy" => Some(provider.to_string()),
+        "claude" => Some("anthropic".to_string()),
+        "gemini" => Some("google".to_string()),
+        "gpt" => Some("openai".to_string()),
+        _ => None, // "cli", unknown, or unified-resolving-to-cli
     }
+}
+
+/// Wrap `inner` with the shared per-provider limiter (from `config.rate_limits`)
+/// and the optional per-agent limiter (from frontmatter `rate_limit`). Always
+/// wraps: with both limiters `None` the decorator's `throttle()` awaits
+/// nothing, so this is a zero-cost pass-through.
+fn wrap_rate_limited(agent: &Agent, inner: Box<dyn Provider>) -> Box<dyn Provider> {
+    use super::{Rate, RateLimitedProvider, RateLimiter, shared_provider_limiter};
+
+    let provider_limiter = rate_limit_key(agent.metadata.provider.as_str()).and_then(|key| {
+        let rate = crate::core::config::load_user_config()
+            .rate_limits
+            .get(&key)
+            .map(|&per_min| Rate::from_per_minute(per_min as f64));
+        shared_provider_limiter(&key, rate)
+    });
+
+    let agent_limiter = agent
+        .metadata
+        .rate_limit
+        .as_deref()
+        .and_then(Rate::parse)
+        .map(|r| std::sync::Arc::new(RateLimiter::new(r)));
+
+    Box::new(RateLimitedProvider::new(
+        std::sync::Arc::from(inner),
+        provider_limiter,
+        agent_limiter,
+    ))
 }
 
 /// Create a provider from a unified tool name, preferring CLI if available.
@@ -245,5 +287,124 @@ mod tests {
         // echo should be available on all systems
         assert!(cli_available("echo"));
         assert!(!cli_available("this_command_does_not_exist_xyz"));
+    }
+
+    #[test]
+    fn rate_limit_key_maps_providers() {
+        assert_eq!(rate_limit_key("anthropic"), Some("anthropic".to_string()));
+        assert_eq!(rate_limit_key("openai"), Some("openai".to_string()));
+        assert_eq!(rate_limit_key("google"), Some("google".to_string()));
+        assert_eq!(rate_limit_key("proxy"), Some("proxy".to_string()));
+        // unified names map to their API backend key
+        assert_eq!(rate_limit_key("claude"), Some("anthropic".to_string()));
+        assert_eq!(rate_limit_key("gemini"), Some("google".to_string()));
+        assert_eq!(rate_limit_key("gpt"), Some("openai".to_string()));
+        // pure CLI: no per-provider quota key
+        assert_eq!(rate_limit_key("cli"), None);
+        assert_eq!(rate_limit_key("unknown-tool"), None);
+    }
+
+    /// `wrap_rate_limited` with an agent-level `rate_limit` throttles even
+    /// when no shared provider-key limiter applies. Uses `provider: "cli"`
+    /// (maps to no `rate_limit_key`) so this test never touches the
+    /// process-global `shared_provider_limiter` registry — no unique-key
+    /// concern here (contrast with tests that DO hit that registry, which
+    /// must use a key suffixed for the test to avoid cross-test collision
+    /// under parallel `cargo test`).
+    #[tokio::test]
+    async fn wrap_rate_limited_agent_limiter_throttles_without_provider_key() {
+        use crate::core::agent::AgentMetadata;
+        use crate::providers::traits::{
+            ChatMessage, CompletionRequest, CompletionResponse, ProviderMetadata, TokenStream,
+        };
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::{Duration, Instant};
+
+        struct CountingProvider {
+            calls: Arc<AtomicUsize>,
+        }
+        #[async_trait::async_trait]
+        impl Provider for CountingProvider {
+            async fn complete(
+                &self,
+                _req: CompletionRequest,
+            ) -> anyhow::Result<CompletionResponse> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CompletionResponse {
+                    content: "ok".into(),
+                    model: "m".into(),
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    cost: 0.0,
+                })
+            }
+            async fn stream(&self, _req: CompletionRequest) -> anyhow::Result<TokenStream> {
+                anyhow::bail!("unused")
+            }
+            fn metadata(&self) -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "counting".into(),
+                    models: vec![],
+                    supports_streaming: false,
+                }
+            }
+        }
+
+        fn req() -> CompletionRequest {
+            CompletionRequest {
+                model: "m".into(),
+                system_prompt: String::new(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: None,
+            }
+        }
+
+        let agent = Agent {
+            name: "test-agent".into(),
+            source: std::path::PathBuf::from("test.md"),
+            metadata: AgentMetadata {
+                provider: "cli".into(),
+                model: None,
+                command: Some("echo".into()),
+                args: None,
+                temperature: 0.7,
+                max_tokens: None,
+                timeout: None,
+                tags: vec![],
+                stacks: vec![],
+                scope: vec![],
+                model_fallback: vec![],
+                cost_limit: None,
+                rate_limit: Some("1/sec".to_string()),
+                context_window: None,
+                mode: None,
+                orchestration: None,
+                triggers: None,
+                ring_config: None,
+            },
+            system_prompt: String::new(),
+            instructions: None,
+            output_format: None,
+            pipeline: None,
+            context: None,
+        };
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let inner: Box<dyn Provider> = Box::new(CountingProvider {
+            calls: calls.clone(),
+        });
+        let wrapped = wrap_rate_limited(&agent, inner);
+
+        wrapped.complete(req()).await.unwrap();
+        let start = Instant::now();
+        wrapped.complete(req()).await.unwrap();
+        // Agent-level "1/sec" burst 1: the 2nd call must wait ~1s.
+        assert!(start.elapsed() >= Duration::from_millis(800));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,3 +6,8 @@ pub mod factory;
 pub mod proxy;
 pub mod rate_limiter;
 pub mod traits;
+
+// Re-exported for `factory.rs` wiring (rate-limit Lot 1, Task 3); not yet
+// consumed on this branch, hence the allow.
+#[allow(unused_imports)]
+pub use rate_limiter::{Rate, RateLimitedProvider, RateLimiter, shared_provider_limiter};

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -7,7 +7,5 @@ pub mod proxy;
 pub mod rate_limiter;
 pub mod traits;
 
-// Re-exported for `factory.rs` wiring (rate-limit Lot 1, Task 3); not yet
-// consumed on this branch, hence the allow.
-#[allow(unused_imports)]
+// Re-exported for `factory.rs` wiring (rate-limit Lot 1, Task 3).
 pub use rate_limiter::{Rate, RateLimitedProvider, RateLimiter, shared_provider_limiter};

--- a/src/providers/rate_limiter.rs
+++ b/src/providers/rate_limiter.rs
@@ -1,4 +1,8 @@
-use std::sync::Mutex;
+use crate::providers::traits::{
+    CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
+};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 /// A parsed rate: sustained refill (`per_sec`) plus bucket capacity (`burst`).
@@ -100,6 +104,72 @@ impl RateLimiter {
     }
 }
 
+/// Wraps a `Provider` and awaits up to two limiters (shared-per-provider,
+/// then per-agent) before delegating. The tighter one effectively governs.
+pub struct RateLimitedProvider {
+    inner: Arc<dyn Provider>,
+    provider_limiter: Option<Arc<RateLimiter>>,
+    agent_limiter: Option<Arc<RateLimiter>>,
+}
+
+impl RateLimitedProvider {
+    pub fn new(
+        inner: Arc<dyn Provider>,
+        provider_limiter: Option<Arc<RateLimiter>>,
+        agent_limiter: Option<Arc<RateLimiter>>,
+    ) -> Self {
+        Self {
+            inner,
+            provider_limiter,
+            agent_limiter,
+        }
+    }
+
+    async fn throttle(&self) {
+        if let Some(l) = &self.provider_limiter {
+            tracing::debug!("rate-limit: throttling provider call (provider limiter)");
+            l.acquire().await;
+        }
+        if let Some(l) = &self.agent_limiter {
+            tracing::debug!("rate-limit: throttling provider call (agent limiter)");
+            l.acquire().await;
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for RateLimitedProvider {
+    async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        self.throttle().await;
+        self.inner.complete(request).await
+    }
+
+    async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
+        self.throttle().await;
+        self.inner.stream(request).await
+    }
+
+    fn metadata(&self) -> ProviderMetadata {
+        self.inner.metadata()
+    }
+}
+
+static PROVIDER_LIMITERS: OnceLock<Mutex<HashMap<String, Arc<RateLimiter>>>> = OnceLock::new();
+
+/// Return (memoized, process-global) the shared limiter for `key`, creating it
+/// from `rate` on first use. `None` when no rate is configured for `key`.
+pub fn shared_provider_limiter(key: &str, rate: Option<Rate>) -> Option<Arc<RateLimiter>> {
+    let rate = rate?;
+    let map = PROVIDER_LIMITERS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().expect("provider limiter registry poisoned");
+    Some(
+        guard
+            .entry(key.to_string())
+            .or_insert_with(|| Arc::new(RateLimiter::new(rate)))
+            .clone(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,5 +249,129 @@ mod tests {
         let start = Instant::now();
         limiter.acquire().await; // must not panic, must return promptly (burst available)
         assert!(start.elapsed() < Duration::from_millis(100));
+    }
+
+    use crate::providers::traits::{
+        ChatMessage, CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
+    };
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingProvider {
+        calls: Arc<AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl Provider for CountingProvider {
+        async fn complete(&self, _req: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(CompletionResponse {
+                content: "ok".into(),
+                model: "m".into(),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+            })
+        }
+        async fn stream(&self, _req: CompletionRequest) -> anyhow::Result<TokenStream> {
+            anyhow::bail!("unused")
+        }
+        fn metadata(&self) -> ProviderMetadata {
+            ProviderMetadata {
+                name: "counting".into(),
+                models: vec![],
+                supports_streaming: false,
+            }
+        }
+    }
+    fn req() -> CompletionRequest {
+        CompletionRequest {
+            model: "m".into(),
+            system_prompt: String::new(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn no_limiters_never_blocks() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let p = RateLimitedProvider::new(
+            Arc::new(CountingProvider {
+                calls: calls.clone(),
+            }),
+            None,
+            None,
+        );
+        let start = Instant::now();
+        for _ in 0..50 {
+            p.complete(req()).await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 50);
+        assert!(start.elapsed() < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn shared_provider_limiter_throttles_across_decorators() {
+        // Two decorators sharing ONE provider limiter (burst 2, 1/sec refill).
+        let shared = Arc::new(RateLimiter::new(Rate {
+            per_sec: 1.0,
+            burst: 2.0,
+        }));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let a = RateLimitedProvider::new(
+            Arc::new(CountingProvider {
+                calls: calls.clone(),
+            }),
+            Some(shared.clone()),
+            None,
+        );
+        let b = RateLimitedProvider::new(
+            Arc::new(CountingProvider {
+                calls: calls.clone(),
+            }),
+            Some(shared.clone()),
+            None,
+        );
+        // 2 immediate (burst), then the 3rd (via the OTHER decorator) must wait ~1s.
+        a.complete(req()).await.unwrap();
+        a.complete(req()).await.unwrap();
+        let start = Instant::now();
+        b.complete(req()).await.unwrap();
+        assert!(start.elapsed() >= Duration::from_millis(800));
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn agent_limiter_tightens_and_both_must_pass() {
+        // Loose provider limiter, tight per-agent limiter -> agent limiter governs.
+        let provider = Arc::new(RateLimiter::new(Rate::from_per_minute(600.0))); // basically loose
+        let agent = Arc::new(RateLimiter::new(Rate {
+            per_sec: 1.0,
+            burst: 1.0,
+        })); // 1 then wait
+        let calls = Arc::new(AtomicUsize::new(0));
+        let p = RateLimitedProvider::new(
+            Arc::new(CountingProvider {
+                calls: calls.clone(),
+            }),
+            Some(provider),
+            Some(agent),
+        );
+        p.complete(req()).await.unwrap();
+        let start = Instant::now();
+        p.complete(req()).await.unwrap();
+        assert!(start.elapsed() >= Duration::from_millis(800));
+    }
+
+    #[test]
+    fn shared_registry_memoizes_by_key() {
+        let a = shared_provider_limiter("anthropic", Some(Rate::from_per_minute(50.0))).unwrap();
+        let b = shared_provider_limiter("anthropic", Some(Rate::from_per_minute(50.0))).unwrap();
+        assert!(Arc::ptr_eq(&a, &b)); // same key -> same Arc
+        assert!(shared_provider_limiter("nokey", None).is_none());
     }
 }

--- a/src/providers/rate_limiter.rs
+++ b/src/providers/rate_limiter.rs
@@ -1,6 +1,42 @@
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+/// A parsed rate: sustained refill (`per_sec`) plus bucket capacity (`burst`).
+/// `burst` is the window count, floored at 1.0 so a single request can always
+/// pass before throttling kicks in (a capacity < 1 would deadlock acquire).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rate {
+    pub per_sec: f64,
+    pub burst: f64,
+}
+
+impl Rate {
+    /// Build a rate from a requests-per-minute value (used by `config.rate_limits`).
+    pub fn from_per_minute(per_minute: f64) -> Rate {
+        Rate {
+            per_sec: per_minute / 60.0,
+            burst: per_minute.max(1.0),
+        }
+    }
+
+    /// Parse "N/sec", "N/min", "N/hour" (with aliases). Precise — no integer
+    /// truncation. Returns `None` on malformed input.
+    pub fn parse(s: &str) -> Option<Rate> {
+        let (count_str, unit) = s.split_once('/')?;
+        let count: f64 = count_str.trim().parse::<u32>().ok()? as f64;
+        let per_sec = match unit.trim() {
+            "s" | "sec" | "second" => count,
+            "m" | "min" | "minute" => count / 60.0,
+            "h" | "hr" | "hour" => count / 3600.0,
+            _ => return None,
+        };
+        Some(Rate {
+            per_sec,
+            burst: count.max(1.0),
+        })
+    }
+}
+
 /// Token-bucket rate limiter for provider calls.
 pub struct RateLimiter {
     state: Mutex<BucketState>,
@@ -14,14 +50,14 @@ struct BucketState {
 }
 
 impl RateLimiter {
-    /// Create a rate limiter allowing `max_per_minute` requests per minute.
-    pub fn new(max_per_minute: u32) -> Self {
-        let max = max_per_minute as f64;
+    /// Create a limiter from a `Rate`. A non-positive `per_sec`/`burst` means
+    /// "unlimited": `acquire()` never waits.
+    pub fn new(rate: Rate) -> Self {
         Self {
             state: Mutex::new(BucketState {
-                tokens: max,
-                max_tokens: max,
-                refill_rate: max / 60.0,
+                tokens: rate.burst,
+                max_tokens: rate.burst,
+                refill_rate: rate.per_sec,
                 last_refill: Instant::now(),
             }),
         }
@@ -34,6 +70,14 @@ impl RateLimiter {
                 // If the mutex is poisoned, we can't recover, so we panic with a clear message.
                 // This should never happen in practice unless there's a panic inside the lock.
                 let mut state = self.state.lock().expect("rate limiter mutex poisoned");
+
+                // Unlimited: no throttle configured. Short-circuit before any
+                // wait-duration math so `deficit / refill_rate` (which would be
+                // `inf`/`NaN` when `refill_rate <= 0.0`) is never computed.
+                if state.refill_rate <= 0.0 || state.max_tokens <= 0.0 {
+                    return;
+                }
+
                 let now = Instant::now();
                 let elapsed = now.duration_since(state.last_refill).as_secs_f64();
                 state.tokens = (state.tokens + elapsed * state.refill_rate).min(state.max_tokens);
@@ -54,19 +98,6 @@ impl RateLimiter {
             }
         }
     }
-
-    /// Parse a rate limit string like "10/min", "60/hour", "5/sec".
-    /// Returns requests per minute.
-    pub fn parse_rate(rate_str: &str) -> Option<u32> {
-        let (count_str, unit) = rate_str.split_once('/')?;
-        let count: u32 = count_str.trim().parse().ok()?;
-        match unit.trim() {
-            "s" | "sec" | "second" => Some(count * 60),
-            "m" | "min" | "minute" => Some(count),
-            "h" | "hr" | "hour" => Some(count.max(1) / 60),
-            _ => None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -74,36 +105,79 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_rate_formats() {
-        assert_eq!(RateLimiter::parse_rate("10/min"), Some(10));
-        assert_eq!(RateLimiter::parse_rate("1/sec"), Some(60));
-        assert_eq!(RateLimiter::parse_rate("60/hour"), Some(1));
-        assert_eq!(RateLimiter::parse_rate("5/m"), Some(5));
-        assert_eq!(RateLimiter::parse_rate("invalid"), None);
+    fn rate_parse_is_precise_no_truncation() {
+        // per-minute canonical form
+        let r = Rate::parse("10/min").unwrap();
+        assert!((r.per_sec - 10.0 / 60.0).abs() < 1e-9);
+        assert_eq!(r.burst, 10.0);
+
+        // per-second
+        let r = Rate::parse("1/sec").unwrap();
+        assert!((r.per_sec - 1.0).abs() < 1e-9);
+        assert_eq!(r.burst, 1.0);
+
+        // per-hour: the OLD bug truncated 30/hour -> 0. Now precise.
+        let r = Rate::parse("30/hour").unwrap();
+        assert!((r.per_sec - 30.0 / 3600.0).abs() < 1e-9);
+        assert_eq!(r.burst, 30.0);
+
+        // sub-1/window still yields burst >= 1 (so a single request can pass)
+        let r = Rate::parse("1/hour").unwrap();
+        assert!((r.per_sec - 1.0 / 3600.0).abs() < 1e-12);
+        assert_eq!(r.burst, 1.0);
+
+        // aliases
+        assert!(Rate::parse("5/m").is_some());
+        assert!(Rate::parse("2/second").is_some());
+        assert!(Rate::parse("100/hr").is_some());
+
+        // invalid
+        assert!(Rate::parse("invalid").is_none());
+        assert!(Rate::parse("10/decade").is_none());
+        assert!(Rate::parse("abc/min").is_none());
     }
 
     #[tokio::test]
-    async fn acquire_within_limit() {
-        let limiter = RateLimiter::new(60); // 1 per second
+    async fn acquire_unlimited_never_waits_and_never_panics() {
+        // per_sec 0 == unlimited; the OLD code panicked here (from_secs_f64(inf)).
+        let limiter = RateLimiter::new(Rate {
+            per_sec: 0.0,
+            burst: 0.0,
+        });
+        let start = Instant::now();
+        for _ in 0..1000 {
+            limiter.acquire().await;
+        }
+        assert!(start.elapsed() < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn acquire_within_burst_is_immediate() {
+        let limiter = RateLimiter::new(Rate::from_per_minute(60.0)); // burst 60
         let start = Instant::now();
         limiter.acquire().await;
         limiter.acquire().await;
-        // Two immediate acquires should work since bucket starts full
         assert!(start.elapsed() < Duration::from_millis(100));
     }
 
     #[tokio::test]
-    async fn acquire_waits_when_exhausted() {
-        let limiter = RateLimiter::new(60); // 1 per second
-
-        // Drain all tokens
+    async fn acquire_waits_when_burst_exhausted() {
+        let limiter = RateLimiter::new(Rate::from_per_minute(60.0)); // 1/sec, burst 60
         for _ in 0..60 {
             limiter.acquire().await;
         }
-
         let start = Instant::now();
         limiter.acquire().await;
-        // Should have waited ~1 second for a refill
-        assert!(start.elapsed() >= Duration::from_millis(900));
+        // Refill is 1/sec, so the 61st waits ~1s. Generous margin (non-flaky).
+        assert!(start.elapsed() >= Duration::from_millis(800));
+    }
+
+    #[tokio::test]
+    async fn low_hourly_rate_does_not_panic_and_passes_first_call() {
+        // 30/hour: OLD code -> new(0) -> panic on first acquire. Now: burst 30 -> passes.
+        let limiter = RateLimiter::new(Rate::parse("30/hour").unwrap());
+        let start = Instant::now();
+        limiter.acquire().await; // must not panic, must return promptly (burst available)
+        assert!(start.elapsed() < Duration::from_millis(100));
     }
 }

--- a/src/providers/rate_limiter.rs
+++ b/src/providers/rate_limiter.rs
@@ -158,6 +158,8 @@ static PROVIDER_LIMITERS: OnceLock<Mutex<HashMap<String, Arc<RateLimiter>>>> = O
 
 /// Return (memoized, process-global) the shared limiter for `key`, creating it
 /// from `rate` on first use. `None` when no rate is configured for `key`.
+/// First-write-wins per key: if `key` is already registered, its existing
+/// rate is kept and this call's `rate` is ignored (even if it differs).
 pub fn shared_provider_limiter(key: &str, rate: Option<Rate>) -> Option<Arc<RateLimiter>> {
     let rate = rate?;
     let map = PROVIDER_LIMITERS.get_or_init(|| Mutex::new(HashMap::new()));


### PR DESCRIPTION
Fait avancer #265 (Lot 1 sur 2).

## Contexte
Le rate-limiting était **exposé mais inerte** (no-op + panique `parse_rate("N/hour")` pour N<60 + config morte + moteurs ES court-circuités). Ce Lot 1 le rend **réel** (throttling proactif). Lot 2 (résilience 429/529) suivra. Spec `docs/superpowers/specs/2026-07-27-rate-limiting-design.md`. Subagent-driven, 3 tâches relues + revue finale whole-branch opus (READY TO MERGE).

## Contenu
- **`RateLimiter` remis à plat** (`bceb2d6`) : type `Rate{per_sec,burst}`, `parse` précis (`/hour`=N/3600, `burst=count.max(1)`), **garde anti-panique** (refill ≤ 0 → illimité, plus de `from_secs_f64(inf)`). Blocs no-op de `run.rs` retirés.
- **`RateLimitedProvider` + registre** (`2f8a770`) : décorateur du trait `Provider` (limiteur partagé par provider **+** limiteur par agent, les deux `await`és avant délégation ; `metadata` pass-through) ; registre process-global `shared_provider_limiter` (memoïzé par clé, first-write-wins) ; **non feature-gated**.
- **Câblage factory** (`31dc9e4`) : `create_provider` enveloppe **toujours** l'inner → couvre **tous** les call-sites (4 moteurs ES, resume, single/multi-agent, `audit --deep`) via le trait, sans le modifier. Ranime `config.rate_limits` (req/min→`Rate`) + frontmatter `rate_limit`. `rate_limit_key` : anthropic/openai/google/proxy + unifiés (claude→anthropic, gemini→google, gpt→openai) ; cli→pas de cap.

## Garanties (revue + tests)
Panique éliminée par construction · always-wrap = vrai no-op quand aucun cap · pas de deadlock (`MutexGuard` relâché avant `await`) · `burst≥1` → 1ᵉʳ appel immédiat · unités req/min cohérentes · aucun chemin production ne contourne le décorateur.

## Comportement (conforme spec validée)
Throttling **actif par défaut** (config peuplée), mais `burst=compte/min` → runs simples/petites orchestrations passent sans attente ; seuls runs très longs / shell durable throttlent. **Absence de cap → illimité.** Throttle silencieux + `tracing::debug`.

## Gate
clippy 3 modes clean · fmt clean · test `tui` 1009 / `tui,storage` 1053. Revue finale opus re-exécute la gate.

## Follow-ups backlog (non bloquants)
- **Lot 2** : 429/529 + Retry-After + backoff (dans le même décorateur).
- `rate_limit_key(claude)=anthropic` applique le cap API au CLI claude résolu (conservateur ; affiner Lot 2 en dérivant de CLI-vs-API réellement résolu).
- `serde(default)` asymétrie : `config.yaml` existante sans section `rate_limits` → illimité (vs config générée → throttlée). Quirk préexistant observable.

## Smoke (Dimitri) — comportemental, pas visuel
Un run normal doit passer sans throttle perceptible :
```
cargo run --bin armadai -- run dev-lead "<un task court>"
```
(Optionnel) throttle réel : mettre `rate_limit: "2/min"` dans le frontmatter d'un agent et le pipe → le 3ᵉ appel attend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
