### PR TITLE
refactor(oh7): gate core ENV_MUTEX behind test-support feature + share models-cache filename const (#252)

### DIFF
--- a/crates/armadai-core/Cargo.toml
+++ b/crates/armadai-core/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 description = "ArmadAI — reusable orchestration core: domain types, Provider/EventLog traits, parser, event-sourced engine."
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow = "1"
 thiserror = "2"

--- a/crates/armadai-core/src/config.rs
+++ b/crates/armadai-core/src/config.rs
@@ -44,6 +44,11 @@ pub fn config_dir() -> PathBuf {
     config_base.join("armadai")
 }
 
+/// Filename of the shared models.dev catalogue cache under the config dir.
+/// Written by `armadai-providers`' model_registry; read (for IDs) by
+/// `core::model_resolution`. Single source of truth for the two readers.
+pub const MODELS_CACHE_FILE: &str = "models-cache.json";
+
 /// Return the ArmadAI data root directory (for persistent storage, e.g. SQLite).
 ///
 /// Resolution order:
@@ -446,16 +451,12 @@ providers:
 
 /// Global mutex to serialise tests that mutate `ARMADAI_CONFIG_DIR`.
 ///
-/// Any test in any module — in this crate or in downstream crates (the
-/// `armadai` bin's tests reach into this via `armadai_core::config::ENV_MUTEX`)
-/// — that calls `std::env::set_var("ARMADAI_CONFIG_DIR", …)` must hold this
-/// lock for the duration of the test to avoid data races when the test suite
-/// runs with multiple threads (the default).
-///
-/// Not `#[cfg(test)]`-gated: a downstream crate's test build compiles this
-/// crate as an ordinary (non-test) dependency, so a test-only item here
-/// would be invisible to it. The cost of always compiling one static
-/// `Mutex<()>` is negligible.
+/// Test-only. Exposed behind the `test-support` feature (and `cfg(test)` for
+/// this crate's own tests) so downstream crates can serialise their env-var
+/// tests against the same lock — a downstream test build enables
+/// `armadai-core/test-support` via its `[dev-dependencies]`. It is NOT part of
+/// the production public API (absent unless a test build pulls it in).
+#[cfg(any(test, feature = "test-support"))]
 pub static ENV_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 

--- a/crates/armadai-core/src/model_resolution.rs
+++ b/crates/armadai-core/src/model_resolution.rs
@@ -106,7 +106,7 @@ fn load_cached_model_ids(provider: &str) -> Option<Vec<String>> {
         providers: std::collections::HashMap<String, Vec<CachedEntry>>,
     }
 
-    let path = crate::config::config_dir().join("models-cache.json");
+    let path = crate::config::config_dir().join(crate::config::MODELS_CACHE_FILE);
     let content = std::fs::read_to_string(path).ok()?;
     let cached: CachedRegistry = serde_json::from_str(&content).ok()?;
     let entries = cached.providers.get(provider)?;

--- a/crates/armadai-providers/Cargo.toml
+++ b/crates/armadai-providers/Cargo.toml
@@ -22,4 +22,5 @@ tokio-stream = { version = "0.1", features = ["io-util"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-native-roots"], optional = true }
 
 [dev-dependencies]
+armadai-core = { path = "../armadai-core", features = ["test-support"] }
 tempfile = "3"

--- a/crates/armadai-providers/src/model_registry/fetch.rs
+++ b/crates/armadai-providers/src/model_registry/fetch.rs
@@ -5,7 +5,7 @@ use armadai_core::config::config_dir;
 
 use super::ModelEntry;
 
-const CACHE_FILE: &str = "models-cache.json";
+const CACHE_FILE: &str = armadai_core::config::MODELS_CACHE_FILE;
 // Only the refetch decision (load_cache_from, online path) consults the TTL;
 // the cache-only display loaders ignore age. Gated to where it's used so
 // non-providers-api builds don't flag it dead.

--- a/crates/armadai/Cargo.toml
+++ b/crates/armadai/Cargo.toml
@@ -85,6 +85,7 @@ anstyle = "1.0.14"
 anstream = "1.0.0"
 
 [dev-dependencies]
+armadai-core = { path = "../armadai-core", features = ["test-support"] }
 assert_cmd = "2.2.2"
 schemars = "1.2.1"
 tempfile = "3"


### PR DESCRIPTION
## Core API polish (suivis non-bloquants M2 + M1)

**M2 — `ENV_MUTEX` hors de l'API publique de prod.** Le mutex de sérialisation des tests était `pub` inconditionnel dans `armadai-core` (crate réutilisable). Il est désormais gaté `#[cfg(any(test, feature = "test-support"))]` + feature `test-support` sur core ; le bin et `armadai-providers` l'activent en `[dev-dependencies]`. Avec resolver 3, une feature activée uniquement via dev-dep ne fuit pas dans le build normal → `ENV_MUTEX` **disparaît de l'API de prod** (vérifié : `cargo build --release` + `cargo build -p armadai-core` compilent, aucun code de prod ne l'utilisait). Les 11 sites d'usage sont tous `#[cfg(test)]`.

**M1 — nom de fichier du cache models.dev en source unique.** `pub const MODELS_CACHE_FILE` dans `core::config` ; consommé par `core::model_resolution` et par `armadai-providers/fetch.rs` (alias local `CACHE_FILE`, 6 usages inchangés). Fin du littéral dupliqué.

**Vérifs indépendantes** : gate verte (fmt + clippy 3 modes + test `tui`/`tui,storage`/`tui,providers-api` = 1064/1088/1078 + providers `api` = 66, inchangés). Revue indépendante : Approved (0 issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)