### PR TITLE
refactor(oh7): Lot 1e — move SqliteLog out of core into the bin (#252)

### DIFF
--- a/src/cli/projections.rs
+++ b/src/cli/projections.rs
@@ -88,7 +88,8 @@ pub async fn execute(action: ProjectionsAction) -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use crate::core::orchestration::es::event::ExecutionEvent;
-    use crate::core::orchestration::es::log::{EventLog, SqliteLog};
+    use crate::core::orchestration::es::log::EventLog;
+    use crate::storage::es_log::SqliteLog;
     use crate::storage::{init_embedded, queries};
 
     /// Helper: construct a minimal blackboard event log suitable for

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -253,8 +253,8 @@ async fn execute_resume(
     #[cfg(feature = "storage")]
     {
         use crate::core::orchestration::es::engine::replay;
-        use crate::core::orchestration::es::log::SqliteLog;
         use crate::core::orchestration::es::state::RunStatus;
+        use crate::storage::es_log::SqliteLog;
 
         let headless = headless || json;
 
@@ -362,8 +362,8 @@ async fn resume_run(
     human_output: bool,
 ) -> anyhow::Result<()> {
     use crate::core::orchestration::es::bridge::synthetic_run_start;
-    use crate::core::orchestration::es::log::SqliteLog;
     use crate::core::orchestration::es::state::{RunStatus, fold};
+    use crate::storage::es_log::SqliteLog;
 
     let db = crate::storage::init_db()?;
     let log = SqliteLog::new(db.clone());
@@ -1233,7 +1233,7 @@ async fn dispatch_direct_es(
 
     #[cfg(feature = "storage")]
     let (state, events) = {
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         match crate::storage::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
@@ -2207,7 +2207,7 @@ async fn dispatch_blackboard_es(
 
     #[cfg(feature = "storage")]
     let state = {
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         match crate::storage::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
@@ -2270,7 +2270,7 @@ async fn dispatch_ring_es(
 
     #[cfg(feature = "storage")]
     let (state, events) = {
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         match crate::storage::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
@@ -2333,7 +2333,7 @@ async fn dispatch_hierarchical_es(
 
     #[cfg(feature = "storage")]
     let (state, events) = {
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         match crate::storage::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
@@ -3658,7 +3658,7 @@ mod es_switch_tests {
     #[tokio::test]
     async fn blackboard_es_run_persists_event_log() {
         use crate::core::orchestration::es::blackboard::run_blackboard_es;
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::init_embedded;
 
         // (a): Setup — same roster as `blackboard_es_state_is_recorded_via_
@@ -3714,8 +3714,8 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn ring_es_run_persists_event_log() {
-        use crate::core::orchestration::es::log::SqliteLog;
         use crate::core::orchestration::es::ring::run_ring_es;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::init_embedded;
 
         let db = init_embedded().unwrap();
@@ -3766,7 +3766,7 @@ mod es_switch_tests {
     #[tokio::test]
     async fn hierarchical_es_run_persists_event_log() {
         use crate::core::orchestration::es::hierarchical::run_hierarchical_es;
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::init_embedded;
 
         let db = init_embedded().unwrap();
@@ -3815,7 +3815,7 @@ mod es_switch_tests {
     #[tokio::test]
     async fn blackboard_es_run_projects_tables_from_log() {
         use crate::core::orchestration::es::blackboard::run_blackboard_es;
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::{init_embedded, queries};
 
         let db = init_embedded().unwrap();
@@ -4255,7 +4255,7 @@ mod es_switch_tests {
         use std::collections::BTreeMap;
 
         use crate::core::orchestration::es::direct::run_direct_es;
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
 
         let mut agent_meta = BTreeMap::new();
         agent_meta.insert(
@@ -4310,7 +4310,7 @@ mod es_switch_tests {
         let (live_capture, live_sink) = capture_sink();
         run_direct_against_sqlite_log(db.clone(), &run_id, &live_sink).await;
 
-        let replay_log = crate::core::orchestration::es::log::SqliteLog::new(db);
+        let replay_log = crate::storage::es_log::SqliteLog::new(db);
         let (replay_capture, replay_sink) = capture_sink();
         crate::cli::run_replay::replay_from_log(&replay_log, &run_id, &replay_sink, false).unwrap();
 
@@ -4384,7 +4384,7 @@ mod es_switch_tests {
         let (_live_capture, live_sink) = capture_sink();
         run_direct_against_sqlite_log(db.clone(), &run_id, &live_sink).await;
 
-        let replay_log = crate::core::orchestration::es::log::SqliteLog::new(db);
+        let replay_log = crate::storage::es_log::SqliteLog::new(db);
         let (replay_capture, replay_sink) = capture_sink();
         crate::cli::run_replay::replay_from_log(&replay_log, &run_id, &replay_sink, false).unwrap();
 
@@ -4434,7 +4434,7 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn replay_of_completed_ring_run_with_votes_includes_vote_tally() {
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::init_embedded;
 
         let db = init_embedded().unwrap();
@@ -4506,7 +4506,7 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[test]
     fn replay_unknown_run_id_errors() {
-        use crate::core::orchestration::es::log::SqliteLog;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::init_embedded;
 
         let log = SqliteLog::new(init_embedded().unwrap());
@@ -4558,8 +4558,8 @@ mod es_switch_tests {
     async fn resume_emits_run_start_bookend_before_the_mid_stream_events() {
         use crate::core::orchestration::es::bridge::synthetic_run_start;
         use crate::core::orchestration::es::direct::resume_direct_es;
-        use crate::core::orchestration::es::log::SqliteLog;
         use crate::core::orchestration::es::state::fold;
+        use crate::storage::es_log::SqliteLog;
         use crate::storage::init_embedded;
 
         let db = init_embedded().unwrap();

--- a/src/cli/run_es_record.rs
+++ b/src/cli/run_es_record.rs
@@ -333,8 +333,9 @@ pub fn record_ring_es_into(
 /// is malformed (e.g. no `RunStarted`) or storage fails.
 #[cfg(feature = "storage")]
 pub fn project_run(db: &crate::storage::Database, run_id: &str) -> anyhow::Result<()> {
-    use crate::core::orchestration::es::log::{EventLog, SqliteLog};
+    use crate::core::orchestration::es::log::EventLog;
     use crate::core::orchestration::es::state::fold;
+    use crate::storage::es_log::SqliteLog;
 
     // 1. Read the event log for this run.
     let log = SqliteLog::new(db.clone());
@@ -804,7 +805,7 @@ mod storage_tests {
         let db = init_embedded().unwrap();
 
         // Persist a minimal blackboard log via SqliteLog.
-        let mut log = crate::core::orchestration::es::log::SqliteLog::new(db.clone());
+        let mut log = crate::storage::es_log::SqliteLog::new(db.clone());
         for e in sample_blackboard_events("run-x") {
             use crate::core::orchestration::es::log::EventLog;
             log.append("run-x", &e).unwrap();

--- a/src/cli/run_replay.rs
+++ b/src/cli/run_replay.rs
@@ -88,7 +88,7 @@ pub async fn replay_run(
     sink: &Arc<dyn EventSink>,
     human_output: bool,
 ) -> anyhow::Result<()> {
-    use crate::core::orchestration::es::log::SqliteLog;
+    use crate::storage::es_log::SqliteLog;
 
     let db = crate::storage::init_db()?;
     let log = SqliteLog::new(db);

--- a/src/core/orchestration/es/log.rs
+++ b/src/core/orchestration/es/log.rs
@@ -1,9 +1,9 @@
 //! Event log persistence for orchestration runs (OH1 Lot 1 socle).
 //!
 //! `EventLog` is the storage-agnostic trait; `InMemoryLog` is the always-on
-//! implementation (used by tests and non-persistent runs), `SqliteLog` (gated
-//! behind the `storage` feature) persists into the `execution_events` table
-//! (schema v3, see `crate::storage::schema`).
+//! implementation (used by tests and non-persistent runs). A SQL-backed
+//! implementation lives bin-side under `crate::storage` (behind the
+//! `storage` feature), since `core` must stay storage-free.
 
 use std::collections::HashMap;
 
@@ -36,70 +36,6 @@ impl EventLog for InMemoryLog {
 
     fn events(&self, run_id: &str) -> anyhow::Result<Vec<ExecutionEvent>> {
         Ok(self.events.get(run_id).cloned().unwrap_or_default())
-    }
-}
-
-/// Extract the internal serde tag (`t`, e.g. `"run_started"`) from an
-/// `ExecutionEvent`'s serialized form, used as the `kind` column value.
-fn event_kind(event: &ExecutionEvent) -> anyhow::Result<String> {
-    let value = serde_json::to_value(event)?;
-    value
-        .get("t")
-        .and_then(|t| t.as_str())
-        .map(str::to_string)
-        .ok_or_else(|| anyhow::anyhow!("ExecutionEvent serialized without a `t` tag"))
-}
-
-/// SQLite-backed `EventLog`, persisting into `execution_events`
-/// (schema v3). Gated behind the `storage` feature.
-#[cfg(feature = "storage")]
-pub struct SqliteLog {
-    db: crate::storage::Database,
-}
-
-#[cfg(feature = "storage")]
-impl SqliteLog {
-    /// Wrap an existing storage handle.
-    pub fn new(db: crate::storage::Database) -> Self {
-        Self { db }
-    }
-}
-
-#[cfg(feature = "storage")]
-impl EventLog for SqliteLog {
-    fn append(&mut self, run_id: &str, event: &ExecutionEvent) -> anyhow::Result<()> {
-        let kind = event_kind(event)?;
-        let payload_json = serde_json::to_string(event)?;
-        let conn = self
-            .db
-            .lock()
-            .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
-        let seq: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM execution_events WHERE run_id = ?1",
-            rusqlite::params![run_id],
-            |r| r.get(0),
-        )?;
-        conn.execute(
-            "INSERT INTO execution_events (run_id, seq, kind, payload_json) VALUES (?1, ?2, ?3, ?4)",
-            rusqlite::params![run_id, seq, kind, payload_json],
-        )?;
-        Ok(())
-    }
-
-    fn events(&self, run_id: &str) -> anyhow::Result<Vec<ExecutionEvent>> {
-        let conn = self
-            .db
-            .lock()
-            .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
-        let mut stmt = conn.prepare(
-            "SELECT payload_json FROM execution_events WHERE run_id = ?1 ORDER BY seq ASC",
-        )?;
-        let rows = stmt.query_map(rusqlite::params![run_id], |r| r.get::<_, String>(0))?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(serde_json::from_str(&row?)?);
-        }
-        Ok(out)
     }
 }
 
@@ -142,24 +78,6 @@ mod tests {
         assert!(matches!(got[0], E::RunStarted { .. }));
         assert!(matches!(got[2], E::Completed { .. }));
         assert!(log.events("absent").unwrap().is_empty());
-    }
-
-    #[cfg(feature = "storage")]
-    #[test]
-    fn sqlite_log_roundtrip() {
-        let db = crate::storage::init_embedded().unwrap();
-        let mut log = SqliteLog::new(db);
-        for e in sample() {
-            log.append("r1", &e).unwrap();
-        }
-        let got = log.events("r1").unwrap();
-        assert_eq!(got.len(), 3);
-        // Assert the full ordering, not just the last element — this is the
-        // property that would break if `seq` were computed wrong (e.g.
-        // reversed or unstable ORDER BY).
-        assert!(matches!(got[0], E::RunStarted { .. }));
-        assert!(matches!(got[1], E::AgentObserved { .. }));
-        assert!(matches!(got[2], E::Completed { .. }));
     }
 
     /// Extract the `content` field of an `AgentObserved` event, panicking on
@@ -214,12 +132,5 @@ mod tests {
     #[test]
     fn in_memory_multi_run_id_seq_isolation() {
         assert_multi_run_id_seq_isolation(InMemoryLog::default());
-    }
-
-    #[cfg(feature = "storage")]
-    #[test]
-    fn sqlite_multi_run_id_seq_isolation() {
-        let db = crate::storage::init_embedded().unwrap();
-        assert_multi_run_id_seq_isolation(SqliteLog::new(db));
     }
 }

--- a/src/core/orchestration/es/mod.rs
+++ b/src/core/orchestration/es/mod.rs
@@ -28,9 +28,6 @@ pub use engine::{
 };
 #[allow(unused_imports)]
 pub use event::ExecutionEvent;
-#[cfg(feature = "storage")]
-#[allow(unused_imports)]
-pub use log::SqliteLog;
 #[allow(unused_imports)]
 pub use log::{EventLog, InMemoryLog};
 #[allow(unused_imports)]

--- a/src/storage/es_log.rs
+++ b/src/storage/es_log.rs
@@ -1,0 +1,171 @@
+//! SQLite-backed `EventLog` implementation (OH7 Lot 1 Task 1e).
+//!
+//! `SqliteLog` persists into the `execution_events` table (schema v3, see
+//! `crate::storage::schema`). It lives bin-side (not in `core`) because it
+//! depends on `rusqlite` and `crate::storage::Database` — `core` only owns
+//! the storage-agnostic `EventLog` trait and the always-on `InMemoryLog`
+//! (see `crate::core::orchestration::es::log`).
+
+use crate::core::orchestration::es::event::ExecutionEvent;
+use crate::core::orchestration::es::log::EventLog;
+
+/// Extract the internal serde tag (`t`, e.g. `"run_started"`) from an
+/// `ExecutionEvent`'s serialized form, used as the `kind` column value.
+fn event_kind(event: &ExecutionEvent) -> anyhow::Result<String> {
+    let value = serde_json::to_value(event)?;
+    value
+        .get("t")
+        .and_then(|t| t.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("ExecutionEvent serialized without a `t` tag"))
+}
+
+/// SQLite-backed `EventLog`, persisting into `execution_events`
+/// (schema v3).
+pub struct SqliteLog {
+    db: crate::storage::Database,
+}
+
+impl SqliteLog {
+    /// Wrap an existing storage handle.
+    pub fn new(db: crate::storage::Database) -> Self {
+        Self { db }
+    }
+}
+
+impl EventLog for SqliteLog {
+    fn append(&mut self, run_id: &str, event: &ExecutionEvent) -> anyhow::Result<()> {
+        let kind = event_kind(event)?;
+        let payload_json = serde_json::to_string(event)?;
+        let conn = self
+            .db
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+        let seq: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM execution_events WHERE run_id = ?1",
+            rusqlite::params![run_id],
+            |r| r.get(0),
+        )?;
+        conn.execute(
+            "INSERT INTO execution_events (run_id, seq, kind, payload_json) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![run_id, seq, kind, payload_json],
+        )?;
+        Ok(())
+    }
+
+    fn events(&self, run_id: &str) -> anyhow::Result<Vec<ExecutionEvent>> {
+        let conn = self
+            .db
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Database lock poisoned: {}", e))?;
+        let mut stmt = conn.prepare(
+            "SELECT payload_json FROM execution_events WHERE run_id = ?1 ORDER BY seq ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![run_id], |r| r.get::<_, String>(0))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(serde_json::from_str(&row?)?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::orchestration::es::event::ExecutionEvent as E;
+
+    fn sample() -> Vec<E> {
+        vec![
+            E::RunStarted {
+                run_id: "r1".into(),
+                pattern: "direct".into(),
+                agents: vec!["a".into()],
+                input: "x".into(),
+                project: None,
+            },
+            E::AgentObserved {
+                agent: "a".into(),
+                content: "hi".into(),
+                tokens_in: 1,
+                tokens_out: 1,
+                cost: 0.0,
+                model: "m".into(),
+            },
+            E::Completed {
+                content: "hi".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn sqlite_log_roundtrip() {
+        let db = crate::storage::init_embedded().unwrap();
+        let mut log = SqliteLog::new(db);
+        for e in sample() {
+            log.append("r1", &e).unwrap();
+        }
+        let got = log.events("r1").unwrap();
+        assert_eq!(got.len(), 3);
+        // Assert the full ordering, not just the last element — this is the
+        // property that would break if `seq` were computed wrong (e.g.
+        // reversed or unstable ORDER BY).
+        assert!(matches!(got[0], E::RunStarted { .. }));
+        assert!(matches!(got[1], E::AgentObserved { .. }));
+        assert!(matches!(got[2], E::Completed { .. }));
+    }
+
+    /// Extract the `content` field of an `AgentObserved` event, panicking on
+    /// any other variant. Used to check per-event identity/order in the
+    /// multi-`run_id` isolation test below.
+    fn observed_content(event: &E) -> &str {
+        match event {
+            E::AgentObserved { content, .. } => content,
+            other => panic!("expected AgentObserved, got {other:?}"),
+        }
+    }
+
+    /// Build an `AgentObserved` event carrying `run_id` and `idx` in its
+    /// `content`, so a mis-isolated log (e.g. a `seq`/PK collision between
+    /// two `run_id`s) shows up as a wrong-content or leaked event rather
+    /// than just a wrong count.
+    fn marker(run_id: &str, idx: usize) -> E {
+        E::AgentObserved {
+            agent: "a".into(),
+            content: format!("{run_id}-{idx}"),
+            tokens_in: 1,
+            tokens_out: 1,
+            cost: 0.0,
+            model: "m".into(),
+        }
+    }
+
+    /// Interleave appends to two distinct `run_id`s (rA, rB, rA, rB, rA) and
+    /// verify each `run_id` gets back exactly its own events, in insertion
+    /// order, with none of the other's leaking in. This is the scenario
+    /// that would break under a `seq`/`(run_id, seq)` collision. (Mirrors
+    /// `crate::core::orchestration::es::log::tests::assert_multi_run_id_seq_isolation`
+    /// for `InMemoryLog` — duplicated here since `SqliteLog` now lives in a
+    /// different crate/module and that helper is private to core's tests.)
+    #[test]
+    fn sqlite_multi_run_id_seq_isolation() {
+        let db = crate::storage::init_embedded().unwrap();
+        let mut log = SqliteLog::new(db);
+        let run_ids = ["rA", "rB", "rA", "rB", "rA"];
+        for (idx, run_id) in run_ids.iter().enumerate() {
+            log.append(run_id, &marker(run_id, idx)).unwrap();
+        }
+
+        let a = log.events("rA").unwrap();
+        let b = log.events("rB").unwrap();
+
+        assert_eq!(a.len(), 3, "rA should have exactly its 3 own events");
+        assert_eq!(b.len(), 2, "rB should have exactly its 2 own events");
+
+        let a_contents: Vec<&str> = a.iter().map(observed_content).collect();
+        assert_eq!(a_contents, vec!["rA-0", "rA-2", "rA-4"]);
+
+        let b_contents: Vec<&str> = b.iter().map(observed_content).collect();
+        assert_eq!(b_contents, vec!["rB-1", "rB-3"]);
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "storage")]
+pub mod es_log;
 pub mod queries;
 pub mod schema;
 


### PR DESCRIPTION
Dernier sous-lot d'**OH7 Lot 1** — rend `armadai-core` **storage-free**. Refactor **pur** par split.

- **Restent dans `core::orchestration::es::log`** : trait `EventLog` + `InMemoryLog` (toujours-actifs) + leurs tests.
- **Sortis vers `src/storage/es_log.rs`** (bin, gated `storage`) : `SqliteLog` + `impl core::…::EventLog for SqliteLog` + son test + le helper `event_kind()`. SQL schema-v3 **byte-identique**.
- Re-export `es::SqliteLog` retiré (pas de shim) ; `cli/{run_replay,run,projections,run_es_record}` repointés vers `crate::storage::es_log::SqliteLog`.

## Invariant (le but de tout le Lot 1)
`grep -rn 'rusqlite\|use crate::storage' src/core` → **vide** → `armadai-core` est désormais une **vraie feuille** sans dépendance interne ni dépendance lourde optionnelle.

Gate clippy 3 modes `-D warnings` + tests 2 modes (1042 `tui` / 1088 `tui,storage`, resume/replay + es_log e2e OK) verts (vérifié indép au compilateur).

Minor (suivi) : un helper de test (~15 l.) dupliqué côté bin (privé au module de test de core) — tradeoff pré-workspace, à remplacer par un crate test-utils quand core deviendra un crate séparé.

**Clôt le Lot 1** (casser les cycles). Prochain : Lot 2 (workspace + extraction des feuilles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)