### PR TITLE
ci: grant checks:write to Security Audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,6 +22,11 @@ on:
 
 permissions:
   contents: read
+  # `rustsec/audit-check` creates a check-run to surface advisories as
+  # annotations. On `push` events that requires `checks: write`; without it
+  # the action fails with "Resource not accessible by integration" even when
+  # the audit itself is clean.
+  checks: write
 
 jobs:
   audit:


### PR DESCRIPTION
## Problème

Sur les pushes vers `master`, le job **Security Audit** échoue avec `Resource not accessible by integration` **alors que `cargo audit` est propre** (0 vulnérabilité ; 1 warning `serial` unmaintained, non bloquant avec `deny: vulnerabilities`).

Cause : `rustsec/audit-check@v2` crée un *check-run* pour annoter les advisories. Sur les événements `push`, cela exige la permission `checks: write` ; le workflow n'accordait que `contents: read`.

## Fix

Ajoute `checks: write` aux permissions du workflow `audit.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)