### PR TITLE
feat(plugin): Workroom delegation tree for `armadai watch` (#252)

### DIFF
--- a/crates/armadai/src/cli/watch.rs
+++ b/crates/armadai/src/cli/watch.rs
@@ -1,5 +1,12 @@
 use crate::claude_adapter::{drive_session, session_index};
 
+/// Minimal synthetic project config so the Workroom seeds the transcript's
+/// root agent ("claude") as the Coordinator — the delegated subagents (added
+/// dynamically as role Agent, see Workroom::ensure_agent) then indent beneath
+/// it in the hierarchical tree. A watched Claude Code session has no
+/// armadai.yaml, so we synthesize the minimum init_from_config needs.
+const WATCH_ROOT_CONFIG: &str = "coordinator: claude\n";
+
 /// `armadai watch` — attach the Workroom to a Claude Code session (from the
 /// index the plugin populates) and stream reconstructed RunEvents.
 ///
@@ -34,7 +41,7 @@ pub async fn execute(_last: bool, session: Option<String>, json: bool) -> anyhow
     // Live Workroom TUI, fed by the transcript adapter. `follow=true` tails.
     let (_run_id, _content) = crate::shell::run_view::run_orchestration_tui(
         move |sink| async move { drive_session(picked, sink, true).await },
-        None,
+        Some(WATCH_ROOT_CONFIG.to_string()),
         None,
     )
     .await?;
@@ -44,6 +51,19 @@ pub async fn execute(_last: bool, session: Option<String>, json: bool) -> anyhow
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn root_agent_is_seeded_as_coordinator() {
+        use crate::shell::workroom::{AgentRole, Workroom};
+        let mut wr = Workroom::new();
+        wr.init_from_config(WATCH_ROOT_CONFIG);
+        let claude = wr
+            .agents_for_test()
+            .iter()
+            .find(|a| a.name == "claude")
+            .expect("synthetic config seeds the root agent");
+        assert_eq!(claude.role, AgentRole::Coordinator);
+    }
 
     /// Holds `ENV_MUTEX` for the duration of `ARMADAI_SESSION_INDEX`
     /// mutation, serialising it against other env-mutating tests across the

--- a/crates/armadai/src/shell/workroom.rs
+++ b/crates/armadai/src/shell/workroom.rs
@@ -497,6 +497,7 @@ impl Workroom {
                 self.visible = true;
             }
             RunEvent::AgentStart { agent, .. } => {
+                self.ensure_agent(agent);
                 self.mark_working(agent, now);
                 // The ES ring/blackboard engines emit agent_start/agent_end/vote
                 // but never `Delegate`, so `current_agent` (which drives the
@@ -506,6 +507,7 @@ impl Workroom {
                 self.current_agent = Some(agent.clone());
             }
             RunEvent::AgentEnd { agent, content, .. } => {
+                self.ensure_agent(agent);
                 self.mark_done(agent, now);
                 let first = content.lines().next().unwrap_or("").trim();
                 if !first.is_empty() {
@@ -513,6 +515,7 @@ impl Workroom {
                 }
             }
             RunEvent::Delegate { from, to } => {
+                self.ensure_agent(to);
                 self.transition(from, AgentState::Delegating, now);
                 self.current_agent = Some(to.clone());
             }
@@ -541,6 +544,25 @@ impl Workroom {
                 }
             }
             RunEvent::Warning { .. } => {}
+        }
+    }
+
+    /// Ensure an agent node exists (role Agent for dynamically-appearing agents,
+    /// e.g. subagents delegated during an `armadai watch` run where no config
+    /// pre-seeded the roster). No-op if the agent already exists (its role is
+    /// preserved — the config path is unaffected).
+    fn ensure_agent(&mut self, name: &str) {
+        if !self.agents.iter().any(|a| a.name == name) {
+            self.agents.push(TrackedAgent {
+                name: name.to_string(),
+                state: AgentState::Idle,
+                role: AgentRole::Agent,
+                started_at: None,
+                finished_at: None,
+                spinner_frame: 0,
+                last_action: None,
+                transitions: Vec::new(),
+            });
         }
     }
 
@@ -1056,6 +1078,67 @@ mod tests {
         let mut wr = Workroom::new();
         wr.init_from_config(config);
         wr
+    }
+
+    #[test]
+    fn dynamically_delegated_agents_become_nodes() {
+        use armadai_core::events::RunEvent;
+        let t = std::time::Instant::now();
+        let mut wr = Workroom::new();
+        // watch-style: RunStart seeds only the root.
+        wr.on_run_event_at(
+            &RunEvent::RunStart {
+                run_id: "r".into(),
+                v: 1,
+                agents: vec!["claude".into()],
+                prov: "claude".into(),
+                model: "m".into(),
+                in_chars: 0,
+            },
+            t,
+        );
+        assert_eq!(wr.agents.len(), 1);
+        // A delegation to an unknown agent must create its node.
+        wr.on_run_event_at(
+            &RunEvent::Delegate {
+                from: "claude".into(),
+                to: "core-specialist".into(),
+            },
+            t,
+        );
+        wr.on_run_event_at(
+            &RunEvent::AgentStart {
+                agent: "core-specialist".into(),
+                prov: "claude".into(),
+                model: "m".into(),
+            },
+            t,
+        );
+        assert!(
+            wr.agents.iter().any(|a| a.name == "core-specialist"),
+            "delegated subagent should appear as a node"
+        );
+        // AgentStart for another unknown agent also creates it.
+        wr.on_run_event_at(
+            &RunEvent::AgentStart {
+                agent: "qa-specialist".into(),
+                prov: "claude".into(),
+                model: "m".into(),
+            },
+            t,
+        );
+        assert_eq!(
+            wr.agents.len(),
+            3,
+            "claude + core-specialist + qa-specialist"
+        );
+        // New nodes are role Agent (indented under a coordinator in the tree).
+        let core = wr
+            .agents
+            .iter()
+            .find(|a| a.name == "core-specialist")
+            .unwrap();
+        assert_eq!(core.role, AgentRole::Agent);
     }
 
     #[test]


### PR DESCRIPTION
## Workroom — arbre de délégation pour `armadai watch`

Suite au test réel de P1 : le Workroom piloté par `armadai watch` n'affichait qu'un nœud racine `claude` ; les sous-agents délégués tombaient en timeline « delegating ». Ce lot les fait apparaître comme **nœuds enfants**.

L'arbre « hierarchical » du Workroom indente **par rôle** (`Coordinator=0 / Lead=1 / Agent=2`, via `tree_prefix`), sans champ parent. Donc :
- **`ensure_agent`** (`workroom.rs`) : `on_run_event_at` crée un nœud (rôle `Agent`) pour tout agent inconnu vu en `AgentStart`/`Delegate{to}`/`AgentEnd`. **Idempotent** (no-op si présent) → chemin `armadai run` (agents pré-seedés par config) **inchangé**.
- **`watch`** (`watch.rs`) : seed la racine `claude` en `Coordinator` via une config synthétique `coordinator: claude` → les sous-agents (`Agent`) s'indentent dessous. Arbre à 2 niveaux `claude → core-specialist, qa-specialist…`. Le chemin `--json` (headless) est inchangé.

**Vérifs** : `armadai-core` intact ; workroom suite 41/41 (0 régression) ; watch 5/5 ; clippy 3 combos + fmt clean. Revue indépendante : Approved (0 Critical/Important, pas de régression `run`).

**Validation visuelle** attendue (Dimitri) : `armadai watch --session mini` (lisible) et `--session demo` (73 sous-agents).

Hors périmètre : profondeur multi-niveaux (sous-agents dans `agent-<id>.jsonl`, P2+) ; tool calls individuels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)