### PR TITLE
docs: fix stale test-mode description in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ CI runs clippy in **3 feature modes** to catch lints that only trip under one co
 - `--no-default-features --features tui,providers-api`
 - `--no-default-features --features tui,web,storage`
 
-Tests run in 2 modes: `--no-default-features --features tui` and `--no-default-features --features tui,storage` (the latter also covers the `e2e` integration test target). Build (`--release`) uses `--no-default-features --features tui,storage`.
+Tests run in 3 modes: `--no-default-features --features tui`, `--no-default-features --features tui,storage,e2e-fake` (this one also covers the SQLite storage paths and the gaveldrop e2e suite, run via the `--test gaveldrop` target), and `--no-default-features --features tui,providers-api`. Build (`--release`) uses `--no-default-features --features tui,storage`.
 
 ## Feature Flags
 


### PR DESCRIPTION
`CLAUDE.md` still described the test setup from before the gaveldrop migration (#323):

- claimed **2** test modes — CI runs **3** (`tui`, `tui,storage,e2e-fake`, `tui,providers-api`)
- pointed at the old `e2e` integration test target — the suite is now `--test gaveldrop`, behind the `e2e-fake` feature (a bare `--features tui,storage` no longer runs it)

One-line correction, now matching `.github/workflows/ci.yml`. Doc-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)