### PR TITLE
fix(orchestration): persist the agent roster in RunStarted so replay reconstructs prov/model

### DIFF
--- a/crates/armadai-core/src/orchestration/es/blackboard.rs
+++ b/crates/armadai-core/src/orchestration/es/blackboard.rs
@@ -765,6 +765,7 @@ pub async fn run_blackboard_es(
             agents: agent_order.clone(),
             input: input.to_string(),
             project: None,
+            roster: Default::default(),
         },
         ExecutionEvent::ConfigSnapshot {
             config_json: serde_json::to_string(&config).unwrap_or_default(),
@@ -891,6 +892,7 @@ mod tests {
             agents: agents.iter().map(|a| a.to_string()).collect(),
             input: "task".into(),
             project: None,
+            roster: Default::default(),
         }
     }
 
@@ -1544,6 +1546,7 @@ mod tests {
                 agents: agents.iter().map(|a| a.to_string()).collect(),
                 input: "task".into(),
                 project: None,
+                roster: Default::default(),
             }
         }
 
@@ -2097,6 +2100,7 @@ mod tests {
                     agents: agent_order,
                     input: "task".to_string(),
                     project: None,
+                    roster: Default::default(),
                 },
             )
             .unwrap();
@@ -2139,6 +2143,7 @@ mod tests {
                     agents: vec!["a".to_string()],
                     input: "task".to_string(),
                     project: None,
+                    roster: Default::default(),
                 },
             )
             .unwrap();

--- a/crates/armadai-core/src/orchestration/es/blackboard.rs
+++ b/crates/armadai-core/src/orchestration/es/blackboard.rs
@@ -758,6 +758,7 @@ pub async fn run_blackboard_es(
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
     let agent_order: Vec<String> = agents.keys().cloned().collect();
+    let roster = super::bridge::roster_from_agents(&agents);
     let initial = vec![
         ExecutionEvent::RunStarted {
             run_id: run_id.to_string(),
@@ -765,7 +766,7 @@ pub async fn run_blackboard_es(
             agents: agent_order.clone(),
             input: input.to_string(),
             project: None,
-            roster: Default::default(),
+            roster,
         },
         ExecutionEvent::ConfigSnapshot {
             config_json: serde_json::to_string(&config).unwrap_or_default(),

--- a/crates/armadai-core/src/orchestration/es/bridge.rs
+++ b/crates/armadai-core/src/orchestration/es/bridge.rs
@@ -21,8 +21,36 @@ use std::collections::BTreeMap;
 use super::event::ExecutionEvent;
 use super::log::EventLog;
 use super::state::ExecutionState;
+use crate::agent::Agent;
 use crate::events::{EventSink, RunEvent};
 use crate::orchestration::hierarchical::{DelegationEvent, OrchestrationResult};
+
+/// Build the `RunStarted.roster`/`agent_meta` table (roster key -> `(provider,
+/// configured model)`) from a loaded agent roster. Mirrors
+/// `cli::run::agent_meta_from_roster` (the live path's equivalent, built from
+/// the same `Agent` structs) — kept as a core-side helper so every ES engine's
+/// `run_*_es` assembly function (`direct`/`blackboard`/`ring`/`hierarchical`)
+/// can populate `RunStarted.roster` at emission time without the `armadai-core`
+/// crate depending on the `armadai` crate's CLI module.
+///
+/// Every entry uses the agent's *configured* model (`agent.metadata.model`),
+/// not the effectively-resolved `latest:auto` tier — same convention
+/// `agent_meta_from_roster`/`AgentStart` already follow (see this module's
+/// `map_execution_to_run_events` doc).
+pub fn roster_from_agents(agents: &BTreeMap<String, Agent>) -> BTreeMap<String, (String, String)> {
+    agents
+        .iter()
+        .map(|(key, agent)| {
+            (
+                key.clone(),
+                (
+                    agent.metadata.provider.clone(),
+                    agent.metadata.model.clone().unwrap_or_default(),
+                ),
+            )
+        })
+        .collect()
+}
 
 /// Per-event projection: `ExecutionEvent` → zero or more `RunEvent`s, given a
 /// side table of agent metadata (`agent_meta`, roster key → `(prov, model)`).
@@ -776,6 +804,7 @@ mod tests {
                 agents: vec![],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             ExecutionEvent::Halted {
                 reason: "budget".into(),
@@ -874,6 +903,7 @@ mod tests {
                 agents: vec!["lead".into(), "core".into()],
                 input: "task".into(),
                 project: None,
+                roster: Default::default(),
             },
             ExecutionEvent::AgentInvoked {
                 agent: "lead".into(),
@@ -957,6 +987,7 @@ mod tests {
             agents: vec!["a".into()],
             input: "x".into(),
             project: None,
+            roster: Default::default(),
         }];
         let state = fold(&events);
         let result = to_orchestration_result(&state, &events);
@@ -1006,5 +1037,75 @@ mod tests {
         let state = fold(&events);
         let result = to_orchestration_result(&state, &events);
         assert_eq!(result.content, "final answer");
+    }
+
+    // ── (d) roster_from_agents ──────────────────────────────────────
+
+    fn test_agent(provider: &str, model: Option<&str>) -> Agent {
+        Agent {
+            name: "a".to_string(),
+            source: std::path::PathBuf::from("a.md"),
+            metadata: crate::agent::AgentMetadata {
+                provider: provider.to_string(),
+                model: model.map(str::to_string),
+                command: None,
+                args: None,
+                temperature: 0.7,
+                max_tokens: None,
+                timeout: None,
+                tags: vec![],
+                stacks: vec![],
+                scope: vec![],
+                model_fallback: vec![],
+                cost_limit: None,
+                rate_limit: None,
+                context_window: None,
+                mode: None,
+                orchestration: None,
+                triggers: None,
+                ring_config: None,
+            },
+            system_prompt: "prompt".to_string(),
+            instructions: None,
+            output_format: None,
+            pipeline: None,
+            context: None,
+        }
+    }
+
+    #[test]
+    fn roster_from_agents_maps_provider_and_configured_model() {
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "core".to_string(),
+            test_agent("anthropic", Some("claude-x")),
+        );
+        agents.insert("qa".to_string(), test_agent("google", Some("gemini-y")));
+
+        let roster = roster_from_agents(&agents);
+
+        assert_eq!(
+            roster.get("core"),
+            Some(&("anthropic".to_string(), "claude-x".to_string()))
+        );
+        assert_eq!(
+            roster.get("qa"),
+            Some(&("google".to_string(), "gemini-y".to_string()))
+        );
+    }
+
+    #[test]
+    fn roster_from_agents_defaults_missing_model_to_empty_string() {
+        // Mirrors `agent_meta_from_roster`'s own `unwrap_or_default()` for an
+        // agent with no configured `model` (e.g. a CLI-provider agent).
+        let mut agents = BTreeMap::new();
+        agents.insert("cli-agent".to_string(), test_agent("claude-cli", None));
+
+        let roster = roster_from_agents(&agents);
+
+        assert_eq!(
+            roster.get("cli-agent"),
+            Some(&("claude-cli".to_string(), String::new()))
+        );
     }
 }

--- a/crates/armadai-core/src/orchestration/es/direct.rs
+++ b/crates/armadai-core/src/orchestration/es/direct.rs
@@ -270,6 +270,7 @@ pub async fn run_direct_es(
         agents: vec![agent.to_string()],
         input: input.to_string(),
         project: None,
+        roster: Default::default(),
     }];
 
     let decider = DirectDecider::new(agent, input, agents.clone(), routing_rules);
@@ -507,6 +508,7 @@ mod tests {
                 agents: vec!["solo".to_string()],
                 input: "do the thing".to_string(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();
@@ -556,6 +558,7 @@ mod tests {
                 agents: vec!["solo".to_string()],
                 input: "do the thing".to_string(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();
@@ -616,6 +619,7 @@ mod tests {
                 agents: vec!["solo".to_string()],
                 input: "do the thing".to_string(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();
@@ -758,6 +762,7 @@ mod tests {
             agents: vec!["solo".into()],
             input: "go".into(),
             project: None,
+            roster: Default::default(),
         }]);
         let actions = decider.decide(&state);
         assert_eq!(actions.len(), 1);
@@ -773,6 +778,7 @@ mod tests {
                 agents: vec!["solo".into()],
                 input: "go".into(),
                 project: None,
+                roster: Default::default(),
             },
             ExecutionEvent::AgentInvoked {
                 agent: "solo".into(),
@@ -804,6 +810,7 @@ mod tests {
             agents: vec!["solo".into()],
             input: "go".into(),
             project: None,
+            roster: Default::default(),
         }]);
         let actions = decider.decide(&state);
         assert_eq!(actions.len(), 2);

--- a/crates/armadai-core/src/orchestration/es/direct.rs
+++ b/crates/armadai-core/src/orchestration/es/direct.rs
@@ -264,13 +264,31 @@ pub async fn run_direct_es(
     routing_rules: RoutingRules,
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
+    // Direct's roster is the single invoked agent — scope `roster_from_agents`
+    // to just that key (rather than the whole `agents` map, which today only
+    // ever holds that one entry anyway, see `dispatch_direct_es`) so
+    // `RunStarted.roster` stays correct even if a future caller passes a
+    // larger map in.
+    let roster: BTreeMap<String, (String, String)> = agents
+        .get(agent)
+        .map(|a| {
+            (
+                agent.to_string(),
+                (
+                    a.metadata.provider.clone(),
+                    a.metadata.model.clone().unwrap_or_default(),
+                ),
+            )
+        })
+        .into_iter()
+        .collect();
     let initial = vec![ExecutionEvent::RunStarted {
         run_id: run_id.to_string(),
         pattern: "direct".to_string(),
         agents: vec![agent.to_string()],
         input: input.to_string(),
         project: None,
-        roster: Default::default(),
+        roster,
     }];
 
     let decider = DirectDecider::new(agent, input, agents.clone(), routing_rules);

--- a/crates/armadai-core/src/orchestration/es/engine.rs
+++ b/crates/armadai-core/src/orchestration/es/engine.rs
@@ -466,6 +466,7 @@ mod tests {
             agents: vec!["a".into(), "b".into(), "c".into()],
             input: "go".into(),
             project: None,
+            roster: Default::default(),
         }];
         run_event_sourced("r", init, &decider, &eff, &mut log)
             .await
@@ -547,6 +548,7 @@ mod tests {
             agents: batch.iter().map(|s| s.agent.clone()).collect(),
             input: "go".into(),
             project: None,
+            roster: Default::default(),
         }];
         run_event_sourced("r", init, &decider, &eff, &mut log)
             .await
@@ -608,6 +610,7 @@ mod tests {
             agents: vec!["a".into(), "b".into(), "c".into()],
             input: "go".into(),
             project: None,
+            roster: Default::default(),
         }];
         let state = run_event_sourced("r", init, &decider, &FailBEff, &mut log)
             .await
@@ -689,6 +692,7 @@ mod tests {
             agents: vec!["a".into()],
             input: "go".into(),
             project: None,
+            roster: Default::default(),
         }];
         let st = run_event_sourced("r", init, &D, &Eff, &mut log)
             .await
@@ -776,6 +780,7 @@ mod tests {
                 agents: vec!["a".into(), "b".into()],
                 input: "go".into(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();
@@ -833,6 +838,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "go".into(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();
@@ -864,6 +870,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "go".into(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();

--- a/crates/armadai-core/src/orchestration/es/event.rs
+++ b/crates/armadai-core/src/orchestration/es/event.rs
@@ -24,6 +24,24 @@ pub enum ExecutionEvent {
         agents: Vec<String>,
         input: String,
         project: Option<String>,
+        /// The run's roster metadata: agent name -> `(provider, configured
+        /// model)`, mirroring the live path's `agent_meta`/`agent_meta_from_roster`
+        /// (`cli::run.rs`) — see [`super::bridge::roster_from_agents`], which
+        /// every production `RunStarted` emission site builds this from.
+        /// Persisted here (rather than only threaded through in-memory at
+        /// emission time) because `ExecutionEvent` otherwise never records an
+        /// agent's provider anywhere, and the model configured for an
+        /// agent's first invocation isn't reconstructable from the rest of
+        /// the log either — so a read-only consumer (`armadai run --replay`)
+        /// would have no way to enrich `AgentInvoked -> AgentStart` with the
+        /// run's real provider/model without it. `#[serde(default)]` is
+        /// required: event logs written before this field existed have no
+        /// `roster` key at all, and must still deserialize — they fall back
+        /// to an empty roster, i.e. the documented "no roster available"
+        /// behavior (`AgentStart` carries empty `prov`/`model`), not a hard
+        /// error.
+        #[serde(default)]
+        roster: std::collections::BTreeMap<String, (String, String)>,
     },
     /// A snapshot of the run's orchestration config (serialized as JSON).
     /// Emitted immediately after `RunStarted` by the blackboard, ring, and
@@ -137,4 +155,72 @@ pub enum ExecutionEvent {
 /// so the hierarchical `is_final_answer` reads it as a plain final answer.
 pub fn delegation_failed_content(error: &str) -> String {
     format!("[Delegation failed: {error}]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Backward-compatibility regression lock (bugfix `fix/replay-prov-model-roster`):
+    /// an event log written by a version of ArmadAI that predates the
+    /// `roster` field has no `roster` key in its persisted `RunStarted` JSON
+    /// at all. `#[serde(default)]` must make that still deserialize
+    /// successfully — falling back to an empty roster (today's documented
+    /// "no roster available" fallback, see `bridge.rs`'s
+    /// `agent_invoked_maps_to_agent_start_with_empty_prov_model_when_meta_absent`)
+    /// rather than a hard deserialization error that would make an old log
+    /// unreadable by `armadai run --replay`/`--resume`.
+    #[test]
+    fn run_started_without_roster_field_deserializes_to_empty_default() {
+        let json = r#"{
+            "t": "run_started",
+            "run_id": "r",
+            "pattern": "direct",
+            "agents": ["solo"],
+            "input": "do the thing",
+            "project": null
+        }"#;
+
+        let event: ExecutionEvent = serde_json::from_str(json).expect(
+            "a RunStarted event with no persisted `roster` key must still deserialize \
+             (old event logs predate this field)",
+        );
+
+        match event {
+            ExecutionEvent::RunStarted { roster, .. } => {
+                assert!(
+                    roster.is_empty(),
+                    "roster must default to empty when absent from the JSON, got: {roster:?}"
+                );
+            }
+            other => panic!("expected RunStarted, got {other:?}"),
+        }
+    }
+
+    /// Round-trip proof that a populated `roster` survives serialize ->
+    /// deserialize unchanged, complementing the "absent field" case above.
+    #[test]
+    fn run_started_roster_round_trips_through_json() {
+        let mut roster = std::collections::BTreeMap::new();
+        roster.insert(
+            "solo".to_string(),
+            ("anthropic".to_string(), "concrete-model".to_string()),
+        );
+        let event = ExecutionEvent::RunStarted {
+            run_id: "r".into(),
+            pattern: "direct".into(),
+            agents: vec!["solo".into()],
+            input: "do the thing".into(),
+            project: None,
+            roster: roster.clone(),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let round_tripped: ExecutionEvent = serde_json::from_str(&json).unwrap();
+
+        match round_tripped {
+            ExecutionEvent::RunStarted { roster: got, .. } => assert_eq!(got, roster),
+            other => panic!("expected RunStarted, got {other:?}"),
+        }
+    }
 }

--- a/crates/armadai-core/src/orchestration/es/hierarchical.rs
+++ b/crates/armadai-core/src/orchestration/es/hierarchical.rs
@@ -1419,6 +1419,7 @@ pub async fn run_hierarchical_es(
             agents: agent_names,
             input: input.to_string(),
             project: None,
+            roster: Default::default(),
         },
         ExecutionEvent::ConfigSnapshot {
             config_json: serde_json::to_string(&config).unwrap_or_default(),
@@ -1620,6 +1621,7 @@ mod tests {
                 agents: agents.iter().map(|a| a.to_string()).collect(),
                 input: "build X".into(),
                 project: None,
+                roster: Default::default(),
             }
         }
 
@@ -2989,6 +2991,7 @@ mod tests {
                 agents: agents.iter().map(|a| a.to_string()).collect(),
                 input: input.into(),
                 project: None,
+                roster: Default::default(),
             }
         }
 
@@ -3561,6 +3564,7 @@ mod tests {
                 agents: agent_names,
                 input: "build X".to_string(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();
@@ -3768,6 +3772,7 @@ mod tests {
                 agents: vec!["dev-lead".to_string()],
                 input: "build X".to_string(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();

--- a/crates/armadai-core/src/orchestration/es/hierarchical.rs
+++ b/crates/armadai-core/src/orchestration/es/hierarchical.rs
@@ -1412,6 +1412,7 @@ pub async fn run_hierarchical_es(
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
     let agent_names: Vec<String> = agents.keys().cloned().collect();
+    let roster = super::bridge::roster_from_agents(&agents);
     let initial = vec![
         ExecutionEvent::RunStarted {
             run_id: run_id.to_string(),
@@ -1419,7 +1420,7 @@ pub async fn run_hierarchical_es(
             agents: agent_names,
             input: input.to_string(),
             project: None,
-            roster: Default::default(),
+            roster,
         },
         ExecutionEvent::ConfigSnapshot {
             config_json: serde_json::to_string(&config).unwrap_or_default(),

--- a/crates/armadai-core/src/orchestration/es/log.rs
+++ b/crates/armadai-core/src/orchestration/es/log.rs
@@ -52,6 +52,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::AgentObserved {
                 agent: "a".into(),

--- a/crates/armadai-core/src/orchestration/es/ring.rs
+++ b/crates/armadai-core/src/orchestration/es/ring.rs
@@ -1035,6 +1035,7 @@ pub async fn run_ring_es(
     cost_limit: Option<f64>,
     log: &mut impl EventLog,
 ) -> anyhow::Result<ExecutionState> {
+    let roster = super::bridge::roster_from_agents(&agents);
     let initial = vec![
         ExecutionEvent::RunStarted {
             run_id: run_id.to_string(),
@@ -1042,7 +1043,7 @@ pub async fn run_ring_es(
             agents: agent_order.clone(),
             input: input.to_string(),
             project: None,
-            roster: Default::default(),
+            roster,
         },
         ExecutionEvent::ConfigSnapshot {
             config_json: serde_json::to_string(&config).unwrap_or_default(),

--- a/crates/armadai-core/src/orchestration/es/ring.rs
+++ b/crates/armadai-core/src/orchestration/es/ring.rs
@@ -1042,6 +1042,7 @@ pub async fn run_ring_es(
             agents: agent_order.clone(),
             input: input.to_string(),
             project: None,
+            roster: Default::default(),
         },
         ExecutionEvent::ConfigSnapshot {
             config_json: serde_json::to_string(&config).unwrap_or_default(),
@@ -1139,6 +1140,7 @@ mod tests {
             agents: agents.iter().map(|a| a.to_string()).collect(),
             input: "task".into(),
             project: None,
+            roster: Default::default(),
         }
     }
 
@@ -2437,6 +2439,7 @@ mod tests {
                     agents: vec!["a".to_string(), "b".to_string()],
                     input: "task".to_string(),
                     project: None,
+                    roster: Default::default(),
                 },
             )
             .unwrap();
@@ -2477,6 +2480,7 @@ mod tests {
                     agents: vec!["a".to_string()],
                     input: "task".to_string(),
                     project: None,
+                    roster: Default::default(),
                 },
             )
             .unwrap();

--- a/crates/armadai-core/src/orchestration/es/state.rs
+++ b/crates/armadai-core/src/orchestration/es/state.rs
@@ -134,6 +134,11 @@ pub fn apply(state: &mut ExecutionState, event: &ExecutionEvent) {
             agents,
             input: _,
             project: _,
+            // Read only by the bridge (`map_execution_to_run_events`'s
+            // `agent_meta`) and by replay (`run_replay.rs`), not by this
+            // pure state projection — `ExecutionState` has no roster-meta
+            // field of its own to fold it into.
+            roster: _,
         } => {
             state.run_id = run_id.clone();
             state.pattern = pattern.clone();
@@ -336,6 +341,7 @@ mod tests {
                 agents: vec!["dev-lead".into(), "core".into()],
                 input: "task".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::AgentInvoked {
                 agent: "dev-lead".into(),
@@ -403,6 +409,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::AgentObserved {
                 agent: "a".into(),
@@ -434,6 +441,7 @@ mod tests {
                 agents: vec!["a".into(), "b".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::RoundStarted { round: 1 },
             E::BoardEntryAdded {
@@ -463,6 +471,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::ModelRouted {
                 agent: "a".into(),
@@ -483,6 +492,7 @@ mod tests {
                 agents: vec!["a".into(), "b".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::AskedPeer {
                 from: "a".into(),
@@ -510,6 +520,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::ConfigSnapshot {
                 config_json: "{\"max_rounds\":5}".into(),

--- a/crates/armadai/src/cli/projections.rs
+++ b/crates/armadai/src/cli/projections.rs
@@ -102,6 +102,7 @@ mod tests {
                 agents: vec!["a".to_string(), "b".to_string()],
                 input: "do research".to_string(),
                 project: None,
+                roster: Default::default(),
             },
             ExecutionEvent::ConfigSnapshot {
                 config_json:

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -4418,6 +4418,50 @@ mod es_switch_tests {
         assert_eq!(tail["agents"], serde_json::json!(1));
     }
 
+    /// Bugfix regression lock (`fix/replay-prov-model-roster`): a replayed
+    /// `AgentStart` must carry the run's REAL provider/model, not the
+    /// "no roster available" empty-string fallback. `run_direct_against_sqlite_log`
+    /// drives the real production `run_direct_es` — which now persists
+    /// `RunStarted.roster` (built via `roster_from_agents` from the `agents`
+    /// map it holds, here `test_agent("solo")`'s `anthropic`/`concrete-model`)
+    /// — against a real `SqliteLog`, exactly like every other test in this
+    /// section. `replay_from_log` must recover that roster from the log's
+    /// `RunStarted` event (rather than the unconditional empty `agent_meta`
+    /// it used before the fix) so the replayed `agent_start` in the JSON
+    /// stream shows the same values a live run's did.
+    #[cfg(feature = "storage")]
+    #[tokio::test]
+    async fn replay_reconstructs_agent_start_prov_model_from_persisted_roster() {
+        use armadai_storage::open_in_memory;
+
+        let db = open_in_memory().unwrap();
+        let run_id = uuid::Uuid::new_v4().to_string();
+
+        let (_live_capture, live_sink) = capture_sink();
+        run_direct_against_sqlite_log(db.clone(), &run_id, &live_sink).await;
+
+        let replay_log = crate::es_log::SqliteLog::new(db);
+        let (replay_capture, replay_sink) = capture_sink();
+        crate::cli::run_replay::replay_from_log(&replay_log, &run_id, &replay_sink, false).unwrap();
+
+        let events = replay_capture.events.lock().unwrap();
+        let agent_start = events
+            .iter()
+            .find(|e| e["t"] == "agent_start")
+            .expect("replayed stream must contain an agent_start event");
+
+        assert_eq!(
+            agent_start["prov"], "anthropic",
+            "replayed AgentStart must carry the run's real provider (from the \
+             persisted RunStarted.roster), got: {agent_start:?}"
+        );
+        assert_eq!(
+            agent_start["model"], "concrete-model",
+            "replayed AgentStart must carry the run's real configured model \
+             (from the persisted RunStarted.roster), got: {agent_start:?}"
+        );
+    }
+
     /// Re-review fix, regression lock: `--replay` of a `ring` run with
     /// non-empty `state.ring.votes` must include the `[votes] …` tally in
     /// the terminal `Result.content`, exactly like the live path and
@@ -4449,6 +4493,7 @@ mod es_switch_tests {
                 agents: vec!["a".to_string(), "b".to_string()],
                 input: "review the design".to_string(),
                 project: None,
+                roster: Default::default(),
             },
             ExecutionEvent::LapStarted { lap: 1 },
             ExecutionEvent::ContributionAdded {
@@ -4579,6 +4624,7 @@ mod es_switch_tests {
                 agents: vec!["solo".to_string()],
                 input: "do the thing".to_string(),
                 project: None,
+                roster: Default::default(),
             },
         )
         .unwrap();

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -4286,20 +4286,6 @@ mod es_switch_tests {
         .unwrap();
     }
 
-    /// Strip the fields `replay_run` cannot reconstruct from the persisted
-    /// event log alone (see `run_replay.rs`'s module doc: `AgentStart`'s
-    /// `prov`/`model` need the pre-run roster, which the log never carries)
-    /// before comparing a live vs. replayed `RunEvent` sequence. Every other
-    /// field of every other event must still match exactly.
-    #[cfg(feature = "storage")]
-    fn normalize_for_replay_comparison(mut v: serde_json::Value) -> serde_json::Value {
-        if v["t"] == "agent_start" {
-            v["prov"] = serde_json::Value::String(String::new());
-            v["model"] = serde_json::Value::String(String::new());
-        }
-        v
-    }
-
     #[cfg(feature = "storage")]
     #[tokio::test]
     async fn replay_reproduces_the_live_run_event_sequence() {
@@ -4321,7 +4307,6 @@ mod es_switch_tests {
             .unwrap()
             .iter()
             .cloned()
-            .map(normalize_for_replay_comparison)
             .collect();
         let replayed: Vec<_> = replay_capture
             .events
@@ -4329,7 +4314,6 @@ mod es_switch_tests {
             .unwrap()
             .iter()
             .cloned()
-            .map(normalize_for_replay_comparison)
             .collect();
 
         assert!(!live.is_empty(), "sanity: the live run must emit events");
@@ -4360,8 +4344,8 @@ mod es_switch_tests {
         let replayed_mid_stream: Vec<_> = replayed[1..replayed.len() - 1].to_vec();
         assert_eq!(
             live, replayed_mid_stream,
-            "replay must reproduce the same mid-stream RunEvent sequence (modulo the \
-             non-reconstructable AgentStart.prov/model gap, already stripped above)"
+            "replay must reproduce the same mid-stream RunEvent sequence exactly — including \
+             AgentStart.prov/model, now that the roster round-trips through RunStarted"
         );
     }
 

--- a/crates/armadai/src/cli/run_es_record.rs
+++ b/crates/armadai/src/cli/run_es_record.rs
@@ -774,6 +774,7 @@ mod storage_tests {
                 agents: vec!["a".to_string(), "b".to_string()],
                 input: "do research".to_string(),
                 project: None,
+                roster: Default::default(),
             },
             ExecutionEvent::ConfigSnapshot {
                 config_json:

--- a/crates/armadai/src/cli/run_replay.rs
+++ b/crates/armadai/src/cli/run_replay.rs
@@ -41,32 +41,40 @@
 //!   database — see `run.rs`'s
 //!   `replay_reproduces_the_live_run_event_sequence` test.
 //!
-//! ## Known fidelity gap: `AgentStart.prov`/`model`
+//! ## Former fidelity gap: `AgentStart.prov`/`model` (CLOSED)
 //!
 //! `map_execution_to_run_events` fills `AgentStart.prov`/`model` from an
 //! `agent_meta` side table (roster key -> `(provider, configured model)`)
 //! that the LIVE path builds from the run's `Agent` definitions *before*
 //! invoking anything (see `dispatch_direct_es`/`agent_meta_from_roster` in
-//! `run.rs`). `ExecutionEvent` never records an agent's provider name at
-//! all, and the model configured for an agent's *first* invocation (which is
-//! what `AgentStart` shows, not the resolved tier) isn't reconstructable
-//! from the log alone either — only `AgentObserved.model` is logged, and
-//! only after the call already happened. Replay therefore calls
-//! `map_execution_to_run_events` with an **empty** `agent_meta`, which is
-//! the function's documented "no roster available" fallback (see
-//! `bridge.rs`'s `agent_invoked_maps_to_agent_start_with_empty_prov_model_when_meta_absent`
-//! test): every replayed `AgentStart` carries `prov: ""`, `model: ""`,
-//! whatever the live run's actually were. Every other field of every other
-//! event (content/tokens/cost/agent names, `AgentEnd`/`Route`/`Board`/`Vote`/
+//! `run.rs`). This used to be a replay-only gap: `ExecutionEvent` recorded no
+//! agent provider anywhere, and the model configured for an agent's *first*
+//! invocation (what `AgentStart` shows, not the resolved tier) wasn't
+//! reconstructable from the rest of the log either — only `AgentObserved.model`
+//! is logged, and only after the call already happened — so replay called
+//! `map_execution_to_run_events` with an unconditionally **empty**
+//! `agent_meta`, and every replayed `AgentStart` carried `prov: ""`,
+//! `model: ""` regardless of what the live run's actually were.
+//!
+//! Fixed by persisting the roster directly in the log: every production
+//! `RunStarted` emission (`run_direct_es`/`run_blackboard_es`/`run_ring_es`/
+//! `run_hierarchical_es`, via
+//! [`armadai_core::orchestration::es::bridge::roster_from_agents`]) now
+//! carries `roster: BTreeMap<agent, (provider, configured model)>` on the
+//! event itself. `replay_from_log` recovers it by scanning `events` for the
+//! first `RunStarted` and cloning its `roster` — the exact same shape
+//! `agent_meta` already expected, so no other bridge code needed to change.
+//! `RunStarted.roster` is `#[serde(default)]`, so a log written by an older
+//! version of ArmadAI (no `roster` field persisted at all) still
+//! deserializes; it just falls back to an empty roster, i.e. the ORIGINAL
+//! fallback behavior above (empty `prov`/`model`) rather than an error — see
+//! `bridge.rs`'s
+//! `agent_invoked_maps_to_agent_start_with_empty_prov_model_when_meta_absent`
+//! test, which still documents that fallback for a log/roster with no
+//! metadata. Every other field of every other event
+//! (content/tokens/cost/agent names, `AgentEnd`/`Route`/`Board`/`Vote`/
 //! `Delegate`/`Warning`/...) round-trips through the log exactly, since it's
 //! carried verbatim by the `ExecutionEvent` that produced it.
-//!
-//! Tracked on `fix/replay-prov-model-roster`: `RunStarted` (OH1 socle) now
-//! has a `roster` field (`#[serde(default)]`, see `event.rs`) and
-//! `armadai-core::orchestration::es::bridge::roster_from_agents` builds it —
-//! but no production `RunStarted` emission populates it yet, and this
-//! module doesn't consume it yet either, so the gap above still applies
-//! until both land.
 //!
 //! `human_output` gates the two pieces of direct terminal output this
 //! module performs (a muted `replay <run_id>` banner and, on success, the
@@ -138,6 +146,7 @@ pub(crate) fn replay_from_log<L: armadai_core::orchestration::es::log::EventLog>
     use armadai_core::orchestration::es::bridge::{
         map_execution_to_run_events, synthetic_run_start, to_orchestration_result,
     };
+    use armadai_core::orchestration::es::event::ExecutionEvent;
     use armadai_core::orchestration::es::state::fold;
 
     let events = log.events(run_id)?;
@@ -168,10 +177,22 @@ pub(crate) fn replay_from_log<L: armadai_core::orchestration::es::log::EventLog>
         &events,
     ));
 
-    // No roster is available on this read-only path (see module docs): every
-    // `AgentInvoked` replays through the empty-`agent_meta` fallback, so its
-    // `AgentStart` carries empty `prov`/`model` rather than the live run's.
-    let agent_meta: BTreeMap<String, (String, String)> = BTreeMap::new();
+    // The roster persisted in `RunStarted.roster` (see module docs) is what
+    // lets replay reconstruct `agent_meta` without re-executing anything: the
+    // FIRST `RunStarted` in the log carries it (there is exactly one per run,
+    // except for a nested C9 sub-run's own ephemeral child log, which this
+    // top-level replay never reads). Falls back to an empty map for event
+    // logs written before `roster` existed (`#[serde(default)]` on the
+    // field) — the same "no roster available" fallback `map_execution_to_run_events`
+    // has always documented, so replaying an old log degrades gracefully to
+    // empty `prov`/`model` rather than erroring.
+    let agent_meta: BTreeMap<String, (String, String)> = events
+        .iter()
+        .find_map(|e| match e {
+            ExecutionEvent::RunStarted { roster, .. } => Some(roster.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
     for event in &events {
         for re in map_execution_to_run_events(event, &agent_meta) {
             sink.emit(&re);

--- a/crates/armadai/src/cli/run_replay.rs
+++ b/crates/armadai/src/cli/run_replay.rs
@@ -61,6 +61,13 @@
 //! `Delegate`/`Warning`/...) round-trips through the log exactly, since it's
 //! carried verbatim by the `ExecutionEvent` that produced it.
 //!
+//! Tracked on `fix/replay-prov-model-roster`: `RunStarted` (OH1 socle) now
+//! has a `roster` field (`#[serde(default)]`, see `event.rs`) and
+//! `armadai-core::orchestration::es::bridge::roster_from_agents` builds it —
+//! but no production `RunStarted` emission populates it yet, and this
+//! module doesn't consume it yet either, so the gap above still applies
+//! until both land.
+//!
 //! `human_output` gates the two pieces of direct terminal output this
 //! module performs (a muted `replay <run_id>` banner and, on success, the
 //! run's final answer) — mirroring the `!json && !quiet` gate `run.rs`'s

--- a/crates/armadai/src/es_log.rs
+++ b/crates/armadai/src/es_log.rs
@@ -83,6 +83,7 @@ mod tests {
                 agents: vec!["a".into()],
                 input: "x".into(),
                 project: None,
+                roster: Default::default(),
             },
             E::AgentObserved {
                 agent: "a".into(),


### PR DESCRIPTION
`armadai run --replay <run_id>` re-emitted every `agent_start` with empty `prov`/`model`, because the agent roster (name → provider/configured-model) was never persisted in the event-sourced log (the known OH1 Lot 6 "RunStarted no prov/model roster" gap). Surfaced by giving the gaveldrop e2e adapter a two-exchange run→replay case.

**Fix:** `ExecutionEvent::RunStarted` gains a `roster` field (`#[serde(default)]`, so logs written by earlier versions still deserialize), populated at every pattern's dispatch (direct/blackboard/ring/hierarchical + nested C9 sub-runs, all of which already hold the loaded `Agent` structs). Replay reconstructs `agent_meta` from `RunStarted.roster` instead of an empty map.

- TDD: a failing regression test (`734cfe4`), then the fix (`9819ee5`).
- The pre-existing replay-roundtrip test now asserts `prov`/`model` round-trip exactly instead of stripping them (`729ee23`) — it's the roundtrip that proves the fix.
- Independent review: READY TO MERGE (backward-compat locked by test, all 4 patterns + nested C9 verified, replay degrades gracefully, red→green reproduced independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)