### PR TITLE
fix(shell): separate consecutive Claude assistant messages (#293)

### DIFF
--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -630,7 +630,7 @@ async fn event_loop(
                         }
                         StreamEvent::Message(text) => {
                             app.workroom.apply_stream_text(&text);
-                            app.append_to_streaming(&text);
+                            app.append_message_block(&text);
                             got_data = true;
                         }
                         StreamEvent::Result(resp) => {
@@ -661,8 +661,11 @@ async fn event_loop(
                     if is_json_mode {
                         use super::json_runner::{StreamEvent, parse_stream_event};
                         match parse_stream_event(&cmd, &line) {
-                            StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                            StreamEvent::Delta(text) => {
                                 app.append_to_streaming(&text);
+                            }
+                            StreamEvent::Message(text) => {
+                                app.append_message_block(&text);
                             }
                             StreamEvent::Result(resp) => {
                                 result_event = Some(resp);
@@ -947,7 +950,7 @@ async fn execute_tandem(
                         }
                         StreamEvent::Message(text) => {
                             app.workroom.apply_stream_text(&text);
-                            app.append_to_tandem_stream(&stream.stream_id, &text);
+                            app.append_to_tandem_stream_block(&stream.stream_id, &text);
                             got_data = true;
                         }
                         StreamEvent::Result(resp) => {
@@ -1009,8 +1012,11 @@ async fn execute_tandem(
             if is_json_mode {
                 use super::json_runner::{StreamEvent, parse_stream_event};
                 match parse_stream_event(&stream.cmd, &line) {
-                    StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                    StreamEvent::Delta(text) => {
                         app.append_to_tandem_stream(&stream.stream_id, &text);
+                    }
+                    StreamEvent::Message(text) => {
+                        app.append_to_tandem_stream_block(&stream.stream_id, &text);
                     }
                     StreamEvent::Result(resp) => {
                         stream.result_event = Some(resp);
@@ -1333,7 +1339,7 @@ async fn execute_pipeline_steps(
                         }
                         StreamEvent::Message(text) => {
                             app.workroom.apply_stream_text(&text);
-                            app.append_to_streaming(&text);
+                            app.append_message_block(&text);
                             got_data = true;
                         }
                         StreamEvent::Result(resp) => {
@@ -1366,8 +1372,11 @@ async fn execute_pipeline_steps(
                         if is_json_mode {
                             use super::json_runner::{StreamEvent, parse_stream_event};
                             match parse_stream_event(&resolved.cmd, &line) {
-                                StreamEvent::Delta(text) | StreamEvent::Message(text) => {
+                                StreamEvent::Delta(text) => {
                                     app.append_to_streaming(&text);
+                                }
+                                StreamEvent::Message(text) => {
+                                    app.append_message_block(&text);
                                 }
                                 StreamEvent::Result(resp) => {
                                     step_result_event = Some(resp);

--- a/src/shell/json_runner.rs
+++ b/src/shell/json_runner.rs
@@ -178,7 +178,13 @@ fn parse_claude_stream_event(event_type: &str, json: &Value) -> StreamEvent {
                     .collect::<Vec<_>>()
                     .join("");
                 if !text.is_empty() {
-                    return StreamEvent::Delta(text);
+                    // Claude Code emits one COMPLETE assistant message per
+                    // `assistant` event (the full `message.content` array), not
+                    // token deltas — so this is a whole message. Returning
+                    // `Message` (not `Delta`) lets the accumulator separate
+                    // consecutive messages with a paragraph boundary instead of
+                    // gluing them (#293).
+                    return StreamEvent::Message(text);
                 }
             }
             StreamEvent::Ignored
@@ -662,6 +668,18 @@ mod tests {
         // Valid JSON for claude but no delta/message/result text events
         let jsonl = r#"{"type":"system","subtype":"init","session_id":"x","tools":[]}"#;
         assert_eq!(collect_text_from_jsonl("claude", jsonl), "");
+    }
+
+    #[test]
+    fn test_parse_claude_assistant_event_is_a_complete_message() {
+        // Claude Code emits one COMPLETE assistant message per `assistant`
+        // event, so it must parse as `Message` (which the accumulator
+        // paragraph-separates) — not `Delta` (concatenated verbatim). #293.
+        let line = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"## Synthèse\"}]}}";
+        match parse_stream_event("claude", line) {
+            StreamEvent::Message(t) => assert_eq!(t, "## Synthèse"),
+            other => panic!("expected Message, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/shell/tui.rs
+++ b/src/shell/tui.rs
@@ -192,6 +192,28 @@ impl ShellApp {
         }
     }
 
+    /// Append a **complete message block** (as opposed to a token delta) to the
+    /// current streaming response, inserting a paragraph boundary first so two
+    /// consecutive whole messages don't glue together. Claude Code's
+    /// `stream-json` emits one complete `assistant` event per message, so a
+    /// turn with a preamble message followed by the answer would otherwise
+    /// render as `…preamble.## Heading` — the `##` lands mid-line and stops
+    /// being a markdown heading (#293). Deltas (true token chunks) keep using
+    /// [`Self::append_to_streaming`] and are never separated.
+    pub fn append_message_block(&mut self, text: &str) {
+        if let Some(last) = self.messages.last_mut()
+            && !last.is_user
+            && !last.is_system
+        {
+            if !last.content.is_empty() && !last.content.ends_with('\n') {
+                last.content.push_str("\n\n");
+            }
+            last.content.push_str(text);
+            self.manual_scroll = false;
+            self.scroll = 0;
+        }
+    }
+
     /// Start a streaming response for a specific provider in tandem mode
     /// Returns a unique ID for this stream to prevent collision when the same provider appears twice
     pub fn start_tandem_stream(&mut self, provider_label: &str) -> String {
@@ -218,6 +240,25 @@ impl ShellApp {
             .rev()
             .find(|m| m.id.as_deref() == Some(stream_id) && !m.is_user && !m.is_system)
         {
+            msg.content.push_str(text);
+            self.manual_scroll = false;
+            self.scroll = 0;
+        }
+    }
+
+    /// Tandem-stream counterpart of [`Self::append_message_block`]: append a
+    /// complete message to the matching tandem stream, separating it from a
+    /// previous message with a paragraph boundary (#293).
+    pub fn append_to_tandem_stream_block(&mut self, stream_id: &str, text: &str) {
+        if let Some(msg) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find(|m| m.id.as_deref() == Some(stream_id) && !m.is_user && !m.is_system)
+        {
+            if !msg.content.is_empty() && !msg.content.ends_with('\n') {
+                msg.content.push_str("\n\n");
+            }
             msg.content.push_str(text);
             self.manual_scroll = false;
             self.scroll = 0;
@@ -1212,6 +1253,45 @@ mod tests {
         assert!(!app.messages[1].is_user);
         assert!(!app.messages[0].is_system);
         assert!(!app.messages[1].is_system);
+    }
+
+    #[test]
+    fn append_message_block_separates_messages_so_heading_renders() {
+        // #293: two complete assistant messages (a preamble, then an answer
+        // opening with a markdown heading) must be paragraph-separated, so the
+        // `##` starts a line and renders as a heading instead of gluing to the
+        // preamble (`…agents.## Synthèse`, which pulldown-cmark reads as plain
+        // text).
+        let mut app = ShellApp::new("Claude".to_string());
+        app.start_streaming_response();
+        app.append_message_block("Je lance les deux agents.");
+        app.append_message_block("## Synthèse\nRésultat.");
+
+        let content = app.get_last_assistant_content();
+        assert!(
+            content.contains("agents.\n\n## Synthèse"),
+            "expected a paragraph boundary before the heading, got: {content:?}"
+        );
+
+        // The renderer now yields a bold heading span for "Synthèse" — which it
+        // would not if the `##` were mid-line.
+        let lines = crate::shell::md_render::render_markdown(&content);
+        let has_heading = lines.iter().any(|l| {
+            l.spans.iter().any(|s| {
+                s.content.contains("Synthèse") && s.style.add_modifier.contains(Modifier::BOLD)
+            })
+        });
+        assert!(has_heading, "## Synthèse should render as a bold heading");
+    }
+
+    #[test]
+    fn append_message_block_no_double_boundary_when_prev_ends_with_newline() {
+        let mut app = ShellApp::new("Claude".to_string());
+        app.start_streaming_response();
+        app.append_message_block("line\n");
+        app.append_message_block("next");
+        // Previous block already ended with a newline: no extra "\n\n".
+        assert_eq!(app.get_last_assistant_content(), "line\nnext");
     }
 
     #[test]


### PR DESCRIPTION
## Problème (#293)

Dans `armadai shell`, quand `claude` produit **plusieurs messages dans un tour** (préambule « Je lance… » puis la réponse « ## Synthèse … »), ils étaient **collés** : `…descriptions.## Synthèse`. Le `##` n'étant plus en début de ligne, pulldown-cmark ne le rendait pas comme titre (le renderer `md_render.rs` est correct — c'était l'assemblage amont).

**Racine** : le `stream-json` de Claude Code émet **un message complet par événement `assistant`** (le `message.content[]` entier), mais `parse_claude_stream_event` les mappait en `StreamEvent::Delta`, concaténés verbatim par l'accumulateur.

## Fix

- Événement `assistant` de Claude → `StreamEvent::Message` (message complet), pas `Delta`.
- Les `Message` **distincts** sont séparés par une frontière `\n\n` (`append_message_block` / `append_to_tandem_stream_block`) ; les vrais token-`Delta` restent concaténés verbatim (aucune coupure en plein mot).
- Gemini/codex distinguaient déjà `Delta` (token) vs `Message` (complet) → routage cohérent.

## Tests
- `parse` : un événement `assistant` claude → `Message`.
- `append_message_block` : frontière insérée entre 2 messages ; pas de double frontière si le précédent finit par `\n` ; intégration md_render → `## Synthèse` rendu en titre gras.
- Gate : clippy 3 modes + tests 2 modes verts.

## ⚠️ NE PAS MERGER avant vérification live
Le fix suppose que Claude Code n'émet **jamais** un message unique en plusieurs événements `assistant` (sinon la frontière couperait en plein message). C'est le comportement attendu de `-p --output-format stream-json --verbose`, mais **à confirmer sur un vrai `claude`** (le harnais fake-claude n'émet qu'un message par appel, ne reproduit pas le multi-message). Test live : lancer `armadai shell`, faire produire à claude un préambule + une réponse avec titres markdown, et vérifier (1) les titres se rendent, (2) **aucun** saut de ligne parasite en plein message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)