### PR TITLE
feat(oh1): parallelism Lot 1 (socle) — Action::InvokeParallel + AgentFailed (#250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "dialoguer",
+ "futures-util",
  "include_dir",
  "portable-pty",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ providers-api = ["dep:reqwest"]
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 async-trait = "0.1"
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/docs/superpowers/plans/2026-07-27-oh1-parallelism-lot1.md
+++ b/docs/superpowers/plans/2026-07-27-oh1-parallelism-lot1.md
@@ -1,0 +1,721 @@
+# OH1 Parallelism — Lot 1 (socle) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a socle-level `Action::InvokeParallel` to the event-sourced orchestration engine that runs independent delegations concurrently while recording events in a deterministic order, with bounded concurrency and collect-and-record failure resilience.
+
+**Architecture:** The generic `run_loop` (`src/core/orchestration/es/engine.rs`) gains one new action variant carrying its own concurrency cap. Its handler records all `AgentInvoked` in `Vec` order, runs the effects concurrently via `futures_util`'s `buffer_unordered`, then records each outcome back in `Vec` order (independent of completion order) — a per-item failure becomes a new `ExecutionEvent::AgentFailed` event instead of aborting the run. No orchestration pattern emits the new action in this lot (that is Lot 2); tests drive it against a mock `EffectRunner`.
+
+**Tech Stack:** Rust edition 2024, `tokio`, `async-trait`, `futures-util` (promoted to a direct dependency for `buffer_unordered`), event-sourcing engine under `src/core/orchestration/es/`.
+
+## Global Constraints
+
+- Target branch: `master` (master-only model). Work happens on `feat/oh1-parallel` (already contains the design spec).
+- Reference spec: `docs/superpowers/specs/2026-07-27-oh1-parallelism-design.md`.
+- The ES engine compiles in **all** CI feature modes → any new dependency (`futures-util`) must be **non-optional** (a plain `[dependencies]` entry, not feature-gated).
+- The generic engine signatures `run_event_sourced` / `resume_event_sourced` / `run_loop` MUST stay unchanged — the concurrency cap is carried inside the `InvokeParallel` action, not passed as a parameter.
+- Determinism is the cardinal invariant: recorded event order = the decider's `Vec` order, **never** completion order. Replay/resume fold purely over recorded order.
+- `apply` is a pure, total, deterministic reducer — no I/O, no clock, no randomness.
+- Collect-and-record: a failed `run_invoke` records `AgentFailed` and the run continues; it never propagates an `Err` that aborts the loop.
+- Gate per task: `cargo fmt --all` + clippy 3 modes (`--no-default-features --features tui` / `tui,providers-api` / `tui,web,storage`) `-D warnings` + `cargo test --no-default-features --features tui` + `cargo test --no-default-features --features tui,storage`.
+- `rust-analyzer` diagnostics are unreliable here (stale ABI / inactive-cfg / E0308 false positives) — **always verify at the compiler** with `cargo`.
+- `cat` is aliased to `bat`; use `command cat` if you must cat.
+- Conventional Commits, single type per commit, trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- One PR for the whole lot + independent review + Dimitri validation.
+
+---
+
+## File Structure
+
+- `src/core/orchestration/es/event.rs` — add `ExecutionEvent::AgentFailed { agent, error }` variant + a shared `delegation_failed_content(error)` helper (single source of the failure marker string, consumed by both `apply` and the bridge — DRY).
+- `src/core/orchestration/es/state.rs` — add the `apply(AgentFailed)` reducer arm (push an `assistant` marker message so the agent reads as "settled"; do **not** touch the budget).
+- `src/core/orchestration/es/bridge.rs` — map `AgentFailed` → `RunEvent::AgentEnd` (closes the Workroom tile).
+- `src/core/orchestration/es/engine.rs` — add `Action::InvokeParallel { batch, max_concurrency }` + `struct InvokeSpec`, the `run_loop` handler, and mock-driven tests.
+- `src/core/orchestration/mod.rs` — add `OrchestrationConfig::max_concurrency: Option<u32>` field + `max_concurrency()` accessor (default 4). Consumed by the hierarchical decider in Lot 2; here it is the config surface only.
+- `Cargo.toml` — promote `futures-util` to a direct, non-optional dependency.
+
+---
+
+## Task 1: `AgentFailed` event plumbing (event + reducer + bridge)
+
+**Files:**
+- Modify: `src/core/orchestration/es/event.rs` (add variant + helper)
+- Modify: `src/core/orchestration/es/state.rs:155-174` (add `apply` arm after the `AgentObserved` arm)
+- Modify: `src/core/orchestration/es/bridge.rs:98-111` (add mapping arm) and `src/core/orchestration/es/bridge.rs:190-200` (remove `AgentFailed` from the catch-all if the compiler flags non-exhaustiveness — it will be handled explicitly)
+
+**Interfaces:**
+- Produces:
+  - `ExecutionEvent::AgentFailed { agent: String, error: String }` — a recorded delegation failure.
+  - `pub fn delegation_failed_content(error: &str) -> String` in `event.rs` — returns `format!("[Delegation failed: {error}]")`. The single source of the marker string.
+- Consumes: the existing `ChatMessage { role: String, content: String }` (from `src/providers/traits.rs`), `RunEvent::AgentEnd { agent, tin, tout, cost, content }` (from `src/core/events.rs`).
+
+- [ ] **Step 1: Write the failing reducer test**
+
+Add to the existing `#[cfg(test)] mod tests` in `src/core/orchestration/es/state.rs` (it already uses `ExecutionEvent as E` and builds states via `apply`; match that style):
+
+```rust
+#[test]
+fn agent_failed_pushes_assistant_marker_and_leaves_budget_untouched() {
+    let mut st = ExecutionState::default();
+    apply(&mut st, &E::AgentInvoked {
+        agent: "b".into(),
+        input: "do it".into(),
+    });
+    apply(&mut st, &E::AgentFailed {
+        agent: "b".into(),
+        error: "boom".into(),
+    });
+
+    let convo = st.conversations.get("b").expect("conversation exists");
+    assert_eq!(convo.len(), 2);
+    assert_eq!(convo[0].role, "user");
+    assert_eq!(convo[1].role, "assistant");
+    assert_eq!(convo[1].content, "[Delegation failed: boom]");
+    // AgentFailed must not move budget counters (unlike AgentObserved).
+    assert_eq!(st.budget_tokens_in, 0);
+    assert_eq!(st.budget_tokens_out, 0);
+    assert_eq!(st.budget_cost, 0.0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --no-default-features --features tui agent_failed_pushes_assistant_marker -- --nocapture`
+Expected: FAIL to compile — `no variant named AgentFailed` on `ExecutionEvent`.
+
+- [ ] **Step 3: Add the event variant + marker helper**
+
+In `src/core/orchestration/es/event.rs`, add the variant inside `enum ExecutionEvent` (place it right after the `Completed { content: String }` common variant, before the `// ── Hierarchical ──` section):
+
+```rust
+    /// A delegated invocation failed. Recorded instead of aborting the run
+    /// (collect-and-record): the reducer pushes an `assistant` marker so the
+    /// agent reads as "settled" (a coordinator that awaits this child then
+    /// synthesizes over the partial results), and the run continues.
+    AgentFailed { agent: String, error: String },
+```
+
+Add the shared marker helper at module level in `event.rs` (after the enum):
+
+```rust
+/// The `assistant`-role content recorded for a failed delegation. Single
+/// source of the marker string, consumed by both the reducer (`apply`) and
+/// the `RunEvent` bridge so they never drift. Contains no `@agent:` marker,
+/// so the hierarchical `is_final_answer` reads it as a plain final answer.
+pub fn delegation_failed_content(error: &str) -> String {
+    format!("[Delegation failed: {error}]")
+}
+```
+
+- [ ] **Step 4: Add the `apply` reducer arm**
+
+In `src/core/orchestration/es/state.rs`, add this arm immediately after the `ExecutionEvent::AgentObserved { .. }` arm (ends at line ~174). Import the helper via the existing `use` of the event module (the arm references `super`-level `delegation_failed_content`; use the crate path):
+
+```rust
+        ExecutionEvent::AgentFailed { agent, error } => {
+            // Push an `assistant` marker so `latest_response(agent)` is
+            // `Some` and the child reads as settled — otherwise a hierarchical
+            // coordinator would await a child that never responds
+            // (`awaiting_in_flight`). Budget counters are deliberately left
+            // untouched (no successful call happened).
+            state
+                .conversations
+                .entry(agent.clone())
+                .or_default()
+                .push(ChatMessage {
+                    role: "assistant".to_string(),
+                    content: crate::core::orchestration::es::event::delegation_failed_content(
+                        error,
+                    ),
+                });
+        }
+```
+
+(If `ChatMessage` is not already imported in `state.rs`, it is — the `AgentObserved` arm above already builds `ChatMessage`. Reuse the same import.)
+
+- [ ] **Step 5: Run the reducer test to verify it passes**
+
+Run: `cargo test --no-default-features --features tui agent_failed_pushes_assistant_marker -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 6: Write the failing bridge test**
+
+Add to the `#[cfg(test)] mod tests` in `src/core/orchestration/es/bridge.rs` (it already exercises `map_execution_to_run_events`; match its style — it builds an empty `BTreeMap` for `agent_meta`):
+
+```rust
+#[test]
+fn agent_failed_maps_to_agent_end_with_marker() {
+    let meta: std::collections::BTreeMap<String, (String, String)> = Default::default();
+    let evs = map_execution_to_run_events(
+        &ExecutionEvent::AgentFailed {
+            agent: "b".into(),
+            error: "boom".into(),
+        },
+        &meta,
+    );
+    assert_eq!(evs.len(), 1);
+    match &evs[0] {
+        RunEvent::AgentEnd { agent, tin, tout, cost, content } => {
+            assert_eq!(agent, "b");
+            assert_eq!(*tin, 0);
+            assert_eq!(*tout, 0);
+            assert_eq!(*cost, 0.0);
+            assert_eq!(content, "[Delegation failed: boom]");
+        }
+        other => panic!("expected AgentEnd, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 7: Run the bridge test to verify it fails**
+
+Run: `cargo test --no-default-features --features tui agent_failed_maps_to_agent_end -- --nocapture`
+Expected: FAIL — non-exhaustive `match` / unknown variant, or the mapping returns `[]` if `AgentFailed` fell into the catch-all.
+
+- [ ] **Step 8: Add the bridge mapping arm**
+
+In `src/core/orchestration/es/bridge.rs`, add this arm right after the `ExecutionEvent::AgentObserved { .. }` arm (line ~111):
+
+```rust
+        ExecutionEvent::AgentFailed { agent, error } => vec![RunEvent::AgentEnd {
+            agent: agent.clone(),
+            tin: 0,
+            tout: 0,
+            cost: 0.0,
+            content: crate::core::orchestration::es::event::delegation_failed_content(error),
+        }],
+```
+
+If the compiler reports the terminal catch-all (lines ~190-200, the `Completed | RunStarted | ... => vec![]` group) is now unreachable/exhaustive-conflicting, no change is needed there — `AgentFailed` is matched explicitly above it. If instead the compiler still complains about non-exhaustiveness, ensure `AgentFailed` is not accidentally listed in the catch-all group.
+
+- [ ] **Step 9: Run the bridge test to verify it passes**
+
+Run: `cargo test --no-default-features --features tui agent_failed_maps_to_agent_end -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 10: Run the gate**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui
+cargo test --no-default-features --features tui,storage
+```
+Expected: all green (note: any other `match` over `ExecutionEvent` in the codebase may now need an `AgentFailed` arm — clippy/compiler will point to the exact file:line; add a sensible arm following the neighbours).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/core/orchestration/es/event.rs src/core/orchestration/es/state.rs src/core/orchestration/es/bridge.rs
+git commit -m "feat(oh1): add AgentFailed event with reducer and RunEvent bridge
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `Action::InvokeParallel` + concurrent `run_loop` handler
+
+**Files:**
+- Modify: `Cargo.toml` (promote `futures-util` to a direct dependency)
+- Modify: `src/core/orchestration/es/engine.rs:30-42` (add variant + `InvokeSpec`), `:173-201` (add handler arm), `:291-359` (add tests)
+
+**Interfaces:**
+- Consumes: `ExecutionEvent::AgentFailed { agent, error }` (Task 1); `append_and_apply(log, run_id, state, event)`; the `EffectRunner::run_invoke(&self, agent: &str, input: &str, state: &ExecutionState) -> anyhow::Result<ExecutionEvent>` trait (unchanged).
+- Produces:
+  - `Action::InvokeParallel { batch: Vec<InvokeSpec>, max_concurrency: usize }` on the `Action` enum.
+  - `pub struct InvokeSpec { pub agent: String, pub input: String }`.
+
+- [ ] **Step 1: Promote `futures-util` to a direct dependency**
+
+`futures-util` is already in `Cargo.lock` (transitive via reqwest/tokio), so this pulls nothing new. Add to `Cargo.toml` under `[dependencies]` (keep it non-optional so the ES engine compiles in every feature mode):
+
+```toml
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+```
+
+Run `cargo build --no-default-features --features tui` to confirm it resolves.
+Expected: builds; `Cargo.lock` unchanged except the dependency graph edge.
+
+- [ ] **Step 2: Write the failing determinism test**
+
+Add to `#[cfg(test)] mod tests` in `src/core/orchestration/es/engine.rs`. This mock decider emits one `InvokeParallel([a, b, c])` before any observation, then `Complete`. The mock runner sleeps **longer for earlier `Vec` positions** so completion order (c, b, a) is the reverse of `Vec` order (a, b, c); it also records completion order into a shared `Vec`. The test asserts the **recorded log** keeps `Vec` order regardless.
+
+```rust
+    use std::sync::{Arc, Mutex};
+
+    struct ParDecider {
+        batch: Vec<InvokeSpec>,
+        cap: usize,
+    }
+    impl Decider for ParDecider {
+        fn decide(&self, s: &ExecutionState) -> Vec<Action> {
+            // Once any agent has an assistant turn, the batch has run: complete.
+            let ran = s
+                .conversations
+                .values()
+                .any(|c| c.iter().any(|m| m.role == "assistant"));
+            if ran {
+                vec![Action::Complete { content: "done".into() }]
+            } else {
+                vec![Action::InvokeParallel {
+                    batch: self.batch.clone(),
+                    max_concurrency: self.cap,
+                }]
+            }
+        }
+    }
+
+    // Runner: sleeps longer for lower-index agents so completions arrive in
+    // reverse Vec order; records the completion order it actually observed.
+    struct OrderedEff {
+        order: Vec<String>,               // Vec order a,b,c → delays 30,20,10ms
+        completions: Arc<Mutex<Vec<String>>>,
+    }
+    #[async_trait]
+    impl EffectRunner for OrderedEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            let idx = self.order.iter().position(|a| a == agent).unwrap_or(0);
+            let delay_ms = 30u64.saturating_sub(idx as u64 * 10);
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            self.completions.lock().unwrap().push(agent.to_string());
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: format!("resp-{agent}"),
+                tokens_in: 1,
+                tokens_out: 1,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_parallel_records_in_vec_order_not_completion_order() {
+        let batch = vec![
+            InvokeSpec { agent: "a".into(), input: "x".into() },
+            InvokeSpec { agent: "b".into(), input: "x".into() },
+            InvokeSpec { agent: "c".into(), input: "x".into() },
+        ];
+        let completions = Arc::new(Mutex::new(Vec::new()));
+        let decider = ParDecider { batch: batch.clone(), cap: 4 };
+        let eff = OrderedEff {
+            order: vec!["a".into(), "b".into(), "c".into()],
+            completions: completions.clone(),
+        };
+        let mut log = InMemoryLog::default();
+        let init = vec![E::RunStarted {
+            run_id: "r".into(),
+            pattern: "test".into(),
+            agents: vec!["a".into(), "b".into(), "c".into()],
+            input: "go".into(),
+            project: None,
+        }];
+        run_event_sourced("r", init, &decider, &eff, &mut log)
+            .await
+            .unwrap();
+
+        let events = log.events("r").unwrap();
+        // Recorded observation order == Vec order a,b,c.
+        let observed: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                E::AgentObserved { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(observed, vec!["a", "b", "c"]);
+        // Recorded invocation order == Vec order a,b,c too.
+        let invoked: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                E::AgentInvoked { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(invoked, vec!["a", "b", "c"]);
+        // Sanity: completions actually arrived in a different (reverse) order,
+        // proving the ordering above is not incidental.
+        let comp = completions.lock().unwrap().clone();
+        assert_eq!(comp, vec!["c", "b", "a"]);
+    }
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo test --no-default-features --features tui invoke_parallel_records_in_vec_order -- --nocapture`
+Expected: FAIL to compile — `no variant named InvokeParallel` / `cannot find type InvokeSpec`.
+
+- [ ] **Step 4: Add the `Action` variant + `InvokeSpec`**
+
+In `src/core/orchestration/es/engine.rs`, extend the `Action` enum (currently ends with `Complete { content: String }` around line 41) and add `InvokeSpec` just after it:
+
+```rust
+    /// Invoke several agents concurrently. The loop records one
+    /// `AgentInvoked` per `batch` entry in `Vec` order, runs the effects
+    /// concurrently (at most `max_concurrency` in flight), then records each
+    /// outcome back in `Vec` order — independent of completion order, so
+    /// replay/resume stay deterministic. A per-entry failure is recorded as
+    /// `AgentFailed` and the run continues (collect-and-record).
+    InvokeParallel {
+        batch: Vec<InvokeSpec>,
+        max_concurrency: usize,
+    },
+```
+
+```rust
+/// One unit of work inside an [`Action::InvokeParallel`] batch. Named
+/// distinctly from the `Action::Invoke` variant to avoid confusion.
+#[derive(Debug, Clone)]
+pub struct InvokeSpec {
+    pub agent: String,
+    pub input: String,
+}
+```
+
+- [ ] **Step 5: Add the `run_loop` handler arm**
+
+Add `use futures_util::StreamExt;` to the imports at the top of `engine.rs`. Then add this arm to the `match action` block in `run_loop` (after the `Action::Invoke { .. }` arm, before `Action::Emit`):
+
+```rust
+                Action::InvokeParallel { batch, max_concurrency } => {
+                    // 1. Record every invocation up-front, in Vec order
+                    //    (deterministic). Emitting all AgentInvoked before any
+                    //    outcome also makes every agent read as "working" at
+                    //    once in the Workroom.
+                    for spec in &batch {
+                        append_and_apply(
+                            log,
+                            run_id,
+                            state,
+                            ExecutionEvent::AgentInvoked {
+                                agent: spec.agent.clone(),
+                                input: spec.input.clone(),
+                            },
+                        )?;
+                    }
+
+                    // 2. Run effects concurrently over a shared, immutable
+                    //    snapshot of the now-updated state. `buffer_unordered`
+                    //    polls the borrowing futures in place (no spawn, no
+                    //    'static bound). Nothing is appended during this phase,
+                    //    so only shared borrows of `state`/`effects` are live.
+                    let snapshot: &ExecutionState = state;
+                    let cap = max_concurrency.max(1);
+                    let mut outcomes: Vec<(usize, anyhow::Result<ExecutionEvent>)> =
+                        futures_util::stream::iter(batch.iter().enumerate())
+                            .map(|(i, spec)| async move {
+                                (i, effects.run_invoke(&spec.agent, &spec.input, snapshot).await)
+                            })
+                            .buffer_unordered(cap)
+                            .collect()
+                            .await;
+
+                    // 3. Restore Vec order (buffer_unordered yields in
+                    //    completion order), then append outcomes in Vec order.
+                    //    A failure becomes AgentFailed; the run continues.
+                    outcomes.sort_by_key(|(i, _)| *i);
+                    for (i, res) in outcomes {
+                        let event = match res {
+                            Ok(ev) => ev,
+                            Err(e) => ExecutionEvent::AgentFailed {
+                                agent: batch[i].agent.clone(),
+                                error: e.to_string(),
+                            },
+                        };
+                        append_and_apply(log, run_id, state, event)?;
+                    }
+                }
+```
+
+- [ ] **Step 6: Run the determinism test to verify it passes**
+
+Run: `cargo test --no-default-features --features tui invoke_parallel_records_in_vec_order -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing cap test**
+
+Add to the same test module. Mock runner tracks live concurrency with atomics and records the max observed; a batch of 6 with `max_concurrency: 2` must never exceed 2 in flight.
+
+```rust
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CapEff {
+        live: AtomicUsize,
+        max_seen: AtomicUsize,
+    }
+    #[async_trait]
+    impl EffectRunner for CapEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            let now = self.live.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_seen.fetch_max(now, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            self.live.fetch_sub(1, Ordering::SeqCst);
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: "r".into(),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_parallel_respects_concurrency_cap() {
+        let batch: Vec<InvokeSpec> = (0..6)
+            .map(|i| InvokeSpec { agent: format!("a{i}"), input: "x".into() })
+            .collect();
+        let decider = ParDecider { batch: batch.clone(), cap: 2 };
+        let eff = CapEff {
+            live: AtomicUsize::new(0),
+            max_seen: AtomicUsize::new(0),
+        };
+        let mut log = InMemoryLog::default();
+        let init = vec![E::RunStarted {
+            run_id: "r".into(),
+            pattern: "test".into(),
+            agents: batch.iter().map(|s| s.agent.clone()).collect(),
+            input: "go".into(),
+            project: None,
+        }];
+        run_event_sourced("r", init, &decider, &eff, &mut log)
+            .await
+            .unwrap();
+        assert!(
+            eff.max_seen.load(Ordering::SeqCst) <= 2,
+            "observed {} concurrent invocations, cap was 2",
+            eff.max_seen.load(Ordering::SeqCst)
+        );
+    }
+```
+
+- [ ] **Step 8: Run the cap test**
+
+Run: `cargo test --no-default-features --features tui invoke_parallel_respects_concurrency_cap -- --nocapture`
+Expected: PASS (the handler already caps via `buffer_unordered(cap)` — this test locks the behavior in).
+
+- [ ] **Step 9: Write the failing partial-failure test**
+
+The runner `Err`s for agent `b`; assert the log records `AgentObserved a`, `AgentFailed b`, `AgentObserved c` in Vec order, the run still completes, and `b`'s conversation ends with the assistant marker.
+
+```rust
+    struct FailBEff;
+    #[async_trait]
+    impl EffectRunner for FailBEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            if agent == "b" {
+                anyhow::bail!("boom");
+            }
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: format!("resp-{agent}"),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_parallel_records_failure_and_continues() {
+        let batch = vec![
+            InvokeSpec { agent: "a".into(), input: "x".into() },
+            InvokeSpec { agent: "b".into(), input: "x".into() },
+            InvokeSpec { agent: "c".into(), input: "x".into() },
+        ];
+        let decider = ParDecider { batch: batch.clone(), cap: 4 };
+        let mut log = InMemoryLog::default();
+        let init = vec![E::RunStarted {
+            run_id: "r".into(),
+            pattern: "test".into(),
+            agents: vec!["a".into(), "b".into(), "c".into()],
+            input: "go".into(),
+            project: None,
+        }];
+        let state = run_event_sourced("r", init, &decider, &FailBEff, &mut log)
+            .await
+            .unwrap();
+
+        // Run still completed (failure did not abort the loop).
+        assert_eq!(state.status, RunStatus::Completed);
+
+        // Outcomes recorded in Vec order: observed a, failed b, observed c.
+        let events = log.events("r").unwrap();
+        let outcome_kinds: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                E::AgentObserved { agent, .. } => Some(agent.as_str()),
+                E::AgentFailed { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(outcome_kinds, vec!["a", "b", "c"]);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, E::AgentFailed { agent, .. } if agent == "b")));
+
+        // b reads as settled: last turn is the assistant failure marker.
+        let convo_b = state.conversations.get("b").unwrap();
+        assert_eq!(convo_b.last().unwrap().role, "assistant");
+        assert_eq!(convo_b.last().unwrap().content, "[Delegation failed: boom]");
+    }
+```
+
+- [ ] **Step 10: Run the partial-failure test**
+
+Run: `cargo test --no-default-features --features tui invoke_parallel_records_failure_and_continues -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 11: Run the gate**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui
+cargo test --no-default-features --features tui,storage
+```
+Expected: all green. If clippy flags the `match action` in `run_loop` or any other `Action` match as non-exhaustive, add the `InvokeParallel` arm where indicated.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/core/orchestration/es/engine.rs
+git commit -m "feat(oh1): add Action::InvokeParallel with bounded concurrent run_loop
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `OrchestrationConfig::max_concurrency` config surface
+
+**Files:**
+- Modify: `src/core/orchestration/mod.rs:154-215` (add field to the struct + accessor in the `impl OrchestrationConfig` block)
+
+**Interfaces:**
+- Produces: `OrchestrationConfig::max_concurrency: Option<u32>` field + `pub fn max_concurrency(&self) -> usize` (default 4). Consumed by the hierarchical decider in Lot 2.
+
+- [ ] **Step 1: Write the failing accessor test**
+
+Add to the test module in `src/core/orchestration/mod.rs` (if none exists, create `#[cfg(test)] mod tests { use super::*; ... }` at the end of the file):
+
+```rust
+    #[test]
+    fn max_concurrency_defaults_to_four() {
+        let cfg = OrchestrationConfig::default();
+        assert_eq!(cfg.max_concurrency(), 4);
+    }
+
+    #[test]
+    fn max_concurrency_honors_override() {
+        let cfg = OrchestrationConfig {
+            max_concurrency: Some(8),
+            ..OrchestrationConfig::default()
+        };
+        assert_eq!(cfg.max_concurrency(), 8);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --no-default-features --features tui max_concurrency -- --nocapture`
+Expected: FAIL to compile — `no field max_concurrency` / `no method named max_concurrency`.
+
+- [ ] **Step 3: Add the field**
+
+In `src/core/orchestration/mod.rs`, add to `struct OrchestrationConfig` in the `// ── Shared limits (all patterns) ──` block (next to `max_iterations`), with a serde default so existing `armadai.yaml` files without the key keep working:
+
+```rust
+    /// Max number of delegations executed concurrently within a single
+    /// parallel fan-out batch (default: 4). Consumed by patterns that opt into
+    /// `Action::InvokeParallel` (hierarchical, Lot 2).
+    #[serde(default)]
+    pub max_concurrency: Option<u32>,
+```
+
+- [ ] **Step 4: Add the accessor**
+
+In the `impl OrchestrationConfig` block (next to `max_iterations()`), add:
+
+```rust
+    pub fn max_concurrency(&self) -> usize {
+        self.max_concurrency.unwrap_or(4) as usize
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test --no-default-features --features tui max_concurrency -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 6: Run the gate**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --no-default-features --features tui -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
+cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+cargo test --no-default-features --features tui
+cargo test --no-default-features --features tui,storage
+```
+Expected: all green. If adding the field breaks any struct-literal construction of `OrchestrationConfig` elsewhere (the compiler will name the file:line), add `max_concurrency: None,` there or switch that literal to `..Default::default()`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/orchestration/mod.rs
+git commit -m "feat(oh1): add OrchestrationConfig.max_concurrency (default 4)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- `Action::InvokeParallel { batch, max_concurrency }` + `InvokeSpec` → Task 2. ✅
+- Deterministic recorded order (AgentInvoked×N then outcomes, Vec order) → Task 2 handler + determinism test. ✅
+- `buffer_unordered(max_concurrency)` bounded concurrency → Task 2 handler + cap test. ✅
+- `ExecutionEvent::AgentFailed { agent, error }` (event + reducer + bridge) → Task 1. ✅
+- Reducer pushes assistant marker so child reads as settled → Task 1 reducer test. ✅
+- Budget untouched on failure → Task 1 reducer test. ✅
+- Bridge → `RunEvent::AgentEnd` → Task 1 bridge test. ✅
+- Collect-and-record (run continues) → Task 2 partial-failure test. ✅
+- `OrchestrationConfig::max_concurrency` field + accessor default 4 → Task 3. ✅
+- Engine signatures unchanged (cap on the action) → guaranteed by Task 2's variant shape (no signature edits). ✅
+- `futures-util` non-optional direct dep → Task 2 Step 1. ✅
+- Ring/direct/blackboard untouched → no task modifies them (they never emit `InvokeParallel`). ✅
+- Out of scope (blackboard parallelism, #279 rich failure render, #270 timeout, hierarchical opt-in) → not in this lot (Lot 2 / separate features). ✅
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases" — every code step carries complete code. ✅
+
+**3. Type consistency:**
+- `InvokeSpec { agent: String, input: String }` — used identically in Task 2 variant, tests, and handler. ✅
+- `ExecutionEvent::AgentFailed { agent: String, error: String }` — same shape in Task 1 (event/apply/bridge) and Task 2 (handler/tests). ✅
+- `delegation_failed_content(error: &str) -> String` — defined in Task 1, consumed by apply + bridge; the literal `"[Delegation failed: boom]"` in every test matches `format!("[Delegation failed: {error}]")`. ✅
+- `RunEvent::AgentEnd { agent, tin, tout, cost, content }` — field names match `src/core/events.rs:22-28`. ✅
+- `ChatMessage { role, content }` — matches `src/providers/traits.rs:18`. ✅
+- `max_concurrency()` accessor name consistent across Task 3 and the Lot 2 consumer note. ✅

--- a/docs/superpowers/specs/2026-07-27-oh1-parallelism-design.md
+++ b/docs/superpowers/specs/2026-07-27-oh1-parallelism-design.md
@@ -61,9 +61,12 @@ pub enum Action {
     Invoke { agent: String, input: String },
     /// Invoke several agents concurrently. The loop records one
     /// `AgentInvoked` per entry in Vec order, runs the effects concurrently
-    /// (bounded), then records each outcome in Vec order — independent of
-    /// completion order, so replay/resume stay deterministic.
-    InvokeParallel(Vec<InvokeSpec>),
+    /// (bounded by `max_concurrency`), then records each outcome in Vec order
+    /// — independent of completion order, so replay/resume stay deterministic.
+    InvokeParallel {
+        batch: Vec<InvokeSpec>,
+        max_concurrency: usize,
+    },
     Emit(ExecutionEvent),
     Halt { reason: String },
     Complete { content: String },
@@ -110,11 +113,14 @@ exactement `[AgentInvoked×N (ordre Vec)]` puis `[outcome×N (ordre Vec)]`,
 totalement indépendants de l'ordre de complétion → `replay` (fold pur) et
 `resume` restent déterministes.
 
-**Le cap `max_concurrency`** est passé en paramètre à `run_event_sourced`
-(dérivé de `OrchestrationConfig` au point d'appel, défaut 4). Choix : paramètre
-explicite du moteur plutôt que relecture de `state.config_json` dans la boucle —
-garde le moteur générique découplé du schéma de config. `Action::Invoke`
-(séquentiel) ignore le cap.
+**Le cap `max_concurrency` est porté par l'action `InvokeParallel` elle-même**
+(pas par la signature du moteur). Choix : le moteur générique
+(`run_event_sourced`/`resume_event_sourced`) garde sa signature **inchangée** →
+aucun des 8 points d'entrée (direct/blackboard/ring/hierarchical × run+resume)
+n'est touché en Lot 1, et un pattern qui n'opte pas ignore totalement le cap.
+Le décideur qui émet `InvokeParallel` fixe le cap (le hiérarchique lira
+`config.max_concurrency()` en Lot 2, défaut 4). `Action::Invoke` (séquentiel)
+n'a pas de cap.
 
 ### 3. Nouvel event `ExecutionEvent::AgentFailed { agent, error }`
 
@@ -180,34 +186,36 @@ successifs). Aucun changement Workroom dans ce périmètre.
 
 ## Impact par surface
 
-- **`es/engine.rs`** : `Action::InvokeParallel` + struct `Invoke` ; handler dans
-  `run_loop` ; param `max_concurrency` sur `run_event_sourced` (et le chemin
-  `resume`). Dép. `futures` (`buffer_unordered`) — déjà transitive, à confirmer
-  en dépendance directe.
+- **`es/engine.rs`** : `Action::InvokeParallel { batch, max_concurrency }` +
+  struct `InvokeSpec` ; handler dans `run_loop`. Signatures
+  `run_event_sourced`/`resume_event_sourced`/`run_loop` **inchangées** (cap
+  porté par l'action). Dép. `futures-util` (`buffer_unordered`) — déjà dans le
+  graphe (transitif via reqwest/tokio), à promouvoir en dépendance directe.
 - **`es/event.rs`** : variante `AgentFailed { agent, error }`.
 - **`es/state.rs`** : bras `apply(AgentFailed)` (push `assistant` + marqueur).
 - **`es/bridge.rs`** : bras `AgentFailed` → `RunEvent::AgentEnd`.
 - **`es/hierarchical.rs`** (Lot 2) : `dispatch_actions` émet `InvokeParallel`.
 - **`core/orchestration/mod.rs`** : champ `max_concurrency: Option<u32>` sur
   `OrchestrationConfig` (défaut 4), suivant le motif des autres limites partagées.
-- **Points d'appel** (`cli/run.rs`) : dériver `max_concurrency` de la config et le
-  passer à `run_event_sourced`/resume.
+- **Décideur hiérarchique** (Lot 2) : lit `config.max_concurrency()` et le place
+  dans l'action `InvokeParallel`. Aucun changement des points d'appel `cli/run.rs`.
 - **Ring / direct / blackboard** : **inchangés** (n'émettent pas `InvokeParallel`).
 - **`--resume`/`--replay`** : inchangés fonctionnellement (fold pur sur ordre
   enregistré stable).
 
 ## Découpage en sous-lots (une PR chacun + revue indé + validation Dimitri)
 
-- **Lot 1 — Socle** : `Action::InvokeParallel` + struct `Invoke` ;
-  `ExecutionEvent::AgentFailed` (event + `apply` + bridge) ; handler `run_loop`
-  (`buffer_unordered`, ordre Vec déterministe, collect-and-record) ; param
-  `max_concurrency` + champ `OrchestrationConfig` (défaut 4). Tests **sur mock
-  `EffectRunner`** (aucun pattern ne l'émet encore) : déterminisme d'ordre, cap
-  respecté, échec partiel enregistré + run continue.
-- **Lot 2 — Opt-in hiérarchique** : `dispatch_actions` émet `InvokeParallel` ;
-  câblage `max_concurrency` au point d'appel `run` ; test d'intégration
-  hiérarchique (fan-out concurrent, ordre enregistré déterministe, un enfant en
-  échec → synthèse sur partiel).
+- **Lot 1 — Socle** : `Action::InvokeParallel { batch, max_concurrency }` +
+  struct `InvokeSpec` ; `ExecutionEvent::AgentFailed` (event + `apply` + bridge) ;
+  handler `run_loop` (`buffer_unordered`, ordre Vec déterministe,
+  collect-and-record) ; champ `OrchestrationConfig::max_concurrency` +
+  accesseur `max_concurrency()` (défaut 4). Tests **sur mock `EffectRunner`**
+  (aucun pattern ne l'émet encore) : déterminisme d'ordre, cap respecté, échec
+  partiel enregistré + run continue.
+- **Lot 2 — Opt-in hiérarchique** : `dispatch_actions` émet `InvokeParallel` (cap
+  = `config.max_concurrency()`) ; test d'intégration hiérarchique (fan-out
+  concurrent, ordre enregistré déterministe, un enfant en échec → synthèse sur
+  partiel).
 
 ## Hors périmètre
 

--- a/docs/superpowers/specs/2026-07-27-oh1-parallelism-design.md
+++ b/docs/superpowers/specs/2026-07-27-oh1-parallelism-design.md
@@ -1,0 +1,276 @@
+# OH1 parallélisme — Design (#250)
+
+## Contexte
+
+Le moteur d'orchestration event-sourcé exécute les délégations **une par une**.
+Le cœur générique `run_event_sourced` (`src/core/orchestration/es/engine.rs`)
+tourne ainsi : `decider.decide(&state) -> Vec<Action>`, puis pour **chaque**
+`Action` dans l'ordre, `Action::Invoke { agent, input }` déclenche
+`append_and_apply(AgentInvoked)` → `effects.run_invoke(...).await` (**séquentiel,
+bloquant**) → `append_and_apply(AgentObserved)`. Le hiérarchique
+(`es/hierarchical.rs::dispatch_actions`) produit un fan-out sous forme de batch
+`[Emit(Delegated A), Invoke A, Emit(Delegated B), Invoke B, …]` via
+`plan_from_response`.flat_map(`invoke_actions`) — mais le run_loop les exécute en
+série.
+
+**Motivation concrète (constatée cette session)** : chaque tour `claude -p` d'un
+spécialiste est une **session agentique complète (~500 s)**. En hiérarchique, un
+coordinateur qui délègue à N spécialistes indépendants les exécute en série →
+un run réel prend **N × ~500 s**. Le parallélisme rend les délégations
+indépendantes concurrentes → temps mur ≈ le plus lent d'un lot, pas la somme.
+
+**Contrainte cardinale** : le log event-sourcé (`execution_events`, `seq`
+déterministe) doit rester **rejouable/reprenable** (`--resume`/`--replay`,
+livrés OH1 Lot 6). `replay` est un fold pur sur l'ordre **enregistré** ;
+`resume_event_sourced` réamorce depuis ce fold. Donc l'ordre **enregistré** des
+events doit être **stable et indépendant de l'ordre de complétion**, sinon deux
+replays du même run divergent.
+
+Item milestone : **#250** (P0, `epic:core`, `epic-a` maturité du cœur).
+
+## Objectif
+
+Rendre l'exécution de délégations **indépendantes** concurrente **au niveau du
+socle** (moteur générique), avec :
+- un **ordre enregistré déterministe** (= ordre du `Vec` fourni par le décideur,
+  **jamais** l'ordre de complétion) ;
+- une **concurrence bornée** (cap par défaut, override config) ;
+- une **résilience** : l'échec d'une délégation n'avorte pas le run (collect-and-record).
+
+Chaque pattern **opte** pour le parallélisme en émettant la nouvelle action ; les
+patterns séquentiels par nature (ring) et mono-agent (direct) restent inchangés.
+
+## Décisions validées (Dimitri, 2026-07-27)
+
+1. **Généralisation au socle** : nouvelle action `Action::InvokeParallel` dans le
+   moteur générique. Tous les patterns y **optent** ; aucun n'est parallélisé de
+   force. Lot 1 livre le socle + tests sur mock ; Lot 2 fait opter le hiérarchique.
+2. **Concurrence bornée + override** : cap par défaut **4**, surchargé par
+   `orchestration.max_concurrency` (`armadai.yaml`). `buffer_unordered(cap)`.
+3. **Échec = collect-and-record** : un `run_invoke` qui échoue devient un
+   **nouvel event `ExecutionEvent::AgentFailed { agent, error }`** (pas une
+   propagation d'`Err` qui avorte le run). Le run continue ; le coordinateur
+   synthétise les résultats partiels.
+
+## Architecture
+
+### 1. Nouvelle action `Action::InvokeParallel` (`es/engine.rs`)
+
+```rust
+pub enum Action {
+    Invoke { agent: String, input: String },
+    /// Invoke several agents concurrently. The loop records one
+    /// `AgentInvoked` per entry in Vec order, runs the effects concurrently
+    /// (bounded), then records each outcome in Vec order — independent of
+    /// completion order, so replay/resume stay deterministic.
+    InvokeParallel(Vec<InvokeSpec>),
+    Emit(ExecutionEvent),
+    Halt { reason: String },
+    Complete { content: String },
+}
+
+/// One unit of work inside an `InvokeParallel` batch. Named distinctly from
+/// the `Action::Invoke` variant to avoid confusion.
+pub struct InvokeSpec { pub agent: String, pub input: String }
+```
+
+`Action::Invoke` **reste inchangée** (chemin séquentiel : ring, et tout décideur
+qui n'opte pas). C'est le seul ajout à l'enum — pas de changement du trait
+`Decider` ni du trait `EffectRunner` (signature `run_invoke` conservée).
+
+### 2. Handler `InvokeParallel` dans `run_loop`
+
+Ordre déterministe garanti par une **séparation stricte record ↔ exécution** :
+
+1. **Append séquentiel des `AgentInvoked`** dans l'ordre du `Vec` (déterministe) :
+   pour chaque `InvokeSpec { agent, input }`, `append_and_apply(AgentInvoked { agent, input })`.
+   *(Émettre tous les `AgentInvoked` d'abord = tous les agents apparaissent
+   « working » en même temps dans la Workroom — voir §6.)*
+2. **Exécution concurrente bornée** : snapshot de l'état courant (`&state`
+   immuable, cohérent avec la signature `run_invoke(&self, agent, input, &state)`),
+   puis
+   ```rust
+   let outcomes: Vec<anyhow::Result<ExecutionEvent>> =
+       futures::stream::iter(batch.iter().enumerate())
+           .map(|(i, inv)| async move {
+               (i, effects.run_invoke(&inv.agent, &inv.input, &state).await)
+           })
+           .buffer_unordered(max_concurrency)
+           .collect::<Vec<_>>().await;
+   ```
+   On collecte en conservant l'**indice** pour rétablir l'ordre du `Vec`
+   (`buffer_unordered` rend les résultats dans l'ordre de complétion).
+3. **Append des outcomes dans l'ordre du `Vec`** (tri par indice) : pour chaque
+   entrée, `Ok(event)` → `append_and_apply(event)` (typiquement `AgentObserved`) ;
+   `Err(e)` → `append_and_apply(AgentFailed { agent, error: e.to_string() })`.
+   **Le run continue** (collect-and-record).
+
+**Invariant de déterminisme** : les events appendés pour un batch sont
+exactement `[AgentInvoked×N (ordre Vec)]` puis `[outcome×N (ordre Vec)]`,
+totalement indépendants de l'ordre de complétion → `replay` (fold pur) et
+`resume` restent déterministes.
+
+**Le cap `max_concurrency`** est passé en paramètre à `run_event_sourced`
+(dérivé de `OrchestrationConfig` au point d'appel, défaut 4). Choix : paramètre
+explicite du moteur plutôt que relecture de `state.config_json` dans la boucle —
+garde le moteur générique découplé du schéma de config. `Action::Invoke`
+(séquentiel) ignore le cap.
+
+### 3. Nouvel event `ExecutionEvent::AgentFailed { agent, error }`
+
+```rust
+/// A delegated invocation failed. Recorded instead of aborting the run
+/// (collect-and-record): the coordinator synthesizes partial results.
+AgentFailed { agent: String, error: String },
+```
+
+**Réducteur (`apply`, `es/state.rs`) — décision structurelle critique** :
+`apply(AgentFailed)` **doit pousser un message `assistant`** dans
+`state.conversations[agent]`, avec un contenu marqueur, p.ex.
+`"[Delegation failed: <error>]"`. Raison : le décideur hiérarchique détecte
+qu'un enfant est « en vol / non réglé » via `latest_response(to).is_none()`
+(`awaiting_in_flight`, `es/hierarchical.rs:358`) et `is_settled` via
+`latest_response(...).is_some_and(is_final_answer)`. Si `AgentFailed` ne
+poussait rien, `latest_response(enfant échoué)` resterait `None` → le
+coordinateur **attendrait indéfiniment** un enfant qui ne répondra jamais
+(run bloqué jusqu'au turn-cap). En poussant le marqueur, l'enfant devient
+« réglé » et la synthèse démarre sur les résultats partiels.
+
+- Le marqueur `[Delegation failed: …]` **ne contient aucun marqueur `@agent:`**
+  → `is_final_answer` (`es/hierarchical.rs:198`) le lit comme une réponse finale
+  ordinaire (pas une nouvelle délégation). À vérifier au test.
+- `AgentFailed` **n'incrémente pas** le budget (tokens/coût) — contrairement à
+  `AgentObserved`.
+
+**Pont `RunEvent` (`es/bridge.rs`)** : `AgentFailed { agent, error }` →
+`RunEvent::AgentEnd { agent, tin: 0, tout: 0, cost: 0.0, content: "[Delegation failed: <error>]" }`
+(clôt la tuile « working » de l'agent dans la Workroom). *(Le rendu enrichi des
+échecs — badge, couleur — est laissé au rapport de run #279 ; ici on ferme
+proprement la tuile.)* La fonction de contenu final du bridge (fallback sur le
+dernier `AgentObserved`, `bridge.rs:288`) reste inchangée ; un `AgentFailed`
+n'est pas un `Completed`.
+
+### 4. Projections / `--replay`
+
+`replay` folde le log via `apply`. Comme `AgentFailed` est un event enregistré à
+part entière avec une règle `apply` déterministe, aucun traitement spécial :
+`--replay` reconstruit `conversations` (avec le marqueur d'échec) et le bridge
+régénère les `RunEvent` à l'identique. Le contenu final synthétisé par le
+coordinateur inclut donc déjà les résultats partiels.
+
+### 5. Opt-in hiérarchique (Lot 2, `es/hierarchical.rs::dispatch_actions`)
+
+Le fan-out actuel `[Emit(Delegated A), Invoke A, Emit(Delegated B), Invoke B, …]`
+devient `[Emit(Delegated A), Emit(Delegated B), …, InvokeParallel([A, B, …])]` :
+les `Emit(Delegated)` (purs, bookkeeping du `hier.trace`) restent séquentiels et
+**précèdent** l'`InvokeParallel` unique portant les N invocations. Aucun autre
+changement du décideur : `awaiting_in_flight`/`is_settled`/`synthesis_count`
+raisonnent sur `conversations`, alimentées identiquement par le run_loop.
+La délégation en profondeur (un enfant qui délègue à son tour) reste un batch
+séparé au tour suivant — la concurrence est **intra-lot**, la profondeur reste
+sérialisée par les tours du décideur (correct : un enfant ne peut déléguer
+qu'après avoir été invoqué).
+
+### 6. Workroom
+
+Déjà compatible : le run_loop émet tous les `AgentInvoked` (→ `RunEvent::AgentStart`)
+**avant** les observations → plusieurs agents « working » simultanément.
+Les `AgentObserved`/`AgentFailed` arrivent dans l'ordre du `Vec` (→ `AgentEnd`
+successifs). Aucun changement Workroom dans ce périmètre.
+
+## Impact par surface
+
+- **`es/engine.rs`** : `Action::InvokeParallel` + struct `Invoke` ; handler dans
+  `run_loop` ; param `max_concurrency` sur `run_event_sourced` (et le chemin
+  `resume`). Dép. `futures` (`buffer_unordered`) — déjà transitive, à confirmer
+  en dépendance directe.
+- **`es/event.rs`** : variante `AgentFailed { agent, error }`.
+- **`es/state.rs`** : bras `apply(AgentFailed)` (push `assistant` + marqueur).
+- **`es/bridge.rs`** : bras `AgentFailed` → `RunEvent::AgentEnd`.
+- **`es/hierarchical.rs`** (Lot 2) : `dispatch_actions` émet `InvokeParallel`.
+- **`core/orchestration/mod.rs`** : champ `max_concurrency: Option<u32>` sur
+  `OrchestrationConfig` (défaut 4), suivant le motif des autres limites partagées.
+- **Points d'appel** (`cli/run.rs`) : dériver `max_concurrency` de la config et le
+  passer à `run_event_sourced`/resume.
+- **Ring / direct / blackboard** : **inchangés** (n'émettent pas `InvokeParallel`).
+- **`--resume`/`--replay`** : inchangés fonctionnellement (fold pur sur ordre
+  enregistré stable).
+
+## Découpage en sous-lots (une PR chacun + revue indé + validation Dimitri)
+
+- **Lot 1 — Socle** : `Action::InvokeParallel` + struct `Invoke` ;
+  `ExecutionEvent::AgentFailed` (event + `apply` + bridge) ; handler `run_loop`
+  (`buffer_unordered`, ordre Vec déterministe, collect-and-record) ; param
+  `max_concurrency` + champ `OrchestrationConfig` (défaut 4). Tests **sur mock
+  `EffectRunner`** (aucun pattern ne l'émet encore) : déterminisme d'ordre, cap
+  respecté, échec partiel enregistré + run continue.
+- **Lot 2 — Opt-in hiérarchique** : `dispatch_actions` émet `InvokeParallel` ;
+  câblage `max_concurrency` au point d'appel `run` ; test d'intégration
+  hiérarchique (fan-out concurrent, ordre enregistré déterministe, un enfant en
+  échec → synthèse sur partiel).
+
+## Hors périmètre
+
+- **Parallélisme blackboard** (agents concurrents intra-round) : opt-in
+  ultérieur possible (même socle), non traité ici.
+- **Rapport de run consolidé (#279)** : rendu enrichi des échecs (badge/couleur
+  Workroom + vue TUI/Web). Ici, `AgentFailed` ferme juste la tuile.
+- **Timeout par délégation (#270)** : orthogonal (reset de budget-temps
+  par tour). Non traité.
+- **Coordination inter-process** du cap : le cap est intra-run/process.
+
+## Tests
+
+**Lot 1 (mock `EffectRunner`)** :
+- **Déterminisme d'ordre** : un décideur mock émet `InvokeParallel([A, B, C])`
+  avec un runner dont les complétions arrivent dans le désordre (p.ex. C, A, B) ;
+  le log enregistré est exactement `AgentInvoked A/B/C` puis `AgentObserved A/B/C`
+  (ordre Vec), **indépendant** de l'ordre de complétion. Deux exécutions →
+  logs identiques ; `replay` du log → état identique.
+- **Cap respecté** : runner instrumenté comptant la concurrence courante (max
+  observé) ; `InvokeParallel` de 6 avec `max_concurrency=2` → jamais >2 en vol.
+- **Échec partiel (collect-and-record)** : runner qui `Err` sur B ; le log
+  contient `AgentObserved A`, `AgentFailed B`, `AgentObserved C` (ordre Vec) ;
+  le run **continue** (pas d'`Err` propagée, statut non avorté) ; `apply` a
+  poussé un message `assistant` marqueur pour B.
+- **Bridge** : `AgentFailed` → un `RunEvent::AgentEnd` avec le contenu marqueur.
+- **`is_final_answer`** : le marqueur `[Delegation failed: …]` est traité comme
+  réponse finale (pas comme délégation).
+- **Non-régression** : `Action::Invoke` séquentielle inchangée ; direct/ring
+  compilent et passent.
+
+**Lot 2 (intégration hiérarchique, style e2e déterministe existant)** :
+- Fan-out coordinateur→3 spécialistes via `InvokeParallel` ; ordre enregistré
+  déterministe ; un spécialiste en échec → le coordinateur synthétise sur les 2
+  réussis ; run complété (non bloqué).
+
+## Gate (par lot)
+
+`cargo fmt --all` + clippy **3 modes** (`tui` / `tui,providers-api` /
+`tui,web,storage`) `-D warnings` + `cargo test --no-default-features --features tui`
++ `cargo test --no-default-features --features tui,storage` (couvre la cible e2e).
+`rust-analyzer` non fiable (diagnostics ABI/stale) → **vérifier au compilateur**.
+Conventional Commits, trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## Risques
+
+- **`apply(AgentFailed)` = point de rupture silencieux** : si le marqueur n'est
+  pas poussé dans `conversations`, le hiérarchique se bloque (attente d'un enfant
+  jamais réglé). C'est **le** invariant à tester explicitement (test « échec
+  partiel » ci-dessus). Documenté dans le code au bras `apply`.
+- **Ordre enregistré vs complétion** : la tentation d'appender au fil des
+  complétions (`buffer_unordered` les livre déséquencées) casserait le
+  déterminisme replay. Le handler **doit** ré-ordonner par indice avant
+  d'appender. Test de déterminisme = garde-fou.
+- **Cap & rate-limit (Lot 1 rate-limit, #269)** : le décorateur rate-limit
+  plafonne déjà par provider ; `max_concurrency` est un second plafond
+  orthogonal (nombre d'invocations en vol). Les deux se composent (le plus
+  strict gagne de facto) — pas de couplage à coder.
+- **Dépendance `futures`** : confirmer `buffer_unordered` disponible en
+  dépendance directe (sinon l'ajouter à `Cargo.toml`), et le gating features
+  (le moteur ES est compilé dans tous les modes CI).
+- **`&state` immuable partagé dans `buffer_unordered`** : `run_invoke` prend
+  `&ExecutionState` ; le batch lit un snapshot **cohérent** pris après les
+  `AgentInvoked` (donc chaque invocation voit son propre `user`-turn, mais **pas**
+  les `AgentObserved` de ses pairs du même lot — correct : les délégations d'un
+  lot sont indépendantes par construction).

--- a/src/core/orchestration/es/bridge.rs
+++ b/src/core/orchestration/es/bridge.rs
@@ -109,6 +109,13 @@ pub fn map_execution_to_run_events(
             cost: *cost,
             content: content.clone(),
         }],
+        ExecutionEvent::AgentFailed { agent, error } => vec![RunEvent::AgentEnd {
+            agent: agent.clone(),
+            tin: 0,
+            tout: 0,
+            cost: 0.0,
+            content: crate::core::orchestration::es::event::delegation_failed_content(error),
+        }],
         ExecutionEvent::ModelRouted {
             agent,
             tier,
@@ -436,6 +443,35 @@ mod tests {
                 assert_eq!(model, "claude-x");
             }
             other => panic!("expected [AgentStart with meta], got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_failed_maps_to_agent_end_with_marker() {
+        let meta: std::collections::BTreeMap<String, (String, String)> = Default::default();
+        let evs = map_execution_to_run_events(
+            &ExecutionEvent::AgentFailed {
+                agent: "b".into(),
+                error: "boom".into(),
+            },
+            &meta,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            RunEvent::AgentEnd {
+                agent,
+                tin,
+                tout,
+                cost,
+                content,
+            } => {
+                assert_eq!(agent, "b");
+                assert_eq!(*tin, 0);
+                assert_eq!(*tout, 0);
+                assert_eq!(*cost, 0.0);
+                assert_eq!(content, "[Delegation failed: boom]");
+            }
+            other => panic!("expected AgentEnd, got {other:?}"),
         }
     }
 

--- a/src/core/orchestration/es/engine.rs
+++ b/src/core/orchestration/es/engine.rs
@@ -12,6 +12,7 @@
 use super::event::ExecutionEvent;
 use super::log::EventLog;
 use super::state::{ExecutionState, RunStatus, apply, fold};
+use futures_util::StreamExt;
 
 /// Maximum number of loop iterations `run_event_sourced` will perform before
 /// giving up and halting the run.
@@ -39,6 +40,24 @@ pub enum Action {
     /// Complete the run with final `content` (terminal — recorded as
     /// `Completed`).
     Complete { content: String },
+    /// Invoke several agents concurrently. The loop records one
+    /// `AgentInvoked` per `batch` entry in `Vec` order, runs the effects
+    /// concurrently (at most `max_concurrency` in flight), then records each
+    /// outcome back in `Vec` order — independent of completion order, so
+    /// replay/resume stay deterministic. A per-entry failure is recorded as
+    /// `AgentFailed` and the run continues (collect-and-record).
+    InvokeParallel {
+        batch: Vec<InvokeSpec>,
+        max_concurrency: usize,
+    },
+}
+
+/// One unit of work inside an [`Action::InvokeParallel`] batch. Named
+/// distinctly from the `Action::Invoke` variant to avoid confusion.
+#[derive(Debug, Clone)]
+pub struct InvokeSpec {
+    pub agent: String,
+    pub input: String,
 }
 
 /// Pure, deterministic decision function: given the current projected
@@ -197,6 +216,72 @@ where
                 Action::Complete { content } => {
                     append_and_apply(log, run_id, state, ExecutionEvent::Completed { content })?;
                 }
+                Action::InvokeParallel {
+                    batch,
+                    max_concurrency,
+                } => {
+                    // 1. Record every invocation up-front, in Vec order
+                    //    (deterministic). Emitting all AgentInvoked before any
+                    //    outcome also makes every agent read as "working" at
+                    //    once in the Workroom.
+                    for spec in &batch {
+                        append_and_apply(
+                            log,
+                            run_id,
+                            state,
+                            ExecutionEvent::AgentInvoked {
+                                agent: spec.agent.clone(),
+                                input: spec.input.clone(),
+                            },
+                        )?;
+                    }
+
+                    // 2. Run effects concurrently over a shared, immutable
+                    //    snapshot of the now-updated state. `buffer_unordered`
+                    //    polls the borrowing futures in place (no spawn, no
+                    //    'static bound). Nothing is appended during this phase,
+                    //    so only shared borrows of `state`/`effects` are live.
+                    let snapshot: &ExecutionState = state;
+                    let cap = max_concurrency.max(1);
+                    // NOTE: iterate over owned clones (`InvokeSpec` is two
+                    // `String`s — cheap) rather than `batch.iter()`. Borrowing
+                    // the batch here makes rustc infer the closure's argument
+                    // as a higher-ranked `for<'r> &'r InvokeSpec` (it must
+                    // unify with `Map`'s generic `Stream::Item` bound used by
+                    // `buffer_unordered`), which then fails to unify with the
+                    // concrete lifetime borrowed by the returned async block's
+                    // captured `spec` — "implementation of `FnOnce` is not
+                    // general enough". Owning the item removes the borrowed
+                    // lifetime from the closure signature entirely. Index
+                    // tagging + the later `sort_by_key` still restore Vec
+                    // order, so this changes nothing about ordering/semantics.
+                    let mut outcomes: Vec<(usize, anyhow::Result<ExecutionEvent>)> =
+                        futures_util::stream::iter(batch.iter().cloned().enumerate())
+                            .map(|(i, spec)| async move {
+                                (
+                                    i,
+                                    effects.run_invoke(&spec.agent, &spec.input, snapshot).await,
+                                )
+                            })
+                            .buffer_unordered(cap)
+                            .collect()
+                            .await;
+
+                    // 3. Restore Vec order (buffer_unordered yields in
+                    //    completion order), then append outcomes in Vec order.
+                    //    A failure becomes AgentFailed; the run continues.
+                    outcomes.sort_by_key(|(i, _)| *i);
+                    for (i, res) in outcomes {
+                        let event = match res {
+                            Ok(ev) => ev,
+                            Err(e) => ExecutionEvent::AgentFailed {
+                                agent: batch[i].agent.clone(),
+                                error: e.to_string(),
+                            },
+                        };
+                        append_and_apply(log, run_id, state, event)?;
+                    }
+                }
             }
         }
     }
@@ -294,6 +379,265 @@ mod tests {
     use crate::core::orchestration::es::event::ExecutionEvent as E;
     use crate::core::orchestration::es::log::InMemoryLog;
     use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+
+    struct ParDecider {
+        batch: Vec<InvokeSpec>,
+        cap: usize,
+    }
+    impl Decider for ParDecider {
+        fn decide(&self, s: &ExecutionState) -> Vec<Action> {
+            // Once any agent has an assistant turn, the batch has run: complete.
+            let ran = s
+                .conversations
+                .values()
+                .any(|c| c.iter().any(|m| m.role == "assistant"));
+            if ran {
+                vec![Action::Complete {
+                    content: "done".into(),
+                }]
+            } else {
+                vec![Action::InvokeParallel {
+                    batch: self.batch.clone(),
+                    max_concurrency: self.cap,
+                }]
+            }
+        }
+    }
+
+    // Runner: sleeps longer for lower-index agents so completions arrive in
+    // reverse Vec order; records the completion order it actually observed.
+    struct OrderedEff {
+        order: Vec<String>, // Vec order a,b,c → delays 30,20,10ms
+        completions: Arc<Mutex<Vec<String>>>,
+    }
+    #[async_trait]
+    impl EffectRunner for OrderedEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            let idx = self.order.iter().position(|a| a == agent).unwrap_or(0);
+            let delay_ms = 30u64.saturating_sub(idx as u64 * 10);
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            self.completions.lock().unwrap().push(agent.to_string());
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: format!("resp-{agent}"),
+                tokens_in: 1,
+                tokens_out: 1,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_parallel_records_in_vec_order_not_completion_order() {
+        let batch = vec![
+            InvokeSpec {
+                agent: "a".into(),
+                input: "x".into(),
+            },
+            InvokeSpec {
+                agent: "b".into(),
+                input: "x".into(),
+            },
+            InvokeSpec {
+                agent: "c".into(),
+                input: "x".into(),
+            },
+        ];
+        let completions = Arc::new(Mutex::new(Vec::new()));
+        let decider = ParDecider {
+            batch: batch.clone(),
+            cap: 4,
+        };
+        let eff = OrderedEff {
+            order: vec!["a".into(), "b".into(), "c".into()],
+            completions: completions.clone(),
+        };
+        let mut log = InMemoryLog::default();
+        let init = vec![E::RunStarted {
+            run_id: "r".into(),
+            pattern: "test".into(),
+            agents: vec!["a".into(), "b".into(), "c".into()],
+            input: "go".into(),
+            project: None,
+        }];
+        run_event_sourced("r", init, &decider, &eff, &mut log)
+            .await
+            .unwrap();
+
+        let events = log.events("r").unwrap();
+        // Recorded observation order == Vec order a,b,c.
+        let observed: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                E::AgentObserved { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(observed, vec!["a", "b", "c"]);
+        // Recorded invocation order == Vec order a,b,c too.
+        let invoked: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                E::AgentInvoked { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(invoked, vec!["a", "b", "c"]);
+        // Sanity: completions actually arrived in a different (reverse) order,
+        // proving the ordering above is not incidental.
+        let comp = completions.lock().unwrap().clone();
+        assert_eq!(comp, vec!["c", "b", "a"]);
+    }
+
+    struct CapEff {
+        live: std::sync::atomic::AtomicUsize,
+        max_seen: std::sync::atomic::AtomicUsize,
+    }
+    #[async_trait]
+    impl EffectRunner for CapEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            let now = self.live.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            self.max_seen
+                .fetch_max(now, std::sync::atomic::Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            self.live.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: "r".into(),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_parallel_respects_concurrency_cap() {
+        let batch: Vec<InvokeSpec> = (0..6)
+            .map(|i| InvokeSpec {
+                agent: format!("a{i}"),
+                input: "x".into(),
+            })
+            .collect();
+        let decider = ParDecider {
+            batch: batch.clone(),
+            cap: 2,
+        };
+        let eff = CapEff {
+            live: std::sync::atomic::AtomicUsize::new(0),
+            max_seen: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let mut log = InMemoryLog::default();
+        let init = vec![E::RunStarted {
+            run_id: "r".into(),
+            pattern: "test".into(),
+            agents: batch.iter().map(|s| s.agent.clone()).collect(),
+            input: "go".into(),
+            project: None,
+        }];
+        run_event_sourced("r", init, &decider, &eff, &mut log)
+            .await
+            .unwrap();
+        assert!(
+            eff.max_seen.load(std::sync::atomic::Ordering::SeqCst) <= 2,
+            "observed {} concurrent invocations, cap was 2",
+            eff.max_seen.load(std::sync::atomic::Ordering::SeqCst)
+        );
+    }
+
+    struct FailBEff;
+    #[async_trait]
+    impl EffectRunner for FailBEff {
+        async fn run_invoke(
+            &self,
+            agent: &str,
+            _input: &str,
+            _s: &ExecutionState,
+        ) -> anyhow::Result<E> {
+            if agent == "b" {
+                anyhow::bail!("boom");
+            }
+            Ok(E::AgentObserved {
+                agent: agent.into(),
+                content: format!("resp-{agent}"),
+                tokens_in: 0,
+                tokens_out: 0,
+                cost: 0.0,
+                model: "m".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_parallel_records_failure_and_continues() {
+        let batch = vec![
+            InvokeSpec {
+                agent: "a".into(),
+                input: "x".into(),
+            },
+            InvokeSpec {
+                agent: "b".into(),
+                input: "x".into(),
+            },
+            InvokeSpec {
+                agent: "c".into(),
+                input: "x".into(),
+            },
+        ];
+        let decider = ParDecider {
+            batch: batch.clone(),
+            cap: 4,
+        };
+        let mut log = InMemoryLog::default();
+        let init = vec![E::RunStarted {
+            run_id: "r".into(),
+            pattern: "test".into(),
+            agents: vec!["a".into(), "b".into(), "c".into()],
+            input: "go".into(),
+            project: None,
+        }];
+        let state = run_event_sourced("r", init, &decider, &FailBEff, &mut log)
+            .await
+            .unwrap();
+
+        // Run still completed (failure did not abort the loop).
+        assert_eq!(state.status, RunStatus::Completed);
+
+        // Outcomes recorded in Vec order: observed a, failed b, observed c.
+        let events = log.events("r").unwrap();
+        let outcome_kinds: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                E::AgentObserved { agent, .. } => Some(agent.as_str()),
+                E::AgentFailed { agent, .. } => Some(agent.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(outcome_kinds, vec!["a", "b", "c"]);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, E::AgentFailed { agent, .. } if agent == "b"))
+        );
+
+        // b reads as settled: last turn is the assistant failure marker.
+        let convo_b = state.conversations.get("b").unwrap();
+        assert_eq!(convo_b.last().unwrap().role, "assistant");
+        assert_eq!(convo_b.last().unwrap().content, "[Delegation failed: boom]");
+    }
 
     // Decider: invoke "a" once (when no observation yet), then complete.
     struct D;

--- a/src/core/orchestration/es/event.rs
+++ b/src/core/orchestration/es/event.rs
@@ -54,6 +54,11 @@ pub enum ExecutionEvent {
     Halted { reason: String },
     /// The run completed successfully with final content.
     Completed { content: String },
+    /// A delegated invocation failed. Recorded instead of aborting the run
+    /// (collect-and-record): the reducer pushes an `assistant` marker so the
+    /// agent reads as "settled" (a coordinator that awaits this child then
+    /// synthesizes over the partial results), and the run continues.
+    AgentFailed { agent: String, error: String },
 
     // ── Hierarchical ─────────────────────────────────────────────
     /// A superior delegated a task to a subordinate.
@@ -124,4 +129,12 @@ pub enum ExecutionEvent {
     },
     /// The ring outcome was resolved.
     OutcomeResolved { outcome: String },
+}
+
+/// The `assistant`-role content recorded for a failed delegation. Single
+/// source of the marker string, consumed by both the reducer (`apply`) and
+/// the `RunEvent` bridge so they never drift. Contains no `@agent:` marker,
+/// so the hierarchical `is_final_answer` reads it as a plain final answer.
+pub fn delegation_failed_content(error: &str) -> String {
+    format!("[Delegation failed: {error}]")
 }

--- a/src/core/orchestration/es/state.rs
+++ b/src/core/orchestration/es/state.rs
@@ -172,6 +172,23 @@ pub fn apply(state: &mut ExecutionState, event: &ExecutionEvent) {
             state.budget_tokens_out += u64::from(*tokens_out);
             state.budget_cost += *cost;
         }
+        ExecutionEvent::AgentFailed { agent, error } => {
+            // Push an `assistant` marker so `latest_response(agent)` is
+            // `Some` and the child reads as settled — otherwise a hierarchical
+            // coordinator would await a child that never responds
+            // (`awaiting_in_flight`). Budget counters are deliberately left
+            // untouched (no successful call happened).
+            state
+                .conversations
+                .entry(agent.clone())
+                .or_default()
+                .push(ChatMessage {
+                    role: "assistant".to_string(),
+                    content: crate::core::orchestration::es::event::delegation_failed_content(
+                        error,
+                    ),
+                });
+        }
         ExecutionEvent::ModelRouted { agent, tier, .. } => {
             state.routed_tiers.insert(agent.clone(), tier.clone());
         }
@@ -348,6 +365,35 @@ mod tests {
         assert!((st.budget_cost - 0.01).abs() < 1e-9);
         // conversation recorded for dev-lead (invoked + observed)
         assert!(!st.conversations.get("dev-lead").unwrap().is_empty());
+    }
+
+    #[test]
+    fn agent_failed_pushes_assistant_marker_and_leaves_budget_untouched() {
+        let mut st = ExecutionState::default();
+        apply(
+            &mut st,
+            &E::AgentInvoked {
+                agent: "b".into(),
+                input: "do it".into(),
+            },
+        );
+        apply(
+            &mut st,
+            &E::AgentFailed {
+                agent: "b".into(),
+                error: "boom".into(),
+            },
+        );
+
+        let convo = st.conversations.get("b").expect("conversation exists");
+        assert_eq!(convo.len(), 2);
+        assert_eq!(convo[0].role, "user");
+        assert_eq!(convo[1].role, "assistant");
+        assert_eq!(convo[1].content, "[Delegation failed: boom]");
+        // AgentFailed must not move budget counters (unlike AgentObserved).
+        assert_eq!(st.budget_tokens_in, 0);
+        assert_eq!(st.budget_tokens_out, 0);
+        assert_eq!(st.budget_cost, 0.0);
     }
 
     #[test]

--- a/src/core/orchestration/mod.rs
+++ b/src/core/orchestration/mod.rs
@@ -177,6 +177,12 @@ pub struct OrchestrationConfig {
     /// Max total iterations across all agents (default: 50).
     pub max_iterations: Option<u32>,
 
+    /// Max number of delegations executed concurrently within a single
+    /// parallel fan-out batch (default: 4). Consumed by patterns that opt into
+    /// `Action::InvokeParallel` (hierarchical, Lot 2).
+    #[serde(default)]
+    pub max_concurrency: Option<u32>,
+
     /// Global timeout in seconds (default: 300).
     pub timeout: Option<u64>,
 
@@ -204,6 +210,10 @@ impl OrchestrationConfig {
 
     pub fn max_iterations(&self) -> u32 {
         self.max_iterations.unwrap_or(50)
+    }
+
+    pub fn max_concurrency(&self) -> usize {
+        self.max_concurrency.unwrap_or(4) as usize
     }
 
     pub fn timeout_secs(&self) -> u64 {
@@ -836,5 +846,20 @@ teams:
             ..Default::default()
         };
         assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn max_concurrency_defaults_to_four() {
+        let cfg = OrchestrationConfig::default();
+        assert_eq!(cfg.max_concurrency(), 4);
+    }
+
+    #[test]
+    fn max_concurrency_honors_override() {
+        let cfg = OrchestrationConfig {
+            max_concurrency: Some(8),
+            ..OrchestrationConfig::default()
+        };
+        assert_eq!(cfg.max_concurrency(), 8);
     }
 }


### PR DESCRIPTION
## Résumé

Lot 1 (socle) de #250 « OH1 parallélisme ». Ajoute le **socle** d'exécution concurrente des délégations dans le moteur d'orchestration event-sourcé. **Aucun pattern n'émet encore la nouvelle action** — le socle est dormant jusqu'au Lot 2 (opt-in hiérarchique).

### Changements
- **`ExecutionEvent::AgentFailed { agent, error }`** : event d'échec enregistré. `apply` pousse un marqueur `assistant` `[Delegation failed: <error>]` (l'enfant échoué lit comme « réglé » → un coordinateur hiérarchique ne l'attend pas indéfiniment) ; budget intact ; bridge → `RunEvent::AgentEnd`.
- **`Action::InvokeParallel { batch, max_concurrency }`** + handler `run_loop` : append `AgentInvoked ×N` (ordre Vec), exécution concurrente bornée via `futures_util::buffer_unordered(cap)` sur un snapshot `&state` partagé, puis append des outcomes **dans l'ordre Vec** (index + `sort_by_key`, indépendant de l'ordre de complétion) ; un `Err` par item devient `AgentFailed` et le run continue (**collect-and-record**).
- **`OrchestrationConfig::max_concurrency: Option<u32>`** + accesseur `max_concurrency()` (défaut 4), consommé par le hiérarchique en Lot 2.

### Invariants
- **Déterminisme** : ordre enregistré = ordre Vec, jamais l'ordre de complétion → replay/resume restent déterministes.
- Signatures du moteur (`run_event_sourced`/`resume_event_sourced`/`run_loop`) **inchangées** (cap porté par l'action).
- `futures-util` promu en dépendance directe **non-optionnelle** (le moteur ES compile dans tous les modes CI).
- Rétro-compat : `#[serde(default)]` conteneur → les `armadai.yaml` existants désérialisent `None` → défaut 4.

### Tests
3 tests sur mock `EffectRunner` : déterminisme (complétion inversée `[c,b,a]` vs ordre enregistré `[a,b,c]`), cap respecté, échec partiel (run continue + `AgentFailed` en position Vec + enfant réglé). Suite complète verte (1035 `tui` / 1079 `tui,storage`), clippy 3 modes clean.

### Suivi Lot 2 (relevé en revue finale, dormant ici)
`bridge.rs:286` `to_orchestration_result` ne considère pas `AgentFailed` → si un batch échoue **entièrement** sans synthèse, le contenu résultat serait vide. Critère d'acceptation Lot 2 : surfacer l'échec.

Spec : `docs/superpowers/specs/2026-07-27-oh1-parallelism-design.md`
Plan : `docs/superpowers/plans/2026-07-27-oh1-parallelism-lot1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)