### PR TITLE
chore(cli): default-run = armadai (`cargo run` picks the main bin) (#252)

### DIFF
--- a/crates/armadai/Cargo.toml
+++ b/crates/armadai/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "ArmadAI — AI agent orchestrator. Define, manage and run specialized agents from Markdown files."
+# This package ships two bins (armadai + fake-claude); default `cargo run` to the main one.
+default-run = "armadai"
 
 [[bin]]
 name = "armadai"


### PR DESCRIPTION
Le package `armadai` embarque deux bins (`armadai` + `fake-claude`), donc `cargo run` échoue en ambiguïté (`could not determine which binary to run`). Ajout de `default-run = "armadai"` dans `crates/armadai/Cargo.toml` → `cargo run -- <cmd>` cible le bin principal sans `--bin`.

Vérifié : `cargo run --features tui -- watch --help` fonctionne sans `--bin`. N'affecte pas la CI (commandes explicites) ni le build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)