### PR TITLE
fix(storage): anchor relative storage.path + guard tests from the real DB (#266, #267)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -3205,10 +3205,56 @@ mod es_switch_tests {
         (capture, dyn_sink)
     }
 
+    /// Redirect `storage` at a throwaway temp DB for the scope of a test, so
+    /// the ES dispatch's persistence (`SqliteLog` via `crate::storage::init_db`)
+    /// never writes into the user's real event log (#267). Points
+    /// `ARMADAI_CONFIG_DIR` at a temp `config.yaml` whose `storage.path` is a
+    /// scratch sqlite file; serialised via `ENV_MUTEX` and restored on drop.
+    /// Mirrors the guard in `src/web/api.rs` tests.
+    struct TempStorageGuard {
+        _dir: tempfile::TempDir,
+        orig: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl TempStorageGuard {
+        fn new() -> Self {
+            let lock = crate::core::config::ENV_MUTEX.lock().unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("test.sqlite");
+            let config_yaml = format!(
+                "storage:\n  mode: embedded\n  path: \"{}\"\n",
+                db_path.display()
+            );
+            std::fs::write(dir.path().join("config.yaml"), config_yaml).unwrap();
+            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            unsafe {
+                std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
+            }
+            Self {
+                _dir: dir,
+                orig,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for TempStorageGuard {
+        fn drop(&mut self) {
+            match self.orig.take() {
+                // SAFETY: restoring original env state at end of test scope.
+                Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
+                None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
+            }
+        }
+    }
+
     // ── T5a: direct ──────────────────────────────────────────────────
 
     #[tokio::test]
     async fn direct_es_completes_with_content_tokens_and_observability() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the answer"]));
 
@@ -3253,6 +3299,7 @@ mod es_switch_tests {
     /// contract, which only dropped `agent_end` and kept `agent_start`.
     #[tokio::test]
     async fn direct_es_quiet_suppresses_all_intermediate_events() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the answer"]));
 
@@ -3285,6 +3332,7 @@ mod es_switch_tests {
     /// event and stdout `println!`) stays full-length.
     #[tokio::test]
     async fn direct_es_max_content_truncates_agent_end_content_only() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the full answer"]));
 
@@ -3319,6 +3367,7 @@ mod es_switch_tests {
     /// bridge, which emitted `prov: "", model: ""`.
     #[tokio::test]
     async fn direct_es_agent_start_carries_real_prov_model_and_real_end_content() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let provider: Arc<dyn Provider> = Arc::new(ScriptedProvider::new(&["the answer"]));
 
@@ -3394,6 +3443,7 @@ mod es_switch_tests {
 
     #[tokio::test]
     async fn hierarchical_es_delegates_synthesizes_and_emits_observability() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let (agents, providers) = hierarchical_roster();
 
@@ -3436,6 +3486,7 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn hierarchical_es_result_is_recorded_via_record_hierarchical_into() {
+        let _storage = TempStorageGuard::new();
         use crate::storage::{init_embedded, queries};
 
         let (_capture, sink) = capture_sink();
@@ -3509,6 +3560,7 @@ mod es_switch_tests {
 
     #[tokio::test]
     async fn blackboard_es_converges_and_emits_board_observability() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let (agents, providers) = blackboard_roster();
 
@@ -3556,6 +3608,7 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn blackboard_es_state_is_recorded_via_record_blackboard_es_into() {
+        let _storage = TempStorageGuard::new();
         use crate::storage::{init_embedded, queries};
 
         let (_capture, sink) = capture_sink();
@@ -3849,6 +3902,7 @@ mod es_switch_tests {
 
     #[tokio::test]
     async fn ring_es_resolves_and_emits_vote_observability() {
+        let _storage = TempStorageGuard::new();
         let (capture, sink) = capture_sink();
         let (agents, providers) = ring_roster();
         let config = RingConfig {
@@ -3902,6 +3956,7 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn ring_es_state_is_recorded_via_record_ring_es_into() {
+        let _storage = TempStorageGuard::new();
         use crate::storage::{init_embedded, queries};
 
         let (_capture, sink) = capture_sink();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,18 +2,62 @@ pub mod queries;
 pub mod schema;
 
 use rusqlite::Connection;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 pub type Database = Arc<Mutex<Connection>>;
 
+/// Resolve a possibly-relative `storage.path` to an absolute path.
+///
+/// Absolute paths are used verbatim. A **relative** path (e.g. the legacy
+/// default `data/armadai.sqlite`) used to be opened relative to the current
+/// working directory, so the event log lived in a different DB per CWD and
+/// `--resume`/`--replay` only worked from the directory the run started in
+/// (#266). Anchor such paths under the user data dir instead, so the DB is
+/// CWD-independent, and warn once so the user can migrate their config to an
+/// absolute path.
+fn resolve_storage_path(configured: &str) -> PathBuf {
+    let p = Path::new(configured);
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            "storage.path '{configured}' is relative and was resolved under the data dir \
+             (it used to be CWD-relative, which fragments the event log per directory and \
+             breaks --resume/--replay from another directory). Set an absolute storage.path \
+             in config.yaml to silence this."
+        );
+    });
+    crate::core::config::data_dir().join(p)
+}
+
 /// Initialize a persistent SQLite database at the configured path.
 pub fn init_db() -> anyhow::Result<Database> {
     let config = crate::core::config::load_user_config();
-    let path = &config.storage.path;
-    if let Some(parent) = std::path::Path::new(path).parent() {
+    let path = resolve_storage_path(&config.storage.path);
+
+    // Safety net (#267): no test may open the real user database. Tests must
+    // redirect storage (e.g. point `ARMADAI_CONFIG_DIR` at a temp config, or
+    // use `init_embedded()`); a test that reaches the real data-dir DB is a
+    // silent-pollution bug, so fail loudly at the source instead of writing
+    // `test-run`-style rows into the user's real event log.
+    #[cfg(test)]
+    {
+        let real = crate::core::config::data_dir();
+        assert!(
+            !path.starts_with(&real),
+            "init_db() would open the real user database at {} during a test — \
+             redirect storage (ARMADAI_CONFIG_DIR -> temp config) or use init_embedded()",
+            path.display()
+        );
+    }
+
+    if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let conn = Connection::open(path)?;
+    let conn = Connection::open(&path)?;
     schema::apply(&conn)?;
     Ok(Arc::new(Mutex::new(conn)))
 }
@@ -24,4 +68,29 @@ pub fn init_embedded() -> anyhow::Result<Database> {
     let conn = Connection::open_in_memory()?;
     schema::apply(&conn)?;
     Ok(Arc::new(Mutex::new(conn)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_storage_path_used_verbatim() {
+        let abs = if cfg!(windows) {
+            r"C:\tmp\db.sqlite"
+        } else {
+            "/tmp/db.sqlite"
+        };
+        assert_eq!(resolve_storage_path(abs), PathBuf::from(abs));
+    }
+
+    #[test]
+    fn relative_storage_path_anchored_under_data_dir() {
+        // The legacy CWD-relative default must resolve to an absolute path
+        // under the data dir, not against the current working directory.
+        let resolved = resolve_storage_path("data/armadai.sqlite");
+        assert!(resolved.is_absolute());
+        assert!(resolved.starts_with(crate::core::config::data_dir()));
+        assert!(resolved.ends_with("data/armadai.sqlite"));
+    }
 }


### PR DESCRIPTION
Deux petits sujets storage liés (une PR, deux commits).

## #266 — `storage.path` relatif au CWD
Une config avec un `storage.path` **relatif** (le défaut historique `data/armadai.sqlite`) était ouverte relativement au **CWD** → le log d'événements ES vivait dans `<cwd>/data/armadai.sqlite`, fragmenté par répertoire, et `--resume`/`--replay` ne marchaient que depuis le répertoire du run.

**Fix** : `resolve_storage_path()` ancre tout chemin relatif sous le **data dir** (CWD-indépendant) et avertit une fois (`tracing::warn!`) pour migrer vers un chemin absolu. Les chemins absolus sont inchangés.

## #267 — les tests polluaient la vraie DB
Un garde-fou `#[cfg(test)]` dans `init_db()` **panique** si un test ouvrirait la vraie DB utilisateur (`~/.local/share/armadai/armadai.sqlite`), au lieu d'y écrire silencieusement (source des lignes `test-run` accumulées).

Le garde a **débusqué 10 tests réels** (`cli::run::es_switch_tests`) qui pilotaient la persistance `SqliteLog`→`init_db()` dans la vraie DB. Ils sont redirigés vers une DB temp via un `TempStorageGuard` (`ARMADAI_CONFIG_DIR` → config temp, comme le guard de `src/web/api.rs`).

## Tests
- `resolve_storage_path` : absolu verbatim ; relatif ancré sous le data dir.
- Les 10 tests `es_switch_tests` redirigés (garde vert). Gate : clippy 3 modes + tests 2 modes verts.

## Note (hors PR)
Résidu stale dans la vraie DB de l'environnement de dev (13 events `test-run` + ids de mes runs smoke non isolés) — nettoyage optionnel séparé, pas une régression de code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)