### PR TITLE
feat(plugin): label watch subagents by description + stamp started_at (#252)

### DIFF
--- a/crates/armadai/src/claude_adapter/mapper.rs
+++ b/crates/armadai/src/claude_adapter/mapper.rs
@@ -31,7 +31,7 @@ pub struct Mapper {
     tin: u32,
     tout: u32,
     last_text: String,
-    spawns: HashMap<String, String>, // tool_use_id -> subagent_type
+    spawns: HashMap<String, String>, // tool_use_id -> agent label (description, else subagent_type)
     agents_seen: std::collections::HashSet<String>,
     finished: bool,
 }
@@ -90,15 +90,26 @@ impl Mapper {
                         Block::AgentSpawn {
                             tool_use_id,
                             subagent_type,
+                            description,
                         } => {
-                            self.spawns.insert(tool_use_id, subagent_type.clone());
-                            self.agents_seen.insert(subagent_type.clone());
+                            // Parallel same-`subagent_type` subagents (e.g. three
+                            // "Explore") share a type but carry distinct
+                            // `description`s. Label by description so they stay
+                            // distinct Workroom nodes and are counted correctly;
+                            // fall back to `subagent_type` when absent.
+                            let label = if description.trim().is_empty() {
+                                subagent_type
+                            } else {
+                                description.trim().to_string()
+                            };
+                            self.spawns.insert(tool_use_id, label.clone());
+                            self.agents_seen.insert(label.clone());
                             out.push(RunEvent::Delegate {
                                 from: ROOT.to_string(),
-                                to: subagent_type.clone(),
+                                to: label.clone(),
                             });
                             out.push(RunEvent::AgentStart {
-                                agent: subagent_type,
+                                agent: label,
                                 prov: PROV.to_string(),
                                 model: self.model.clone(),
                             });
@@ -205,10 +216,12 @@ mod tests {
     fn subagent_spawn_and_result_emit_delegate_start_end() {
         let mut m = Mapper::new("s2");
         let mut evs = m.push(assistant(vec![Block::Text("start".into())], 5, 1));
+        // A non-empty `description` becomes the agent LABEL (not `subagent_type`).
         evs.extend(m.push(assistant(
             vec![Block::AgentSpawn {
                 tool_use_id: "tu1".into(),
                 subagent_type: "core".into(),
+                description: "Refonte du parser".into(),
             }],
             2,
             1,
@@ -219,17 +232,22 @@ mod tests {
         }])));
         evs.extend(m.push(assistant(vec![Block::Text("final".into())], 1, 1)));
         evs.extend(m.finish());
+        // Delegate/AgentStart/AgentEnd all carry the description, not "core".
         assert!(evs.iter().any(
-            |e| matches!(e, RunEvent::Delegate { from, to } if from == "claude" && to == "core")
+            |e| matches!(e, RunEvent::Delegate { from, to } if from == "claude" && to == "Refonte du parser")
+        ));
+        assert!(evs.iter().any(
+            |e| matches!(e, RunEvent::AgentStart { agent, .. } if agent == "Refonte du parser")
+        ));
+        assert!(evs.iter().any(
+            |e| matches!(e, RunEvent::AgentEnd { agent, content, .. } if agent == "Refonte du parser" && content == "sub done")
         ));
         assert!(
-            evs.iter()
-                .any(|e| matches!(e, RunEvent::AgentStart { agent, .. } if agent == "core"))
+            !evs.iter()
+                .any(|e| matches!(e, RunEvent::AgentStart { agent, .. } if agent == "core")),
+            "subagent_type must not be used as label when a description is present"
         );
-        assert!(evs.iter().any(
-            |e| matches!(e, RunEvent::AgentEnd { agent, content, .. } if agent == "core" && content == "sub done")
-        ));
-        // agents count in Result = claude + core = 2
+        // agents count in Result = claude + "Refonte du parser" = 2
         match evs.last().unwrap() {
             RunEvent::Result {
                 agents,
@@ -261,6 +279,7 @@ mod tests {
             vec![Block::AgentSpawn {
                 tool_use_id: "tu1".into(),
                 subagent_type: "core".into(),
+                description: String::new(),
             }],
             1,
             1,
@@ -321,10 +340,12 @@ mod tests {
                 Block::AgentSpawn {
                     tool_use_id: "tu1".into(),
                     subagent_type: "core".into(),
+                    description: String::new(),
                 },
                 Block::AgentSpawn {
                     tool_use_id: "tu2".into(),
                     subagent_type: "cli".into(),
+                    description: String::new(),
                 },
             ],
             1,
@@ -353,5 +374,79 @@ mod tests {
             ),
             "second spawn's AgentEnd must NOT be dropped"
         );
+    }
+
+    /// Real Claude Code case: several parallel subagents share ONE
+    /// `subagent_type` ("Explore") but carry DISTINCT `description`s. Labeling
+    /// by `subagent_type` would collapse them into a single Workroom node and
+    /// undercount `Result.agents`. Labeling by `description` keeps them
+    /// distinct: two spawns → two AgentStart/AgentEnd + `Result.agents == 3`
+    /// (claude + A + B).
+    #[test]
+    fn same_subagent_type_distinct_descriptions_do_not_collapse() {
+        let mut m = Mapper::new("s7");
+        let _ = m.push(assistant(vec![Block::Text("start".into())], 1, 1));
+        let evs_spawn = m.push(assistant(
+            vec![
+                Block::AgentSpawn {
+                    tool_use_id: "tu1".into(),
+                    subagent_type: "Explore".into(),
+                    description: "A".into(),
+                },
+                Block::AgentSpawn {
+                    tool_use_id: "tu2".into(),
+                    subagent_type: "Explore".into(),
+                    description: "B".into(),
+                },
+            ],
+            1,
+            1,
+        ));
+        // Two distinct AgentStart, one per description.
+        assert!(
+            evs_spawn
+                .iter()
+                .any(|e| matches!(e, RunEvent::AgentStart { agent, .. } if agent == "A")),
+            "spawn A must start a node labeled by its description"
+        );
+        assert!(
+            evs_spawn
+                .iter()
+                .any(|e| matches!(e, RunEvent::AgentStart { agent, .. } if agent == "B")),
+            "spawn B must start a distinct node — not collapse into A"
+        );
+        assert_eq!(
+            evs_spawn
+                .iter()
+                .filter(|e| matches!(e, RunEvent::AgentStart { .. }))
+                .count(),
+            2,
+            "two distinct subagent nodes, not one collapsed"
+        );
+
+        let evs_end = m.push(RelevantEntry::ToolResults(vec![
+            ToolResult {
+                tool_use_id: "tu1".into(),
+                text: "A done".into(),
+            },
+            ToolResult {
+                tool_use_id: "tu2".into(),
+                text: "B done".into(),
+            },
+        ]));
+        assert!(evs_end.iter().any(
+            |e| matches!(e, RunEvent::AgentEnd { agent, content, .. } if agent == "A" && content == "A done")
+        ));
+        assert!(evs_end.iter().any(
+            |e| matches!(e, RunEvent::AgentEnd { agent, content, .. } if agent == "B" && content == "B done")
+        ));
+
+        let evs_fin = m.finish();
+        match evs_fin.last().unwrap() {
+            RunEvent::Result { agents, .. } => {
+                assert_eq!(*agents, 3, "claude + A + B — no collapse");
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
     }
 }

--- a/crates/armadai/src/claude_adapter/mod.rs
+++ b/crates/armadai/src/claude_adapter/mod.rs
@@ -169,11 +169,25 @@ fn register_from_reader(mut r: impl Read) -> anyhow::Result<()> {
     if session_id.is_empty() || transcript_path.is_empty() {
         return Ok(()); // nothing usable; do not error
     }
+    // The SessionStart hook payload has no `timestamp`. The hook fires at
+    // session start, so stamp `started_at` with the current time when the
+    // payload omits (or leaves empty) a timestamp — otherwise it stays "".
+    let started_at = {
+        let ts = v
+            .get("timestamp")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        if ts.is_empty() {
+            chrono::Utc::now().to_rfc3339()
+        } else {
+            ts.to_string()
+        }
+    };
     let entry = SessionRef {
         session_id,
         transcript_path: transcript_path.into(),
         cwd: get("cwd"),
-        started_at: get("timestamp"),
+        started_at,
     };
     if let Err(e) = session_index::append(&entry) {
         tracing::warn!("failed to register Claude Code session: {e}");
@@ -346,5 +360,38 @@ mod tests {
         }
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].session_id, "z");
+    }
+
+    /// Fix B: the SessionStart hook payload carries NO `timestamp`, so
+    /// `started_at` used to stay "". It must instead be stamped with the
+    /// current time (RFC3339) at registration.
+    #[test]
+    fn register_from_reader_stamps_started_at_when_payload_has_no_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let idx = dir.path().join("idx.jsonl");
+        // SAFETY: single-threaded test; serialise env via ENV_MUTEX.
+        let _g = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("ARMADAI_SESSION_INDEX", &idx);
+        }
+        // No `timestamp` field at all.
+        let payload = r#"{"session_id":"nots","transcript_path":"/t/nots.jsonl","cwd":"/c"}"#;
+        register_from_reader(payload.as_bytes()).unwrap();
+        let v = session_index::load().unwrap();
+        unsafe {
+            std::env::remove_var("ARMADAI_SESSION_INDEX");
+        }
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].session_id, "nots");
+        assert!(
+            !v[0].started_at.is_empty(),
+            "started_at must be stamped when the payload has no timestamp"
+        );
+        // Must be a parseable RFC3339 timestamp.
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&v[0].started_at).is_ok(),
+            "started_at must be valid RFC3339, got {:?}",
+            v[0].started_at
+        );
     }
 }

--- a/crates/armadai/src/claude_adapter/transcript.rs
+++ b/crates/armadai/src/claude_adapter/transcript.rs
@@ -7,6 +7,7 @@ pub enum Block {
     AgentSpawn {
         tool_use_id: String,
         subagent_type: String,
+        description: String,
     },
     Other,
 }
@@ -96,9 +97,16 @@ fn parse_assistant(msg: &Value) -> Option<RelevantEntry> {
                     .and_then(Value::as_str)
                     .unwrap_or("agent")
                     .to_string();
+                let description = b
+                    .get("input")
+                    .and_then(|i| i.get("description"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
                 blocks.push(Block::AgentSpawn {
                     tool_use_id: id,
                     subagent_type: sub,
+                    description,
                 });
             }
             Some("tool_use") => blocks.push(Block::Other),
@@ -217,12 +225,29 @@ mod tests {
 
     #[test]
     fn parses_agent_spawn_tool_use() {
-        let line = r#"{"type":"assistant","message":{"model":"m","content":[{"type":"tool_use","id":"tu1","name":"Agent","input":{"subagent_type":"core-specialist","prompt":"x"}}],"usage":{"input_tokens":1,"output_tokens":1}}}"#;
+        let line = r#"{"type":"assistant","message":{"model":"m","content":[{"type":"tool_use","id":"tu1","name":"Agent","input":{"subagent_type":"core-specialist","description":"Architecture du workspace","prompt":"x"}}],"usage":{"input_tokens":1,"output_tokens":1}}}"#;
         match parse_line(line).unwrap() {
             RelevantEntry::Assistant { blocks, .. } => {
                 assert!(matches!(blocks.as_slice(),
-                    [Block::AgentSpawn { tool_use_id, subagent_type }]
-                    if tool_use_id == "tu1" && subagent_type == "core-specialist"));
+                    [Block::AgentSpawn { tool_use_id, subagent_type, description }]
+                    if tool_use_id == "tu1"
+                        && subagent_type == "core-specialist"
+                        && description == "Architecture du workspace"));
+            }
+            _ => panic!("expected Assistant"),
+        }
+    }
+
+    /// A `tool_use{name:"Agent"}` without an `input.description` must parse
+    /// with an empty `description` (mapper falls back to `subagent_type`).
+    #[test]
+    fn parses_agent_spawn_without_description_defaults_empty() {
+        let line = r#"{"type":"assistant","message":{"model":"m","content":[{"type":"tool_use","id":"tu9","name":"Agent","input":{"subagent_type":"Explore","prompt":"x"}}],"usage":{"input_tokens":1,"output_tokens":1}}}"#;
+        match parse_line(line).unwrap() {
+            RelevantEntry::Assistant { blocks, .. } => {
+                assert!(matches!(blocks.as_slice(),
+                    [Block::AgentSpawn { subagent_type, description, .. }]
+                    if subagent_type == "Explore" && description.is_empty()));
             }
             _ => panic!("expected Assistant"),
         }


### PR DESCRIPTION
## `armadai watch` — sous-agents distincts + `started_at` (raffinements du test live)

Surfacé par le **test d'intégration Claude Code réel** : les 3 sous-agents parallèles partageaient tous `subagent_type:"Explore"` → ils se fondaient en **un seul** nœud Workroom et `Result.agents` sous-comptait (2 au lieu de 4).

- **A** : `transcript::Block::AgentSpawn` porte la `description` du tool `Agent` ; le mapper nomme le sous-agent par sa **description** (trim, fallback `subagent_type`), clé = `tool_use_id`. → nœuds distincts + compte d'agents correct.
- **B** : le payload `SessionStart` n'a pas de `timestamp` → `started_at` était vide ; désormais estampillé `chrono::Utc::now().to_rfc3339()` à l'enregistrement quand absent.

**Vérifié compilateur + RUNTIME** sur le vrai transcript du test : `watch --json` émet `delegate -> Architecture du Cargo workspace / Commandes CLI armadai / Analyse de la CI` (3 labels distincts) avec `Result.agents=4`. clippy 3 combos + fmt clean, `armadai-core` intact. Revue indépendante : A ✅ / B ✅, Approved.

Bin-side uniquement (aucune variante `RunEvent` ajoutée). Validation visuelle attendue : re-jouer la session → 3 tâches nommées sous `claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)