### PR TITLE
refactor(oh7): Lot 2d — extract armadai-storage leaf crate (#252)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "armadai-secrets",
+ "armadai-storage",
  "assert_cmd",
  "async-trait",
  "axum",
@@ -139,6 +140,16 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "tracing",
+]
+
+[[package]]
+name = "armadai-storage"
+version = "1.0.0-rc.5"
+dependencies = [
+ "anyhow",
+ "rusqlite",
+ "serde",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ path = "src/bin/fake-claude.rs"
 default = ["tui", "web", "storage", "providers-api"]
 tui = ["dep:ratatui", "dep:crossterm", "dep:portable-pty", "dep:strip-ansi-escapes", "dep:unicode-width"]
 web = ["dep:axum", "dep:tower-http"]
-storage = ["dep:rusqlite"]
+storage = ["dep:armadai-storage", "dep:rusqlite"]
 providers-api = ["dep:reqwest"]
 
 [dependencies]
 # Workspace crates
 armadai-secrets = { path = "crates/armadai-secrets" }
+armadai-storage = { path = "crates/armadai-storage", optional = true }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/armadai-storage/Cargo.toml
+++ b/crates/armadai-storage/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "armadai-storage"
+version = "1.0.0-rc.5"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ArmadAI — SQLite-backed persistence (runs + event log)."
+
+[dependencies]
+anyhow = "1"
+rusqlite = { version = "0.40", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/armadai-storage/src/lib.rs
+++ b/crates/armadai-storage/src/lib.rs
@@ -19,9 +19,9 @@ pub fn open(path: &Path) -> anyhow::Result<Database> {
     Ok(Arc::new(Mutex::new(conn)))
 }
 
-/// Initialize an in-memory SQLite database (for tests).
-#[cfg(test)]
-pub fn init_embedded() -> anyhow::Result<Database> {
+/// Open an in-memory SQLite database with the schema applied. Used by tests
+/// (bin-side and crate-side) that must not touch the real user database.
+pub fn open_in_memory() -> anyhow::Result<Database> {
     let conn = Connection::open_in_memory()?;
     schema::apply(&conn)?;
     Ok(Arc::new(Mutex::new(conn)))

--- a/crates/armadai-storage/src/queries.rs
+++ b/crates/armadai-storage/src/queries.rs
@@ -657,7 +657,7 @@ pub fn delete_projection_for_run(db: &Database, run_id: &str) -> anyhow::Result<
 /// event log. Callers that need the pattern for EVERY run (e.g.
 /// `armadai run --resume`) must fall back to the event-sourced
 /// `ExecutionState::pattern` (folded from the log's own `RunStarted` event
-/// via [`crate::core::orchestration::es::engine::replay`]), which is always
+/// via `core::orchestration::es::engine::replay`), which is always
 /// populated regardless of pattern.
 pub fn get_run_pattern(db: &Database, run_id: &str) -> anyhow::Result<Option<String>> {
     let conn = db
@@ -692,7 +692,7 @@ pub fn all_event_log_run_ids(db: &Database) -> anyhow::Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::init_embedded;
+    use crate::open_in_memory;
 
     fn sample_run(agent: &str, cost: f64) -> RunRecord {
         RunRecord {
@@ -712,7 +712,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_history() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         insert_run(&db, sample_run("agent-a", 0.01)).unwrap();
         insert_run(&db, sample_run("agent-b", 0.02)).unwrap();
 
@@ -726,7 +726,7 @@ mod tests {
 
     #[test]
     fn test_run_project_roundtrips_through_history() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let mut with_project = sample_run("agent-a", 0.01);
         with_project.project = Some("/home/user/my-project".to_string());
         insert_run(&db, with_project).unwrap();
@@ -742,7 +742,7 @@ mod tests {
 
     #[test]
     fn test_costs_summary() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         insert_run(&db, sample_run("agent-a", 0.01)).unwrap();
         insert_run(&db, sample_run("agent-a", 0.02)).unwrap();
         insert_run(&db, sample_run("agent-b", 0.05)).unwrap();
@@ -758,7 +758,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_orchestration_run() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         // First insert a parent run
         insert_run(&db, sample_run("agent-a", 0.01)).unwrap();
         let run_id = {
@@ -788,7 +788,7 @@ mod tests {
 
     #[test]
     fn test_get_run_pattern_returns_stored_pattern() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         // `orchestration_runs.run_id` is a FK into `runs.id` — insert the
         // parent row first, exactly like `test_insert_and_get_orchestration_run`.
         insert_run_with_id(
@@ -820,7 +820,7 @@ mod tests {
     /// `None` as "unknown run".
     #[test]
     fn test_get_run_pattern_none_for_unknown_run() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         assert_eq!(get_run_pattern(&db, "no-such-run").unwrap(), None);
     }
 
@@ -831,7 +831,7 @@ mod tests {
         // `limit` rows and filtering roots out in Rust afterwards — the
         // latter lets children consume slots in the LIMIT window and can
         // silently return fewer than `limit` roots.
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
 
         insert_run_with_id(&db, "root-1", sample_run("agent-a", 0.01)).unwrap();
         insert_run_with_id(&db, "root-2", sample_run("agent-a", 0.02)).unwrap();
@@ -895,7 +895,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_board_entries() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         insert_run(&db, sample_run("agent-a", 0.01)).unwrap();
         let run_id = {
             let conn = db.lock().unwrap();
@@ -958,7 +958,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_ring_contributions() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         insert_run(&db, sample_run("agent-a", 0.01)).unwrap();
         let run_id = {
             let conn = db.lock().unwrap();
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_ring_votes() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         insert_run(&db, sample_run("agent-a", 0.01)).unwrap();
         let run_id = {
             let conn = db.lock().unwrap();
@@ -1058,35 +1058,35 @@ mod tests {
 
     #[test]
     fn test_get_orchestration_run_not_found() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let result = get_orchestration_run(&db, "nonexistent").unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn test_get_board_entries_empty() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let entries = get_board_entries(&db, "nonexistent").unwrap();
         assert!(entries.is_empty());
     }
 
     #[test]
     fn test_get_ring_contributions_empty() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let contribs = get_ring_contributions(&db, "nonexistent").unwrap();
         assert!(contribs.is_empty());
     }
 
     #[test]
     fn test_get_ring_votes_empty() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let votes = get_ring_votes(&db, "nonexistent").unwrap();
         assert!(votes.is_empty());
     }
 
     #[test]
     fn test_orchestration_run_parent_and_children() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         // parent hierarchical run
         insert_run(&db, sample_run("coord", 0.0)).unwrap();
         let parent_id = {
@@ -1145,7 +1145,7 @@ mod tests {
 
     #[test]
     fn test_delegation_events_roundtrip() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         insert_run(&db, sample_run("coord", 0.0)).unwrap();
         let run_id = {
             let conn = db.lock().unwrap();

--- a/crates/armadai-storage/src/schema.rs
+++ b/crates/armadai-storage/src/schema.rs
@@ -216,7 +216,7 @@ fn migrate_to_v2(conn: &Connection) -> anyhow::Result<()> {
 }
 
 /// v2 → v3: add `execution_events`, the append-only event-sourcing log for
-/// orchestration runs (OH1 Lot 1 socle — `crate::core::orchestration::es`).
+/// orchestration runs (OH1 Lot 1 socle — `core::orchestration::es`).
 /// `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` are both
 /// idempotent, so this is safe to run unconditionally (a fresh database
 /// already has the table from `apply`'s base batch above, in which case this

--- a/src/cli/costs.rs
+++ b/src/cli/costs.rs
@@ -2,7 +2,7 @@ pub async fn execute(agent: Option<String>, _from: Option<String>) -> anyhow::Re
     #[cfg(feature = "storage")]
     {
         use crate::db::init_db;
-        use crate::storage::queries;
+        use armadai_storage::queries;
 
         let db = init_db()?;
         let summaries = queries::get_costs_summary(&db, agent.as_deref())?;

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -2,7 +2,7 @@ pub async fn execute(agent: Option<String>) -> anyhow::Result<()> {
     #[cfg(feature = "storage")]
     {
         use crate::db::init_db;
-        use crate::storage::queries;
+        use armadai_storage::queries;
 
         let db = init_db()?;
 

--- a/src/cli/projections.rs
+++ b/src/cli/projections.rs
@@ -25,7 +25,7 @@ pub enum ProjectionsAction {
 }
 
 #[cfg(feature = "storage")]
-use crate::storage::Database;
+use armadai_storage::Database;
 
 /// Rebuild projections for a single run from its event log.
 ///
@@ -44,7 +44,7 @@ pub fn rebuild_run(db: &Database, run_id: &str) -> anyhow::Result<()> {
 /// projector is idempotent).
 #[cfg(feature = "storage")]
 pub fn rebuild_all(db: &Database) -> anyhow::Result<usize> {
-    let run_ids = crate::storage::queries::all_event_log_run_ids(db)?;
+    let run_ids = armadai_storage::queries::all_event_log_run_ids(db)?;
     let count = run_ids.len();
     for run_id in run_ids {
         rebuild_run(db, &run_id)?;
@@ -90,7 +90,7 @@ mod tests {
     use crate::core::orchestration::es::event::ExecutionEvent;
     use crate::core::orchestration::es::log::EventLog;
     use crate::es_log::SqliteLog;
-    use crate::storage::{init_embedded, queries};
+    use armadai_storage::{open_in_memory, queries};
 
     /// Helper: construct a minimal blackboard event log suitable for
     /// projection tests (copied from run_es_record.rs storage_tests).
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn rebuild_reprojects_a_run_from_the_log() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
 
         // Persist a log + project once.
         let run_id = "run-y";
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn rebuild_all_projects_all_runs_in_the_log() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
 
         // Persist two runs.
         let mut log = SqliteLog::new(db.clone());

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -385,7 +385,7 @@ async fn resume_run(
     // back to the log-folded `state.pattern` — the ONLY source available for
     // `direct` runs, which never get an `orchestration_runs` row (see
     // `queries::get_run_pattern`'s doc comment).
-    let pattern = crate::storage::queries::get_run_pattern(&db, run_id)
+    let pattern = armadai_storage::queries::get_run_pattern(&db, run_id)
         .ok()
         .flatten()
         .unwrap_or_else(|| state.pattern.clone());
@@ -1385,7 +1385,7 @@ struct RunMetrics {
 #[cfg(feature = "storage")]
 fn record_run(metrics: &RunMetrics, input: &str, output: &str, project: Option<&str>) {
     use crate::db::init_db;
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,
@@ -2489,14 +2489,14 @@ fn apply_ring_overrides(
 /// delegation trace. Returns the provided hierarchical `run_id`.
 #[cfg(feature = "storage")]
 pub(crate) fn record_hierarchical_into(
-    db: &crate::storage::Database,
+    db: &armadai_storage::Database,
     run_id: &str,
     result: &crate::core::orchestration::hierarchical::OrchestrationResult,
     config: &crate::core::orchestration::OrchestrationConfig,
     input: &str,
     project: Option<&str>,
 ) -> anyhow::Result<String> {
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     // 1. Parent run record.
     let parent = queries::RunRecord {
@@ -2959,11 +2959,11 @@ mod storage_tests {
     use super::*;
     use crate::core::orchestration::OrchestrationConfig;
     use crate::core::orchestration::hierarchical::{DelegationEvent, OrchestrationResult};
-    use crate::storage::{init_embedded, queries};
+    use armadai_storage::{open_in_memory, queries};
 
     #[test]
     fn hierarchical_run_and_trace_are_persisted() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
 
         // A hierarchical result with one delegation event.
         let result = OrchestrationResult {
@@ -3001,7 +3001,7 @@ mod storage_tests {
 
     #[test]
     fn hierarchical_run_records_project_on_parent() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
 
         let result = OrchestrationResult {
             content: "final".to_string(),
@@ -3488,7 +3488,7 @@ mod es_switch_tests {
     #[tokio::test]
     async fn hierarchical_es_result_is_recorded_via_record_hierarchical_into() {
         let _storage = TempStorageGuard::new();
-        use crate::storage::{init_embedded, queries};
+        use armadai_storage::{open_in_memory, queries};
 
         let (_capture, sink) = capture_sink();
         let (agents, providers) = hierarchical_roster();
@@ -3513,7 +3513,7 @@ mod es_switch_tests {
         // (d): the same `record_hierarchical_into` the switched "hierarchical"
         // match arm calls (via `record_orchestration_hierarchical`) persists
         // the ES-derived `OrchestrationResult`.
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
         let returned =
             record_hierarchical_into(&db, &run_id, &result, &config, "build X", None).unwrap();
@@ -3610,7 +3610,7 @@ mod es_switch_tests {
     #[tokio::test]
     async fn blackboard_es_state_is_recorded_via_record_blackboard_es_into() {
         let _storage = TempStorageGuard::new();
-        use crate::storage::{init_embedded, queries};
+        use armadai_storage::{open_in_memory, queries};
 
         let (_capture, sink) = capture_sink();
         let (agents, providers) = blackboard_roster();
@@ -3634,7 +3634,7 @@ mod es_switch_tests {
         // (d): the same `record_blackboard_es_into` the switched "blackboard"
         // match arm calls (via `record_blackboard_es`) persists the folded
         // `ExecutionState`.
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
         let returned = crate::cli::run_es_record::record_blackboard_es_into(
             &db, &run_id, &state, &config, "task", None, None,
@@ -3660,12 +3660,12 @@ mod es_switch_tests {
     async fn blackboard_es_run_persists_event_log() {
         use crate::core::orchestration::es::blackboard::run_blackboard_es;
         use crate::es_log::SqliteLog;
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
         // (a): Setup — same roster as `blackboard_es_state_is_recorded_via_
         // record_blackboard_es_into`, but we drive the ES loop with a
         // SqliteLog directly to verify persistence.
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = "it-bb-log-1";
         let (agents, providers) = blackboard_roster();
         let config = BlackboardConfig::default();
@@ -3717,9 +3717,9 @@ mod es_switch_tests {
     async fn ring_es_run_persists_event_log() {
         use crate::core::orchestration::es::ring::run_ring_es;
         use crate::es_log::SqliteLog;
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = "it-ring-log-1";
         let (agents, providers) = ring_roster();
         let config = RingConfig {
@@ -3768,9 +3768,9 @@ mod es_switch_tests {
     async fn hierarchical_es_run_persists_event_log() {
         use crate::core::orchestration::es::hierarchical::run_hierarchical_es;
         use crate::es_log::SqliteLog;
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = "it-hier-log-1";
         let (agents, providers) = hierarchical_roster();
         let config = flat_config("dev-lead", &["core-specialist"]);
@@ -3817,9 +3817,9 @@ mod es_switch_tests {
     async fn blackboard_es_run_projects_tables_from_log() {
         use crate::core::orchestration::es::blackboard::run_blackboard_es;
         use crate::es_log::SqliteLog;
-        use crate::storage::{init_embedded, queries};
+        use armadai_storage::{open_in_memory, queries};
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = "it-bb-proj-1";
         let (agents, providers) = blackboard_roster();
         let config = BlackboardConfig::default();
@@ -3958,7 +3958,7 @@ mod es_switch_tests {
     #[tokio::test]
     async fn ring_es_state_is_recorded_via_record_ring_es_into() {
         let _storage = TempStorageGuard::new();
-        use crate::storage::{init_embedded, queries};
+        use armadai_storage::{open_in_memory, queries};
 
         let (_capture, sink) = capture_sink();
         let (agents, providers) = ring_roster();
@@ -3985,7 +3985,7 @@ mod es_switch_tests {
 
         // (d): the same `record_ring_es_into` the switched "ring" match arm
         // calls (via `record_ring_es`) persists the folded `ExecutionState`.
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
         let returned = crate::cli::run_es_record::record_ring_es_into(
             &db, &run_id, &state, &config, "task", None, None,
@@ -4227,7 +4227,7 @@ mod es_switch_tests {
     // These tests drive `run_replay::replay_from_log` — the `pub(crate)`,
     // generic-over-`EventLog` core `replay_run` wraps around its own
     // `crate::db::init_db()` call — directly against an in-memory
-    // `SqliteLog` (`init_embedded()`), the SAME idiom
+    // `SqliteLog` (`open_in_memory()`), the SAME idiom
     // `blackboard_es_run_persists_event_log`/`ring_es_run_persists_event_log`
     // already use above. This deliberately avoids exercising `init_db()`
     // itself (which resolves the real, global, config-dependent DB path):
@@ -4249,7 +4249,7 @@ mod es_switch_tests {
     /// (which would call the real `crate::db::init_db()`).
     #[cfg(feature = "storage")]
     async fn run_direct_against_sqlite_log(
-        db: crate::storage::Database,
+        db: armadai_storage::Database,
         run_id: &str,
         sink: &Arc<dyn EventSink>,
     ) {
@@ -4303,9 +4303,9 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn replay_reproduces_the_live_run_event_sequence() {
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
 
         let (live_capture, live_sink) = capture_sink();
@@ -4377,9 +4377,9 @@ mod es_switch_tests {
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn replay_full_stream_starts_with_run_start_and_ends_with_result() {
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
 
         let (_live_capture, live_sink) = capture_sink();
@@ -4436,9 +4436,9 @@ mod es_switch_tests {
     #[tokio::test]
     async fn replay_of_completed_ring_run_with_votes_includes_vote_tally() {
         use crate::es_log::SqliteLog;
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
 
         let mut log = SqliteLog::new(db.clone());
@@ -4508,9 +4508,9 @@ mod es_switch_tests {
     #[test]
     fn replay_unknown_run_id_errors() {
         use crate::es_log::SqliteLog;
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let log = SqliteLog::new(init_embedded().unwrap());
+        let log = SqliteLog::new(open_in_memory().unwrap());
         let (_capture, sink) = capture_sink();
         let err = crate::cli::run_replay::replay_from_log(&log, "does-not-exist", &sink, false)
             .unwrap_err();
@@ -4561,9 +4561,9 @@ mod es_switch_tests {
         use crate::core::orchestration::es::direct::resume_direct_es;
         use crate::core::orchestration::es::state::fold;
         use crate::es_log::SqliteLog;
-        use crate::storage::init_embedded;
+        use armadai_storage::open_in_memory;
 
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let run_id = uuid::Uuid::new_v4().to_string();
 
         // Simulate a crashed run: only `RunStarted` was ever persisted (the

--- a/src/cli/run_es_record.rs
+++ b/src/cli/run_es_record.rs
@@ -166,7 +166,7 @@ fn ring_contributions_text(state: &ExecutionState) -> String {
 /// live `blackboard::Board`. Returns the provided `run_id`.
 #[cfg(feature = "storage")]
 pub fn record_blackboard_es_into(
-    db: &crate::storage::Database,
+    db: &armadai_storage::Database,
     run_id: &str,
     state: &ExecutionState,
     config: &BlackboardConfig,
@@ -174,7 +174,7 @@ pub fn record_blackboard_es_into(
     parent_run_id: Option<&str>,
     project: Option<&str>,
 ) -> anyhow::Result<String> {
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let status = match state.status {
         RunStatus::Halted => "halted",
@@ -241,7 +241,7 @@ pub fn record_blackboard_es_into(
 /// provided `run_id`.
 #[cfg(feature = "storage")]
 pub fn record_ring_es_into(
-    db: &crate::storage::Database,
+    db: &armadai_storage::Database,
     run_id: &str,
     state: &ExecutionState,
     config: &RingConfig,
@@ -249,7 +249,7 @@ pub fn record_ring_es_into(
     parent_run_id: Option<&str>,
     project: Option<&str>,
 ) -> anyhow::Result<String> {
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let status = match state.status {
         RunStatus::Halted => "halted",
@@ -332,7 +332,7 @@ pub fn record_ring_es_into(
 /// Returns `Ok(())` when the projection succeeds, or an error if the event log
 /// is malformed (e.g. no `RunStarted`) or storage fails.
 #[cfg(feature = "storage")]
-pub fn project_run(db: &crate::storage::Database, run_id: &str) -> anyhow::Result<()> {
+pub fn project_run(db: &armadai_storage::Database, run_id: &str) -> anyhow::Result<()> {
     use crate::core::orchestration::es::log::EventLog;
     use crate::core::orchestration::es::state::fold;
     use crate::es_log::SqliteLog;
@@ -364,7 +364,7 @@ pub fn project_run(db: &crate::storage::Database, run_id: &str) -> anyhow::Resul
         .ok_or_else(|| anyhow::anyhow!("No RunStarted event in log for run {}", run_id))?;
 
     // 4. Delete any existing projection rows (idempotence: clear before rebuilding).
-    crate::storage::queries::delete_projection_for_run(db, run_id)?;
+    armadai_storage::queries::delete_projection_for_run(db, run_id)?;
 
     // 5. Rebuild the projection by calling the pattern-specific record function.
     match pattern.as_str() {
@@ -559,7 +559,7 @@ mod tests {
 mod storage_tests {
     use super::*;
     use crate::core::orchestration::es::state::{BoardEntryRec, ContribRec, VoteRec};
-    use crate::storage::{init_embedded, queries};
+    use armadai_storage::{open_in_memory, queries};
 
     fn sample_blackboard_state() -> ExecutionState {
         let mut state = ExecutionState {
@@ -637,7 +637,7 @@ mod storage_tests {
 
     #[test]
     fn record_blackboard_es_into_persists_run_and_entries() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let state = sample_blackboard_state();
         let config = BlackboardConfig::default();
 
@@ -675,7 +675,7 @@ mod storage_tests {
 
     #[test]
     fn record_blackboard_es_into_links_parent_run_id_and_project() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let state = sample_blackboard_state();
         let config = BlackboardConfig::default();
 
@@ -703,7 +703,7 @@ mod storage_tests {
 
     #[test]
     fn record_ring_es_into_persists_run_contributions_and_votes() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let state = sample_ring_state();
         let config = RingConfig::default();
 
@@ -748,7 +748,7 @@ mod storage_tests {
 
     #[test]
     fn record_blackboard_es_into_uses_caller_run_id() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
         let state = sample_blackboard_state();
         let cfg = BlackboardConfig::default();
         let returned =
@@ -802,7 +802,7 @@ mod storage_tests {
 
     #[test]
     fn project_run_is_idempotent() {
-        let db = init_embedded().unwrap();
+        let db = open_in_memory().unwrap();
 
         // Persist a minimal blackboard log via SqliteLog.
         let mut log = crate::es_log::SqliteLog::new(db.clone());

--- a/src/core/orchestration/es/log.rs
+++ b/src/core/orchestration/es/log.rs
@@ -2,7 +2,7 @@
 //!
 //! `EventLog` is the storage-agnostic trait; `InMemoryLog` is the always-on
 //! implementation (used by tests and non-persistent runs). A SQL-backed
-//! implementation lives bin-side under `crate::storage` (behind the
+//! implementation lives bin-side under `armadai_storage` (behind the
 //! `storage` feature), since `core` must stay storage-free.
 
 use std::collections::HashMap;

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,12 +2,12 @@
 //!
 //! Owns the config-driven path resolution that used to live in the storage
 //! module's `init_db`. Depends on `crate::core::config`; delegates the actual
-//! open+schema to the storage wrapper (`crate::storage::open`), which is
+//! open+schema to the storage wrapper (`armadai_storage::open`), which is
 //! core-free. Kept bin-side so `armadai-storage` stays a pure rusqlite leaf.
 
 use std::path::{Path, PathBuf};
 
-use crate::storage::Database;
+use armadai_storage::Database;
 
 /// Resolve a possibly-relative `storage.path` to an absolute path.
 ///
@@ -44,12 +44,12 @@ pub fn init_db() -> anyhow::Result<Database> {
         assert!(
             !path.starts_with(&real),
             "init_db() would open the real user database at {} during a test — \
-             redirect storage (ARMADAI_CONFIG_DIR -> temp config) or use init_embedded()",
+             redirect storage (ARMADAI_CONFIG_DIR -> temp config) or use open_in_memory()",
             path.display()
         );
     }
 
-    crate::storage::open(&path)
+    armadai_storage::open(&path)
 }
 
 #[cfg(test)]

--- a/src/es_log.rs
+++ b/src/es_log.rs
@@ -1,8 +1,8 @@
 //! SQLite-backed `EventLog` implementation (OH7 Lot 1 Task 1e).
 //!
 //! `SqliteLog` persists into the `execution_events` table (schema v3, see
-//! `crate::storage::schema`). It lives bin-side (not in `core`) because it
-//! depends on `rusqlite` and `crate::storage::Database` — `core` only owns
+//! `armadai_storage::schema`). It lives bin-side (not in `core`) because it
+//! depends on `rusqlite` and `armadai_storage::Database` — `core` only owns
 //! the storage-agnostic `EventLog` trait and the always-on `InMemoryLog`
 //! (see `crate::core::orchestration::es::log`).
 
@@ -23,12 +23,12 @@ fn event_kind(event: &ExecutionEvent) -> anyhow::Result<String> {
 /// SQLite-backed `EventLog`, persisting into `execution_events`
 /// (schema v3).
 pub struct SqliteLog {
-    db: crate::storage::Database,
+    db: armadai_storage::Database,
 }
 
 impl SqliteLog {
     /// Wrap an existing storage handle.
-    pub fn new(db: crate::storage::Database) -> Self {
+    pub fn new(db: armadai_storage::Database) -> Self {
         Self { db }
     }
 }
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn sqlite_log_roundtrip() {
-        let db = crate::storage::init_embedded().unwrap();
+        let db = armadai_storage::open_in_memory().unwrap();
         let mut log = SqliteLog::new(db);
         for e in sample() {
             log.append("r1", &e).unwrap();
@@ -149,7 +149,7 @@ mod tests {
     /// different crate/module and that helper is private to core's tests.)
     #[test]
     fn sqlite_multi_run_id_seq_isolation() {
-        let db = crate::storage::init_embedded().unwrap();
+        let db = armadai_storage::open_in_memory().unwrap();
         let mut log = SqliteLog::new(db);
         let run_ids = ["rA", "rB", "rA", "rB", "rA"];
         for (idx, run_id) in run_ids.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,6 @@ mod registry;
 mod shell;
 mod skills_registry;
 mod starters_registry;
-#[cfg(feature = "storage")]
-mod storage;
 #[cfg(feature = "tui")]
 mod theme;
 #[cfg(feature = "tui")]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -615,7 +615,7 @@ impl App {
     #[cfg(feature = "storage")]
     pub fn load_orchestration_runs(&mut self) {
         use crate::db::init_db;
-        use crate::storage::queries;
+        use armadai_storage::queries;
 
         let db = match init_db() {
             Ok(db) => db,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -406,7 +406,7 @@ fn handle_top_level_esc(app: &mut app::App) -> bool {
 #[cfg(feature = "storage")]
 fn load_storage_data(app: &mut app::App) {
     use crate::db::init_db;
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,

--- a/src/tui/views/orchestration.rs
+++ b/src/tui/views/orchestration.rs
@@ -116,7 +116,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 pub fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(entry) = app.selected_orchestration_entry() {
         use crate::db::init_db;
-        use crate::storage::queries;
+        use armadai_storage::queries;
 
         let detail_content = match init_db() {
             Ok(db) => {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -293,7 +293,7 @@ pub async fn get_agent(Path(name): Path<String>) -> Json<serde_json::Value> {
 #[cfg(feature = "storage")]
 pub async fn get_history() -> Json<Vec<HistoryEntry>> {
     use crate::db::init_db;
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,
@@ -328,7 +328,7 @@ pub async fn get_history() -> Json<Vec<HistoryEntry>> {
 #[cfg(feature = "storage")]
 pub async fn get_costs() -> Json<Vec<CostSummary>> {
     use crate::db::init_db;
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let db = match init_db() {
         Ok(db) => db,
@@ -635,7 +635,7 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
     #[cfg(feature = "storage")]
     {
         use crate::db::init_db;
-        use crate::storage::queries;
+        use armadai_storage::queries;
         if let Ok(db) = init_db()
             && let Ok(runs) = queries::get_root_orchestration_runs(&db, 50)
         {
@@ -690,14 +690,14 @@ pub async fn get_orchestration_trace() -> Json<serde_json::Value> {
 /// nested children so their entries render identically.
 #[cfg(feature = "storage")]
 fn fetch_run_entries(
-    db: &crate::storage::Database,
+    db: &armadai_storage::Database,
     run_id: &str,
 ) -> (
     Vec<serde_json::Value>,
     Vec<serde_json::Value>,
     Vec<serde_json::Value>,
 ) {
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let board_entries = queries::get_board_entries(db, run_id)
         .unwrap_or_default()
@@ -753,7 +753,7 @@ fn fetch_run_entries(
 #[cfg(feature = "storage")]
 pub async fn get_orchestration_trace_detail(Path(run_id): Path<String>) -> Json<serde_json::Value> {
     use crate::db::init_db;
-    use crate::storage::queries;
+    use armadai_storage::queries;
 
     let empty = || {
         serde_json::json!({
@@ -905,7 +905,7 @@ pub async fn get_orchestration_topology() -> Json<serde_json::Value> {
 mod tests {
     use super::*;
     use crate::core::config::ENV_MUTEX;
-    use crate::storage::queries::{
+    use armadai_storage::queries::{
         BoardEntryRecord, DelegationEventRecord, OrchestrationRunRecord, RingVoteRecord, RunRecord,
         insert_board_entry, insert_delegation_event, insert_orchestration_run, insert_ring_vote,
         insert_run_with_id,


### PR DESCRIPTION
## OH7 Lot 2d — extraction `armadai-storage`

Dernière tâche du Lot 2. Extrait `src/storage/` vers `crates/armadai-storage/` comme **feuille pure** (0 `use crate::` cross-crate, aucune dépendance sur `core`).

- `init_embedded()` (`#[cfg(test)]`) → `pub fn open_in_memory()` non-gated (visible aux tests du bin cross-crate ; pas de dead_code en crate lib).
- Intra-doc-links `[crate::core::…]` → texte brut (+ nettoyage d'une mention `crate::core` → `core` en doc-comment).
- Deps crate réconciliées au compilateur : `anyhow`, `rusqlite` (bundled), `serde`, `uuid`.
- `rusqlite` **reste** dep bin optionnelle (`es_log.rs` fait du `rusqlite::params!` direct) : `storage = ["dep:armadai-storage", "dep:rusqlite"]`.
- `mod storage;` retiré ; ~19 fichiers `crate::storage` → `armadai_storage`.

**Garde-fou portabilité prouvé** : `cargo build --no-default-features --features tui` ne tire ni rusqlite ni armadai-storage (`cargo tree`).
**Réconciliation tests** (aucun perdu, relocalisé) : bin 1042 (`tui`) / 1066 (`tui,storage`) + crate `armadai-storage` 22 = 1088.

Gate verte 3 modes clippy + `cargo build -p armadai-storage`. Revue indépendante : clean, mergeable en l'état.

Plan : `docs/superpowers/plans/2026-07-28-oh7-lot2-workspace-leaves.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)