### PR TITLE
refactor(oh7): Lot 2b — move init_db/path-resolution to bin db module, storage now core-free (#252)

### DIFF
--- a/src/cli/costs.rs
+++ b/src/cli/costs.rs
@@ -1,7 +1,8 @@
 pub async fn execute(agent: Option<String>, _from: Option<String>) -> anyhow::Result<()> {
     #[cfg(feature = "storage")]
     {
-        use crate::storage::{init_db, queries};
+        use crate::db::init_db;
+        use crate::storage::queries;
 
         let db = init_db()?;
         let summaries = queries::get_costs_summary(&db, agent.as_deref())?;

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -1,7 +1,8 @@
 pub async fn execute(agent: Option<String>) -> anyhow::Result<()> {
     #[cfg(feature = "storage")]
     {
-        use crate::storage::{init_db, queries};
+        use crate::db::init_db;
+        use crate::storage::queries;
 
         let db = init_db()?;
 

--- a/src/cli/projections.rs
+++ b/src/cli/projections.rs
@@ -58,7 +58,7 @@ pub async fn execute(action: ProjectionsAction) -> anyhow::Result<()> {
         ProjectionsAction::Rebuild { run, all: _all } => {
             #[cfg(feature = "storage")]
             {
-                let db = crate::storage::init_db()?;
+                let db = crate::db::init_db()?;
 
                 if let Some(id) = run {
                     rebuild_run(&db, &id)?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -262,7 +262,7 @@ async fn execute_resume(
         // mirrors the agent path's own `use_tui` gate in `execute`, which
         // needs to know the pattern is "orchestrated" before offering it.
         let peek = {
-            let db = crate::storage::init_db()?;
+            let db = crate::db::init_db()?;
             let log = SqliteLog::new(db);
             replay(run_id, &log)?
         };
@@ -365,7 +365,7 @@ async fn resume_run(
     use crate::core::orchestration::es::state::{RunStatus, fold};
     use crate::es_log::SqliteLog;
 
-    let db = crate::storage::init_db()?;
+    let db = crate::db::init_db()?;
     let log = SqliteLog::new(db.clone());
     // Read the raw log back once, up front: `fold` gives the roster/status
     // needed to validate + dispatch the resume below, and the SAME raw
@@ -544,7 +544,7 @@ async fn resume_run(
 
     let events = proj_log.events(run_id)?;
 
-    match crate::storage::init_db() {
+    match crate::db::init_db() {
         Ok(db2) => {
             if let Err(e) = crate::cli::run_es_record::project_run(&db2, run_id) {
                 tracing::warn!("failed to project resumed run {}: {}", run_id, e);
@@ -1234,7 +1234,7 @@ async fn dispatch_direct_es(
     #[cfg(feature = "storage")]
     let (state, events) = {
         use crate::es_log::SqliteLog;
-        match crate::storage::init_db() {
+        match crate::db::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
                 tracing::warn!("event log storage unavailable, run will not be persisted: {e}");
@@ -1384,7 +1384,8 @@ struct RunMetrics {
 
 #[cfg(feature = "storage")]
 fn record_run(metrics: &RunMetrics, input: &str, output: &str, project: Option<&str>) {
-    use crate::storage::{init_db, queries};
+    use crate::db::init_db;
+    use crate::storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,
@@ -1887,7 +1888,7 @@ async fn run_orchestrated_inner(
 
             #[cfg(feature = "storage")]
             {
-                match crate::storage::init_db() {
+                match crate::db::init_db() {
                     Ok(db) => {
                         if let Err(e) = crate::cli::run_es_record::project_run(&db, &_run_id) {
                             tracing::warn!("failed to project run {}: {}", _run_id, e);
@@ -1966,7 +1967,7 @@ async fn run_orchestrated_inner(
 
             #[cfg(feature = "storage")]
             {
-                match crate::storage::init_db() {
+                match crate::db::init_db() {
                     Ok(db) => {
                         if let Err(e) = crate::cli::run_es_record::project_run(&db, &_run_id) {
                             tracing::warn!("failed to project run {}: {}", _run_id, e);
@@ -2077,7 +2078,7 @@ async fn run_orchestrated_inner(
 
             #[cfg(feature = "storage")]
             {
-                match crate::storage::init_db() {
+                match crate::db::init_db() {
                     Ok(db) => {
                         if let Err(e) = crate::cli::run_es_record::project_run(&db, &_run_id) {
                             tracing::warn!("failed to project run {}: {}", _run_id, e);
@@ -2208,7 +2209,7 @@ async fn dispatch_blackboard_es(
     #[cfg(feature = "storage")]
     let state = {
         use crate::es_log::SqliteLog;
-        match crate::storage::init_db() {
+        match crate::db::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
                 tracing::warn!("event log storage unavailable, run will not be persisted: {e}");
@@ -2271,7 +2272,7 @@ async fn dispatch_ring_es(
     #[cfg(feature = "storage")]
     let (state, events) = {
         use crate::es_log::SqliteLog;
-        match crate::storage::init_db() {
+        match crate::db::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
                 tracing::warn!("event log storage unavailable, run will not be persisted: {e}");
@@ -2334,7 +2335,7 @@ async fn dispatch_hierarchical_es(
     #[cfg(feature = "storage")]
     let (state, events) = {
         use crate::es_log::SqliteLog;
-        match crate::storage::init_db() {
+        match crate::db::init_db() {
             Ok(db) => run_with_log!(SqliteLog::new(db)),
             Err(e) => {
                 tracing::warn!("event log storage unavailable, run will not be persisted: {e}");
@@ -3206,7 +3207,7 @@ mod es_switch_tests {
     }
 
     /// Redirect `storage` at a throwaway temp DB for the scope of a test, so
-    /// the ES dispatch's persistence (`SqliteLog` via `crate::storage::init_db`)
+    /// the ES dispatch's persistence (`SqliteLog` via `crate::db::init_db`)
     /// never writes into the user's real event log (#267). Points
     /// `ARMADAI_CONFIG_DIR` at a temp `config.yaml` whose `storage.path` is a
     /// scratch sqlite file; serialised via `ENV_MUTEX` and restored on drop.
@@ -4225,7 +4226,7 @@ mod es_switch_tests {
     //
     // These tests drive `run_replay::replay_from_log` — the `pub(crate)`,
     // generic-over-`EventLog` core `replay_run` wraps around its own
-    // `crate::storage::init_db()` call — directly against an in-memory
+    // `crate::db::init_db()` call — directly against an in-memory
     // `SqliteLog` (`init_embedded()`), the SAME idiom
     // `blackboard_es_run_persists_event_log`/`ring_es_run_persists_event_log`
     // already use above. This deliberately avoids exercising `init_db()`
@@ -4233,7 +4234,7 @@ mod es_switch_tests {
     // an earlier version of this test mutated `ARMADAI_CONFIG_DIR`/
     // `XDG_DATA_HOME` process-wide to sandbox `init_db()`, which raced with
     // OTHER tests in this same file (`dispatch_ring_es` et al.) that also
-    // call `crate::storage::init_db()` internally under `storage` but hold
+    // call `crate::db::init_db()` internally under `storage` but hold
     // no such guard — those tests intermittently failed to open their own
     // (unrelated) DB while this test's temp dirs existed/were torn down
     // concurrently. Testing the generic core instead sidesteps that
@@ -4245,7 +4246,7 @@ mod es_switch_tests {
     /// pattern) so the "live" side of the determinism test below persists
     /// through the exact same `SqliteLog`/`SinkProjectingLog` machinery a
     /// real `--storage` run does, without going through `dispatch_direct_es`
-    /// (which would call the real `crate::storage::init_db()`).
+    /// (which would call the real `crate::db::init_db()`).
     #[cfg(feature = "storage")]
     async fn run_direct_against_sqlite_log(
         db: crate::storage::Database,
@@ -4538,7 +4539,7 @@ mod es_switch_tests {
     // files on disk via `resolve_agents_dir`/`resolve_agent_path` — driving
     // it directly in a hermetic unit test would mean mutating the process
     // CWD/project resolution, racing every other test in this file that
-    // also touches `crate::storage::init_db()`/project resolution (same
+    // also touches `crate::db::init_db()`/project resolution (same
     // reasoning as the big comment above the `--replay` determinism tests).
     // This test instead drives the EXACT sequence `resume_run` performs on
     // an injected `SqliteLog`: fold the log, emit `synthetic_run_start` from

--- a/src/cli/run_replay.rs
+++ b/src/cli/run_replay.rs
@@ -31,7 +31,7 @@
 //!
 //! Split in two on purpose:
 //! - [`replay_run`] is the CLI-facing entry point: opens the real
-//!   `SqliteLog` via `crate::storage::init_db()` (the actual, global,
+//!   `SqliteLog` via `crate::db::init_db()` (the actual, global,
 //!   config-resolved DB — same one every other storage-gated run path
 //!   opens) and hands off to...
 //! - [`replay_from_log`], generic over any [`EventLog`], which does the
@@ -77,7 +77,7 @@ use crate::core::events::EventSink;
 use crate::core::events::RunEvent;
 
 /// Replay a finished run: open the real, config-resolved event log
-/// (`crate::storage::init_db()` + `SqliteLog`) and re-emit the same
+/// (`crate::db::init_db()` + `SqliteLog`) and re-emit the same
 /// `RunEvent` sequence a live run produced for it, executing no effects.
 /// Returns an error if `run_id` has no persisted events (unknown id) or if
 /// the `storage` feature isn't compiled in (the event log only persists
@@ -90,7 +90,7 @@ pub async fn replay_run(
 ) -> anyhow::Result<()> {
     use crate::es_log::SqliteLog;
 
-    let db = crate::storage::init_db()?;
+    let db = crate::db::init_db()?;
     let log = SqliteLog::new(db);
     replay_from_log(&log, run_id, sink, human_output)
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,76 @@
+//! Bin-side database bootstrap (OH7 Lot 2b).
+//!
+//! Owns the config-driven path resolution that used to live in the storage
+//! module's `init_db`. Depends on `crate::core::config`; delegates the actual
+//! open+schema to the storage wrapper (`crate::storage::open`), which is
+//! core-free. Kept bin-side so `armadai-storage` stays a pure rusqlite leaf.
+
+use std::path::{Path, PathBuf};
+
+use crate::storage::Database;
+
+/// Resolve a possibly-relative `storage.path` to an absolute path.
+///
+/// Absolute paths are used verbatim. A relative path (e.g. the legacy default
+/// `data/armadai.sqlite`) is anchored under the user data dir so the DB is
+/// CWD-independent and `--resume`/`--replay` work from any directory (#266),
+/// warning once so the user can migrate their config to an absolute path.
+fn resolve_storage_path(configured: &str) -> PathBuf {
+    let p = Path::new(configured);
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            "storage.path '{configured}' is relative and was resolved under the data dir \
+             (it used to be CWD-relative, which fragments the event log per directory and \
+             breaks --resume/--replay from another directory). Set an absolute storage.path \
+             in config.yaml to silence this."
+        );
+    });
+    crate::core::config::data_dir().join(p)
+}
+
+/// Initialize a persistent SQLite database at the configured path.
+pub fn init_db() -> anyhow::Result<Database> {
+    let config = crate::core::config::load_user_config();
+    let path = resolve_storage_path(&config.storage.path);
+
+    // Safety net (#267): no test may open the real user database.
+    #[cfg(test)]
+    {
+        let real = crate::core::config::data_dir();
+        assert!(
+            !path.starts_with(&real),
+            "init_db() would open the real user database at {} during a test — \
+             redirect storage (ARMADAI_CONFIG_DIR -> temp config) or use init_embedded()",
+            path.display()
+        );
+    }
+
+    crate::storage::open(&path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_storage_path_used_verbatim() {
+        let abs = if cfg!(windows) {
+            r"C:\tmp\db.sqlite"
+        } else {
+            "/tmp/db.sqlite"
+        };
+        assert_eq!(resolve_storage_path(abs), PathBuf::from(abs));
+    }
+
+    #[test]
+    fn relative_storage_path_anchored_under_data_dir() {
+        let resolved = resolve_storage_path("data/armadai.sqlite");
+        assert!(resolved.is_absolute());
+        assert!(resolved.starts_with(crate::core::config::data_dir()));
+        assert!(resolved.ends_with("data/armadai.sqlite"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ mod audit;
 mod cli;
 mod core;
 #[cfg(feature = "storage")]
+mod db;
+#[cfg(feature = "storage")]
 mod es_log;
 mod linker;
 mod logging;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,62 +2,19 @@ pub mod queries;
 pub mod schema;
 
 use rusqlite::Connection;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 pub type Database = Arc<Mutex<Connection>>;
 
-/// Resolve a possibly-relative `storage.path` to an absolute path.
-///
-/// Absolute paths are used verbatim. A **relative** path (e.g. the legacy
-/// default `data/armadai.sqlite`) used to be opened relative to the current
-/// working directory, so the event log lived in a different DB per CWD and
-/// `--resume`/`--replay` only worked from the directory the run started in
-/// (#266). Anchor such paths under the user data dir instead, so the DB is
-/// CWD-independent, and warn once so the user can migrate their config to an
-/// absolute path.
-fn resolve_storage_path(configured: &str) -> PathBuf {
-    let p = Path::new(configured);
-    if p.is_absolute() {
-        return p.to_path_buf();
-    }
-    static WARNED: std::sync::Once = std::sync::Once::new();
-    WARNED.call_once(|| {
-        tracing::warn!(
-            "storage.path '{configured}' is relative and was resolved under the data dir \
-             (it used to be CWD-relative, which fragments the event log per directory and \
-             breaks --resume/--replay from another directory). Set an absolute storage.path \
-             in config.yaml to silence this."
-        );
-    });
-    crate::core::config::data_dir().join(p)
-}
-
-/// Initialize a persistent SQLite database at the configured path.
-pub fn init_db() -> anyhow::Result<Database> {
-    let config = crate::core::config::load_user_config();
-    let path = resolve_storage_path(&config.storage.path);
-
-    // Safety net (#267): no test may open the real user database. Tests must
-    // redirect storage (e.g. point `ARMADAI_CONFIG_DIR` at a temp config, or
-    // use `init_embedded()`); a test that reaches the real data-dir DB is a
-    // silent-pollution bug, so fail loudly at the source instead of writing
-    // `test-run`-style rows into the user's real event log.
-    #[cfg(test)]
-    {
-        let real = crate::core::config::data_dir();
-        assert!(
-            !path.starts_with(&real),
-            "init_db() would open the real user database at {} during a test — \
-             redirect storage (ARMADAI_CONFIG_DIR -> temp config) or use init_embedded()",
-            path.display()
-        );
-    }
-
+/// Open a persistent SQLite database at `path` and apply the schema.
+/// Pure storage primitive: no config/path-resolution logic (that lives
+/// bin-side in `crate::db`).
+pub fn open(path: &Path) -> anyhow::Result<Database> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let conn = Connection::open(&path)?;
+    let conn = Connection::open(path)?;
     schema::apply(&conn)?;
     Ok(Arc::new(Mutex::new(conn)))
 }
@@ -68,29 +25,4 @@ pub fn init_embedded() -> anyhow::Result<Database> {
     let conn = Connection::open_in_memory()?;
     schema::apply(&conn)?;
     Ok(Arc::new(Mutex::new(conn)))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn absolute_storage_path_used_verbatim() {
-        let abs = if cfg!(windows) {
-            r"C:\tmp\db.sqlite"
-        } else {
-            "/tmp/db.sqlite"
-        };
-        assert_eq!(resolve_storage_path(abs), PathBuf::from(abs));
-    }
-
-    #[test]
-    fn relative_storage_path_anchored_under_data_dir() {
-        // The legacy CWD-relative default must resolve to an absolute path
-        // under the data dir, not against the current working directory.
-        let resolved = resolve_storage_path("data/armadai.sqlite");
-        assert!(resolved.is_absolute());
-        assert!(resolved.starts_with(crate::core::config::data_dir()));
-        assert!(resolved.ends_with("data/armadai.sqlite"));
-    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -614,7 +614,8 @@ impl App {
 
     #[cfg(feature = "storage")]
     pub fn load_orchestration_runs(&mut self) {
-        use crate::storage::{init_db, queries};
+        use crate::db::init_db;
+        use crate::storage::queries;
 
         let db = match init_db() {
             Ok(db) => db,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -405,7 +405,8 @@ fn handle_top_level_esc(app: &mut app::App) -> bool {
 
 #[cfg(feature = "storage")]
 fn load_storage_data(app: &mut app::App) {
-    use crate::storage::{init_db, queries};
+    use crate::db::init_db;
+    use crate::storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -115,7 +115,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
 pub fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(entry) = app.selected_orchestration_entry() {
-        use crate::storage::{init_db, queries};
+        use crate::db::init_db;
+        use crate::storage::queries;
 
         let detail_content = match init_db() {
             Ok(db) => {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -292,7 +292,8 @@ pub async fn get_agent(Path(name): Path<String>) -> Json<serde_json::Value> {
 
 #[cfg(feature = "storage")]
 pub async fn get_history() -> Json<Vec<HistoryEntry>> {
-    use crate::storage::{init_db, queries};
+    use crate::db::init_db;
+    use crate::storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,
@@ -326,7 +327,8 @@ pub async fn get_history() -> Json<Vec<HistoryEntry>> {
 
 #[cfg(feature = "storage")]
 pub async fn get_costs() -> Json<Vec<CostSummary>> {
-    use crate::storage::{init_db, queries};
+    use crate::db::init_db;
+    use crate::storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,
@@ -632,7 +634,8 @@ pub async fn get_starter_config(Path(name): Path<String>) -> impl IntoResponse {
 pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
     #[cfg(feature = "storage")]
     {
-        use crate::storage::{init_db, queries};
+        use crate::db::init_db;
+        use crate::storage::queries;
         if let Ok(db) = init_db()
             && let Ok(runs) = queries::get_root_orchestration_runs(&db, 50)
         {
@@ -749,7 +752,8 @@ fn fetch_run_entries(
 /// `run_id`.
 #[cfg(feature = "storage")]
 pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<serde_json::Value> {
-    use crate::storage::{init_db, queries};
+    use crate::db::init_db;
+    use crate::storage::queries;
 
     let empty = || {
         serde_json::json!({
@@ -956,7 +960,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_orchestration_trace_detail_returns_run_and_entries() {
         let _guard = TempStorageGuard::new();
-        let db = crate::storage::init_db().unwrap();
+        let db = crate::db::init_db().unwrap();
 
         // `orchestration_runs.run_id` references `runs(id)`, so seed the
         // parent row first (mirrors how the orchestration engine writes both
@@ -1053,7 +1057,7 @@ mod tests {
     async fn test_get_orchestration_trace_detail_unknown_run_is_null() {
         let _guard = TempStorageGuard::new();
         // Ensure the DB/schema exists even though no run is inserted.
-        drop(crate::storage::init_db().unwrap());
+        drop(crate::db::init_db().unwrap());
 
         let response = get_orchestration_trace_detail(Path("does-not-exist".to_string())).await;
         let value = response.0;
@@ -1066,7 +1070,7 @@ mod tests {
     #[tokio::test]
     async fn test_trace_detail_hierarchical_has_delegation_events_and_children() {
         let _guard = TempStorageGuard::new();
-        let db = crate::storage::init_db().unwrap();
+        let db = crate::db::init_db().unwrap();
 
         // Parent hierarchical run.
         insert_run_with_id(


### PR DESCRIPTION
## OH7 Lot 2b — `init_db`/résolution-chemin → bin `db`, storage core-free

Casse la seconde arête `storage → core`. `init_db`, `resolve_storage_path` et le garde-fou de test (#267) — tous dépendants de `core::config` — sortent de `storage/mod.rs` vers un nouveau module bin `src/db.rs`. `src/storage/mod.rs` devient **entièrement core-free**.

**Déplacement pur** (aucun changement de logique) :
- `src/db.rs` (nouveau) : `init_db` + `resolve_storage_path` (ancrage #266 + warn-once) + garde-fou #267 + 2 tests de résolution (déplacés, pas supprimés)
- `storage/mod.rs` : nouvelle primitive pure `open(path)` (create_dir + `Connection::open` + `schema::apply` + `Arc<Mutex>`) ; `init_db` délègue à `storage::open`. `init_embedded` inchangé. `PathBuf` import réduit.
- ~13 call-sites `crate::storage::init_db` → `crate::db::init_db`

**Invariant** : `grep "crate::core" src/storage/mod.rs` → vide. Gate verte 3 modes clippy + tests 1042/1088 (inchangés). Revue indépendante : clean (gate rejoué).

Plan : `docs/superpowers/plans/2026-07-28-oh7-lot2-workspace-leaves.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)