### PR TITLE
chore(oh7): centralize shared dependency versions in [workspace.dependencies] (#252)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,22 @@ resolver = "3"
 edition = "2024"
 license = "PolyForm-Noncommercial-1.0.0"
 repository = "https://github.com/Dr0drigues/swarm-festai"
+
+[workspace.dependencies]
+anyhow = "1"
+thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml_ng = "0.10"
+async-trait = "0.1"
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+tokio = { version = "1" }
+tokio-stream = { version = "0.1", features = ["io-util"] }
+tracing = "0.1"
+pulldown-cmark = "0.13"
+include_dir = "0.7"
+dialoguer = "0.12"
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-native-roots"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
+uuid = { version = "1" }
+tempfile = "3"

--- a/crates/armadai-core/Cargo.toml
+++ b/crates/armadai-core/Cargo.toml
@@ -10,19 +10,19 @@ description = "ArmadAI — reusable orchestration core: domain types, Provider/E
 test-support = []
 
 [dependencies]
-anyhow = "1"
-thiserror = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_yaml_ng = "0.10"
-async-trait = "0.1"
-futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-tokio = { version = "1", features = ["time", "macros", "rt", "rt-multi-thread", "sync"] }
-tokio-stream = { version = "0.1", features = ["io-util"] }
-pulldown-cmark = "0.13"
-include_dir = "0.7"
-tracing = "0.1"
-dialoguer = "0.12"
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+async-trait = { workspace = true }
+futures-util = { workspace = true }
+tokio = { workspace = true, features = ["time", "macros", "rt", "rt-multi-thread", "sync"] }
+tokio-stream = { workspace = true }
+pulldown-cmark = { workspace = true }
+include_dir = { workspace = true }
+tracing = { workspace = true }
+dialoguer = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/armadai-providers/Cargo.toml
+++ b/crates/armadai-providers/Cargo.toml
@@ -12,15 +12,15 @@ api = ["dep:reqwest", "dep:armadai-secrets"]
 [dependencies]
 armadai-core = { path = "../armadai-core" }
 armadai-secrets = { path = "../armadai-secrets", optional = true }
-anyhow = "1"
-async-trait = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tokio = { version = "1", features = ["process", "io-util", "time", "macros", "rt", "rt-multi-thread", "sync"] }
-tokio-stream = { version = "0.1", features = ["io-util"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-native-roots"], optional = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true, features = ["process", "io-util", "time", "macros", "rt", "rt-multi-thread", "sync"] }
+tokio-stream = { workspace = true }
+reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 armadai-core = { path = "../armadai-core", features = ["test-support"] }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/armadai-secrets/Cargo.toml
+++ b/crates/armadai-secrets/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "ArmadAI — SOPS + age encrypted provider secrets loader."
 
 [dependencies]
-anyhow = "1"
-serde = { version = "1", features = ["derive"] }
-serde_yaml_ng = "0.10"
-tracing = "0.1"
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_yaml_ng = { workspace = true }
+tracing = { workspace = true }

--- a/crates/armadai-storage/Cargo.toml
+++ b/crates/armadai-storage/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "ArmadAI — SQLite-backed persistence (runs + event log)."
 
 [dependencies]
-anyhow = "1"
-rusqlite = { version = "0.40", features = ["bundled"] }
-serde = { version = "1", features = ["derive"] }
-uuid = { version = "1", features = ["v4"] }
+anyhow = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }

--- a/crates/armadai/Cargo.toml
+++ b/crates/armadai/Cargo.toml
@@ -29,15 +29,15 @@ armadai-secrets = { path = "../armadai-secrets" }
 armadai-storage = { path = "../armadai-storage", optional = true }
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
-tokio-stream = { version = "0.1", features = ["io-util"] }
-async-trait = "0.1"
-futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
+async-trait = { workspace = true }
+futures-util = { workspace = true }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
-dialoguer = { version = "0.12", features = ["fuzzy-select"] }
+dialoguer = { workspace = true, features = ["fuzzy-select"] }
 
 # TUI (optional — enable with `tui` feature)
 ratatui = { version = "0.30", optional = true }
@@ -45,37 +45,37 @@ crossterm = { version = "0.29", optional = true }
 unicode-width = { version = "0.2", optional = true }
 
 # HTTP client (optional — enable with `providers-api` feature)
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-native-roots"], optional = true }
+reqwest = { workspace = true, optional = true }
 
 # HTTP server (optional — enable with `web` feature)
 axum = { version = "0.8", optional = true }
 tower-http = { version = "0.7", features = ["cors"], optional = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_yaml_ng = "0.10"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
 
 # Database (optional — enable with `storage` feature)
-rusqlite = { version = "0.40", features = ["bundled"], optional = true }
+rusqlite = { workspace = true, optional = true }
 
 # Markdown parsing
-pulldown-cmark = "0.13"
+pulldown-cmark = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Error handling
-anyhow = "1"
-thiserror = "2"
+anyhow = { workspace = true }
+thiserror = { workspace = true }
 
 # Embedded assets
-include_dir = "0.7"
+include_dir = { workspace = true }
 
 # Utils
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
 
 # PTY support (for interactive shell mode)
 portable-pty = { version = "0.8", optional = true }
@@ -88,4 +88,4 @@ anstream = "1.0.0"
 armadai-core = { path = "../armadai-core", features = ["test-support"] }
 assert_cmd = "2.2.2"
 schemars = "1.2.1"
-tempfile = "3"
+tempfile = { workspace = true }


### PR DESCRIPTION
## `[workspace.dependencies]` — versions partagées centralisées

Anti-dérive : les 17 deps utilisées par ≥2 crates (anyhow, thiserror, serde, serde_json, serde_yaml_ng, async-trait, futures-util, tokio, tokio-stream, tracing, pulldown-cmark, include_dir, dialoguer, reqwest, rusqlite, uuid, tempfile) vivent désormais dans le `[workspace.dependencies]` racine ; les 5 crates les référencent via `{ workspace = true }` (features par crate là où elles varient : tokio/uuid/dialoguer). Les deps **mono-crate** (clap, ratatui, axum, chrono, tracing-subscriber…) restent locales au bin.

**Neutralité de résolution PROUVÉE** (c'est le critère) : `git diff Cargo.lock` **vide** + `cargo tree --workspace` **identique** master↔branche (après normalisation du préfixe de chemin worktree). Aucune version ni feature ne bouge — seule la source des chaînes de version change.

**Aucun code Rust** (6 `Cargo.toml`). Gate verte (fmt + clippy 3 modes + test 1064/1088 + `cargo build -p armadai-core` + release). `optional` conservé par-crate (reqwest/rusqlite), path deps + `test-support` dev-deps intacts. Revue indépendante : Approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)