### PR TITLE
fix(shell): abort a live orchestration run cleanly — kill_on_drop + honest footer (#274)

### DIFF
--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -49,6 +49,15 @@ impl CliProvider {
         cmd.arg(input);
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
+        // Ensure the child is SIGKILLed if the `Child`/future is dropped
+        // without being awaited to completion — e.g. when a caller aborts
+        // the `tokio::spawn`'d task driving `complete()`/`stream()` (see
+        // `shell::run_view::run_loop`'s Ctrl+C/`q` handling). Without this,
+        // an aborted run leaves the CLI subprocess (e.g. `claude`) running
+        // and orphaned, still writing to the inherited stdout/stderr after
+        // the TUI has torn down the alternate screen — looking like "the
+        // run keeps going" even though ArmadAI itself has exited (#274).
+        cmd.kill_on_drop(true);
         cmd
     }
 
@@ -243,6 +252,63 @@ mod tests {
         })
         .await;
         assert!(result.is_err());
+    }
+
+    // ── kill_on_drop (fix for #274: abort must not orphan the subprocess) ──
+
+    /// Best-effort liveness check via `kill -0 <pid>` (POSIX; both the CI
+    /// Linux runners and macOS dev machines have `kill`). A zombie still
+    /// occupies the process table until its parent reaps it, so this
+    /// correctly reports "alive" until the OS/tokio's orphan-queue reaper
+    /// has actually collected it.
+    fn process_alive(pid: i32) -> bool {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    #[tokio::test]
+    async fn dropping_child_kills_orphaned_process_via_kill_on_drop() {
+        // Regression test for #274: the Workroom's `run_loop` aborts a
+        // running orchestration by dropping the `tokio::spawn`'d task
+        // future. Without `kill_on_drop(true)` on the `Command` built in
+        // `build_command`, dropping the future (and its owned `Child`)
+        // leaves the CLI subprocess (e.g. `claude`) running and orphaned —
+        // it keeps writing to the inherited stdout/stderr after the TUI has
+        // torn down, which looks like "the run keeps going" even though
+        // ArmadAI has exited. This asserts the child is actually gone
+        // shortly after the `Child` handle is dropped, unawaited.
+        let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 10);
+        let mut cmd = provider.build_command("sleep 30");
+        let child = cmd.spawn().expect("failed to spawn `sh -c sleep 30`");
+        let pid = child.id().expect("spawned child should have a pid") as i32;
+
+        assert!(
+            process_alive(pid),
+            "sanity check: child {pid} should be running right after spawn"
+        );
+
+        // Simulate `handle.abort()`: drop the future (and the `Child` it
+        // owns) without ever calling `.wait()`/`.output()` on it.
+        drop(child);
+
+        // `kill_on_drop`'s `Drop` impl sends SIGKILL synchronously, but the
+        // process table entry is only cleared once tokio's orphan-queue
+        // reaper collects it (driven by SIGCHLD) — poll briefly instead of
+        // asserting instantaneously.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < deadline && process_alive(pid) {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        assert!(
+            !process_alive(pid),
+            "child process {pid} should have been killed+reaped when the Child was \
+             dropped (kill_on_drop); a still-running process here reproduces the #274 orphan"
+        );
     }
 
     #[tokio::test]

--- a/src/shell/run_view.rs
+++ b/src/shell/run_view.rs
@@ -211,6 +211,65 @@ fn render_detail_popup(frame: &mut Frame, area: Rect, markdown: &str) {
     frame.render_widget(popup, popup_area);
 }
 
+/// Side-effect-free decision for a single keypress in `run_loop`, extracted
+/// so the quit/abort model can be unit tested without a real terminal or
+/// orchestration. `focused`/`finished`/`detail_open` mirror the loop's local
+/// state at the time the key was read.
+///
+/// Fix for #274: `q` (like Ctrl+C) must abort a running run **regardless of
+/// focus** — previously `q` only aborted when `!focused`, so pressing
+/// Ctrl+W to focus the Workroom silently disabled the `q` abort, leaving
+/// Ctrl+C as the only way out (and the CLI subprocess would then orphan
+/// unless `providers::cli` also sets `kill_on_drop`, see that module).
+/// Once `finished`, `q`/Esc keep their unrelated meaning: dismiss the held
+/// final frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyAction {
+    /// Abort the running orchestration (`handle.abort()`) and exit the loop.
+    Abort,
+    /// Exit the loop without aborting (only valid once `finished`).
+    Close,
+    ToggleFocus,
+    SelectPrev,
+    SelectNext,
+    OpenDetail,
+    CloseDetail,
+    None,
+}
+
+fn key_action(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    focused: bool,
+    finished: bool,
+    detail_open: bool,
+) -> KeyAction {
+    // Ctrl+C aborts anytime, even with the detail popup open.
+    if code == KeyCode::Char('c') && modifiers.contains(KeyModifiers::CONTROL) {
+        return KeyAction::Abort;
+    }
+
+    if detail_open {
+        return if matches!(code, KeyCode::Enter | KeyCode::Esc) {
+            KeyAction::CloseDetail
+        } else {
+            KeyAction::None
+        };
+    }
+
+    match code {
+        KeyCode::Char('w') if modifiers.contains(KeyModifiers::CONTROL) => KeyAction::ToggleFocus,
+        KeyCode::Up | KeyCode::Char('k') if focused => KeyAction::SelectPrev,
+        KeyCode::Down | KeyCode::Char('j') if focused => KeyAction::SelectNext,
+        KeyCode::Enter if focused => KeyAction::OpenDetail,
+        KeyCode::Char('q') | KeyCode::Esc if finished => KeyAction::Close,
+        // `q` aborts a running run regardless of focus (#274) — deliberately
+        // not gated on `!focused` anymore.
+        KeyCode::Char('q') => KeyAction::Abort,
+        _ => KeyAction::None,
+    }
+}
+
 /// Drain events, redraw, and poll input until the orchestration finishes and
 /// the user dismisses the final frame (or aborts early). Returns the final
 /// `RunEvent::Result` content (if any) for the caller to print once the
@@ -268,46 +327,31 @@ async fn run_loop(
             }
         })?;
 
-        // Input: Ctrl+C aborts anytime (even with the popup open). While the
-        // detail popup is open, Enter/Esc close it first — that precedence
-        // matters so Esc doesn't fall through to the view-exit handler below
-        // in the same keypress. Ctrl+W toggles focus, Enter opens the detail
-        // popup for the selected agent (when focused), q/Esc dismiss the
-        // held final frame once `finished`.
+        // Input: decision is delegated to the pure `key_action` helper (see
+        // its doc comment for the quit/abort model) — this loop only
+        // performs the resulting side effects.
         if event::poll(Duration::from_millis(80))?
             && let Event::Key(k) = event::read()?
             && k.kind == KeyEventKind::Press
         {
-            if k.code == KeyCode::Char('c') && k.modifiers.contains(KeyModifiers::CONTROL) {
-                handle.abort();
-                break;
-            }
-
-            if detail.is_some() {
-                if matches!(k.code, KeyCode::Enter | KeyCode::Esc) {
-                    detail = None;
+            match key_action(
+                k.code,
+                k.modifiers,
+                workroom.is_focused(),
+                finished,
+                detail.is_some(),
+            ) {
+                KeyAction::Abort => {
+                    handle.abort();
+                    break;
                 }
-            } else {
-                match k.code {
-                    KeyCode::Char('w') if k.modifiers.contains(KeyModifiers::CONTROL) => {
-                        workroom.set_focused(!workroom.is_focused());
-                    }
-                    KeyCode::Up | KeyCode::Char('k') if workroom.is_focused() => {
-                        workroom.select_prev()
-                    }
-                    KeyCode::Down | KeyCode::Char('j') if workroom.is_focused() => {
-                        workroom.select_next()
-                    }
-                    KeyCode::Enter if workroom.is_focused() => {
-                        detail = workroom.selected_detail_markdown();
-                    }
-                    KeyCode::Char('q') | KeyCode::Esc if finished => break,
-                    KeyCode::Char('q') if !workroom.is_focused() => {
-                        handle.abort();
-                        break;
-                    }
-                    _ => {}
-                }
+                KeyAction::Close => break,
+                KeyAction::ToggleFocus => workroom.set_focused(!workroom.is_focused()),
+                KeyAction::SelectPrev => workroom.select_prev(),
+                KeyAction::SelectNext => workroom.select_next(),
+                KeyAction::OpenDetail => detail = workroom.selected_detail_markdown(),
+                KeyAction::CloseDetail => detail = None,
+                KeyAction::None => {}
             }
         }
     }
@@ -329,6 +373,145 @@ mod tests {
     use crate::core::events::{EventSink, RunEvent};
     use crate::shell::workroom::Workroom;
     use std::time::Instant;
+
+    // ── key_action: the #274 quit/abort decision table ──
+
+    const NONE: KeyModifiers = KeyModifiers::NONE;
+    const CTRL: KeyModifiers = KeyModifiers::CONTROL;
+
+    #[test]
+    fn q_aborts_a_running_run_when_unfocused() {
+        assert_eq!(
+            key_action(KeyCode::Char('q'), NONE, false, false, false),
+            KeyAction::Abort
+        );
+    }
+
+    #[test]
+    fn q_aborts_a_running_run_when_focused() {
+        // Regression for #274: previously `q` only aborted when unfocused,
+        // so Ctrl+W (focus toggle) silently disabled the `q` abort and left
+        // Ctrl+C as the only way to quit a live run.
+        assert_eq!(
+            key_action(KeyCode::Char('q'), NONE, true, false, false),
+            KeyAction::Abort
+        );
+    }
+
+    #[test]
+    fn ctrl_c_aborts_regardless_of_focus_or_detail_popup() {
+        for focused in [false, true] {
+            for detail_open in [false, true] {
+                assert_eq!(
+                    key_action(KeyCode::Char('c'), CTRL, focused, false, detail_open),
+                    KeyAction::Abort,
+                    "focused={focused} detail_open={detail_open}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn q_and_esc_dismiss_instead_of_abort_once_finished() {
+        assert_eq!(
+            key_action(KeyCode::Char('q'), NONE, true, true, false),
+            KeyAction::Close
+        );
+        assert_eq!(
+            key_action(KeyCode::Char('q'), NONE, false, true, false),
+            KeyAction::Close
+        );
+        assert_eq!(
+            key_action(KeyCode::Esc, NONE, true, true, false),
+            KeyAction::Close
+        );
+    }
+
+    #[test]
+    fn esc_does_not_abort_a_running_run() {
+        // Esc has no abort meaning while running (only q/Ctrl+C do); it's a
+        // no-op here so it doesn't fall through to anything destructive.
+        assert_eq!(
+            key_action(KeyCode::Esc, NONE, false, false, false),
+            KeyAction::None
+        );
+    }
+
+    #[test]
+    fn ctrl_w_toggles_focus_in_either_direction() {
+        assert_eq!(
+            key_action(KeyCode::Char('w'), CTRL, false, false, false),
+            KeyAction::ToggleFocus
+        );
+        assert_eq!(
+            key_action(KeyCode::Char('w'), CTRL, true, false, false),
+            KeyAction::ToggleFocus
+        );
+    }
+
+    #[test]
+    fn jk_select_only_when_focused() {
+        assert_eq!(
+            key_action(KeyCode::Char('j'), NONE, true, false, false),
+            KeyAction::SelectNext
+        );
+        assert_eq!(
+            key_action(KeyCode::Char('k'), NONE, true, false, false),
+            KeyAction::SelectPrev
+        );
+        assert_eq!(
+            key_action(KeyCode::Down, NONE, true, false, false),
+            KeyAction::SelectNext
+        );
+        assert_eq!(
+            key_action(KeyCode::Up, NONE, true, false, false),
+            KeyAction::SelectPrev
+        );
+        // Unfocused: j/k are not select shortcuts (and not the `q` abort key
+        // either), so they're a no-op.
+        assert_eq!(
+            key_action(KeyCode::Char('j'), NONE, false, false, false),
+            KeyAction::None
+        );
+        assert_eq!(
+            key_action(KeyCode::Char('k'), NONE, false, false, false),
+            KeyAction::None
+        );
+    }
+
+    #[test]
+    fn enter_opens_detail_only_when_focused_and_no_popup_open() {
+        assert_eq!(
+            key_action(KeyCode::Enter, NONE, true, false, false),
+            KeyAction::OpenDetail
+        );
+        assert_eq!(
+            key_action(KeyCode::Enter, NONE, false, false, false),
+            KeyAction::None
+        );
+    }
+
+    #[test]
+    fn enter_or_esc_close_an_open_detail_popup() {
+        assert_eq!(
+            key_action(KeyCode::Enter, NONE, true, false, true),
+            KeyAction::CloseDetail
+        );
+        assert_eq!(
+            key_action(KeyCode::Esc, NONE, true, false, true),
+            KeyAction::CloseDetail
+        );
+        // Any other key with the popup open is a no-op — it doesn't leak
+        // through to select/abort while the popup is up.
+        assert_eq!(
+            key_action(KeyCode::Char('j'), NONE, true, false, true),
+            KeyAction::None
+        );
+        assert_eq!(
+            key_action(KeyCode::Char('q'), NONE, true, false, true),
+            KeyAction::None
+        );
+    }
 
     #[test]
     fn sink_forwards_events_to_projection() {

--- a/src/shell/workroom.rs
+++ b/src/shell/workroom.rs
@@ -847,17 +847,26 @@ impl Workroom {
         }
     }
 
-    /// Append the blank line + Ctrl+W hint footer shared by all layouts.
+    /// Append the blank line + shortcuts hint footer shared by all layouts.
+    ///
+    /// While a run is in progress, `q`/Ctrl+C abort it regardless of focus
+    /// (see `shell::run_view::run_loop`) — Ctrl+W only ever *toggles focus*,
+    /// it never exits, so the RUNNING-state hint must say so (#274: the
+    /// previous "Ctrl+W exit" label was false and the real abort keys went
+    /// unadvertised once focused).
     fn push_footer(&self, lines: &mut Vec<Line>) {
         lines.push(Line::from(""));
         if self.focused {
             lines.push(Line::from(Span::styled(
-                "Ctrl+W exit · j/k select",
+                "q / Ctrl+C abort · Ctrl+W focus · j/k select",
                 theme::muted(),
             )));
             lines.push(Line::from(Span::styled("Enter detail", theme::muted())));
         } else {
-            lines.push(Line::from(Span::styled("Ctrl+W focus", theme::muted())));
+            lines.push(Line::from(Span::styled(
+                "q / Ctrl+C abort · Ctrl+W focus",
+                theme::muted(),
+            )));
         }
         if self.completed {
             let check = theme::glyphs().check;


### PR DESCRIPTION
Closes #274.

## Contexte
Bug (constaté au smoke #273) : impossible de quitter un run d'orchestration **en cours** — « ça continue dans tous les cas », même Ctrl+C.

## Root cause (systematic-debugging, prouvée)
`run_loop` gère **correctement** Ctrl+C (log instrumenté : `EVENT Key(Char('c'),CONTROL,Press) -> CTRL+C branch: abort+break`) et `handle.await` revient en 264µs (sonde). Le vrai coupable : `src/providers/cli.rs` lance `tokio::process::Command` **sans `kill_on_drop(true)`** → à l'abort, la future s'annule et la TUI sort, mais le child `claude` reste **orphelin et continue d'écrire son stdout** sur le terminal restauré → illusion de « ne quitte pas ». Repro `sleep` (silencieux) → orphelin invisible → « coupe direct ».

## Fixes
- **`kill_on_drop(true)`** dans `cli.rs::build_command` (couvre `complete` + `stream`) → le child meurt à l'abort → quit propre. (Non-régression : sur le chemin succès, tokio remet `kill_on_drop=false` quand `output()` résout — vérifié en source.)
- **Footer honnête** (`workroom.rs`) : `q / Ctrl+C abort · Ctrl+W focus · j/k select` (au lieu du faux « Ctrl+W exit »).
- **`q` aborte quel que soit le focus** (`run_view.rs`) : logique clavier extraite en helper pur `key_action(...)` + 9 tests (Ctrl+C anytime, q focus/unfocus, Esc ne coupe pas un run, dismiss quand finished, etc.).

## Tests
`dropping_child_kills_orphaned_process_via_kill_on_drop` (comportemental : spawn `sh -c sleep 30`, drop, poll `kill -0` jusqu'à mort) + 9 tests `key_action`. Gate : clippy 3 modes clean · test `tui` 990 / `tui,storage` 1034.

## Suivis (non bloquants)
- `stream()` a un Child interne non lié au handle abortable (non utilisé en prod aujourd'hui).
- Footer en état `completed` affiche encore la ligne abort (cosmétique).
- qa-specialist `idle` en fin (projection Workroom, séparé).

## Validation manuelle (Dimitri) — LA validation
Relance le run orchestré **real-claude** et presse **Ctrl+C** (ou `q`) en cours : le terminal doit **revenir proprement au prompt**, sans `claude` orphelin qui continue de cracher du texte.
```
cargo run --bin armadai -- run dev-lead "Ne pose aucune question, délègue à @core-specialist / @cli-specialist / @qa-specialist puis synthétise."
# pendant un spécialiste working -> Ctrl+C -> doit quitter net
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
