### PR TITLE
refactor(oh7): Lot 1b — move json_runner from shell to providers (#252)

### DIFF
--- a/src/bin/fake-claude.rs
+++ b/src/bin/fake-claude.rs
@@ -4,7 +4,7 @@
 //! (extracted from the composed prompt via the `FAKE_AGENT_ID:` marker) and a per-agent
 //! call counter (persisted under `FAKE_STATE_DIR/<agent>.count`), it picks the first
 //! matching rule and emits Claude Code's `stream-json` output format on stdout so that
-//! `src/shell/json_runner.rs` parses it exactly like a real `claude -p --output-format
+//! `src/providers/json_runner.rs` parses it exactly like a real `claude -p --output-format
 //! stream-json` invocation.
 //!
 //! The e2e runner shadows `claude` on `PATH` with this binary (see the e2e harness plan),

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -62,7 +62,7 @@ impl CliProvider {
     }
 
     fn parse_json_stdout(&self, raw: &str) -> CompletionResponse {
-        use crate::shell::json_runner::{StreamEvent, parse_stream_event};
+        use crate::providers::json_runner::{StreamEvent, parse_stream_event};
 
         let mut content = String::new();
         let mut result = None;

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -176,11 +176,11 @@ fn create_unified_provider(
         let args = if has_custom_args {
             // Respect the agent's explicit args verbatim (never override them).
             agent.metadata.args.clone().unwrap_or_default()
-        } else if crate::shell::json_runner::supports_json(command) {
+        } else if crate::providers::json_runner::supports_json(command) {
             // Default (no custom args) on a JSON-capable CLI: use the canonical
             // stream-json args so the provider captures real cost/tokens
             // instead of $0.00. The provider parses stdout opportunistically.
-            crate::shell::json_runner::json_mode_args(command)
+            crate::providers::json_runner::json_mode_args(command)
         } else {
             tool.cli_args.iter().map(|s| (*s).to_string()).collect()
         };

--- a/src/providers/json_runner.rs
+++ b/src/providers/json_runner.rs
@@ -608,24 +608,27 @@ fn parse_jsonl_response(provider: &str, raw: &str) -> CliResponse {
     }
 }
 
-/// Text fallback for CLIs without JSON support.
-fn text_fallback(raw: &str) -> CliResponse {
-    let parsed = super::parser::parse_response(raw);
-    CliResponse {
-        content: parsed.content,
-        tokens_in: None,
-        tokens_out: None,
-        cost_usd: None,
-        duration_ms: None,
-        model: None,
-        session_id: None,
-        from_json: false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Test-only helper standing in for the (unreachable-in-production) plain-text
+    // fallback path: no CLI-JSON parsing applies, so the raw text passes through
+    // as-is. Production code never routes through this — providers without JSON
+    // support are already handled verbatim by `collect_text_from_jsonl`, and any
+    // ARMADAI-marker stripping happens downstream in `shell::parser`, not here.
+    fn plain_text_response(raw: &str) -> CliResponse {
+        CliResponse {
+            content: raw.to_string(),
+            tokens_in: None,
+            tokens_out: None,
+            cost_usd: None,
+            duration_ms: None,
+            model: None,
+            session_id: None,
+            from_json: false,
+        }
+    }
 
     // Test-only helpers to exercise the underlying parsers
     fn parse_json_response(provider: &str, raw: &str) -> CliResponse {
@@ -636,12 +639,12 @@ mod tests {
                 "codex" => parse_jsonl_response("codex", raw),
                 "copilot" => parse_jsonl_response("copilot", raw),
                 "opencode" => parse_jsonl_response("opencode", raw),
-                _ => text_fallback(raw),
+                _ => plain_text_response(raw),
             }
         } else if provider == "codex" || provider == "copilot" || provider == "opencode" {
             parse_jsonl_response(provider, raw)
         } else {
-            text_fallback(raw)
+            plain_text_response(raw)
         }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,6 +2,7 @@
 pub mod api;
 pub mod cli;
 pub mod factory;
+pub mod json_runner;
 #[cfg(feature = "providers-api")]
 pub mod proxy;
 pub mod rate_limiter;

--- a/src/shell/app.rs
+++ b/src/shell/app.rs
@@ -28,7 +28,7 @@ fn accumulate_pipeline_metrics(
     aggregated_tokens_in: &mut Option<u64>,
     aggregated_tokens_out: &mut u64,
     aggregated_cost: &mut f64,
-    resp: &super::json_runner::CliResponse,
+    resp: &crate::providers::json_runner::CliResponse,
 ) {
     *aggregated_tokens_in = Some(aggregated_tokens_in.unwrap_or(0) + resp.tokens_in.unwrap_or(0));
     if let Some(out) = resp.tokens_out {
@@ -524,7 +524,7 @@ async fn event_loop(
         let cmd = runner.command().to_string();
         let args: Vec<String> = runner.args().to_vec();
         let prompt = runner.build_prompt_for(&input_clone);
-        let is_json_mode = super::json_runner::supports_json(&cmd);
+        let is_json_mode = crate::providers::json_runner::supports_json(&cmd);
 
         // Spawn CLI with piped stdout for streaming
         let start_time = std::time::Instant::now();
@@ -605,14 +605,14 @@ async fn event_loop(
 
             // Drain all available lines and parse as stream events
             let mut got_data = false;
-            let mut result_event: Option<super::json_runner::CliResponse> = None;
+            let mut result_event: Option<crate::providers::json_runner::CliResponse> = None;
 
             while let Ok(line) = stream_rx.try_recv() {
                 // Log raw stream event for debugging
                 super::session::log_stream_event(session_id, line.trim());
 
                 if is_json_mode {
-                    use super::json_runner::{StreamEvent, parse_stream_event};
+                    use crate::providers::json_runner::{StreamEvent, parse_stream_event};
                     match parse_stream_event(&cmd, &line) {
                         StreamEvent::Init { model, agents } => {
                             if let Some(m) = model {
@@ -659,7 +659,7 @@ async fn event_loop(
                 // Drain remaining
                 while let Ok(line) = stream_rx.try_recv() {
                     if is_json_mode {
-                        use super::json_runner::{StreamEvent, parse_stream_event};
+                        use crate::providers::json_runner::{StreamEvent, parse_stream_event};
                         match parse_stream_event(&cmd, &line) {
                             StreamEvent::Delta(text) => {
                                 app.append_to_streaming(&text);
@@ -806,7 +806,7 @@ async fn execute_tandem(
         cmd: String,
         child: tokio::process::Child,
         stream_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
-        result_event: Option<super::json_runner::CliResponse>,
+        result_event: Option<crate::providers::json_runner::CliResponse>,
         stderr_buffer: Arc<Mutex<String>>,
     }
 
@@ -931,9 +931,9 @@ async fn execute_tandem(
             while let Ok(line) = stream.stream_rx.try_recv() {
                 super::session::log_stream_event(session_id, line.trim());
 
-                let is_json_mode = super::json_runner::supports_json(&stream.cmd);
+                let is_json_mode = crate::providers::json_runner::supports_json(&stream.cmd);
                 if is_json_mode {
-                    use super::json_runner::{StreamEvent, parse_stream_event};
+                    use crate::providers::json_runner::{StreamEvent, parse_stream_event};
                     match parse_stream_event(&stream.cmd, &line) {
                         StreamEvent::Init { model, agents } => {
                             if let Some(m) = model {
@@ -1007,10 +1007,10 @@ async fn execute_tandem(
 
     for mut stream in streams {
         // Drain any remaining stream events
-        let is_json_mode = super::json_runner::supports_json(&stream.cmd);
+        let is_json_mode = crate::providers::json_runner::supports_json(&stream.cmd);
         while let Ok(line) = stream.stream_rx.try_recv() {
             if is_json_mode {
-                use super::json_runner::{StreamEvent, parse_stream_event};
+                use crate::providers::json_runner::{StreamEvent, parse_stream_event};
                 match parse_stream_event(&stream.cmd, &line) {
                     StreamEvent::Delta(text) => {
                         app.append_to_tandem_stream(&stream.stream_id, &text);
@@ -1296,8 +1296,8 @@ async fn execute_pipeline_steps(
             }
         });
 
-        let is_json_mode = super::json_runner::supports_json(&resolved.cmd);
-        let mut step_result_event: Option<super::json_runner::CliResponse> = None;
+        let is_json_mode = crate::providers::json_runner::supports_json(&resolved.cmd);
+        let mut step_result_event: Option<crate::providers::json_runner::CliResponse> = None;
 
         // Stream loop
         loop {
@@ -1322,7 +1322,7 @@ async fn execute_pipeline_steps(
                 super::session::log_stream_event(session_id, line.trim());
 
                 if is_json_mode {
-                    use super::json_runner::{StreamEvent, parse_stream_event};
+                    use crate::providers::json_runner::{StreamEvent, parse_stream_event};
                     match parse_stream_event(&resolved.cmd, &line) {
                         StreamEvent::Init { model, agents } => {
                             if let Some(m) = model {
@@ -1370,7 +1370,7 @@ async fn execute_pipeline_steps(
                     // Drain remaining stream events
                     while let Ok(line) = stream_rx.try_recv() {
                         if is_json_mode {
-                            use super::json_runner::{StreamEvent, parse_stream_event};
+                            use crate::providers::json_runner::{StreamEvent, parse_stream_event};
                             match parse_stream_event(&resolved.cmd, &line) {
                                 StreamEvent::Delta(text) => {
                                     app.append_to_streaming(&text);
@@ -1602,8 +1602,8 @@ async fn execute_pty_turn(
 
 #[cfg(test)]
 mod tests {
-    use super::super::json_runner::CliResponse;
     use super::*;
+    use crate::providers::json_runner::CliResponse;
 
     /// Build a minimal `CliResponse` fixture with only the metrics fields set.
     fn resp(tokens_in: Option<u64>, tokens_out: Option<u64>, cost_usd: Option<f64>) -> CliResponse {

--- a/src/shell/detect.rs
+++ b/src/shell/detect.rs
@@ -30,7 +30,7 @@ pub fn detect_provider() -> Option<RunnerConfig> {
     for command in providers {
         if is_command_available(command) {
             // Use JSON mode args if supported, otherwise text fallback
-            let args = super::json_runner::json_mode_args(command);
+            let args = crate::providers::json_runner::json_mode_args(command);
             return Some(RunnerConfig {
                 command: command.to_string(),
                 args,
@@ -63,7 +63,7 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             let available = is_command_available(cmd);
             ProviderInfo {
                 command: cmd.to_string(),
-                args: super::json_runner::json_mode_args(cmd),
+                args: crate::providers::json_runner::json_mode_args(cmd),
                 display_name: name.to_string(),
                 model_name: if available {
                     detect_model_name(cmd)
@@ -108,7 +108,7 @@ pub fn is_command_available(command: &str) -> bool {
 
 /// Get the base CLI args for a provider (uses JSON mode if available).
 pub fn args_for_provider(command: &str) -> Vec<String> {
-    super::json_runner::json_mode_args(command)
+    crate::providers::json_runner::json_mode_args(command)
 }
 
 /// Get the provider display name for the statusbar.

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -5,7 +5,6 @@
 
 pub mod config;
 pub mod detect;
-pub mod json_runner;
 #[cfg(feature = "tui")]
 pub mod md_render;
 pub mod parser;


### PR DESCRIPTION
Sous-lot 1b d'**OH7 Lot 1**. Refactor **pur** : `shell::json_runner` (parsing stream-json des CLIs providers — un concern provider) → `providers::json_runner`, ce qui casse l'arête `providers → shell`.

## Couplage caché résolu
`json_runner::text_fallback` (fn **privée**) appelait `shell::parser::parse_response` — un résidu `providers → shell`. Analyse : code **mort en production** (seul appelant = son propre test unitaire ; le vrai chemin `collect_text_from_jsonl` ne l'utilise pas). Retiré, équivalent shell-free inliné dans le test (byte-identique pour l'input couvert). Vérifié en revue via les règles de visibilité Rust + équivalence du cas testé.

## Invariant
`grep 'use crate::shell' src/providers` → **vide** (arête providers→shell supprimée ; les mentions `shell::` restantes sont des commentaires).

`json_runner` reste **non-gated** ; pas de shim dans `shell` ; gate clippy 3 modes + tests 2 modes (1042/1088) verts.

Suivi mineur (cosmétique) : renommer le test `test_text_fallback` → `test_plain_text_response`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)