### PR TITLE
refactor(oh7): Lot 1d — move Provider trait into core (dependency inversion) (#252)

### DIFF
--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -8,8 +8,8 @@ use crate::audit::{
     run_audit,
 };
 use crate::core::agent::{Agent, AgentMetadata};
+use crate::core::provider::{ChatMessage, CompletionRequest};
 use crate::providers::factory::create_provider;
-use crate::providers::traits::{ChatMessage, CompletionRequest};
 
 pub(crate) fn min_severity_from(flag: &str, quiet: bool) -> Severity {
     if quiet {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -10,8 +10,8 @@ use crate::core::orchestration::es::event::ExecutionEvent;
 use crate::core::orchestration::es::log::{EventLog, InMemoryLog};
 use crate::core::orchestration::es::state::ExecutionState;
 use crate::core::project::{self, AgentRef, ProjectConfig, ProjectDefaults};
+use crate::core::provider::{ChatMessage, CompletionRequest};
 use crate::providers::factory::create_provider;
-use crate::providers::traits::{ChatMessage, CompletionRequest};
 
 const GUIDED_MODE_INSTRUCTION: &str = "\
 \n\n---\n\n\
@@ -468,7 +468,7 @@ async fn resume_run(
         std::collections::BTreeMap::new();
     let mut providers_map: std::collections::BTreeMap<
         String,
-        Arc<dyn crate::providers::traits::Provider>,
+        Arc<dyn crate::core::provider::Provider>,
     > = std::collections::BTreeMap::new();
     for name in &state.agents {
         let agent_path = resolve_agent_path(&resolution, name)?;
@@ -1181,7 +1181,7 @@ async fn dispatch_direct_es(
     run_id: &str,
     agent_key: &str,
     agent: Agent,
-    provider: Arc<dyn crate::providers::traits::Provider>,
+    provider: Arc<dyn crate::core::provider::Provider>,
     input: &str,
     routing_rules: &crate::core::routing::RoutingRules,
     sink: &Arc<dyn EventSink>,
@@ -1309,7 +1309,7 @@ async fn run_single_agent_es(
 
     // 2. Create provider (step 2).
     let provider_name = agent.metadata.provider.clone();
-    let provider: Arc<dyn crate::providers::traits::Provider> = Arc::from(create_provider(&agent)?);
+    let provider: Arc<dyn crate::core::provider::Provider> = Arc::from(create_provider(&agent)?);
 
     // 4. Guided-mode system-prompt augmentation (step 4).
     let effective_mode = agent
@@ -1490,14 +1490,14 @@ fn resolve_agents_dir(headless: bool) -> AgentResolution {
 fn apply_agent_selection(
     keys: &[String],
     agents: Vec<crate::core::agent::Agent>,
-    providers: Vec<std::sync::Arc<dyn crate::providers::traits::Provider>>,
+    providers: Vec<std::sync::Arc<dyn crate::core::provider::Provider>>,
     route: Option<&str>,
     tags: &[String],
     routes: &std::collections::BTreeMap<String, Vec<String>>,
 ) -> anyhow::Result<(
     Vec<String>,
     Vec<crate::core::agent::Agent>,
-    Vec<std::sync::Arc<dyn crate::providers::traits::Provider>>,
+    Vec<std::sync::Arc<dyn crate::core::provider::Provider>>,
     crate::core::orchestration::agent_selection::AgentSelection,
 )> {
     use std::collections::HashMap;
@@ -1530,7 +1530,7 @@ fn apply_agent_selection(
         String,
         (
             crate::core::agent::Agent,
-            std::sync::Arc<dyn crate::providers::traits::Provider>,
+            std::sync::Arc<dyn crate::core::provider::Provider>,
         ),
     > = HashMap::new();
     for ((key, a), p) in keys.iter().cloned().zip(agents).zip(providers) {
@@ -1585,7 +1585,7 @@ async fn run_orchestrated(
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
 
-    use crate::providers::traits::Provider;
+    use crate::core::provider::Provider;
 
     let mut agents = Vec::new();
     let mut providers: Vec<Arc<dyn Provider>> = Vec::new();
@@ -1675,7 +1675,7 @@ async fn run_orchestrated_inner(
     resolution: &AgentResolution,
     agent_names: &[String],
     mut agents: Vec<crate::core::agent::Agent>,
-    mut providers: Vec<std::sync::Arc<dyn crate::providers::traits::Provider>>,
+    mut providers: Vec<std::sync::Arc<dyn crate::core::provider::Provider>>,
     deprecations: Vec<(Option<String>, Option<String>)>,
     input: &str,
     pattern: &str,
@@ -1704,7 +1704,7 @@ async fn run_orchestrated_inner(
     use crate::core::orchestration::blackboard::BlackboardConfig;
     use crate::core::orchestration::ring::RingConfig;
     use crate::core::project::OrchestrationDefaults;
-    use crate::providers::traits::Provider;
+    use crate::core::provider::Provider;
 
     // Read project-level orchestration overrides (if any).
     let orch_defaults = match resolution {
@@ -2174,7 +2174,7 @@ async fn dispatch_blackboard_es(
     run_id: &str,
     input: &str,
     agents: std::collections::BTreeMap<String, Agent>,
-    providers: std::collections::BTreeMap<String, Arc<dyn crate::providers::traits::Provider>>,
+    providers: std::collections::BTreeMap<String, Arc<dyn crate::core::provider::Provider>>,
     config: crate::core::orchestration::blackboard::BlackboardConfig,
     routing_rules: crate::core::routing::RoutingRules,
     cost_limit: Option<f64>,
@@ -2234,7 +2234,7 @@ async fn dispatch_ring_es(
     input: &str,
     agents: std::collections::BTreeMap<String, Agent>,
     agent_order: Vec<String>,
-    providers: std::collections::BTreeMap<String, Arc<dyn crate::providers::traits::Provider>>,
+    providers: std::collections::BTreeMap<String, Arc<dyn crate::core::provider::Provider>>,
     config: crate::core::orchestration::ring::RingConfig,
     routing_rules: crate::core::routing::RoutingRules,
     cost_limit: Option<f64>,
@@ -2300,7 +2300,7 @@ async fn dispatch_hierarchical_es(
     input: &str,
     config: crate::core::orchestration::OrchestrationConfig,
     agents: std::collections::BTreeMap<String, Agent>,
-    providers: std::collections::BTreeMap<String, Arc<dyn crate::providers::traits::Provider>>,
+    providers: std::collections::BTreeMap<String, Arc<dyn crate::core::provider::Provider>>,
     routing_rules: crate::core::routing::RoutingRules,
     sink: &Arc<dyn EventSink>,
     quiet: bool,
@@ -2762,7 +2762,7 @@ mod selection_tests {
     use std::path::PathBuf;
 
     use crate::core::agent::{Agent, AgentMetadata};
-    use crate::providers::traits::{
+    use crate::core::provider::{
         CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
     };
 
@@ -3073,10 +3073,10 @@ mod es_switch_tests {
     use crate::core::orchestration::es::state::RunStatus;
     use crate::core::orchestration::ring::RingConfig;
     use crate::core::orchestration::{OrchestrationConfig, OrchestrationPattern, TeamConfig};
-    use crate::core::routing::RoutingRules;
-    use crate::providers::traits::{
+    use crate::core::provider::{
         CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
     };
+    use crate::core::routing::RoutingRules;
 
     // ── Shared test infra ────────────────────────────────────────────
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,6 +14,7 @@ pub mod parser;
 pub mod project;
 pub mod project_registry;
 pub mod prompt;
+pub mod provider;
 pub mod registries;
 pub mod routing;
 pub mod skill;

--- a/src/core/orchestration/es/blackboard.rs
+++ b/src/core/orchestration/es/blackboard.rs
@@ -26,8 +26,8 @@ use crate::core::model_resolution::fallback_model_for_tier;
 use crate::core::model_resolution::{ModelTier, resolve_model_for_tier};
 use crate::core::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
 use crate::core::orchestration::llm_agents::{BOARD_ACTION_INSTRUCTIONS, parse_board_action};
+use crate::core::provider::{ChatMessage, CompletionRequest, Provider};
 use crate::core::routing::{BudgetState, RoutingRules, route};
-use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
 /// Agents eligible to contribute on the board's current round, ordered by
 /// the run's roster (`state.agents`) rather than `agents`' own (`BTreeMap`,
@@ -1388,7 +1388,7 @@ mod tests {
     mod effect_runner {
         use super::*;
         use crate::core::agent::AgentMetadata;
-        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
         use std::path::PathBuf;
         use std::sync::Mutex;
 
@@ -1877,7 +1877,7 @@ mod tests {
         use crate::core::orchestration::es::engine::replay;
         use crate::core::orchestration::es::log::InMemoryLog;
         use crate::core::orchestration::es::state::RunStatus;
-        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
         use std::collections::VecDeque;
         use std::path::PathBuf;
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/core/orchestration/es/direct.rs
+++ b/src/core/orchestration/es/direct.rs
@@ -28,8 +28,8 @@ use super::log::EventLog;
 use super::state::ExecutionState;
 use crate::core::agent::Agent;
 use crate::core::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::core::provider::{ChatMessage, CompletionRequest, Provider};
 use crate::core::routing::{RoutingRules, route};
-use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
 /// Parse a tier string as stored in `ExecutionState::routed_tiers` back into
 /// a `ModelTier`. Identical in spirit to the same-named helper in
@@ -322,7 +322,7 @@ mod tests {
     use crate::core::model_resolution::fallback_model_for_tier;
     use crate::core::orchestration::es::log::InMemoryLog;
     use crate::core::orchestration::es::state::RunStatus;
-    use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+    use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
     use std::path::PathBuf;
     use std::sync::Mutex;
 

--- a/src/core/orchestration/es/hierarchical.rs
+++ b/src/core/orchestration/es/hierarchical.rs
@@ -33,8 +33,8 @@ use crate::core::orchestration::protocol::{
 };
 use crate::core::orchestration::ring::RingConfig;
 use crate::core::orchestration::{NestedPattern, OrchestrationConfig, TeamConfig};
+use crate::core::provider::{ChatMessage, CompletionRequest, Provider};
 use crate::core::routing::{BudgetState, RoutingRules, route};
-use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
 /// A single step planned from an LLM response, before any effect has run.
 ///
@@ -2856,7 +2856,7 @@ mod tests {
         use super::*;
         use crate::core::agent::AgentMetadata;
         use crate::core::orchestration::es::state::fold;
-        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
         use std::path::PathBuf;
         use std::sync::Mutex;
 
@@ -3295,7 +3295,7 @@ mod tests {
     use crate::core::orchestration::es::engine::replay;
     use crate::core::orchestration::es::log::InMemoryLog;
     use crate::core::orchestration::es::state::RunStatus;
-    use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+    use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
     use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/core/orchestration/es/ring.rs
+++ b/src/core/orchestration/es/ring.rs
@@ -33,8 +33,8 @@ use crate::core::orchestration::llm_agents::{
     RING_ACTION_INSTRUCTIONS, parse_ring_action, parse_vote_confidence,
 };
 use crate::core::orchestration::ring::{ContributionAction, RingConfig};
+use crate::core::provider::{ChatMessage, CompletionRequest, Provider};
 use crate::core::routing::{BudgetState, RoutingRules, route};
-use crate::providers::traits::{ChatMessage, CompletionRequest, Provider};
 
 /// Maximum number of prior ring contributions re-emitted in a circulation
 /// prompt. Without a cap the ring re-sends the entire transcript on every
@@ -1765,7 +1765,7 @@ mod tests {
     mod effect_runner {
         use super::*;
         use crate::core::agent::AgentMetadata;
-        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
         use std::path::PathBuf;
         use std::sync::Mutex;
 
@@ -2186,7 +2186,7 @@ mod tests {
         use crate::core::orchestration::es::engine::replay;
         use crate::core::orchestration::es::log::InMemoryLog;
         use crate::core::orchestration::es::state::RunStatus;
-        use crate::providers::traits::{CompletionResponse, ProviderMetadata, TokenStream};
+        use crate::core::provider::{CompletionResponse, ProviderMetadata, TokenStream};
         use std::collections::VecDeque;
         use std::path::PathBuf;
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/core/orchestration/es/state.rs
+++ b/src/core/orchestration/es/state.rs
@@ -8,7 +8,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::event::ExecutionEvent;
-use crate::providers::traits::ChatMessage;
+use crate::core::provider::ChatMessage;
 
 /// Terminal/in-flight status of an orchestration run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/core/orchestration/test_helpers.rs
+++ b/src/core/orchestration/test_helpers.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::providers::traits::{
+use crate::core::provider::{
     CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
 };
 

--- a/src/core/provider.rs
+++ b/src/core/provider.rs
@@ -29,6 +29,13 @@ pub struct CompletionResponse {
     pub cost: f64,
 }
 
+// Fields are constructed by every `Provider::metadata()` impl but only read
+// in tests today (`cli/run.rs`). Previously silent because `mod providers;`
+// in `main.rs` carries a blanket `#[allow(dead_code)]`; `core` has no such
+// blanket allow, so the move surfaces this pre-existing dead code. Scoped
+// here rather than widening `core`'s allow — same effective behavior as
+// before the move (OH7 #252 Task 1d, pure refactor, no allow scope change).
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ProviderMetadata {
     pub name: String,

--- a/src/providers/api/anthropic.rs
+++ b/src/providers/api/anthropic.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 
-use crate::providers::traits::*;
+use crate::core::provider::*;
 
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;

--- a/src/providers/api/google.rs
+++ b/src/providers/api/google.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 
-use crate::providers::traits::*;
+use crate::core::provider::*;
 
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 

--- a/src/providers/api/openai.rs
+++ b/src/providers/api/openai.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::providers::traits::*;
+use crate::core::provider::*;
 
 pub struct OpenAiProvider {
     pub api_key: String,

--- a/src/providers/cli.rs
+++ b/src/providers/cli.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use tokio::process::Command;
 
-use super::traits::*;
+use crate::core::provider::*;
 
 /// Generic CLI provider that spawns any configured command.
 pub struct CliProvider {

--- a/src/providers/factory.rs
+++ b/src/providers/factory.rs
@@ -1,6 +1,6 @@
 use crate::core::agent::Agent;
 
-use super::traits::Provider;
+use crate::core::provider::Provider;
 
 /// Known tool definitions for unified provider names.
 /// Each entry maps a user-friendly name to its CLI command and API backend.
@@ -314,7 +314,7 @@ mod tests {
     #[tokio::test]
     async fn wrap_rate_limited_agent_limiter_throttles_without_provider_key() {
         use crate::core::agent::AgentMetadata;
-        use crate::providers::traits::{
+        use crate::core::provider::{
             ChatMessage, CompletionRequest, CompletionResponse, ProviderMetadata, TokenStream,
         };
         use std::sync::Arc;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,7 +6,6 @@ pub mod json_runner;
 #[cfg(feature = "providers-api")]
 pub mod proxy;
 pub mod rate_limiter;
-pub mod traits;
 
 // Re-exported for `factory.rs` wiring (rate-limit Lot 1, Task 3).
 pub use rate_limiter::{Rate, RateLimitedProvider, RateLimiter, shared_provider_limiter};

--- a/src/providers/proxy.rs
+++ b/src/providers/proxy.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use super::traits::*;
+use crate::core::provider::*;
 
 /// Proxy provider that routes through LiteLLM or OpenRouter (OpenAI-compatible API).
 pub struct ProxyProvider {

--- a/src/providers/rate_limiter.rs
+++ b/src/providers/rate_limiter.rs
@@ -1,4 +1,4 @@
-use crate::providers::traits::{
+use crate::core::provider::{
     CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
 };
 use std::collections::HashMap;
@@ -253,7 +253,7 @@ mod tests {
         assert!(start.elapsed() < Duration::from_millis(100));
     }
 
-    use crate::providers::traits::{
+    use crate::core::provider::{
         ChatMessage, CompletionRequest, CompletionResponse, Provider, ProviderMetadata, TokenStream,
     };
     use std::sync::Arc;


### PR DESCRIPTION
Sous-lot 1d d'**OH7 Lot 1** — l'**inversion de dépendance** qui casse `core → providers`. Refactor **pur**.

Le trait `Provider` (+ `CompletionRequest`/`ChatMessage`/`CompletionResponse`/`ProviderMetadata`/`TokenStream`) passe de `providers::traits` → `core::provider`. `providers` **implémente** désormais le contrat et dépend de `core` ; `core` **possède** le contrat et n'importe plus `providers`.

## Invariant (le but)
`grep -rn 'use crate::providers' src/core` → **vide** (l'arête core→providers a disparu ; l'ES appelle `dyn core::provider::Provider`).

- Déplacement byte-identique (contrat feuille, n'importait aucun module crate). `ChatMessage` remonté dans core résout aussi une cross-dep latente de `es::state`.
- Pas de shim ; `super::traits::` (factory/proxy/cli) repointés vers `crate::core::provider::`.
- **Point annexe résolu** : `ProviderMetadata` avait du dead_code masqué par le blanket `#[allow(dead_code)] mod providers;` du bin ; hors de ce blanket dans core, un `#[allow(dead_code)]` **scopé sur la struct** reproduit fidèlement (plus étroitement) la suppression préexistante — pas de nouveau défaut masqué (vérifié en revue).

Gate clippy 3 modes `-D warnings` + tests 2 modes (1042 `tui` / 1088 `tui,storage`) verts (vérifié indép au compilateur).

Reste au Lot 1 : **1e** (SqliteLog core → bin) → `armadai-core` devient une vraie feuille.

🤖 Generated with [Claude Code](https://claude.com/claude-code)