### PR TITLE
ci(oh7): run workspace member crate suites + bare-core build guard (#252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,20 @@ jobs:
       - run: cargo clippy --all-targets --no-default-features --features tui -- -D warnings
       - run: cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
       - run: cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+      # Workspace member crates lint their own test targets too (the bin
+      # clippy above compiles them as path deps but does not lint their
+      # `#[cfg(test)]` targets). armadai-providers needs `api` to cover its
+      # HTTP providers + model_registry online fetch.
+      - run: cargo clippy -p armadai-core --all-targets -- -D warnings
+      - run: cargo clippy -p armadai-secrets --all-targets -- -D warnings
+      - run: cargo clippy -p armadai-storage --all-targets -- -D warnings
+      # Lint armadai-providers in BOTH feature states: the `--features api`
+      # run below does not compile the `#[cfg(not(feature = "api"))]` fallbacks
+      # (stub `create_api_provider`, cache-only `load_models`), and the bin
+      # clippy compiles the crate as a path dep with `--cap-lints=allow`, so
+      # those branches would otherwise escape all linting.
+      - run: cargo clippy -p armadai-providers --all-targets -- -D warnings
+      - run: cargo clippy -p armadai-providers --all-targets --features api -- -D warnings
 
   test:
     name: Test
@@ -79,6 +93,15 @@ jobs:
       # tests/e2e/harness.rs `e2e_suite`), so its report ends up under
       # target/e2e-report/ for the next step to upload.
       - run: cargo test --no-default-features --features tui,storage
+      # Extracted workspace member crates are NOT covered by the root-package
+      # `cargo test` above (they live in crates/*, outside the bin package).
+      # Run their suites explicitly so armadai-core (domain + ES engine),
+      # armadai-providers (incl. the `api`-gated HTTP providers), armadai-storage
+      # and armadai-secrets stay exercised in CI after the OH7 extraction.
+      - run: cargo test -p armadai-core
+      - run: cargo test -p armadai-secrets
+      - run: cargo test -p armadai-storage
+      - run: cargo test -p armadai-providers --features api
       - name: Upload e2e report
         if: always()
         uses: actions/upload-artifact@v4
@@ -102,6 +125,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
       # Build with storage (SQLite bundled) to verify full compilation.
       - run: cargo build --release --no-default-features --features tui,storage
+      # Portability guard (OH7): the reusable core must compile standalone,
+      # featureless, with no heavy deps (no reqwest/rusqlite/ratatui/axum) —
+      # this is what OH2/the Claude Code plugin will depend on. A dep leaking
+      # into core (e.g. via unintended feature unification) fails here.
+      - run: cargo build -p armadai-core
 
   commits:
     name: Conventional Commits


### PR DESCRIPTION
## OH7 Lot 5 (final) — CI workspace-aware + garde-fou cœur-nu

Après les extractions OH7, le `cargo test`/`clippy` du package racine ne couvre plus les crates `crates/*`. Leurs suites (core 470, providers 66 avec `api`, storage 22) **ne tournaient plus en CI** (gap silencieux — vertes en local, non exécutées en CI). Ce lot ferme le gap. **Aucun changement de code Rust** — seul `.github/workflows/ci.yml`.

- **test** : ajout `cargo test -p {armadai-core, armadai-secrets, armadai-storage, armadai-providers --features api}`.
- **clippy** : ajout `-p` `--all-targets -D warnings` pour les 4 crates ; `armadai-providers` linté **dans les deux états** de feature (avec et sans `api`) — les branches `#[cfg(not(feature = "api"))]` échappaient sinon à tout lint (`--cap-lints=allow` en dep path).
- **build** : ajout `cargo build -p armadai-core` — garde-fou portabilité (cœur nu featureless, aucune dep lourde ; une fuite de dep échoue ici).

Vérifié en local sous `-D warnings` : YAML valide ; toutes les commandes vertes (core, providers api=66 + no-api clean, storage 22, secrets 0). Revue indépendante : Approved.

**Clôt OH7 (#252)** : `armadai-core` (feuille featureless réutilisable) + `armadai-providers`/`armadai-storage`/`armadai-secrets` extraits ; bin = interfaces + adaptateurs ; CI workspace-aware.

Plan : `docs/superpowers/plans/2026-07-28-oh7-lot5-ci-final.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)