### PR TITLE
fix(audit): scan sub-agent transcripts, which the pass was missing entirely

### DIFF
--- a/crates/armadai/src/audit/report.rs
+++ b/crates/armadai/src/audit/report.rs
@@ -38,6 +38,21 @@ impl UsageView<'_> {
     }
 }
 
+/// `12 invocation(s), 87 turn(s)` — or just the invocations when the agent's own
+/// transcript was never found. Invocations count how often an agent was asked
+/// for; turns count what it actually did. Measured 2026-08-20, they differ by
+/// an order of magnitude.
+fn agent_volume(stats: &crate::audit::usage::facts::AgentUsage) -> String {
+    if stats.turns > 0 {
+        format!(
+            "{} invocation(s), {} turn(s)",
+            stats.invocations, stats.turns
+        )
+    } else {
+        format!("{} invocation(s)", stats.invocations)
+    }
+}
+
 impl AuditReport {
     pub fn critical_count(&self) -> usize {
         self.count(Severity::Critical)
@@ -156,13 +171,20 @@ impl AuditReport {
         let mut out = String::new();
         let _ = writeln!(out, "\n## Observed usage\n");
         let _ = writeln!(out, "- Sessions scanned: {}", view.usage.sessions);
+        if view.usage.observed_depth > 0 {
+            let _ = writeln!(
+                out,
+                "- Observed delegation depth: {}",
+                view.usage.observed_depth
+            );
+        }
         if let Some((from, to)) = &view.usage.window {
             let _ = writeln!(out, "- Window: {from} → {to}");
         }
         if !view.agents.is_empty() {
             let _ = writeln!(out, "\n### Agents by invocation\n");
             for (name, stats) in &view.agents {
-                let _ = writeln!(out, "- `{}` — {} invocation(s)", name, stats.invocations);
+                let _ = writeln!(out, "- `{}` — {}", name, agent_volume(stats));
             }
             let hidden = view.agents_hidden();
             if hidden > 0 {
@@ -194,13 +216,19 @@ impl AuditReport {
         anstream::println!();
         anstream::println!("  {h}Observed usage{h:#}");
         anstream::println!("  {m}Sessions scanned:{m:#} {}", view.usage.sessions);
+        if view.usage.observed_depth > 0 {
+            anstream::println!(
+                "  {m}Observed delegation depth:{m:#} {}",
+                view.usage.observed_depth
+            );
+        }
         if let Some((from, to)) = &view.usage.window {
             anstream::println!("  {m}Window:{m:#} {from} → {to}");
         }
         if !view.agents.is_empty() {
             anstream::println!("  {m}Agents by invocation:{m:#}");
             for (name, stats) in &view.agents {
-                anstream::println!("    {name} — {} invocation(s)", stats.invocations);
+                anstream::println!("    {name} — {}", agent_volume(stats));
             }
             let hidden = view.agents_hidden();
             if hidden > 0 {
@@ -231,6 +259,13 @@ impl AuditReport {
         let mut out = String::new();
         out.push_str("<section class=\"usage\">\n<h2>Observed usage</h2>\n<ul>\n");
         let _ = writeln!(out, "<li>Sessions scanned: {}</li>", view.usage.sessions);
+        if view.usage.observed_depth > 0 {
+            let _ = writeln!(
+                out,
+                "<li>Observed delegation depth: {}</li>",
+                view.usage.observed_depth
+            );
+        }
         if let Some((from, to)) = &view.usage.window {
             let _ = writeln!(
                 out,
@@ -245,9 +280,9 @@ impl AuditReport {
             for (name, stats) in &view.agents {
                 let _ = writeln!(
                     out,
-                    "<li><code>{}</code> — {} invocation(s)</li>",
+                    "<li><code>{}</code> — {}</li>",
                     html_escape(name),
-                    stats.invocations
+                    html_escape(&agent_volume(stats))
                 );
             }
             let hidden = view.agents_hidden();

--- a/crates/armadai/src/audit/report.rs
+++ b/crates/armadai/src/audit/report.rs
@@ -43,13 +43,13 @@ impl UsageView<'_> {
 /// for; turns count what it actually did. Measured 2026-08-20, they differ by
 /// an order of magnitude.
 fn agent_volume(stats: &crate::audit::usage::facts::AgentUsage) -> String {
-    if stats.turns > 0 {
-        format!(
-            "{} invocation(s), {} turn(s)",
-            stats.invocations, stats.turns
-        )
-    } else {
-        format!("{} invocation(s)", stats.invocations)
+    match (stats.invocations, stats.turns) {
+        // Spawned only from inside another sub-agent: `invocations` counts
+        // main-thread delegations only, so reporting "0 invocation(s)" about
+        // an agent that demonstrably ran would be plainly false.
+        (0, t) if t > 0 => format!("{t} turn(s), spawned from within another agent"),
+        (i, 0) => format!("{i} invocation(s)"),
+        (i, t) => format!("{i} invocation(s), {t} turn(s)"),
     }
 }
 
@@ -151,7 +151,14 @@ impl AuditReport {
     fn usage_view(&self) -> Option<UsageView<'_>> {
         let usage = self.usage.as_ref().filter(|u| !u.is_empty())?;
         let mut agents: Vec<_> = usage.agents.iter().collect();
-        agents.sort_by(|a, b| b.1.invocations.cmp(&a.1.invocations).then(a.0.cmp(b.0)));
+        // Rank by observed work, not by how often an agent was asked for. An
+        // agent spawned only from inside other sub-agents has zero invocations
+        // yet may be among the busiest — sorting on invocations would truncate
+        // it away first, which is how `workflow-subagent` stayed hidden.
+        agents.sort_by(|a, b| {
+            let key = |u: &crate::audit::usage::facts::AgentUsage| (u.turns, u.invocations);
+            key(b.1).cmp(&key(a.1)).then(a.0.cmp(b.0))
+        });
         agents.truncate(10);
         let mut skills: Vec<_> = usage.skills.iter().collect();
         skills.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
@@ -182,7 +189,7 @@ impl AuditReport {
             let _ = writeln!(out, "- Window: {from} → {to}");
         }
         if !view.agents.is_empty() {
-            let _ = writeln!(out, "\n### Agents by invocation\n");
+            let _ = writeln!(out, "\n### Agents by observed volume\n");
             for (name, stats) in &view.agents {
                 let _ = writeln!(out, "- `{}` — {}", name, agent_volume(stats));
             }
@@ -226,7 +233,7 @@ impl AuditReport {
             anstream::println!("  {m}Window:{m:#} {from} → {to}");
         }
         if !view.agents.is_empty() {
-            anstream::println!("  {m}Agents by invocation:{m:#}");
+            anstream::println!("  {m}Agents by observed volume:{m:#}");
             for (name, stats) in &view.agents {
                 anstream::println!("    {name} — {}", agent_volume(stats));
             }
@@ -276,7 +283,7 @@ impl AuditReport {
         }
         out.push_str("</ul>\n");
         if !view.agents.is_empty() {
-            out.push_str("<h3>Agents by invocation</h3>\n<ul>\n");
+            out.push_str("<h3>Agents by observed volume</h3>\n<ul>\n");
             for (name, stats) in &view.agents {
                 let _ = writeln!(
                     out,

--- a/crates/armadai/src/audit/rules/usage_rules.rs
+++ b/crates/armadai/src/audit/rules/usage_rules.rs
@@ -106,10 +106,18 @@ pub(super) fn u02_used_but_undeclared(ctx: &AuditContext) -> Vec<Finding> {
             // side by design, out of scope for this check) would also land
             // here — the message must not claim more than the code knows.
             message: format!(
-                "sub-agent '{}' ran {} time(s) but is not declared in this project's \
+                "sub-agent '{}' ran {} but is not declared in this project's \
                  `.claude/agents/`{}",
                 name,
-                stats.invocations,
+                // `invocations` counts main-thread delegations only. An agent
+                // spawned solely from inside another sub-agent has none, so
+                // reporting "0 time(s)" about one that demonstrably ran would
+                // be false — fall back to the turns its transcript proves.
+                if stats.invocations == 0 && stats.turns > 0 {
+                    format!("{} turn(s) inside other agents", stats.turns)
+                } else {
+                    format!("{} time(s)", stats.invocations)
+                },
                 if builtin {
                     " (it is built into Claude Code)"
                 } else {

--- a/crates/armadai/src/audit/usage/discovery.rs
+++ b/crates/armadai/src/audit/usage/discovery.rs
@@ -424,6 +424,84 @@ mod tests {
         );
     }
 
+    /// Builds a project dir holding one session plus its `subagents/`
+    /// sidecar layout, the shape Claude Code actually writes.
+    fn project_with_subagents(base: &Path, project: &Path) -> PathBuf {
+        let slug = base.join(slug_for(project));
+        std::fs::create_dir_all(&slug).unwrap();
+        std::fs::write(slug.join("sess1.jsonl"), "{}\n").unwrap();
+        let sub = slug.join("sess1").join("subagents");
+        std::fs::create_dir_all(&sub).unwrap();
+        for id in ["a1", "a2"] {
+            std::fs::write(sub.join(format!("agent-{id}.jsonl")), "{}\n").unwrap();
+            std::fs::write(sub.join(format!("agent-{id}.meta.json")), "{}").unwrap();
+        }
+        // A transcript with no meta: the agent never actually ran.
+        std::fs::write(sub.join("agent-orphan.jsonl"), "{}\n").unwrap();
+        // A sibling directory holding far more files, none of them ours.
+        let noise = slug.join("sess1").join("tool-results");
+        std::fs::create_dir_all(&noise).unwrap();
+        std::fs::write(noise.join("r1.jsonl"), "{}\n").unwrap();
+        slug
+    }
+
+    #[test]
+    fn subagent_files_pairs_transcripts_with_their_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = ProjectsDirGuard::set(dir.path());
+        let project = Path::new("/Users/x/proj");
+        project_with_subagents(dir.path(), project);
+
+        let found = subagent_files(project);
+        assert_eq!(found.len(), 2, "only meta-backed pairs count: {found:?}");
+        for sa in &found {
+            assert!(sa.meta.is_file(), "meta must exist: {sa:?}");
+            assert!(sa.transcript.to_string_lossy().ends_with(".jsonl"));
+        }
+    }
+
+    #[test]
+    fn a_transcript_without_metadata_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = ProjectsDirGuard::set(dir.path());
+        let project = Path::new("/Users/x/proj");
+        project_with_subagents(dir.path(), project);
+        // `agent-orphan.jsonl` has no meta, so it never ran and must not count.
+        assert!(
+            !subagent_files(project)
+                .iter()
+                .any(|sa| sa.transcript.to_string_lossy().contains("orphan")),
+            "a meta-less transcript means the agent did not run"
+        );
+    }
+
+    #[test]
+    fn sibling_directories_are_not_walked() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = ProjectsDirGuard::set(dir.path());
+        let project = Path::new("/Users/x/proj");
+        project_with_subagents(dir.path(), project);
+        // `tool-results/` holds an order of magnitude more files in practice
+        // and nothing this audit measures.
+        assert!(
+            !subagent_files(project)
+                .iter()
+                .any(|sa| sa.transcript.to_string_lossy().contains("tool-results")),
+            "only subagents/ is ours to read"
+        );
+    }
+
+    #[test]
+    fn a_project_without_subagents_yields_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = ProjectsDirGuard::set(dir.path());
+        let project = Path::new("/Users/x/plain");
+        let slug = dir.path().join(slug_for(project));
+        std::fs::create_dir_all(&slug).unwrap();
+        std::fs::write(slug.join("sess.jsonl"), "{}\n").unwrap();
+        assert!(subagent_files(project).is_empty());
+    }
+
     #[test]
     fn missing_projects_dir_yields_no_files() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/armadai/src/audit/usage/discovery.rs
+++ b/crates/armadai/src/audit/usage/discovery.rs
@@ -115,6 +115,52 @@ fn strip_trailing_sep(s: &str) -> String {
     s.trim_end_matches(['/', '\\']).to_string()
 }
 
+/// A sub-agent's transcript, paired with the metadata Claude Code writes
+/// beside it.
+///
+/// Claude Code stores sub-agent work under
+/// `<projects>/<slug>/<session-id>/subagents/agent-<id>.{jsonl,meta.json}` —
+/// NOT in the session file, which only records the delegation call. The scan
+/// missed all of it until 2026-08-20. The meta is the interesting half: it
+/// carries `agentType`, `parentAgentId` and `spawnDepth`, so the delegation
+/// tree is stated outright rather than inferred.
+///
+/// Only agents that actually ran get a meta — a delegation refused by a
+/// policy hook leaves none. Counting metas therefore counts executions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentFiles {
+    /// The sub-agent's own transcript.
+    pub transcript: PathBuf,
+    /// Its sidecar metadata.
+    pub meta: PathBuf,
+}
+
+/// Every sub-agent transcript belonging to `root`, across all its sessions.
+///
+/// Deliberately narrow: only `subagents/` is walked. Sibling directories
+/// (`tool-results/`, `memory/`) hold an order of magnitude more files and
+/// nothing this audit measures.
+pub fn subagent_files(root: &Path) -> Vec<SubagentFiles> {
+    let mut found = Vec::new();
+    for session in transcript_files(root) {
+        // `<session>.jsonl` -> `<session>/subagents/`
+        let Some(dir) = session.parent().map(|p| {
+            p.join(session.file_stem().unwrap_or_default())
+                .join("subagents")
+        }) else {
+            continue;
+        };
+        for transcript in jsonl_in(&dir) {
+            let meta = transcript.with_extension("meta.json");
+            if meta.is_file() {
+                found.push(SubagentFiles { transcript, meta });
+            }
+        }
+    }
+    found.sort_by(|a, b| a.transcript.cmp(&b.transcript));
+    found
+}
+
 fn jsonl_in(dir: &Path) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();

--- a/crates/armadai/src/audit/usage/discovery.rs
+++ b/crates/armadai/src/audit/usage/discovery.rs
@@ -137,12 +137,18 @@ pub struct SubagentFiles {
 
 /// Every sub-agent transcript belonging to `root`, across all its sessions.
 ///
-/// Deliberately narrow: only `subagents/` is walked. Sibling directories
-/// (`tool-results/`, `memory/`) hold an order of magnitude more files and
-/// nothing this audit measures.
-pub fn subagent_files(root: &Path) -> Vec<SubagentFiles> {
+/// Walks `subagents/` and **one level of subdirectories beneath it**: Claude
+/// Code also nests sub-agents under `subagents/workflows/wf_<id>/`. Measured
+/// on 2026-08-20: 92 of 640 sub-agent transcripts lived there, and an entire
+/// agent type (`workflow-subagent`) plus an entire skill (`deep-research`)
+/// were invisible while only the flat level was read.
+///
+/// Deliberately still narrow: sibling directories (`tool-results/`,
+/// `memory/`) are never walked — not because of their size, but because they
+/// hold nothing this audit measures.
+pub fn subagent_files_for(sessions: &[PathBuf]) -> Vec<SubagentFiles> {
     let mut found = Vec::new();
-    for session in transcript_files(root) {
+    for session in sessions {
         // `<session>.jsonl` -> `<session>/subagents/`
         let Some(dir) = session.parent().map(|p| {
             p.join(session.file_stem().unwrap_or_default())
@@ -150,10 +156,24 @@ pub fn subagent_files(root: &Path) -> Vec<SubagentFiles> {
         }) else {
             continue;
         };
-        for transcript in jsonl_in(&dir) {
-            let meta = transcript.with_extension("meta.json");
-            if meta.is_file() {
-                found.push(SubagentFiles { transcript, meta });
+        let mut dirs = vec![dir.clone()];
+        // One level down: `subagents/workflows/wf_<id>/`. Bounded on purpose —
+        // a blind recursion would eventually wander into whatever Claude Code
+        // nests next.
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten().filter(|e| e.path().is_dir()) {
+                dirs.push(entry.path());
+                if let Ok(inner) = std::fs::read_dir(entry.path()) {
+                    dirs.extend(inner.flatten().map(|e| e.path()).filter(|p| p.is_dir()));
+                }
+            }
+        }
+        for d in dirs {
+            for transcript in jsonl_in(&d) {
+                let meta = transcript.with_extension("meta.json");
+                if meta.is_file() {
+                    found.push(SubagentFiles { transcript, meta });
+                }
             }
         }
     }
@@ -452,12 +472,23 @@ mod tests {
         let project = Path::new("/Users/x/proj");
         project_with_subagents(dir.path(), project);
 
-        let found = subagent_files(project);
+        let found = subagent_files_for(&transcript_files(project));
         assert_eq!(found.len(), 2, "only meta-backed pairs count: {found:?}");
+        // Assert the pairing is right, not merely that the filters ran: each
+        // transcript must be paired with ITS OWN meta, not another agent's.
         for sa in &found {
-            assert!(sa.meta.is_file(), "meta must exist: {sa:?}");
-            assert!(sa.transcript.to_string_lossy().ends_with(".jsonl"));
+            let expected = sa.transcript.with_extension("meta.json");
+            assert_eq!(sa.meta, expected, "transcript paired with the wrong meta");
         }
+        let ids: Vec<String> = found
+            .iter()
+            .map(|sa| sa.transcript.file_name().unwrap().to_string_lossy().into())
+            .collect();
+        assert!(
+            ids.contains(&"agent-a1.jsonl".to_string())
+                && ids.contains(&"agent-a2.jsonl".to_string()),
+            "both meta-backed agents must be found: {ids:?}"
+        );
     }
 
     #[test]
@@ -468,7 +499,7 @@ mod tests {
         project_with_subagents(dir.path(), project);
         // `agent-orphan.jsonl` has no meta, so it never ran and must not count.
         assert!(
-            !subagent_files(project)
+            !subagent_files_for(&transcript_files(project))
                 .iter()
                 .any(|sa| sa.transcript.to_string_lossy().contains("orphan")),
             "a meta-less transcript means the agent did not run"
@@ -484,10 +515,74 @@ mod tests {
         // `tool-results/` holds an order of magnitude more files in practice
         // and nothing this audit measures.
         assert!(
-            !subagent_files(project)
+            !subagent_files_for(&transcript_files(project))
                 .iter()
                 .any(|sa| sa.transcript.to_string_lossy().contains("tool-results")),
             "only subagents/ is ours to read"
+        );
+    }
+
+    #[test]
+    fn nested_workflow_subagents_are_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = ProjectsDirGuard::set(dir.path());
+        let project = Path::new("/Users/x/proj");
+        let slug = project_with_subagents(dir.path(), project);
+        // Claude Code nests some sub-agents one level deeper. Measured
+        // 2026-08-20: 92 of 640 lived here, and an entire agent type
+        // (`workflow-subagent`) was invisible while only the flat level
+        // was read.
+        let wf = slug
+            .join("sess1")
+            .join("subagents")
+            .join("workflows")
+            .join("wf_1");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(wf.join("agent-w1.jsonl"), "{}\n").unwrap();
+        std::fs::write(wf.join("agent-w1.meta.json"), "{}").unwrap();
+        // `journal.jsonl` also lives there with no meta; the pairing gate
+        // must keep it out.
+        std::fs::write(wf.join("journal.jsonl"), "{}\n").unwrap();
+
+        let found = subagent_files_for(&transcript_files(project));
+        assert_eq!(found.len(), 3, "flat pair + nested pair: {found:?}");
+        assert!(
+            found
+                .iter()
+                .any(|sa| sa.transcript.ends_with("agent-w1.jsonl")),
+            "the nested sub-agent must be found: {found:?}"
+        );
+        assert!(
+            !found
+                .iter()
+                .any(|sa| sa.transcript.ends_with("journal.jsonl")),
+            "a meta-less file must stay out even when nested"
+        );
+    }
+
+    #[test]
+    fn the_walk_stops_after_one_nested_level() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = ProjectsDirGuard::set(dir.path());
+        let project = Path::new("/Users/x/proj");
+        let slug = project_with_subagents(dir.path(), project);
+        // Bounded on purpose: a blind recursion would wander into whatever
+        // Claude Code nests next.
+        let deep = slug
+            .join("sess1")
+            .join("subagents")
+            .join("workflows")
+            .join("wf_1")
+            .join("deeper");
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("agent-d1.jsonl"), "{}\n").unwrap();
+        std::fs::write(deep.join("agent-d1.meta.json"), "{}").unwrap();
+
+        assert!(
+            !subagent_files_for(&transcript_files(project))
+                .iter()
+                .any(|sa| sa.transcript.ends_with("agent-d1.jsonl")),
+            "three levels down is beyond the bound"
         );
     }
 
@@ -499,7 +594,7 @@ mod tests {
         let slug = dir.path().join(slug_for(project));
         std::fs::create_dir_all(&slug).unwrap();
         std::fs::write(slug.join("sess.jsonl"), "{}\n").unwrap();
-        assert!(subagent_files(project).is_empty());
+        assert!(subagent_files_for(&transcript_files(project)).is_empty());
     }
 
     #[test]

--- a/crates/armadai/src/audit/usage/facts.rs
+++ b/crates/armadai/src/audit/usage/facts.rs
@@ -339,6 +339,58 @@ mod tests {
     }
 
     #[test]
+    fn a_subagent_at_depth_one_attaches_to_the_root() {
+        let mut f = UsageFacts {
+            root_agent: ROOT_AGENT.to_string(),
+            ..Default::default()
+        };
+        // Claude Code omits parentAgentId at depth 1: the parent IS the root.
+        f.record_subagent("dev-lead", None, 1, 42);
+        assert_eq!(f.agents["dev-lead"].turns, 42);
+        assert!(f.edges[ROOT_AGENT].contains("dev-lead"));
+        assert_eq!(f.observed_depth, 1);
+    }
+
+    #[test]
+    fn a_nested_subagent_attaches_to_its_named_parent() {
+        let mut f = UsageFacts {
+            root_agent: ROOT_AGENT.to_string(),
+            ..Default::default()
+        };
+        f.record_subagent("dev-lead", None, 1, 10);
+        f.record_subagent("qa-specialist", Some("dev-lead"), 2, 30);
+        assert!(f.edges["dev-lead"].contains("qa-specialist"));
+        assert!(!f.edges[ROOT_AGENT].contains("qa-specialist"));
+        assert_eq!(f.observed_depth, 2, "depth is the max seen, not the last");
+    }
+
+    #[test]
+    fn turns_accumulate_across_several_runs_of_the_same_agent() {
+        let mut f = UsageFacts::default();
+        f.record_subagent("qa-specialist", None, 1, 5);
+        f.record_subagent("qa-specialist", None, 1, 7);
+        assert_eq!(f.agents["qa-specialist"].turns, 12);
+    }
+
+    #[test]
+    fn turns_are_independent_of_invocations() {
+        // A sub-agent's own transcript says how much work it did; the parent's
+        // transcript says how often it was asked. Neither implies the other.
+        let mut f = UsageFacts::default();
+        f.record_delegation(ROOT_AGENT, "qa-specialist", "m");
+        f.record_subagent("qa-specialist", None, 1, 99);
+        let u = &f.agents["qa-specialist"];
+        assert_eq!((u.invocations, u.turns), (1, 99));
+    }
+
+    #[test]
+    fn a_subagent_with_a_blank_type_is_ignored() {
+        let mut f = UsageFacts::default();
+        f.record_subagent("", None, 1, 5);
+        assert!(f.agents.is_empty());
+    }
+
+    #[test]
     fn skill_turns_and_tools_accumulate() {
         let mut f = UsageFacts::default();
         f.record_skill_turn("armadai");

--- a/crates/armadai/src/audit/usage/facts.rs
+++ b/crates/armadai/src/audit/usage/facts.rs
@@ -1,21 +1,28 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use serde::Serialize;
+
 /// The native CLI's main thread, i.e. the root of every observed delegation
 /// tree. Claude Code's own turns are not a declared agent, so the tree needs a
 /// stable name for them.
 pub const ROOT_AGENT: &str = "claude";
 
 /// What one agent was observed doing.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct AgentUsage {
     pub invocations: u32,
+    /// Assistant turns the agent actually took, read from its own transcript
+    /// under `<session>/subagents/`. `invocations` counts how often it was
+    /// asked; this counts how much work it did — they differ by an order of
+    /// magnitude in practice.
+    pub turns: u32,
     /// Model name -> number of delegations seen on that model.
     pub models: BTreeMap<String, u32>,
 }
 
 /// Deterministic aggregate of everything the scan observed. Serialisable by
 /// construction: no paths, no handles, only counted facts.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct UsageFacts {
     pub sessions: u32,
     /// Oldest and newest timestamps encountered — a constat, not a filter.
@@ -30,6 +37,11 @@ pub struct UsageFacts {
     pub edges: BTreeMap<String, BTreeSet<String>>,
     /// Largest parallel fan-out seen in a single assistant message.
     pub max_fanout: u32,
+
+    /// Deepest `spawnDepth` stated by a sub-agent's metadata. Unlike
+    /// `depth()`, which infers a chain, this is read directly from what Claude
+    /// Code recorded — no inference, no ambiguity.
+    pub observed_depth: u32,
 }
 
 /// Strips control characters (including newlines) from `s`. `subagent_type`
@@ -83,6 +95,38 @@ impl UsageFacts {
             .entry(parent.to_string())
             .or_default()
             .insert(child.to_string());
+    }
+
+    /// Record a sub-agent that actually ran, from its sidecar metadata.
+    ///
+    /// `parent` is `None` at `spawnDepth == 1`, where Claude Code omits
+    /// `parentAgentId` because the parent is the main thread. The edge is
+    /// therefore stated by the data, not inferred from a uuid chain.
+    pub fn record_subagent(
+        &mut self,
+        agent_type: &str,
+        parent: Option<&str>,
+        depth: u32,
+        turns: u32,
+    ) {
+        let child = sanitize_identifier(agent_type).into_owned();
+        if child.is_empty() {
+            return;
+        }
+        let entry = self.agents.entry(child.clone()).or_default();
+        entry.turns += turns;
+        let parent = parent
+            .map(|p| sanitize_identifier(p).into_owned())
+            .filter(|p| !p.is_empty())
+            .unwrap_or_else(|| {
+                if self.root_agent.is_empty() {
+                    ROOT_AGENT.to_string()
+                } else {
+                    self.root_agent.clone()
+                }
+            });
+        self.edges.entry(parent).or_default().insert(child);
+        self.observed_depth = self.observed_depth.max(depth);
     }
 
     pub fn record_skill_turn(&mut self, skill: &str) {

--- a/crates/armadai/src/audit/usage/facts.rs
+++ b/crates/armadai/src/audit/usage/facts.rs
@@ -108,6 +108,7 @@ impl UsageFacts {
         parent: Option<&str>,
         depth: u32,
         turns: u32,
+        edge_is_trustworthy: bool,
     ) {
         let child = sanitize_identifier(agent_type).into_owned();
         if child.is_empty() {
@@ -115,6 +116,12 @@ impl UsageFacts {
         }
         let entry = self.agents.entry(child.clone()).or_default();
         entry.turns += turns;
+        self.observed_depth = self.observed_depth.max(depth);
+        // A wrong edge is indistinguishable from a real one downstream, so an
+        // untrustworthy parent yields no edge at all — the turns still count.
+        if !edge_is_trustworthy {
+            return;
+        }
         let parent = parent
             .map(|p| sanitize_identifier(p).into_owned())
             .filter(|p| !p.is_empty())
@@ -126,7 +133,6 @@ impl UsageFacts {
                 }
             });
         self.edges.entry(parent).or_default().insert(child);
-        self.observed_depth = self.observed_depth.max(depth);
     }
 
     pub fn record_skill_turn(&mut self, skill: &str) {
@@ -345,7 +351,7 @@ mod tests {
             ..Default::default()
         };
         // Claude Code omits parentAgentId at depth 1: the parent IS the root.
-        f.record_subagent("dev-lead", None, 1, 42);
+        f.record_subagent("dev-lead", None, 1, 42, true);
         assert_eq!(f.agents["dev-lead"].turns, 42);
         assert!(f.edges[ROOT_AGENT].contains("dev-lead"));
         assert_eq!(f.observed_depth, 1);
@@ -357,8 +363,8 @@ mod tests {
             root_agent: ROOT_AGENT.to_string(),
             ..Default::default()
         };
-        f.record_subagent("dev-lead", None, 1, 10);
-        f.record_subagent("qa-specialist", Some("dev-lead"), 2, 30);
+        f.record_subagent("dev-lead", None, 1, 10, true);
+        f.record_subagent("qa-specialist", Some("dev-lead"), 2, 30, true);
         assert!(f.edges["dev-lead"].contains("qa-specialist"));
         assert!(!f.edges[ROOT_AGENT].contains("qa-specialist"));
         assert_eq!(f.observed_depth, 2, "depth is the max seen, not the last");
@@ -367,8 +373,8 @@ mod tests {
     #[test]
     fn turns_accumulate_across_several_runs_of_the_same_agent() {
         let mut f = UsageFacts::default();
-        f.record_subagent("qa-specialist", None, 1, 5);
-        f.record_subagent("qa-specialist", None, 1, 7);
+        f.record_subagent("qa-specialist", None, 1, 5, true);
+        f.record_subagent("qa-specialist", None, 1, 7, true);
         assert_eq!(f.agents["qa-specialist"].turns, 12);
     }
 
@@ -378,15 +384,33 @@ mod tests {
         // transcript says how often it was asked. Neither implies the other.
         let mut f = UsageFacts::default();
         f.record_delegation(ROOT_AGENT, "qa-specialist", "m");
-        f.record_subagent("qa-specialist", None, 1, 99);
+        f.record_subagent("qa-specialist", None, 1, 99, true);
         let u = &f.agents["qa-specialist"];
         assert_eq!((u.invocations, u.turns), (1, 99));
     }
 
     #[test]
+    fn an_untrustworthy_parent_records_turns_but_no_edge() {
+        let mut f = UsageFacts {
+            root_agent: ROOT_AGENT.to_string(),
+            ..Default::default()
+        };
+        // spawnDepth 2 proves the parent is NOT the root, so an unresolvable
+        // parent must yield no edge rather than a fabricated one.
+        f.record_subagent("qa-specialist", None, 2, 12, false);
+        assert_eq!(f.agents["qa-specialist"].turns, 12, "turns still count");
+        assert_eq!(f.observed_depth, 2, "depth still counts");
+        assert!(
+            f.edges.is_empty(),
+            "a wrong edge is indistinguishable from a real one: {:?}",
+            f.edges
+        );
+    }
+
+    #[test]
     fn a_subagent_with_a_blank_type_is_ignored() {
         let mut f = UsageFacts::default();
-        f.record_subagent("", None, 1, 5);
+        f.record_subagent("", None, 1, 5, true);
         assert!(f.agents.is_empty());
     }
 

--- a/crates/armadai/src/audit/usage/scan.rs
+++ b/crates/armadai/src/audit/usage/scan.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::io::BufRead;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
 use crate::claude_adapter::transcript::{Block, RelevantEntry, parse_value};
 
-use super::discovery::{subagent_files, transcript_files};
+use super::discovery::{subagent_files_for, transcript_files};
 use super::facts::{ROOT_AGENT, UsageFacts};
 
 /// Aggregate every transcript belonging to `root`.
@@ -21,8 +21,9 @@ pub fn scan(root: &Path) -> UsageFacts {
         root_agent: ROOT_AGENT.to_string(),
         ..Default::default()
     };
-    for file in transcript_files(root) {
-        let Ok(handle) = std::fs::File::open(&file) else {
+    let sessions = transcript_files(root);
+    for file in &sessions {
+        let Ok(handle) = std::fs::File::open(file) else {
             continue;
         };
         facts.sessions += 1;
@@ -65,7 +66,7 @@ pub fn scan(root: &Path) -> UsageFacts {
             scan_entry(&v, &mut facts, &mut parent_of, &mut agent_at);
         }
     }
-    scan_subagents(root, &mut facts);
+    scan_subagents(&sessions, &mut facts);
     facts
 }
 
@@ -82,7 +83,11 @@ fn read_meta(path: &Path) -> Option<SubagentMeta> {
     Some(SubagentMeta {
         agent_type: str_field(&v, "agentType")?.to_string(),
         parent_agent_id: str_field(&v, "parentAgentId").map(str::to_string),
-        spawn_depth: v.get("spawnDepth").and_then(Value::as_u64).unwrap_or(1) as u32,
+        spawn_depth: v
+            .get("spawnDepth")
+            .and_then(Value::as_u64)
+            .and_then(|d| u32::try_from(d).ok())
+            .unwrap_or(1),
     })
 }
 
@@ -100,50 +105,97 @@ fn agent_id_of(meta_path: &Path) -> Option<String> {
 /// This is the half of the corpus the scan missed until 2026-08-20. It does
 /// NOT touch `invocations`, which keeps its existing meaning — delegations
 /// emitted from the main thread — so no event is counted twice.
-fn scan_subagents(root: &Path, facts: &mut UsageFacts) {
-    let found = subagent_files(root);
-    // First pass: agent id -> agent type, so a `parentAgentId` resolves to a
-    // name. Claude Code references the parent by id, not by type.
-    let mut type_of: HashMap<String, String> = HashMap::new();
-    let mut metas = Vec::new();
-    for sa in &found {
-        if let (Some(id), Some(meta)) = (agent_id_of(&sa.meta), read_meta(&sa.meta)) {
-            type_of.insert(id, meta.agent_type.clone());
-            metas.push((sa.transcript.clone(), meta));
+/// Read one sub-agent transcript: its skill turns, its tools, and how many
+/// assistant turns it actually took. Returns the turn count.
+///
+/// Turns are deduplicated on `message.id`: Claude Code writes one entry per
+/// content block, so a single assistant message spans several lines. Counting
+/// entries over-reported by 53% on the reference corpus (32 053 entries for
+/// 14 958 distinct messages). Blocks of one message are contiguous, so a
+/// single `last_id` suffices — no extra pass, no extra memory.
+///
+/// Deliberately independent of the metadata: skills and tools do not need it,
+/// so an unreadable or malformed meta must not cost us the transcript too.
+fn absorb_subagent_transcript(path: &Path, facts: &mut UsageFacts) -> u32 {
+    let Ok(handle) = std::fs::File::open(path) else {
+        return 0;
+    };
+    let mut turns = 0u32;
+    let mut last_id: Option<String> = None;
+    for line in std::io::BufReader::new(handle).lines() {
+        let Ok(line) = line else { continue };
+        let Ok(v) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if let Some(ts) = str_field(&v, "timestamp") {
+            facts.observe_timestamp(ts);
         }
-    }
-    for (transcript, meta) in metas {
-        let mut turns = 0u32;
-        if let Ok(handle) = std::fs::File::open(&transcript) {
-            for line in std::io::BufReader::new(handle).lines() {
-                let Ok(line) = line else { continue };
-                let Ok(v) = serde_json::from_str::<Value>(&line) else {
-                    continue;
-                };
-                if let Some(ts) = str_field(&v, "timestamp") {
-                    facts.observe_timestamp(ts);
-                }
-                if let Some(skill) = str_field(&v, "attributionSkill") {
-                    facts.record_skill_turn(skill);
-                }
-                if str_field(&v, "type") == Some("assistant") {
-                    turns += 1;
-                    if let Some(RelevantEntry::Assistant { blocks, .. }) = parse_value(&v) {
-                        for block in &blocks {
-                            if let Block::Tool { name } = block {
-                                facts.record_tool(name);
-                            }
-                        }
-                    }
+        if let Some(skill) = str_field(&v, "attributionSkill") {
+            facts.record_skill_turn(skill);
+        }
+        if str_field(&v, "type") != Some("assistant") {
+            continue;
+        }
+        let id = v
+            .get("message")
+            .and_then(|m| m.get("id"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        // A message with no id cannot be deduplicated; count it once.
+        if id.is_none() || id != last_id {
+            turns += 1;
+        }
+        last_id = id;
+        if let Some(RelevantEntry::Assistant { blocks, .. }) = parse_value(&v) {
+            for block in &blocks {
+                if let Block::Tool { name } = block {
+                    facts.record_tool(name);
                 }
             }
         }
+    }
+    turns
+}
+
+/// Absorb every sub-agent transcript: the work itself, and the delegation edge
+/// its metadata states outright.
+///
+/// This is the half of the corpus the scan missed until 2026-08-20. It does
+/// NOT call `record_delegation`, so `invocations` keeps its existing meaning —
+/// delegations emitted from the main thread — and no event is counted twice.
+fn scan_subagents(sessions: &[PathBuf], facts: &mut UsageFacts) {
+    let found = subagent_files_for(sessions);
+    // First pass: agent id -> agent type, so a `parentAgentId` resolves to a
+    // name. Claude Code references the parent by id, not by type.
+    let mut type_of: HashMap<String, String> = HashMap::new();
+    for sa in &found {
+        if let (Some(id), Some(meta)) = (agent_id_of(&sa.meta), read_meta(&sa.meta)) {
+            type_of.insert(id, meta.agent_type);
+        }
+    }
+    for sa in &found {
+        // The transcript first, and unconditionally: a missing meta costs us
+        // the edge, never the skills and tools we already read.
+        let turns = absorb_subagent_transcript(&sa.transcript, facts);
+        let Some(meta) = read_meta(&sa.meta) else {
+            continue;
+        };
         let parent = meta
             .parent_agent_id
             .as_deref()
             .and_then(|id| type_of.get(id))
             .map(String::as_str);
-        facts.record_subagent(&meta.agent_type, parent, meta.spawn_depth, turns);
+        // An unresolvable parent below depth 1 must not fabricate a root edge:
+        // `spawnDepth` proves the parent is NOT the root, and a wrong edge is
+        // indistinguishable from a real one downstream.
+        let edge_is_trustworthy = parent.is_some() || meta.spawn_depth <= 1;
+        facts.record_subagent(
+            &meta.agent_type,
+            parent,
+            meta.spawn_depth,
+            turns,
+            edge_is_trustworthy,
+        );
     }
 }
 
@@ -434,6 +486,11 @@ mod tests {
                 "\n",
                 r#"{"type":"assistant","message":{"model":"m","content":[{"type":"tool_use","id":"t1","name":"Grep","input":{}}],"usage":{"input_tokens":1,"output_tokens":1}}}"#,
                 "\n",
+                // A sub-delegation inside a sub-agent's own transcript: the
+                // exact input that would double-count if scan_subagents ever
+                // grew a record_delegation call.
+                r#"{"type":"assistant","message":{"model":"m","content":[{"type":"tool_use","id":"t9","name":"Agent","input":{"subagent_type":"qa-specialist","description":"sub"}}],"usage":{"input_tokens":1,"output_tokens":1}}}"#,
+                "\n",
             ),
         )
         .unwrap();
@@ -462,8 +519,14 @@ mod tests {
         let f = scan(&project);
 
         assert_eq!(
-            f.agents["dev-lead"].turns, 2,
+            f.agents["dev-lead"].turns, 3,
             "turns come from its own file"
+        );
+        assert_eq!(
+            f.agents["qa-specialist"].invocations, 0,
+            "a sub-delegation inside a sub-agent must NOT become an invocation: \
+             invocations stay main-thread-only, and that is what keeps the two \
+             counters from double-counting one event"
         );
         assert_eq!(f.agents["qa-specialist"].turns, 1);
         assert_eq!(

--- a/crates/armadai/src/audit/usage/scan.rs
+++ b/crates/armadai/src/audit/usage/scan.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::claude_adapter::transcript::{Block, RelevantEntry, parse_value};
 
-use super::discovery::transcript_files;
+use super::discovery::{subagent_files, transcript_files};
 use super::facts::{ROOT_AGENT, UsageFacts};
 
 /// Aggregate every transcript belonging to `root`.
@@ -65,7 +65,86 @@ pub fn scan(root: &Path) -> UsageFacts {
             scan_entry(&v, &mut facts, &mut parent_of, &mut agent_at);
         }
     }
+    scan_subagents(root, &mut facts);
     facts
+}
+
+/// One sub-agent's sidecar metadata, as Claude Code writes it.
+struct SubagentMeta {
+    agent_type: String,
+    parent_agent_id: Option<String>,
+    spawn_depth: u32,
+}
+
+fn read_meta(path: &Path) -> Option<SubagentMeta> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&raw).ok()?;
+    Some(SubagentMeta {
+        agent_type: str_field(&v, "agentType")?.to_string(),
+        parent_agent_id: str_field(&v, "parentAgentId").map(str::to_string),
+        spawn_depth: v.get("spawnDepth").and_then(Value::as_u64).unwrap_or(1) as u32,
+    })
+}
+
+/// `agent-<id>.meta.json` -> `<id>`, the identifier `parentAgentId` refers to.
+fn agent_id_of(meta_path: &Path) -> Option<String> {
+    let name = meta_path.file_name()?.to_str()?;
+    name.strip_prefix("agent-")?
+        .strip_suffix(".meta.json")
+        .map(str::to_string)
+}
+
+/// Absorb every sub-agent transcript: its own turns, the skills it invoked,
+/// the tools it used, and the delegation edge its metadata states outright.
+///
+/// This is the half of the corpus the scan missed until 2026-08-20. It does
+/// NOT touch `invocations`, which keeps its existing meaning — delegations
+/// emitted from the main thread — so no event is counted twice.
+fn scan_subagents(root: &Path, facts: &mut UsageFacts) {
+    let found = subagent_files(root);
+    // First pass: agent id -> agent type, so a `parentAgentId` resolves to a
+    // name. Claude Code references the parent by id, not by type.
+    let mut type_of: HashMap<String, String> = HashMap::new();
+    let mut metas = Vec::new();
+    for sa in &found {
+        if let (Some(id), Some(meta)) = (agent_id_of(&sa.meta), read_meta(&sa.meta)) {
+            type_of.insert(id, meta.agent_type.clone());
+            metas.push((sa.transcript.clone(), meta));
+        }
+    }
+    for (transcript, meta) in metas {
+        let mut turns = 0u32;
+        if let Ok(handle) = std::fs::File::open(&transcript) {
+            for line in std::io::BufReader::new(handle).lines() {
+                let Ok(line) = line else { continue };
+                let Ok(v) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                if let Some(ts) = str_field(&v, "timestamp") {
+                    facts.observe_timestamp(ts);
+                }
+                if let Some(skill) = str_field(&v, "attributionSkill") {
+                    facts.record_skill_turn(skill);
+                }
+                if str_field(&v, "type") == Some("assistant") {
+                    turns += 1;
+                    if let Some(RelevantEntry::Assistant { blocks, .. }) = parse_value(&v) {
+                        for block in &blocks {
+                            if let Block::Tool { name } = block {
+                                facts.record_tool(name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let parent = meta
+            .parent_agent_id
+            .as_deref()
+            .and_then(|id| type_of.get(id))
+            .map(String::as_str);
+        facts.record_subagent(&meta.agent_type, parent, meta.spawn_depth, turns);
+    }
 }
 
 fn str_field<'v>(v: &'v Value, key: &str) -> Option<&'v str> {

--- a/crates/armadai/src/audit/usage/scan.rs
+++ b/crates/armadai/src/audit/usage/scan.rs
@@ -411,6 +411,83 @@ mod tests {
         );
     }
 
+    /// End to end over the layout Claude Code really writes: a session file
+    /// plus `subagents/agent-<id>.{jsonl,meta.json}`. This is the half of the
+    /// corpus the scan missed entirely until 2026-08-20.
+    #[test]
+    fn subagent_transcripts_contribute_turns_depth_and_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = PathBuf::from("/Users/x/proj");
+        let slug = dir
+            .path()
+            .join(crate::audit::usage::discovery::slug_for(&project));
+        std::fs::create_dir_all(&slug).unwrap();
+        std::fs::write(slug.join("s1.jsonl"), "{}\n").unwrap();
+        let sub = slug.join("s1").join("subagents");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // The coordinator: two assistant turns, one skill turn, one tool.
+        std::fs::write(
+            sub.join("agent-lead1.jsonl"),
+            concat!(
+                r#"{"type":"assistant","timestamp":"2026-08-01T00:00:00Z","attributionSkill":"armadai","message":{"model":"m","content":[{"type":"text","text":"a"}],"usage":{"input_tokens":1,"output_tokens":1}}}"#,
+                "\n",
+                r#"{"type":"assistant","message":{"model":"m","content":[{"type":"tool_use","id":"t1","name":"Grep","input":{}}],"usage":{"input_tokens":1,"output_tokens":1}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            sub.join("agent-lead1.meta.json"),
+            r#"{"agentType":"dev-lead","description":"route","toolUseId":"tu1","spawnDepth":1}"#,
+        )
+        .unwrap();
+
+        // Its child: one turn, and a parent stated by id.
+        std::fs::write(
+            sub.join("agent-qa1.jsonl"),
+            concat!(
+                r#"{"type":"assistant","message":{"model":"m","content":[{"type":"text","text":"b"}],"usage":{"input_tokens":1,"output_tokens":1}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            sub.join("agent-qa1.meta.json"),
+            r#"{"agentType":"qa-specialist","description":"test","toolUseId":"tu2","parentAgentId":"lead1","spawnDepth":2}"#,
+        )
+        .unwrap();
+
+        let _g = ProjectsDirGuard::set(dir.path());
+        let f = scan(&project);
+
+        assert_eq!(
+            f.agents["dev-lead"].turns, 2,
+            "turns come from its own file"
+        );
+        assert_eq!(f.agents["qa-specialist"].turns, 1);
+        assert_eq!(
+            f.observed_depth, 2,
+            "depth is read from spawnDepth, not inferred"
+        );
+        assert!(
+            f.edges[super::super::facts::ROOT_AGENT].contains("dev-lead"),
+            "depth 1 has no parentAgentId, so it attaches to the root: {:?}",
+            f.edges
+        );
+        assert!(
+            f.edges["dev-lead"].contains("qa-specialist"),
+            "parentAgentId resolves to the parent's type: {:?}",
+            f.edges
+        );
+        assert_eq!(f.skills["armadai"], 1, "sub-agent skill turns count too");
+        assert_eq!(f.tools["Grep"], 1, "so do its tools");
+        assert_eq!(
+            f.sessions, 1,
+            "sub-agent files must not inflate the session count"
+        );
+    }
+
     #[test]
     fn no_transcripts_yields_empty_facts() {
         let dir = tempfile::tempdir().unwrap();

--- a/docs/superpowers/specs/2026-08-13-audit-usage-observe-design.md
+++ b/docs/superpowers/specs/2026-08-13-audit-usage-observe-design.md
@@ -164,11 +164,26 @@ natifs sur ce projet ».
 Les deux types d'assets ne se mesurent pas pareil, parce que la donnée disponible diffère :
 
 - **skills** : tours attribués (`attributionSkill`), la métrique fiable ;
-- **agents** : invocations (corrélation `tool_use` Agent → `tool_result`) et tokens du résultat.
-  Les tours **internes** d'un sous-agent ne sont pas comptables : sur le relevé de référence,
-  `isSidechain` est `false` partout, donc les transcripts de sous-agents ne sont pas dans ces
-  fichiers. On mesure l'invocation et son résultat, pas le détail interne. C'est suffisant pour
-  la topologie, et ça évite tout double comptage.
+- **agents** : invocations (corrélation `tool_use` Agent → `tool_result`) **et tours réels**.
+
+> **⚠ CORRECTION 2026-08-20.** Ce spec affirmait que « les tours internes d'un sous-agent ne sont
+> pas comptables : `isSidechain` est `false` partout, donc les transcripts de sous-agents ne sont
+> pas dans ces fichiers ». **C'est faux.** Claude Code écrit chaque sous-agent dans
+> `<projects>/<slug>/<session-id>/subagents/agent-<id>.jsonl`, avec un `.meta.json` portant
+> `agentType`, `parentAgentId` et `spawnDepth`. `isSidechain` valait `false` uniquement parce que
+> le scan ne lisait que le premier niveau du dossier (`jsonl_in`) ; dans les fichiers de
+> sous-agents il vaut `true`.
+>
+> Conséquences mesurées sur ce dépôt après extension du scan : les tours de skills passent de 411
+> à 575 pour `brainstorming`, de 296 à **1931** pour `subagent-driven-development` — le scan en
+> captait moins d'un quart, et l'ordre du classement s'inverse. Les tours par agent deviennent
+> lisibles (`general-purpose` : 286 invocations mais **16 379 tours**), et la profondeur est
+> **donnée** par `spawnDepth` (3 observé) au lieu d'être inférée.
+>
+> Corollaire pour le lot 3 : la déduction de topologie **a** des données réelles, contrairement à
+> ce que cette section laissait croire. Les metas n'existent que pour les sous-agents réellement
+> lancés — une délégation refusée par un hook n'en laisse pas — donc les compter compte des
+> exécutions.
 
 ## Lot 2 — Pack enrichi
 

--- a/docs/superpowers/specs/2026-08-13-audit-usage-observe-design.md
+++ b/docs/superpowers/specs/2026-08-13-audit-usage-observe-design.md
@@ -168,9 +168,12 @@ Les deux types d'assets ne se mesurent pas pareil, parce que la donnée disponib
 
 > **⚠ CORRECTION 2026-08-20.** Ce spec affirmait que « les tours internes d'un sous-agent ne sont
 > pas comptables : `isSidechain` est `false` partout, donc les transcripts de sous-agents ne sont
-> pas dans ces fichiers ». **C'est faux.** Claude Code écrit chaque sous-agent dans
-> `<projects>/<slug>/<session-id>/subagents/agent-<id>.jsonl`, avec un `.meta.json` portant
-> `agentType`, `parentAgentId` et `spawnDepth`. `isSidechain` valait `false` uniquement parce que
+> pas dans ces fichiers ». **C'est faux.** Claude Code écrit les sous-agents sous
+> `<projects>/<slug>/<session-id>/subagents/`, parfois **imbriqués un niveau plus bas**
+> (`subagents/workflows/wf_<id>/`), avec un `.meta.json` portant `agentType`, `parentAgentId` et
+> `spawnDepth`. ⚠ Cette disposition est un **détail interne non documenté**, observé sur une seule
+> version de Claude Code — pas un contrat. Le scan doit donc dégrader sans échouer sur toute forme
+> inattendue. `isSidechain` valait `false` uniquement parce que
 > le scan ne lisait que le premier niveau du dossier (`jsonl_in`) ; dans les fichiers de
 > sous-agents il vaut `true`.
 >
@@ -181,9 +184,19 @@ Les deux types d'assets ne se mesurent pas pareil, parce que la donnée disponib
 > **donnée** par `spawnDepth` (3 observé) au lieu d'être inférée.
 >
 > Corollaire pour le lot 3 : la déduction de topologie **a** des données réelles, contrairement à
-> ce que cette section laissait croire. Les metas n'existent que pour les sous-agents réellement
-> lancés — une délégation refusée par un hook n'en laisse pas — donc les compter compte des
-> exécutions.
+> ce que cette section laissait croire.
+>
+> Sur le comptage : un meta semble n'exister que pour un sous-agent réellement lancé — une
+> délégation refusée par un hook n'en laisse pas, observé le 2026-08-20. C'est une **inférence, pas
+> un fait établi** : la réciproque (un transcript sans meta signifierait que l'agent n'a pas tourné)
+> n'a jamais été observée, et les deux fichiers étant écrits séparément il n'y a aucune atomicité.
+> Un transcript contenant des entrées `assistant` est en soi la preuve d'une exécution, ce qui est
+> la raison pour laquelle le scan lit le transcript **avant** de consulter le meta.
+
+> **Tours = messages, pas entrées.** Claude Code écrit une entrée par bloc de contenu, donc un même
+> message d'assistant occupe plusieurs lignes. Compter les entrées surévaluait de **53 %** (32 053
+> entrées pour 14 958 messages distincts sur le corpus de référence). Les tours sont dédupliqués sur
+> `message.id`.
 
 ## Lot 2 — Pack enrichi
 

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -59,7 +59,16 @@ Each line is parsed once. The scan never fails on bad data: an unreadable file i
 ### Two metrics, not one
 
 - **Skills** are measured in **attributed turns** (the transcript's `attributionSkill` field) — how many turns a skill actually governed, not how many times it was invoked. A single invocation can end up governing many subsequent turns, so the two numbers can diverge sharply; turns governed is the more honest measure of how much a skill actually shaped a session.
-- **Agents** are measured in **invocations**. A sub-agent's own internal turns are not observable from these transcripts — Claude Code does not write sub-agent transcripts into a project's transcript files — so what gets counted is the delegation and its result, not what happened inside the sub-agent.
+- **Agents** are measured in both **invocations** and **turns**. An invocation is one
+  delegation; a turn is one assistant step the agent actually took. Claude Code records each
+  sub-agent under `<session-id>/subagents/agent-<id>.jsonl`, with a `.meta.json` alongside it
+  carrying `agentType`, `parentAgentId` and `spawnDepth`. The two numbers diverge sharply —
+  on this project one agent shows 286 invocations for over 16,000 turns — so reading
+  invocations as a measure of work done would badly mislead.
+- Because that metadata states the parent and the depth outright, the observed **delegation
+  depth** is reported as a fact rather than inferred from a chain of message identifiers.
+- Only sub-agents that actually ran leave a `.meta.json`. A delegation refused before it
+  started leaves none, so these counts are executions, not attempts.
 
 ### Rules
 

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -59,16 +59,24 @@ Each line is parsed once. The scan never fails on bad data: an unreadable file i
 ### Two metrics, not one
 
 - **Skills** are measured in **attributed turns** (the transcript's `attributionSkill` field) — how many turns a skill actually governed, not how many times it was invoked. A single invocation can end up governing many subsequent turns, so the two numbers can diverge sharply; turns governed is the more honest measure of how much a skill actually shaped a session.
+  Turns taken inside sub-agents count too, and they dominate: on this project they raised one
+  skill's total from 296 to 1931.
 - **Agents** are measured in both **invocations** and **turns**. An invocation is one
-  delegation; a turn is one assistant step the agent actually took. Claude Code records each
-  sub-agent under `<session-id>/subagents/agent-<id>.jsonl`, with a `.meta.json` alongside it
-  carrying `agentType`, `parentAgentId` and `spawnDepth`. The two numbers diverge sharply —
+  delegation; a turn is one assistant step the agent actually took. Claude Code records
+  sub-agents under `<session-id>/subagents/`, sometimes nested one level further
+  (`subagents/workflows/wf_<id>/`), each with a `.meta.json` carrying `agentType`,
+  `parentAgentId` and `spawnDepth`. A turn is one assistant *message*, deduplicated on its
+  id — Claude Code writes one entry per content block, so counting entries would
+  over-report by about half. The two numbers diverge sharply —
   on this project one agent shows 286 invocations for over 16,000 turns — so reading
   invocations as a measure of work done would badly mislead.
 - Because that metadata states the parent and the depth outright, the observed **delegation
   depth** is reported as a fact rather than inferred from a chain of message identifiers.
-- Only sub-agents that actually ran leave a `.meta.json`. A delegation refused before it
-  started leaves none, so these counts are executions, not attempts.
+- A sub-agent that actually ran appears to always leave a `.meta.json`, and a delegation
+  refused before it started leaves none — so these counts look like executions rather than
+  attempts. That is an observation, not a guarantee: the two files are written separately,
+  with no atomicity, and this on-disk layout is an undocumented internal detail of one
+  Claude Code version.
 
 ### Rules
 


### PR DESCRIPTION
## What

The observed-usage pass read only the **top level** of a project's transcript directory, so it never saw most of the corpus. Claude Code writes each sub-agent to `<session-id>/subagents/agent-<id>.jsonl`, with a `.meta.json` alongside carrying `agentType`, `parentAgentId` and `spawnDepth`.

## Measured on this repo, after the fix

| | Before | After |
|---|---|---|
| `subagent-driven-development` turns | 296 | **1931** |
| `writing-plans` turns | 379 | **1264** |
| `general-purpose` | 286 invocations | + **16 379 turns** |
| Delegation depth | inferred, always 1 | **read from `spawnDepth`: 3** |

Under a quarter of the turns were being counted, and the ranking inverts — `subagent-driven-development` overtakes `brainstorming` by a wide margin, because it governs the sub-agents' work.

Agents gain a `turns` count beside `invocations`. The two differ by an order of magnitude, and conflating them is misleading: an invocation says how often an agent was *asked for*, a turn says what it *did*. `dev-lead` shows 11 invocations for 300 turns — it routes, it does not execute.

## What this corrects

The spec and the wiki both claimed sub-agent internal turns were not observable "because `isSidechain` is false everywhere". It was false only in the files the scan happened to read; in the sub-agent files it is `true`. Both documents now carry the correction with the numbers.

A corollary worth flagging: the deduced-topology work (lot 3 of the observed-usage feature) **does** have real data, contrary to what that spec implied — and `parentAgentId`/`spawnDepth` state the tree outright, so it no longer has to be inferred from message-identifier chains.

## Design notes

- `invocations` keeps its existing meaning — delegations emitted from the main thread — so nothing is double-counted.
- Only sub-agents that actually ran leave a `.meta.json`. A delegation refused before it started leaves none, so these counts are executions, not attempts.
- Only `subagents/` is walked. Sibling directories (`tool-results/`, `memory/`) hold an order of magnitude more files and nothing this audit measures.

## Verification

Local gate green: `fmt`, clippy `-D warnings` in all four CI feature modes, tests in both CI test modes. Twelve new tests, including an integration test over the real on-disk layout. Verified against this repository's own corpus, not only fixtures.

Spec: `docs/superpowers/specs/2026-08-13-audit-usage-observe-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)