### PR TITLE
feat(core): declare agents in .armadai/agents.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`.
 - `core/` — Domain types: `Agent`, `AgentMetadata`, `PipelineConfig`, `events::RunEvent`/`EventSink`, `routing.rs` (model-tier auto-routing for `latest:auto`). Orchestration lives under `core/orchestration/` (`OrchestrationPattern { Direct, Blackboard, Ring, Hierarchical, Auto }`) with the event-sourced engine under `core/orchestration/es/`. There is no `Task`/`SharedContext`/`Coordinator`/`Pipeline` type.
 - `core/project.rs` — Project config (`armadai.yaml`) with agent/prompt/skill resolution.
 - `core/prompt.rs` — Composable prompt fragments with YAML frontmatter.
-- `core/agent_decl.rs` + `core/agent_source.rs` — declarative agents: `.armadai/agents.yaml` declares agents (defaults merge + prompt composed from fragments with `{{var}}` substitution); `load_agent()` returns an `Agent` where `resolve_agent()` returns a path. `core/template.rs` holds the substitution, shared with `cli/new.rs`.
+- `core/agent_decl.rs` + `core/agent_source.rs` — declarative agents: `.armadai/agents.yaml` declares agents (defaults merge + prompt composed from fragments with `{{var}}` substitution); `load_all_agents()`/`load_agent_by_name()` return `Agent`(s) where `resolve_agent()` returns a path. `core/template.rs` holds the substitution, shared with `cli/new.rs`.
 - `core/skill.rs` — Skills following the Agent Skills open standard (SKILL.md).
 - `core/model_updater.rs` — Deprecated model detection, in-place update, and auto-check with interactive prompt (`auto_check_and_prompt()`). Called automatically by `run`, `link`, and `init`.
 - `core/project_registry.rs` — JSON registry of known projects (auto-registered on `run`/`link`). Supports `prune` for stale entries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Code that depends on optional features must use `#[cfg(feature = "...")]`.
 - `core/` — Domain types: `Agent`, `AgentMetadata`, `PipelineConfig`, `events::RunEvent`/`EventSink`, `routing.rs` (model-tier auto-routing for `latest:auto`). Orchestration lives under `core/orchestration/` (`OrchestrationPattern { Direct, Blackboard, Ring, Hierarchical, Auto }`) with the event-sourced engine under `core/orchestration/es/`. There is no `Task`/`SharedContext`/`Coordinator`/`Pipeline` type.
 - `core/project.rs` — Project config (`armadai.yaml`) with agent/prompt/skill resolution.
 - `core/prompt.rs` — Composable prompt fragments with YAML frontmatter.
+- `core/agent_decl.rs` + `core/agent_source.rs` — declarative agents: `.armadai/agents.yaml` declares agents (defaults merge + prompt composed from fragments with `{{var}}` substitution); `load_agent()` returns an `Agent` where `resolve_agent()` returns a path. `core/template.rs` holds the substitution, shared with `cli/new.rs`.
 - `core/skill.rs` — Skills following the Agent Skills open standard (SKILL.md).
 - `core/model_updater.rs` — Deprecated model detection, in-place update, and auto-check with interactive prompt (`auto_check_and_prompt()`). Called automatically by `run`, `link`, and `init`.
 - `core/project_registry.rs` — JSON registry of known projects (auto-registered on `run`/`link`). Supports `prune` for stale entries.

--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -82,7 +82,10 @@ pub struct AgentMetadata {
     pub ring_config: Option<AgentRingConfig>,
 }
 
-fn default_temperature() -> f32 {
+/// The sampling temperature an agent gets when none is specified anywhere
+/// (Markdown frontmatter default, and the declarative format's fallback
+/// once neither the declaration nor its defaults set one).
+pub fn default_temperature() -> f32 {
     0.7
 }
 

--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -93,7 +93,7 @@ pub fn default_temperature() -> f32 {
 ///
 /// Two names that differ only by case, or by which punctuation/whitespace
 /// they use as a separator, project to the same slug — which is exactly what
-/// the linker uses to name a file on disk. `agent_source::check_no_shadowing`
+/// the linker uses to name a file on disk. `agent_source::shadowing_conflict`
 /// compares slugs rather than raw names for the same reason: a declaration
 /// and a library file that fold to the same slug will overwrite each other
 /// at link time regardless of how differently they are spelled.

--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -89,6 +89,33 @@ pub fn default_temperature() -> f32 {
     0.7
 }
 
+/// Convert an agent name to a kebab-case slug suitable for filenames.
+///
+/// Two names that differ only by case, or by which punctuation/whitespace
+/// they use as a separator, project to the same slug — which is exactly what
+/// the linker uses to name a file on disk. `agent_source::check_no_shadowing`
+/// compares slugs rather than raw names for the same reason: a declaration
+/// and a library file that fold to the same slug will overwrite each other
+/// at link time regardless of how differently they are spelled.
+pub fn slugify(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else if c == ' ' || c == '_' {
+                '-'
+            } else {
+                '\0'
+            }
+        })
+        .filter(|c| *c != '\0')
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipelineConfig {
     /// Agents to chain after this one

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -23,14 +23,6 @@ pub enum PromptStep {
     },
 }
 
-/// Raw shape accepted by serde before validation.
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum RawPromptStep {
-    Plain(String),
-    Parameterised(BTreeMap<String, BTreeMap<String, String>>),
-}
-
 /// Values every agent inherits unless it says otherwise.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -81,21 +73,35 @@ pub struct DeclaredAgents {
     pub agents: Vec<AgentDecl>,
 }
 
+/// `Vec<serde_yaml_ng::Value>` rather than a `#[serde(untagged)]` enum: an
+/// untagged enum's "did not match any variant" error is raised inside
+/// `Vec::deserialize` itself, before this function ever runs, so it cannot be
+/// improved from here. Discriminating by hand lets every rejection say what
+/// shape was found and what shapes are valid.
 fn de_prompt<'de, D>(d: D) -> Result<Vec<PromptStep>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     use serde::de::Error;
-    let raw: Vec<RawPromptStep> = Vec::deserialize(d)?;
+    let raw: Vec<serde_yaml_ng::Value> = Vec::deserialize(d)?;
     raw.into_iter()
         .map(|step| match step {
-            RawPromptStep::Plain(name) => Ok(PromptStep::Plain(name)),
-            RawPromptStep::Parameterised(map) => {
-                // One key means one fragment. Two keys leave no way to know
-                // which fragment the entry is about.
+            serde_yaml_ng::Value::String(name) => Ok(PromptStep::Plain(name)),
+            serde_yaml_ng::Value::Mapping(map) => {
+                // One key means one fragment. Zero or several keys leave no
+                // way to know which fragment the entry is about.
                 let mut it = map.into_iter();
                 match (it.next(), it.next()) {
-                    (Some((fragment, vars)), None) => {
+                    (Some((key, value)), None) => {
+                        let fragment = key.as_str().map(str::to_string).ok_or_else(|| {
+                            D::Error::custom("a prompt step's fragment name must be a string")
+                        })?;
+                        let vars: BTreeMap<String, String> =
+                            serde_yaml_ng::from_value(value).map_err(|e| {
+                                D::Error::custom(format!(
+                                    "a prompt step's variables for `{fragment}` must be a map of strings: {e}"
+                                ))
+                            })?;
                         Ok(PromptStep::Parameterised { fragment, vars })
                     }
                     _ => Err(D::Error::custom(
@@ -103,8 +109,29 @@ where
                     )),
                 }
             }
+            other => Err(D::Error::custom(format!(
+                "a prompt step must be a fragment name or a single-key map of a fragment name to its variables, got {}",
+                describe_yaml_shape(&other)
+            ))),
         })
         .collect()
+}
+
+/// A short, human-readable name for the kind of YAML value found, used to
+/// make a rejection actionable (e.g. "got a sequence" rather than a generic
+/// "invalid type" message).
+fn describe_yaml_shape(v: &serde_yaml_ng::Value) -> &'static str {
+    match v {
+        serde_yaml_ng::Value::Null => "null",
+        serde_yaml_ng::Value::Bool(_) => "a boolean",
+        serde_yaml_ng::Value::Number(_) => "a number",
+        serde_yaml_ng::Value::String(_) => "a string",
+        serde_yaml_ng::Value::Sequence(_) => "a sequence",
+        serde_yaml_ng::Value::Mapping(_) => "a mapping",
+        serde_yaml_ng::Value::Tagged(_) => "a tagged value",
+        #[allow(unreachable_patterns)]
+        _ => "an unrecognised value",
+    }
 }
 
 /// Read and validate an `agents.yaml`.
@@ -227,6 +254,58 @@ agents:
         assert!(
             err.contains("typo_field"),
             "the error must name the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_key_under_defaults_is_rejected_and_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "defaults:\n  typo_default: oops\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("unknown field `typo_default`"),
+            "the error must name the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_key_at_the_top_level_is_rejected_and_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "typo_top: 1\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("unknown field `typo_top`, expected `defaults` or `agents`"),
+            "the error must name the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn a_number_prompt_step_is_rejected_with_actionable_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "agents:\n  - name: x\n    prompt:\n      - 42\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("a fragment name")
+                && err.contains("a single-key map of a fragment name to its variables")
+                && err.contains("a number"),
+            "the error must name the valid shapes and what was found: {err}"
+        );
+    }
+
+    #[test]
+    fn a_sequence_prompt_step_is_rejected_with_actionable_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "agents:\n  - name: x\n    prompt:\n      - [a, b]\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("a fragment name")
+                && err.contains("a single-key map of a fragment name to its variables")
+                && err.contains("a sequence"),
+            "the error must name the valid shapes and what was found: {err}"
         );
     }
 }

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -248,7 +248,15 @@ pub fn compose_prompt(
 
         let rendered = crate::template::render(&frag.body, &vars)
             .map_err(|e| anyhow::anyhow!("agent '{}', fragment '{name}': {e}", decl.name))?;
-        parts.push(rendered.trim_end().to_string());
+        // Trimmed on BOTH ends, not just the end: a fragment authored as a
+        // file with YAML frontmatter routinely has a blank line right after
+        // the frontmatter is stripped (this project's own starter fragments,
+        // e.g. `starters/armadai-authoring/prompts/armadai-conventions.md`,
+        // are written that way), so a leading blank line is exactly as
+        // common as a trailing one. Trimming only the end let that leading
+        // blank line survive into the `"\n\n"` join, piling up two or three
+        // blank lines between fragments instead of one.
+        parts.push(rendered.trim().to_string());
     }
     Ok(parts.join("\n\n"))
 }
@@ -738,6 +746,25 @@ agents:
         let frags = vec![
             fragment("a", "first line\n"),
             fragment("b", "second line\n"),
+        ];
+        let steps = vec![PromptStep::Plain("a".into()), PromptStep::Plain("b".into())];
+        let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();
+        assert_eq!(out, "first line\n\nsecond line");
+    }
+
+    /// A fragment authored as a file with YAML frontmatter routinely has a
+    /// blank line right after the frontmatter is stripped — this project's
+    /// own starter fragments (`starters/armadai-authoring/prompts/
+    /// armadai-conventions.md`) are written that way. A leading blank line
+    /// is therefore exactly as common as a trailing one, and must not
+    /// survive into the join any more than the trailing case above does:
+    /// two fragments each padded with a blank line on both sides must still
+    /// join with exactly one blank line between them, not two or three.
+    #[test]
+    fn leading_and_trailing_blank_lines_in_fragment_bodies_do_not_pile_up_at_the_join() {
+        let frags = vec![
+            fragment("a", "\nfirst line\n\n"),
+            fragment("b", "\nsecond line\n\n"),
         ];
         let steps = vec![PromptStep::Plain("a".into()), PromptStep::Plain("b".into())];
         let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -31,6 +31,8 @@ pub enum PromptStep {
 pub struct AgentDefaults {
     pub provider: Option<String>,
     pub model: Option<String>,
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
     pub temperature: Option<f32>,
     pub max_tokens: Option<u32>,
     pub timeout: Option<u64>,
@@ -50,6 +52,10 @@ pub struct AgentDecl {
     pub provider: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
     #[serde(default)]
     pub temperature: Option<f32>,
     #[serde(default)]
@@ -151,8 +157,8 @@ pub fn load(path: &Path) -> anyhow::Result<DeclaredAgents> {
 ///
 /// Shallow merge: a field absent from the declaration takes the default's
 /// value. Lists are **replaced, never merged** — less expressive, but an agent
-/// that declares a `scope` has exactly that scope, rather than silently
-/// inheriting a wider one.
+/// that declares `tags` has exactly those tags, rather than silently
+/// inheriting a wider set.
 ///
 /// Fails when no `provider` is declared at either level. The `.md` parser
 /// refuses that too (`parser/metadata.rs`), and the two formats must agree on
@@ -174,8 +180,8 @@ pub fn merge_metadata(decl: &AgentDecl, defaults: &AgentDefaults) -> anyhow::Res
     Ok(AgentMetadata {
         provider,
         model: decl.model.clone().or_else(|| defaults.model.clone()),
-        command: None,
-        args: None,
+        command: decl.command.clone().or_else(|| defaults.command.clone()),
+        args: decl.args.clone().or_else(|| defaults.args.clone()),
         temperature: decl
             .temperature
             .or(defaults.temperature)
@@ -372,6 +378,8 @@ agents:
             description: None,
             provider: None,
             model: None,
+            command: None,
+            args: None,
             temperature: None,
             max_tokens: None,
             timeout: None,
@@ -387,6 +395,8 @@ agents:
         AgentDefaults {
             provider: Some("claude".into()),
             model: Some("latest:pro".into()),
+            command: None,
+            args: None,
             temperature: Some(0.3),
             max_tokens: Some(8192),
             timeout: None,
@@ -464,5 +474,96 @@ agents:
                 .provider,
             "cli"
         );
+    }
+
+    /// `cli` is the provider armadai uses to drive claude/gemini/codex as
+    /// subprocesses, and it needs `command` (and usually `args`) to know what
+    /// to run. Without this, the declarative format could not express a whole
+    /// class of agent the `.md` format can.
+    #[test]
+    fn a_declared_cli_provider_carries_its_command_and_args_through() {
+        let mut d = decl("a");
+        d.provider = Some("cli".into());
+        d.command = Some("claude".into());
+        d.args = Some(vec!["--dangerously-skip-permissions".into()]);
+        let m = merge_metadata(&d, &AgentDefaults::default()).unwrap();
+        assert_eq!(m.command.as_deref(), Some("claude"));
+        assert_eq!(
+            m.args,
+            Some(vec!["--dangerously-skip-permissions".to_string()])
+        );
+    }
+
+    /// Same list-replacement rule as `tags`: a declared `args: []` means the
+    /// agent takes no arguments, not "inherit whatever the defaults set".
+    #[test]
+    fn declared_empty_args_means_empty_not_inherit() {
+        let mut d = decl("a");
+        d.provider = Some("cli".into());
+        d.args = Some(vec![]);
+        let defaults = AgentDefaults {
+            args: Some(vec!["--from-defaults".into()]),
+            ..AgentDefaults::default()
+        };
+        let m = merge_metadata(&d, &defaults).unwrap();
+        assert_eq!(m.args, Some(vec![]));
+    }
+
+    /// Every field gets a distinct, recognisable value so a field-swap bug
+    /// (e.g. assigning `timeout` from `max_tokens`, or `stacks` from `tags`)
+    /// fails this test even where the values are "the same shape" — two
+    /// numeric fields, or two string-list fields, that happen to share a
+    /// value would not expose such a bug, so none of them do here.
+    #[test]
+    fn merge_metadata_maps_every_field_without_swapping_any() {
+        let d = AgentDecl {
+            name: "kraken".into(),
+            description: Some("desc-from-decl".into()),
+            provider: Some("provider-from-decl".into()),
+            model: Some("model-from-decl".into()),
+            command: Some("command-from-decl".into()),
+            args: Some(vec!["arg-from-decl".into()]),
+            temperature: Some(0.11),
+            max_tokens: Some(1111),
+            timeout: Some(2222),
+            model_fallback: Some(vec!["fallback-from-decl".into()]),
+            tags: Some(vec!["tag-from-decl".into()]),
+            stacks: Some(vec!["stack-from-decl".into()]),
+            scope: Some(vec!["scope-from-decl".into()]),
+            prompt: vec![],
+        };
+        let defaults = AgentDefaults {
+            provider: Some("provider-from-defaults".into()),
+            model: Some("model-from-defaults".into()),
+            command: Some("command-from-defaults".into()),
+            args: Some(vec!["arg-from-defaults".into()]),
+            temperature: Some(0.99),
+            max_tokens: Some(9999),
+            timeout: Some(8888),
+            model_fallback: vec!["fallback-from-defaults".into()],
+            tags: vec!["tag-from-defaults".into()],
+            stacks: vec!["stack-from-defaults".into()],
+        };
+
+        let m = merge_metadata(&d, &defaults).unwrap();
+
+        assert_eq!(m.provider, "provider-from-decl");
+        assert_eq!(m.model.as_deref(), Some("model-from-decl"));
+        assert_eq!(m.command.as_deref(), Some("command-from-decl"));
+        assert_eq!(m.args, Some(vec!["arg-from-decl".to_string()]));
+        assert_eq!(m.temperature, 0.11);
+        assert_eq!(m.max_tokens, Some(1111));
+        assert_eq!(m.timeout, Some(2222));
+        assert_eq!(m.tags, vec!["tag-from-decl".to_string()]);
+        assert_eq!(m.stacks, vec!["stack-from-decl".to_string()]);
+        assert_eq!(m.scope, vec!["scope-from-decl".to_string()]);
+        assert_eq!(m.model_fallback, vec!["fallback-from-decl".to_string()]);
+        assert_eq!(m.cost_limit, None);
+        assert_eq!(m.rate_limit, None);
+        assert_eq!(m.context_window, None);
+        assert_eq!(m.mode, None);
+        assert_eq!(m.orchestration, None);
+        assert!(m.triggers.is_none());
+        assert!(m.ring_config.is_none());
     }
 }

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -1,0 +1,232 @@
+//! The `.armadai/agents.yaml` format: agents declared rather than written as
+//! Markdown files.
+//!
+//! This module only *reads* the format. Turning a declaration into an `Agent`
+//! (defaults merge, fragment composition) is the rest of this file's job, and
+//! the dispatch between declared and file-backed agents lives in
+//! `agent_source`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// One entry of an agent's `prompt:` list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptStep {
+    /// `- specialist-base`
+    Plain(String),
+    /// `- { armadai-architecture: { module: core } }`
+    Parameterised {
+        fragment: String,
+        vars: BTreeMap<String, String>,
+    },
+}
+
+/// Raw shape accepted by serde before validation.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawPromptStep {
+    Plain(String),
+    Parameterised(BTreeMap<String, BTreeMap<String, String>>),
+}
+
+/// Values every agent inherits unless it says otherwise.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentDefaults {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub timeout: Option<u64>,
+    pub model_fallback: Vec<String>,
+    pub tags: Vec<String>,
+    pub stacks: Vec<String>,
+}
+
+/// One declared agent.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentDecl {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub timeout: Option<u64>,
+    #[serde(default)]
+    pub model_fallback: Option<Vec<String>>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub stacks: Option<Vec<String>>,
+    #[serde(default)]
+    pub scope: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "de_prompt")]
+    pub prompt: Vec<PromptStep>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DeclaredAgents {
+    pub defaults: AgentDefaults,
+    pub agents: Vec<AgentDecl>,
+}
+
+fn de_prompt<'de, D>(d: D) -> Result<Vec<PromptStep>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let raw: Vec<RawPromptStep> = Vec::deserialize(d)?;
+    raw.into_iter()
+        .map(|step| match step {
+            RawPromptStep::Plain(name) => Ok(PromptStep::Plain(name)),
+            RawPromptStep::Parameterised(map) => {
+                // One key means one fragment. Two keys leave no way to know
+                // which fragment the entry is about.
+                let mut it = map.into_iter();
+                match (it.next(), it.next()) {
+                    (Some((fragment, vars)), None) => {
+                        Ok(PromptStep::Parameterised { fragment, vars })
+                    }
+                    _ => Err(D::Error::custom(
+                        "a prompt step must name exactly one fragment",
+                    )),
+                }
+            }
+        })
+        .collect()
+}
+
+/// Read and validate an `agents.yaml`.
+///
+/// A missing file is an error, not an empty set: treating it as empty would
+/// hide a mistyped path behind a fleet that silently has no agents.
+pub fn load(path: &Path) -> anyhow::Result<DeclaredAgents> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+    serde_yaml_ng::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("cannot parse {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+defaults:
+  provider: claude
+  model: latest:pro
+  temperature: 0.3
+  max_tokens: 8192
+
+agents:
+  - name: core-specialist
+    description: Core domain and orchestration engine
+    scope: [src/core/**, src/parser/**]
+    tags: [rust, domain]
+    prompt:
+      - specialist-base
+      - { armadai-architecture: { module: core } }
+
+  - name: ui-specialist
+    temperature: 0.4
+    prompt: [specialist-base]
+"#;
+
+    fn parsed() -> DeclaredAgents {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, SAMPLE).unwrap();
+        load(&p).unwrap()
+    }
+
+    #[test]
+    fn reads_defaults_and_agents() {
+        let d = parsed();
+        assert_eq!(d.defaults.provider.as_deref(), Some("claude"));
+        assert_eq!(d.defaults.temperature, Some(0.3));
+        assert_eq!(d.agents.len(), 2);
+        assert_eq!(d.agents[0].name, "core-specialist");
+    }
+
+    #[test]
+    fn a_plain_prompt_step_is_a_bare_fragment_name() {
+        let d = parsed();
+        assert_eq!(
+            d.agents[0].prompt[0],
+            PromptStep::Plain("specialist-base".into())
+        );
+    }
+
+    #[test]
+    fn a_parameterised_step_carries_its_fragment_and_vars() {
+        let d = parsed();
+        match &d.agents[0].prompt[1] {
+            PromptStep::Parameterised { fragment, vars } => {
+                assert_eq!(fragment, "armadai-architecture");
+                assert_eq!(vars.get("module").map(String::as_str), Some("core"));
+            }
+            other => panic!("expected a parameterised step, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_step_with_several_keys_is_rejected() {
+        // `{ a: {...}, b: {...} }` is ambiguous: which fragment is it?
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(
+            &p,
+            "agents:\n  - name: x\n    prompt:\n      - { a: {}, b: {} }\n",
+        )
+        .unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("exactly one fragment"),
+            "the error must say what is wrong: {err}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_file_reports_where() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "agents:\n  - name: [unclosed\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("agents.yaml"),
+            "the error must name the file: {err}"
+        );
+    }
+
+    #[test]
+    fn a_missing_file_is_an_error_not_an_empty_set() {
+        // Silently treating it as empty would hide a typo'd path.
+        assert!(load(std::path::Path::new("/nonexistent/agents.yaml")).is_err());
+    }
+
+    #[test]
+    fn an_unknown_key_under_an_agent_is_rejected_and_named() {
+        // `deny_unknown_fields` is deliberate on every declared struct: a
+        // mistyped key in a fleet declaration must fail loudly, not be
+        // silently dropped on the floor.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "agents:\n  - name: x\n    typo_field: oops\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("typo_field"),
+            "the error must name the offending key: {err}"
+        );
+    }
+}

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -208,6 +208,47 @@ pub fn merge_metadata(decl: &AgentDecl, defaults: &AgentDefaults) -> anyhow::Res
     })
 }
 
+/// Assemble an agent's system prompt from its declared fragments.
+///
+/// Fails on a missing fragment or an unsubstituted variable. That is the
+/// deliberate inverse of the policy gate, where uncertainty allows: degrading
+/// here would ship an agent whose instructions are amputated, and such an
+/// agent fills the gaps instead of complaining.
+pub fn compose_prompt(
+    steps: &[PromptStep],
+    decl: &AgentDecl,
+    fragments: &[crate::prompt::Prompt],
+) -> anyhow::Result<String> {
+    let mut parts = Vec::new();
+    for step in steps {
+        let (name, extra) = match step {
+            PromptStep::Plain(n) => (n.as_str(), BTreeMap::new()),
+            PromptStep::Parameterised { fragment, vars } => (fragment.as_str(), vars.clone()),
+        };
+        let frag = fragments.iter().find(|f| f.name == name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "agent '{}' references prompt fragment '{name}', which was not found",
+                decl.name
+            )
+        })?;
+
+        // The agent's own fields, then the step's variables — a step may
+        // override an implicit value deliberately.
+        let mut vars: BTreeMap<String, String> = BTreeMap::new();
+        vars.insert("name".into(), decl.name.clone());
+        vars.insert(
+            "description".into(),
+            decl.description.clone().unwrap_or_default(),
+        );
+        vars.extend(extra);
+
+        let rendered = crate::template::render(&frag.body, &vars)
+            .map_err(|e| anyhow::anyhow!("agent '{}', fragment '{name}': {e}", decl.name))?;
+        parts.push(rendered);
+    }
+    Ok(parts.join("\n\n"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -565,5 +606,95 @@ agents:
         assert_eq!(m.orchestration, None);
         assert!(m.triggers.is_none());
         assert!(m.ring_config.is_none());
+    }
+
+    use crate::prompt::Prompt;
+
+    fn fragment(name: &str, body: &str) -> Prompt {
+        Prompt {
+            name: name.into(),
+            description: None,
+            apply_to: vec![],
+            body: body.into(),
+            source: std::path::PathBuf::from(format!("{name}.md")),
+        }
+    }
+
+    #[test]
+    fn fragments_are_concatenated_in_declared_order() {
+        let frags = vec![fragment("a", "first"), fragment("b", "second")];
+        let steps = vec![PromptStep::Plain("b".into()), PromptStep::Plain("a".into())];
+        let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();
+        assert_eq!(out, "second\n\nfirst");
+    }
+
+    #[test]
+    fn a_parameterised_fragment_gets_its_variables() {
+        let frags = vec![fragment("arch", "module is {{module}}")];
+        let steps = vec![PromptStep::Parameterised {
+            fragment: "arch".into(),
+            vars: [("module".to_string(), "core".to_string())]
+                .into_iter()
+                .collect(),
+        }];
+        let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();
+        assert_eq!(out, "module is core");
+    }
+
+    /// The agent's own fields are available to every fragment, with the same
+    /// names `cli/new.rs` uses for templates.
+    #[test]
+    fn the_agents_name_and_description_are_implicit_variables() {
+        let frags = vec![fragment("greet", "I am {{name}}: {{description}}")];
+        let mut d = decl("core-specialist");
+        d.description = Some("the core".into());
+        let out = compose_prompt(&[PromptStep::Plain("greet".into())], &d, &frags).unwrap();
+        assert_eq!(out, "I am core-specialist: the core");
+    }
+
+    /// A step's own variables win over the implicit agent fields — a step may
+    /// deliberately override `name` or `description` for its fragment.
+    #[test]
+    fn a_steps_own_variable_overrides_the_implicit_agent_name() {
+        let frags = vec![fragment("greet", "I am {{name}}")];
+        let steps = vec![PromptStep::Parameterised {
+            fragment: "greet".into(),
+            vars: [("name".to_string(), "something-else".to_string())]
+                .into_iter()
+                .collect(),
+        }];
+        let out = compose_prompt(&steps, &decl("core-specialist"), &frags).unwrap();
+        assert_eq!(out, "I am something-else");
+    }
+
+    #[test]
+    fn a_missing_fragment_is_an_error_naming_it_and_the_agent() {
+        let err = compose_prompt(
+            &[PromptStep::Plain("nope".into())],
+            &decl("core-specialist"),
+            &[],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("nope"), "must name the fragment: {err}");
+        assert!(
+            err.contains("core-specialist"),
+            "must name the agent, or you cannot find it in a 77-agent fleet: {err}"
+        );
+    }
+
+    /// An agent whose prompt still contains `{{module}}` is quietly wrong.
+    #[test]
+    fn an_unsubstituted_variable_fails_the_composition() {
+        let frags = vec![fragment("arch", "module is {{module}}")];
+        let err = compose_prompt(&[PromptStep::Plain("arch".into())], &decl("x"), &frags)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("module"), "must name the variable: {err}");
+    }
+
+    #[test]
+    fn an_empty_prompt_list_yields_an_empty_system_prompt() {
+        assert_eq!(compose_prompt(&[], &decl("x"), &[]).unwrap(), "");
     }
 }

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -36,6 +36,7 @@ pub struct AgentDefaults {
     pub temperature: Option<f32>,
     pub max_tokens: Option<u32>,
     pub timeout: Option<u64>,
+    #[serde(alias = "model_fallbacks")]
     pub model_fallback: Vec<String>,
     pub tags: Vec<String>,
     pub stacks: Vec<String>,
@@ -62,7 +63,7 @@ pub struct AgentDecl {
     pub max_tokens: Option<u32>,
     #[serde(default)]
     pub timeout: Option<u64>,
-    #[serde(default)]
+    #[serde(default, alias = "model_fallbacks")]
     pub model_fallback: Option<Vec<String>>,
     #[serde(default)]
     pub tags: Option<Vec<String>>,
@@ -265,11 +266,12 @@ pub fn compose_prompt(
 /// `defaults`, system prompt composed from `fragments`, `source` stamped as
 /// given by the caller.
 ///
-/// The only place this runs today is `agent_source::load_agent`, for one
-/// declared agent at a time. A bulk loader (loading every agent in a file at
-/// once) is later work; putting the construction here rather than inline at
-/// the single-agent call site means that loader calls this too, instead of
-/// a second, inevitably drifting copy of the same `Agent { .. }` literal.
+/// Called once per declaration from both `agent_source::load_all_agents`
+/// (a whole project's fleet) and `agent_source::load_agent_by_name` (one
+/// agent by name) — putting the construction here, rather than inline at
+/// each call site, means both loaders call this one function instead of
+/// keeping two independently drifting copies of the same `Agent { .. }`
+/// literal.
 pub(crate) fn to_agent(
     decl: &AgentDecl,
     defaults: &AgentDefaults,
@@ -327,6 +329,35 @@ agents:
         assert_eq!(d.defaults.temperature, Some(0.3));
         assert_eq!(d.agents.len(), 2);
         assert_eq!(d.agents[0].name, "core-specialist");
+    }
+
+    /// The `.md` parser accepts both `model_fallback` and `model_fallbacks`
+    /// (`parser/metadata.rs`). Before this alias, the plural on the YAML side
+    /// hit `deny_unknown_fields` and made the *whole file* a
+    /// `DeclarationsUnreadable` — one typo'd key losing every declared agent.
+    #[test]
+    fn the_plural_model_fallbacks_spelling_loads_in_defaults_and_on_an_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(
+            &p,
+            r#"
+defaults:
+  provider: claude
+  model_fallbacks: [latest:fast]
+
+agents:
+  - name: x
+    model_fallbacks: [claude-sonnet-4-5-20250929]
+"#,
+        )
+        .unwrap();
+        let d = load(&p).unwrap();
+        assert_eq!(d.defaults.model_fallback, vec!["latest:fast".to_string()]);
+        assert_eq!(
+            d.agents[0].model_fallback,
+            Some(vec!["claude-sonnet-4-5-20250929".to_string()])
+        );
     }
 
     #[test]

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -11,6 +11,8 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+use crate::agent::{AgentMetadata, default_temperature};
+
 /// One entry of an agent's `prompt:` list.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PromptStep {
@@ -143,6 +145,61 @@ pub fn load(path: &Path) -> anyhow::Result<DeclaredAgents> {
         .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
     serde_yaml_ng::from_str(&raw)
         .map_err(|e| anyhow::anyhow!("cannot parse {}: {e}", path.display()))
+}
+
+/// Build an agent's metadata from its declaration and the shared defaults.
+///
+/// Shallow merge: a field absent from the declaration takes the default's
+/// value. Lists are **replaced, never merged** — less expressive, but an agent
+/// that declares a `scope` has exactly that scope, rather than silently
+/// inheriting a wider one.
+///
+/// Fails when no `provider` is declared at either level. The `.md` parser
+/// refuses that too (`parser/metadata.rs`), and the two formats must agree on
+/// what a valid agent is. Every remaining field is written out explicitly:
+/// `AgentMetadata` has no `Default`, and giving it one would mean `provider:
+/// ""` and `temperature: 0.0` — two wrong values free to propagate.
+pub fn merge_metadata(decl: &AgentDecl, defaults: &AgentDefaults) -> anyhow::Result<AgentMetadata> {
+    let provider = decl
+        .provider
+        .clone()
+        .or_else(|| defaults.provider.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "agent '{}': no provider declared, and none in defaults",
+                decl.name
+            )
+        })?;
+
+    Ok(AgentMetadata {
+        provider,
+        model: decl.model.clone().or_else(|| defaults.model.clone()),
+        command: None,
+        args: None,
+        temperature: decl
+            .temperature
+            .or(defaults.temperature)
+            .unwrap_or_else(default_temperature),
+        max_tokens: decl.max_tokens.or(defaults.max_tokens),
+        timeout: decl.timeout.or(defaults.timeout),
+        tags: decl.tags.clone().unwrap_or_else(|| defaults.tags.clone()),
+        stacks: decl
+            .stacks
+            .clone()
+            .unwrap_or_else(|| defaults.stacks.clone()),
+        scope: decl.scope.clone().unwrap_or_default(),
+        model_fallback: decl
+            .model_fallback
+            .clone()
+            .unwrap_or_else(|| defaults.model_fallback.clone()),
+        cost_limit: None,
+        rate_limit: None,
+        context_window: None,
+        mode: None,
+        orchestration: None,
+        triggers: None,
+        ring_config: None,
+    })
 }
 
 #[cfg(test)]
@@ -306,6 +363,106 @@ agents:
                 && err.contains("a single-key map of a fragment name to its variables")
                 && err.contains("a sequence"),
             "the error must name the valid shapes and what was found: {err}"
+        );
+    }
+
+    fn decl(name: &str) -> AgentDecl {
+        AgentDecl {
+            name: name.into(),
+            description: None,
+            provider: None,
+            model: None,
+            temperature: None,
+            max_tokens: None,
+            timeout: None,
+            model_fallback: None,
+            tags: None,
+            stacks: None,
+            scope: None,
+            prompt: vec![],
+        }
+    }
+
+    fn defaults() -> AgentDefaults {
+        AgentDefaults {
+            provider: Some("claude".into()),
+            model: Some("latest:pro".into()),
+            temperature: Some(0.3),
+            max_tokens: Some(8192),
+            timeout: None,
+            model_fallback: vec!["latest:fast".into()],
+            tags: vec!["shared".into()],
+            stacks: vec![],
+        }
+    }
+
+    #[test]
+    fn an_agent_without_overrides_takes_every_default() {
+        let m = merge_metadata(&decl("a"), &defaults()).unwrap();
+        assert_eq!(m.provider, "claude");
+        assert_eq!(m.model.as_deref(), Some("latest:pro"));
+        assert_eq!(m.temperature, 0.3);
+        assert_eq!(m.max_tokens, Some(8192));
+        assert_eq!(m.tags, vec!["shared".to_string()]);
+    }
+
+    #[test]
+    fn a_scalar_override_wins() {
+        let mut d = decl("a");
+        d.temperature = Some(0.9);
+        assert_eq!(merge_metadata(&d, &defaults()).unwrap().temperature, 0.9);
+    }
+
+    /// Lists are replaced, never merged: an agent that declares its tags has
+    /// exactly those, and does not silently inherit a wider set.
+    #[test]
+    fn a_declared_list_replaces_the_default_rather_than_extending_it() {
+        let mut d = decl("a");
+        d.tags = Some(vec!["own".into()]);
+        let m = merge_metadata(&d, &defaults()).unwrap();
+        assert_eq!(m.tags, vec!["own".to_string()]);
+        assert!(!m.tags.contains(&"shared".to_string()));
+    }
+
+    #[test]
+    fn an_empty_declared_list_means_empty_not_inherit() {
+        let mut d = decl("a");
+        d.tags = Some(vec![]);
+        assert!(merge_metadata(&d, &defaults()).unwrap().tags.is_empty());
+    }
+
+    /// The `.md` parser refuses an agent with no provider
+    /// (`parser/metadata.rs:83`). YAML must refuse it too, or the two formats
+    /// disagree on what a valid agent is.
+    #[test]
+    fn a_provider_declared_nowhere_is_an_error() {
+        let err = merge_metadata(&decl("a"), &AgentDefaults::default())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("provider"), "must say what is missing: {err}");
+        assert!(err.contains("a"), "must name the agent: {err}");
+    }
+
+    #[test]
+    fn temperature_falls_back_to_the_parsers_own_default() {
+        let mut d = decl("a");
+        d.provider = Some("claude".into());
+        let m = merge_metadata(&d, &AgentDefaults::default()).unwrap();
+        // Call the shared function rather than writing 0.7 in a second place:
+        // this test must follow the default, not pin a copy of it.
+        assert_eq!(m.temperature, crate::agent::default_temperature());
+    }
+
+    /// An agent may supply the provider itself with no defaults block at all.
+    #[test]
+    fn an_agent_can_carry_the_provider_alone() {
+        let mut d = decl("a");
+        d.provider = Some("cli".into());
+        assert_eq!(
+            merge_metadata(&d, &AgentDefaults::default())
+                .unwrap()
+                .provider,
+            "cli"
         );
     }
 }

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -233,18 +233,22 @@ pub fn compose_prompt(
         })?;
 
         // The agent's own fields, then the step's variables — a step may
-        // override an implicit value deliberately.
+        // override an implicit value deliberately. `description` is inserted
+        // only when the agent declares one: silently substituting an empty
+        // string here would bypass the very failure this function exists to
+        // enforce, producing exactly the amputated prompt the hard-failure
+        // policy is meant to prevent. A step can still supply `description`
+        // itself via `extra`, even when the agent has none.
         let mut vars: BTreeMap<String, String> = BTreeMap::new();
         vars.insert("name".into(), decl.name.clone());
-        vars.insert(
-            "description".into(),
-            decl.description.clone().unwrap_or_default(),
-        );
+        if let Some(d) = &decl.description {
+            vars.insert("description".into(), d.clone());
+        }
         vars.extend(extra);
 
         let rendered = crate::template::render(&frag.body, &vars)
             .map_err(|e| anyhow::anyhow!("agent '{}', fragment '{name}': {e}", decl.name))?;
-        parts.push(rendered);
+        parts.push(rendered.trim_end().to_string());
     }
     Ok(parts.join("\n\n"))
 }
@@ -696,5 +700,56 @@ agents:
     #[test]
     fn an_empty_prompt_list_yields_an_empty_system_prompt() {
         assert_eq!(compose_prompt(&[], &decl("x"), &[]).unwrap(), "");
+    }
+
+    /// Fragment bodies read from disk routinely end in their own trailing
+    /// newline. Each rendered fragment is trimmed before joining, so the
+    /// `"\n\n"` separator is the only blank line between fragments — not
+    /// three or more. Pinned as the exact literal, not just "contains".
+    #[test]
+    fn trailing_newlines_in_fragment_bodies_do_not_pile_up_at_the_join() {
+        let frags = vec![
+            fragment("a", "first line\n"),
+            fragment("b", "second line\n"),
+        ];
+        let steps = vec![PromptStep::Plain("a".into()), PromptStep::Plain("b".into())];
+        let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();
+        assert_eq!(out, "first line\n\nsecond line");
+    }
+
+    /// The hard-failure principle this module is built on exists precisely so
+    /// an agent with amputated instructions cannot ship silently. Letting
+    /// `description: None` become an empty string would bypass that
+    /// principle for the one field it is most likely to matter for.
+    #[test]
+    fn a_missing_description_fails_the_composition_naming_both_agent_and_field() {
+        let frags = vec![fragment("greet", "Role: {{description}}")];
+        let err = compose_prompt(
+            &[PromptStep::Plain("greet".into())],
+            &decl("core-specialist"),
+            &frags,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("core-specialist"),
+            "must name the agent: {err}"
+        );
+        assert!(err.contains("description"), "must name the field: {err}");
+    }
+
+    /// The escape hatch that keeps the above strictness usable: a step can
+    /// supply `description` itself even when the agent declares none.
+    #[test]
+    fn a_step_can_supply_description_when_the_agent_has_none() {
+        let frags = vec![fragment("greet", "Role: {{description}}")];
+        let steps = vec![PromptStep::Parameterised {
+            fragment: "greet".into(),
+            vars: [("description".to_string(), "from the step".to_string())]
+                .into_iter()
+                .collect(),
+        }];
+        let out = compose_prompt(&steps, &decl("core-specialist"), &frags).unwrap();
+        assert_eq!(out, "Role: from the step");
     }
 }

--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::agent::{AgentMetadata, default_temperature};
+use crate::agent::{Agent, AgentMetadata, default_temperature};
 
 /// One entry of an agent's `prompt:` list.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -251,6 +251,33 @@ pub fn compose_prompt(
         parts.push(rendered.trim_end().to_string());
     }
     Ok(parts.join("\n\n"))
+}
+
+/// Build the `Agent` a single declaration resolves to: metadata merged over
+/// `defaults`, system prompt composed from `fragments`, `source` stamped as
+/// given by the caller.
+///
+/// The only place this runs today is `agent_source::load_agent`, for one
+/// declared agent at a time. A bulk loader (loading every agent in a file at
+/// once) is later work; putting the construction here rather than inline at
+/// the single-agent call site means that loader calls this too, instead of
+/// a second, inevitably drifting copy of the same `Agent { .. }` literal.
+pub(crate) fn to_agent(
+    decl: &AgentDecl,
+    defaults: &AgentDefaults,
+    fragments: &[crate::prompt::Prompt],
+    source: std::path::PathBuf,
+) -> anyhow::Result<Agent> {
+    Ok(Agent {
+        name: decl.name.clone(),
+        source,
+        metadata: merge_metadata(decl, defaults)?,
+        system_prompt: compose_prompt(&decl.prompt, decl, fragments)?,
+        instructions: None,
+        output_format: None,
+        pipeline: None,
+        context: None,
+    })
 }
 
 #[cfg(test)]

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -43,55 +43,6 @@ pub fn load_agent(
     agent_decl::to_agent(decl, &decls.defaults, fragments, path.clone())
 }
 
-/// Refuse a name that exists both as a declaration and as a library file.
-///
-/// The obvious alternative is a precedence rule — local wins, as everywhere
-/// else. It is rejected on purpose: a silent precedence recreates the very
-/// duplicated truth this format exists to remove, and you would edit a `.md`
-/// with no effect and nothing to tell you. Failing forces a choice.
-///
-/// Two refinements over a naive `library.join(name + ".md")` existence
-/// check, both load-bearing:
-///
-/// - Names are compared as **slugs** (`agent::slugify`), not as raw
-///   strings. The linker projects every agent name through the same
-///   `slugify` to name its output file, so a declaration `Core-Specialist`
-///   and a file `core-specialist.md` — or a declaration `Agent (v2.0)` and
-///   a file `agent-v20.md` — land on the *same* filename at link time even
-///   though they are not byte-for-byte equal. Comparing raw names would
-///   pass both cases and let one silently overwrite the other later; only
-///   comparing slugs matches what actually happens on disk.
-/// - `libraries` takes **every** directory a file-backed agent can resolve
-///   from (see `project::resolve_agent`'s `Named` arm: `.armadai/agents/`,
-///   legacy `agents/`, and the user library), not just one. A caller that
-///   checks a single directory can believe the refusal is complete when it
-///   is not — and a later resolution step that tries file-backed agents
-///   first and declarations second, with no precedence rule, is only safe
-///   if a name shared with *any* of them has already failed here.
-///
-/// A library directory that does not exist is not an error — a project
-/// with no local `agents/` directory is normal. A directory that exists
-/// but cannot be read (permissions, not a directory after all) *is*
-/// propagated as an error: unlike "there is nothing there", "it would not
-/// tell me" is exactly the kind of silent gap this function exists to
-/// close.
-///
-/// Rule `C01` of the audit already reports name collisions; loading must
-/// refuse them.
-pub fn check_no_shadowing(project_root: &Path, libraries: &[PathBuf]) -> anyhow::Result<()> {
-    let decls_path = declarations_path(project_root);
-    if !decls_path.is_file() {
-        return Ok(());
-    }
-    let decls = agent_decl::load(&decls_path)?;
-    for decl in &decls.agents {
-        if let Some(collision) = shadowing_conflict(&decl.name, libraries)? {
-            anyhow::bail!(shadowing_message(&decl.name, &decls_path, &collision));
-        }
-    }
-    Ok(())
-}
-
 /// Does `name` (compared as a slug) collide with a `.md` file in any of
 /// `libraries`? Returns the colliding file's path if so, `None` otherwise.
 ///
@@ -161,30 +112,115 @@ pub fn project_fragments(project_root: &Path) -> Vec<Prompt> {
     out
 }
 
+/// One agent `load_all_agents` could not include, and why — the
+/// distinction a caller that WRITES config (`link`) needs and a caller that
+/// only DISPLAYS it (`list`) does not.
+///
+/// `link` must refuse to write a smaller fleet than the one declared, but
+/// only when this chantier's declarative format is the reason: a dropped
+/// declaration, or a shadowing collision. A failure that predates it
+/// entirely — an unparseable `.md`, an `AgentRef` that does not resolve to
+/// any file — keeps its exact old behaviour (warn, link what did load, exit
+/// 0), because that behaviour was never wrong; only the new format's own
+/// failures are. `list` prints every variant's `message()` alike and never
+/// refuses anything, being read-only.
+///
+/// Deliberately structured rather than a flat `String`, so a caller decides
+/// by matching a variant — never by inspecting message text, which is free
+/// to reword without silently changing what refuses a write.
+#[derive(Debug, Clone)]
+pub enum LoadWarning {
+    /// Unrelated to declarative agents: an unparseable `.md`, or a
+    /// `path:`/`named`/`registry:` ref that did not resolve to a file.
+    PreExisting(String),
+    /// A single named declared agent this chantier's format failed to
+    /// load — a broken declaration (metadata/composition error) or a name
+    /// that collided with a file-backed agent. Named so a caller narrowing
+    /// by `--agents` can tell whether the loss is even part of what it is
+    /// about to write.
+    Dropped { agent: String, message: String },
+    /// The whole `.armadai/agents.yaml` failed to load (unreadable, or a
+    /// YAML error) — an unknown number of declared agents, of unknown
+    /// names, are lost. Cannot be scoped to a `--agents` filter the way
+    /// `Dropped` can: any requested name might have been among them.
+    DeclarationsUnreadable(String),
+}
+
+impl LoadWarning {
+    /// The human-readable text every caller's warning loop prints, whatever
+    /// the variant — `link`/`list` never format these three differently.
+    pub fn message(&self) -> &str {
+        match self {
+            LoadWarning::PreExisting(m)
+            | LoadWarning::Dropped { message: m, .. }
+            | LoadWarning::DeclarationsUnreadable(m) => m,
+        }
+    }
+}
+
+/// Whether `warnings` contain a loss a write-side caller (`link`) must
+/// refuse over, given the agents actually being requested: `None` for the
+/// whole fleet, `Some(names)` for a `--agents` filter (compared
+/// case-insensitively, matching `link`'s own filter).
+///
+/// A `PreExisting` loss never blocks — see [`LoadWarning`]'s own doc for
+/// why. A `DeclarationsUnreadable` loss always blocks: it cannot be scoped
+/// by name. A `Dropped` loss blocks only when its agent is among the ones
+/// requested — `--agents good` must not refuse over a `bad` this chantier's
+/// format dropped when `bad` was never going to be written anyway.
+pub fn blocks_a_write(warnings: &[LoadWarning], requested: Option<&[String]>) -> bool {
+    warnings.iter().any(|w| match w {
+        LoadWarning::PreExisting(_) => false,
+        LoadWarning::DeclarationsUnreadable(_) => true,
+        LoadWarning::Dropped { agent, .. } => match requested {
+            None => true,
+            Some(names) => names
+                .iter()
+                .any(|n| n.to_lowercase() == agent.to_lowercase()),
+        },
+    })
+}
+
 /// Every agent a project has: those resolved from files, plus those declared.
 ///
-/// Same `(values, non-fatal errors)` shape as `resolve_all_agents`, so callers
-/// keep their existing warning loop. A broken declaration costs its own agent,
-/// never the whole fleet — a fleet that vanishes because one agent has a typo
-/// is worse than a fleet with a gap and a warning. **This is true of a
-/// shadowing collision too**: it costs only the colliding declaration (with a
-/// warning naming both sources, via `shadowing_message`), not every other
-/// declared agent — the first cut of this function bailed out of the whole
-/// declarations block on the first collision found, which meant one
-/// accidental collision (plausibly against a file the project doesn't even
-/// own, since the check spans the user's whole global library) silently
-/// dropped every other declared agent while callers kept exiting 0.
+/// Same `(values, warnings)` shape as `resolve_all_agents`, so callers keep
+/// their existing warning loop — just typed as [`LoadWarning`] instead of a
+/// flat `String`, so a write-side caller can tell a pre-existing failure
+/// from a loss this chantier's format is responsible for (see
+/// [`blocks_a_write`]). A broken declaration or a shadowing collision costs
+/// only its own agent, never the whole fleet — a fleet that vanishes
+/// because one agent has a typo, or because one collision happens to fall
+/// against a file the project doesn't even own (the check spans the user's
+/// whole global library), is worse than a fleet with a gap and a warning.
 pub fn load_all_agents(
     config: &crate::project::ProjectConfig,
     root: &Path,
     fragments: &[Prompt],
-) -> (Vec<Agent>, Vec<String>) {
-    let (paths, mut errors) = crate::project::resolve_all_agents(config, root);
+) -> (Vec<Agent>, Vec<LoadWarning>) {
     let mut agents = Vec::new();
-    for path in &paths {
-        match crate::parser::parse_agent_file(path) {
-            Ok(a) => agents.push(a),
-            Err(e) => errors.push(format!("failed to parse {}: {e}", path.display())),
+    let mut warnings = Vec::new();
+
+    // File-backed agents. `AgentRef::Declared` is skipped here rather than
+    // handed to `resolve_agent` (which always refuses that variant, by
+    // design, with a message naming `.armadai/agents.yaml`): the agent it
+    // names loads fine below, via the declarations block, regardless of
+    // whether `config.agents` names it at all — every declared agent is
+    // included automatically. Passing it through would report a real,
+    // loadable agent as an unresolvable file, every time.
+    for agent_ref in config
+        .agents
+        .iter()
+        .filter(|r| !matches!(r, AgentRef::Declared { .. }))
+    {
+        match resolve_agent(agent_ref, root) {
+            Ok(path) => match crate::parser::parse_agent_file(&path) {
+                Ok(a) => agents.push(a),
+                Err(e) => warnings.push(LoadWarning::PreExisting(format!(
+                    "failed to parse {}: {e}",
+                    path.display()
+                ))),
+            },
+            Err(e) => warnings.push(LoadWarning::PreExisting(format!("{e}"))),
         }
     }
 
@@ -196,27 +232,41 @@ pub fn load_all_agents(
                 for decl in &decls.agents {
                     match shadowing_conflict(&decl.name, &libraries) {
                         Ok(Some(collision)) => {
-                            errors.push(shadowing_message(&decl.name, &decls_path, &collision));
+                            warnings.push(LoadWarning::Dropped {
+                                agent: decl.name.clone(),
+                                message: shadowing_message(&decl.name, &decls_path, &collision),
+                            });
                             continue;
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            errors.push(format!("{e}"));
+                            warnings.push(LoadWarning::Dropped {
+                                agent: decl.name.clone(),
+                                message: format!("{e}"),
+                            });
                             continue;
                         }
                     }
                     match agent_decl::to_agent(decl, &decls.defaults, fragments, decls_path.clone())
                     {
                         Ok(a) => agents.push(a),
-                        Err(e) => errors.push(format!("{e}")),
+                        Err(e) => warnings.push(LoadWarning::Dropped {
+                            agent: decl.name.clone(),
+                            message: format!("{e}"),
+                        }),
                     }
                 }
             }
-            Err(e) => errors.push(format!("{e}")),
+            // The whole file failed (unreadable, or a top-level YAML
+            // error): every agent it would have declared is lost, none of
+            // them nameable, so this cannot be scoped to a `--agents`
+            // filter the way one bad declaration can — see
+            // `blocks_a_write`.
+            Err(e) => warnings.push(LoadWarning::DeclarationsUnreadable(format!("{e}"))),
         }
     }
 
-    (agents, errors)
+    (agents, warnings)
 }
 
 /// Find one agent by name, whether it is declared or written as a file.
@@ -227,15 +277,23 @@ pub fn load_all_agents(
 /// lookup — then the project's declarations. There is deliberately no
 /// precedence rule for a name that resolves both ways: this function refuses
 /// it outright (see the `shadowing_conflict` check below), the same refusal
-/// `load_all_agents` applies per-declaration and `check_no_shadowing` applies
-/// fleet-wide — a name ambiguous enough to fail `link`/`list` must fail
-/// `run`/`inspect` too, not silently resolve to whichever side is tried
-/// first.
+/// `load_all_agents` applies per-declaration — a name ambiguous enough to
+/// fail `link`/`list` must fail `run`/`inspect` too, not silently resolve to
+/// whichever side is tried first.
 ///
 /// A `config.agents` entry of `AgentRef::Declared` matching `name` is never
 /// handed to `resolve_agent` (which always refuses that variant) — it is
 /// left unmatched here so resolution falls through to the declarations
 /// lookup below, which is what actually resolves it.
+///
+/// An unreadable `.armadai/agents.yaml` does not fail this function on its
+/// own: it cannot declare `name`, so it cannot collide with a file-backed
+/// `name` either. When the file-backed lookup ALSO succeeds, that `.md` is
+/// unambiguous and is served, with a warning (`tracing::warn!`) so the
+/// broken yaml is not silently invisible. Only when the file-backed lookup
+/// fails too does the yaml error become the reason to fail — a working
+/// declaration could have provided this name, so its parse error, not a
+/// generic "not found", is what the caller needs to see.
 pub fn load_agent_by_name(
     name: &str,
     config: &crate::project::ProjectConfig,
@@ -260,22 +318,45 @@ pub fn load_agent_by_name(
     };
 
     let decls_path = declarations_path(project_root);
-    let decls = if decls_path.is_file() {
-        Some(agent_decl::load(&decls_path)?)
+    let (decls, decls_err) = if decls_path.is_file() {
+        match agent_decl::load(&decls_path) {
+            Ok(d) => (Some(d), None),
+            Err(e) => (None, Some(e)),
+        }
     } else {
-        None
+        (None, None)
     };
+
+    if let Some(decls_err) = decls_err {
+        return match file_result {
+            Ok(path) => {
+                tracing::warn!(
+                    "ignoring unparsable {}: {decls_err} (serving the file-backed agent \
+                     '{name}' instead)",
+                    decls_path.display()
+                );
+                crate::parser::parse_agent_file(&path)
+            }
+            Err(file_err) => Err(anyhow::anyhow!(
+                "agent '{name}' not found as a file ({file_err}), and {} could not be read: \
+                 {decls_err}",
+                decls_path.display()
+            )),
+        };
+    }
+
     let declared = decls
         .as_ref()
         .and_then(|d| d.agents.iter().find(|a| a.name == name));
 
     // Collision check scoped to just this one name — no need to scan the
-    // whole fleet the way `check_no_shadowing` does for `load_all_agents`.
-    // Checked against `project::library_dirs` directly, not against whether
-    // `file_result` happened to succeed: an explicit `path:`/`registry:` ref
-    // pointing outside those library dirs is not the ambiguity
-    // `check_no_shadowing` polices, and using `file_result` here would let
-    // `run`/`inspect` accept a name `link`/`list` refuse (or the reverse).
+    // whole fleet the way `check_no_shadowing` does for a full project
+    // validation. Checked against `project::library_dirs` directly, not
+    // against whether `file_result` happened to succeed: an explicit
+    // `path:`/`registry:` ref pointing outside those library dirs is not
+    // the ambiguity this collision check polices, and using `file_result`
+    // here would let `run`/`inspect` accept a name `link`/`list` refuse (or
+    // the reverse).
     if declared.is_some()
         && let Some(collision) =
             shadowing_conflict(name, &crate::project::library_dirs(project_root))?
@@ -455,26 +536,17 @@ agents:
     }
 
     #[test]
-    fn a_name_both_declared_and_written_as_a_file_is_an_error() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path()); // declares `core-specialist`
+    fn shadowing_conflict_finds_a_file_matching_a_declared_name() {
         let lib = tempfile::tempdir().unwrap();
+        let file = lib.path().join("core-specialist.md");
         std::fs::write(
-            lib.path().join("core-specialist.md"),
+            &file,
             "# Core\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi",
         )
         .unwrap();
 
-        let err = check_no_shadowing(dir.path(), &[lib.path().to_path_buf()])
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("core-specialist"), "must name it: {err}");
-        // The point is that neither wins — say so, or the reader will assume
-        // one does.
-        assert!(
-            err.contains("agents.yaml") && err.contains(".md"),
-            "must name both sources so the reader can pick one: {err}"
-        );
+        let found = shadowing_conflict("core-specialist", &[lib.path().to_path_buf()]).unwrap();
+        assert_eq!(found, Some(file));
     }
 
     /// A declaration and a library file that only match once both are
@@ -484,20 +556,13 @@ agents:
     /// two would silently collide at link time instead. Comparing slugs
     /// makes the outcome the same on every platform.
     #[test]
-    fn a_declared_name_collides_with_a_file_that_only_differs_in_case() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path()); // declares `core-specialist`
+    fn shadowing_conflict_matches_case_insensitively() {
         let lib = tempfile::tempdir().unwrap();
-        std::fs::write(lib.path().join("Core-Specialist.md"), "# Core").unwrap();
+        let file = lib.path().join("Core-Specialist.md");
+        std::fs::write(&file, "# Core").unwrap();
 
-        let err = check_no_shadowing(dir.path(), &[lib.path().to_path_buf()])
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("core-specialist"), "must name it: {err}");
-        assert!(
-            err.contains("agents.yaml") && err.contains(".md"),
-            "must name both sources so the reader can pick one: {err}"
-        );
+        let found = shadowing_conflict("core-specialist", &[lib.path().to_path_buf()]).unwrap();
+        assert_eq!(found, Some(file));
     }
 
     /// A declaration and a library file that only collide once punctuation
@@ -505,43 +570,23 @@ agents:
     /// does when it names the output file. Neither a raw-name comparison
     /// nor a case-insensitive one would catch this.
     #[test]
-    fn a_declared_name_collides_with_a_file_only_after_slug_folding() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
-        std::fs::write(
-            dir.path().join(".armadai/agents.yaml"),
-            "defaults:\n  provider: claude\nagents:\n  \
-             - name: \"Agent (v2.0)\"\n    description: d\n    prompt: [base]\n",
-        )
-        .unwrap();
+    fn shadowing_conflict_matches_after_slug_folding() {
         let lib = tempfile::tempdir().unwrap();
-        std::fs::write(lib.path().join("agent-v20.md"), "# Agent").unwrap();
+        let file = lib.path().join("agent-v20.md");
+        std::fs::write(&file, "# Agent").unwrap();
 
-        let err = check_no_shadowing(dir.path(), &[lib.path().to_path_buf()])
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("Agent (v2.0)"), "must name it: {err}");
-        assert!(
-            err.contains("agents.yaml") && err.contains(".md"),
-            "must name both sources so the reader can pick one: {err}"
-        );
+        let found = shadowing_conflict("Agent (v2.0)", &[lib.path().to_path_buf()]).unwrap();
+        assert_eq!(found, Some(file));
     }
 
     #[test]
-    fn distinct_names_are_fine() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path());
+    fn shadowing_conflict_is_none_for_distinct_names() {
         let lib = tempfile::tempdir().unwrap();
         std::fs::write(lib.path().join("other.md"), "# Other").unwrap();
-        assert!(check_no_shadowing(dir.path(), &[lib.path().to_path_buf()]).is_ok());
-    }
-
-    #[test]
-    fn a_project_without_declarations_never_shadows() {
-        let dir = tempfile::tempdir().unwrap();
-        let lib = tempfile::tempdir().unwrap();
-        std::fs::write(lib.path().join("a.md"), "# A").unwrap();
-        assert!(check_no_shadowing(dir.path(), &[lib.path().to_path_buf()]).is_ok());
+        assert_eq!(
+            shadowing_conflict("core-specialist", &[lib.path().to_path_buf()]).unwrap(),
+            None
+        );
     }
 
     /// A directory that simply does not exist (no local `agents/` in this
@@ -549,9 +594,11 @@ agents:
     #[test]
     fn a_missing_library_directory_is_not_an_error() {
         let dir = tempfile::tempdir().unwrap();
-        project(dir.path());
         let missing = dir.path().join("does-not-exist");
-        assert!(check_no_shadowing(dir.path(), &[missing]).is_ok());
+        assert_eq!(
+            shadowing_conflict("core-specialist", &[missing]).unwrap(),
+            None
+        );
     }
 
     /// The whole point of taking every candidate directory instead of one:
@@ -561,28 +608,28 @@ agents:
     /// cannot tolerate.
     #[test]
     fn a_collision_in_the_second_of_several_library_directories_is_caught() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path()); // declares `core-specialist`
         let lib1 = tempfile::tempdir().unwrap();
         std::fs::write(lib1.path().join("other.md"), "# Other").unwrap();
         let lib2 = tempfile::tempdir().unwrap();
-        std::fs::write(lib2.path().join("core-specialist.md"), "# Core").unwrap();
+        let file = lib2.path().join("core-specialist.md");
+        std::fs::write(&file, "# Core").unwrap();
         let lib3 = tempfile::tempdir().unwrap();
         std::fs::write(lib3.path().join("another.md"), "# Another").unwrap();
 
-        let err = check_no_shadowing(
-            dir.path(),
+        let found = shadowing_conflict(
+            "core-specialist",
             &[
                 lib1.path().to_path_buf(),
                 lib2.path().to_path_buf(),
                 lib3.path().to_path_buf(),
             ],
         )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("core-specialist"), "must name it: {err}");
+        .unwrap();
+        assert_eq!(found, Some(file));
     }
 
+    /// Symmetric check: a `- declared: x` entry must resolve to `Declared`,
+    /// not to one of the other three variants.
     /// Symmetric check: a `- declared: x` entry must resolve to `Declared`,
     /// not to one of the other three variants.
     #[test]
@@ -717,7 +764,7 @@ agents:
             "the healthy agent must survive: {errors:?}"
         );
         assert!(
-            errors.iter().any(|e| e.contains("broken")),
+            errors.iter().any(|e| e.message().contains("broken")),
             "the broken one must be reported by name: {errors:?}"
         );
     }
@@ -744,7 +791,9 @@ agents:
                 "a shadowed name must not be silently loaded from either side: {agents:?}"
             );
             assert!(
-                errors.iter().any(|e| e.contains("core-specialist")),
+                errors
+                    .iter()
+                    .any(|e| e.message().contains("core-specialist")),
                 "the collision must be reported: {errors:?}"
             );
         });
@@ -785,10 +834,111 @@ agents:
             assert!(
                 errors
                     .iter()
-                    .any(|e| e.contains("shadowed-one") && e.contains("agents.yaml")),
+                    .any(|e| e.message().contains("shadowed-one")
+                        && e.message().contains("agents.yaml")),
                 "the collision must be reported, naming both sources: {errors:?}"
             );
         });
+    }
+
+    /// Task 7b review, Regression 2: `armadai.yaml`'s `agents:` may list a
+    /// declared agent explicitly via `- declared: x` (for routes/teams to
+    /// point at deliberately) — that must never make the agent unloadable.
+    /// The first cut fed every `AgentRef`, `Declared` included, straight to
+    /// `resolve_all_agents`, which always refuses that variant by design;
+    /// the resulting "error" then permanently blocked `link` once Regression
+    /// 1 was fixed, even though the agent loads fine below via the
+    /// declarations block regardless of what `config.agents` names.
+    #[test]
+    fn a_declared_agentref_in_config_does_not_block_its_own_agent() {
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            project(dir.path()); // declares `core-specialist`, prompt: [base]
+            let config = crate::project::ProjectConfig {
+                agents: vec![AgentRef::Declared {
+                    declared: "core-specialist".into(),
+                }],
+                ..Default::default()
+            };
+
+            let (agents, warnings) = load_all_agents(&config, dir.path(), &fragments());
+            assert!(
+                agents.iter().any(|a| a.name == "core-specialist"),
+                "the declared agent must still load: warnings={warnings:?}"
+            );
+            assert!(
+                warnings.is_empty(),
+                "an explicit `declared:` ref naming a real declaration must not \
+                 produce any warning at all: {warnings:?}"
+            );
+        });
+    }
+
+    /// A whole-file YAML failure (as opposed to one bad declaration) cannot
+    /// be pinned on a single agent name, so it is classified
+    /// `DeclarationsUnreadable`, not `Dropped`.
+    #[test]
+    fn an_unparseable_agents_yaml_is_declarations_unreadable_not_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "agents:\n  - name: [unclosed\n",
+        )
+        .unwrap();
+        let config = crate::project::ProjectConfig::default();
+
+        let (agents, warnings) = load_all_agents(&config, dir.path(), &[]);
+        assert!(
+            agents.is_empty(),
+            "nothing could have been declared: {agents:?}"
+        );
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            matches!(warnings[0], LoadWarning::DeclarationsUnreadable(_)),
+            "must be DeclarationsUnreadable, not Dropped/PreExisting: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn blocks_a_write_ignores_a_pre_existing_failure() {
+        let warnings = vec![LoadWarning::PreExisting("some old .md broke".into())];
+        assert!(!blocks_a_write(&warnings, None));
+        assert!(!blocks_a_write(&warnings, Some(&["anything".to_string()])));
+    }
+
+    #[test]
+    fn blocks_a_write_is_unconditional_for_an_unreadable_declarations_file() {
+        let warnings = vec![LoadWarning::DeclarationsUnreadable("bad yaml".into())];
+        assert!(blocks_a_write(&warnings, None));
+        assert!(blocks_a_write(&warnings, Some(&["unrelated".to_string()])));
+    }
+
+    /// The Regression 1 fix itself: `--agents good` must not refuse a link
+    /// over a `bad` agent this chantier's format dropped, when `bad` was
+    /// never part of what is being written.
+    #[test]
+    fn blocks_a_write_scopes_a_dropped_agent_to_the_request() {
+        let warnings = vec![LoadWarning::Dropped {
+            agent: "bad".into(),
+            message: "bad is broken".into(),
+        }];
+        assert!(
+            blocks_a_write(&warnings, None),
+            "no filter means the whole fleet, including `bad`, was requested"
+        );
+        assert!(
+            !blocks_a_write(&warnings, Some(&["good".to_string()])),
+            "`bad` was never requested, so its drop must not block `good`"
+        );
+        assert!(
+            blocks_a_write(&warnings, Some(&["bad".to_string()])),
+            "`bad` WAS requested, so its own drop must block"
+        );
+        assert!(
+            blocks_a_write(&warnings, Some(&["BAD".to_string()])),
+            "the request match must be case-insensitive, like link's own --agents filter"
+        );
     }
 
     // -----------------------------------------------------------------
@@ -916,5 +1066,80 @@ agents:
                 "must name both sources so the reader can pick one: {err}"
             );
         });
+    }
+
+    /// Task 7b review, Regression 3: `load_agent_by_name` used to load the
+    /// yaml with `?` before ever looking at whether the name resolved as a
+    /// file, so a malformed `.armadai/agents.yaml` broke every file-backed
+    /// agent in the project, not just declared ones. An unparseable yaml
+    /// cannot declare `name`, so it cannot collide with a file-backed
+    /// `name` either — the file is unambiguous and must still be served.
+    #[test]
+    fn a_malformed_agents_yaml_does_not_break_a_file_backed_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "agents:
+  - name: [unclosed
+",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("sentinel.md"),
+            "# Sentinel Prime
+
+## Metadata
+- provider: cli
+- command: sentinel-cmd
+
+## System Prompt
+
+Guard the perimeter.
+",
+        )
+        .unwrap();
+        let config = crate::project::ProjectConfig {
+            agents: vec![AgentRef::Path {
+                path: std::path::PathBuf::from("sentinel.md"),
+            }],
+            ..Default::default()
+        };
+
+        let agent = load_agent_by_name("sentinel", &config, dir.path(), &[]).unwrap();
+        assert_eq!(agent.name, "Sentinel Prime");
+        assert_eq!(agent.metadata.command.as_deref(), Some("sentinel-cmd"));
+    }
+
+    /// The other half of Regression 3's ruling: when the name does NOT
+    /// resolve as a file either, the malformed yaml IS the reason to fail —
+    /// a working declaration could have provided this name — so its own
+    /// parse error, not a generic "not found", must be what the caller
+    /// sees.
+    #[test]
+    fn a_malformed_agents_yaml_fails_hard_when_the_name_is_not_a_file_either() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "agents:
+  - name: [unclosed
+",
+        )
+        .unwrap();
+        let config = crate::project::ProjectConfig::default();
+
+        let err = load_agent_by_name("nowhere", &config, dir.path(), &[])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("nowhere"), "must name the agent: {err}");
+        assert!(
+            err.contains("could not be read") && err.contains("agents.yaml"),
+            "must name the yaml as the reason, not a generic not-found: {err}"
+        );
+        assert!(
+            err.contains("cannot parse"),
+            "must surface the actual yaml error, not swallow it: {err}"
+        );
     }
 }

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -40,16 +40,7 @@ pub fn load_agent(
             anyhow::anyhow!("agent '{declared}' is not declared in {}", path.display())
         })?;
 
-    Ok(Agent {
-        name: decl.name.clone(),
-        source: path.clone(),
-        metadata: agent_decl::merge_metadata(decl, &decls.defaults)?,
-        system_prompt: agent_decl::compose_prompt(&decl.prompt, decl, fragments)?,
-        instructions: None,
-        output_format: None,
-        pipeline: None,
-        context: None,
-    })
+    agent_decl::to_agent(decl, &decls.defaults, fragments, path.clone())
 }
 
 #[cfg(test)]
@@ -113,6 +104,77 @@ mod tests {
             declared: "x".into(),
         };
         assert!(load_agent(&r, dir.path(), &[]).is_err());
+    }
+
+    /// Three declared agents with distinguishable metadata and prompts,
+    /// looked up by the middle name. `load_agent`'s
+    /// `.find(|a| &a.name == declared)` is correct by inspection against a
+    /// single-agent fixture, but that can't tell "found the right one" apart
+    /// from "returned the only one there was" — this fixture can, because
+    /// alpha's and gamma's values would make the assertions below fail just
+    /// as loudly as a completely wrong agent would.
+    #[test]
+    fn a_declared_ref_finds_the_middle_agent_among_several() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            r#"
+defaults:
+  provider: claude
+
+agents:
+  - name: alpha
+    description: the first agent
+    provider: claude
+    prompt: [alpha-frag]
+  - name: beta
+    description: the middle agent
+    provider: openai
+    model: gpt-5
+    prompt: [beta-frag]
+  - name: gamma
+    description: the last agent
+    provider: gemini
+    prompt: [gamma-frag]
+"#,
+        )
+        .unwrap();
+
+        let fragments = vec![
+            crate::prompt::Prompt {
+                name: "alpha-frag".into(),
+                description: None,
+                apply_to: vec![],
+                body: "Alpha body.".into(),
+                source: std::path::PathBuf::from("alpha.md"),
+            },
+            crate::prompt::Prompt {
+                name: "beta-frag".into(),
+                description: None,
+                apply_to: vec![],
+                body: "Beta body.".into(),
+                source: std::path::PathBuf::from("beta.md"),
+            },
+            crate::prompt::Prompt {
+                name: "gamma-frag".into(),
+                description: None,
+                apply_to: vec![],
+                body: "Gamma body.".into(),
+                source: std::path::PathBuf::from("gamma.md"),
+            },
+        ];
+
+        let r = AgentRef::Declared {
+            declared: "beta".into(),
+        };
+        let agent = load_agent(&r, dir.path(), &fragments).unwrap();
+
+        assert_eq!(agent.name, "beta");
+        // Neither alpha's nor gamma's provider/model/prompt — beta's own.
+        assert_eq!(agent.metadata.provider, "openai");
+        assert_eq!(agent.metadata.model, Some("gpt-5".to_string()));
+        assert_eq!(agent.system_prompt, "Beta body.");
     }
 
     /// `AgentRef` is `#[serde(untagged)]`. Adding `Declared` must not shift

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -275,6 +275,22 @@ pub fn load_all_agents(
     // the linker writes, not the raw name — checked once the whole fleet
     // above is assembled, since that is the earliest point both shapes exist
     // to compare.
+    //
+    // A shared slug is not automatically a collision, though: two
+    // `AgentRef`s can legitimately both resolve to the SAME agent (e.g.
+    // `- name: file-agent` and `- path: .armadai/agents/file-agent.md`
+    // naming the identical file) — that is one agent reached twice, and
+    // refusing it took an innocent, unrelated declared agent down with it
+    // in the very project this format is supposed to keep working. `source`
+    // alone cannot tell the two shapes apart for a DECLARED agent, though:
+    // every declaration in one `agents.yaml` shares that file as its
+    // `source`, so two distinct, genuinely colliding declarations would
+    // still look "the same" by source alone. `(source, name)` together is
+    // the right identity: the twice-listed file case parses the same file
+    // both times, so `name` (read from its H1) matches too; two DIFFERENT
+    // declarations sharing a slug via distinct spellings (`core-specialist`
+    // vs `Core Specialist`) keep distinct `name`s even though `source` is
+    // the one shared yaml file, so they are still caught.
     let mut by_slug: std::collections::HashMap<String, Vec<usize>> =
         std::collections::HashMap::new();
     for (i, a) in agents.iter().enumerate() {
@@ -288,19 +304,35 @@ pub fn load_all_agents(
         if idxs.len() < 2 {
             continue;
         }
+        let identity = |i: usize| (agents[i].source.as_path(), agents[i].name.as_str());
+        let mut distinct: Vec<(&std::path::Path, &str)> = Vec::new();
         for &i in idxs {
-            let others: Vec<String> = idxs
+            let key = identity(i);
+            if !distinct.contains(&key) {
+                distinct.push(key);
+            }
+        }
+        if distinct.len() < 2 {
+            // Every entry in this slug bucket is the same agent, reached
+            // through more than one `AgentRef` — not a collision.
+            continue;
+        }
+        for &i in idxs {
+            let this = identity(i);
+            let others: Vec<String> = distinct
                 .iter()
-                .filter(|&&j| j != i)
-                .map(|&j| format!("'{}'", agents[j].name))
+                .filter(|&&other| other != this)
+                .map(|(source, name)| format!("'{name}' (from '{}')", source.display()))
                 .collect();
             warnings.push(LoadWarning::Dropped {
                 agent: agents[i].name.clone(),
                 message: format!(
-                    "agent '{}' projects to the same slug as {} — remove or \
-                     rename one; there is deliberately no precedence between them",
+                    "agent '{}' (from '{}') projects to the same slug as {} — \
+                     remove or rename one; there is deliberately no precedence \
+                     between them",
                     agents[i].name,
-                    others.join(", ")
+                    agents[i].source.display(),
+                    others.join(" and ")
                 ),
             });
         }
@@ -958,6 +990,56 @@ agents:
                     .count(),
                 2,
                 "both sides of the collision must be reported: {warnings:?}"
+            );
+        });
+    }
+
+    /// I4 regression (re-review): the SAME agent listed twice via two
+    /// different `AgentRef`s — `- name: file-agent` and `- path:
+    /// .armadai/agents/file-agent.md`, both resolving to the identical
+    /// file — must not be flagged as a collision. Comparing by slug alone
+    /// cannot tell "two spellings of one agent" apart from "two different
+    /// agents"; the fix is `(source, name)` identity, checked here alongside
+    /// an unrelated declared agent to prove the innocent agent does not get
+    /// dropped as collateral damage the way it did before this fix.
+    #[test]
+    fn load_all_agents_does_not_flag_the_same_agent_listed_twice() {
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            project(dir.path()); // declares `core-specialist`, unrelated
+            let md_dir = dir.path().join(".armadai/agents");
+            std::fs::create_dir_all(&md_dir).unwrap();
+            std::fs::write(
+                md_dir.join("file-agent.md"),
+                "# file-agent\n\n## Metadata\n- provider: claude\n\n\
+                 ## System Prompt\n\nHi\n",
+            )
+            .unwrap();
+            let config = crate::project::ProjectConfig {
+                agents: vec![
+                    AgentRef::Named {
+                        name: "file-agent".into(),
+                    },
+                    AgentRef::Path {
+                        path: std::path::PathBuf::from(".armadai/agents/file-agent.md"),
+                    },
+                ],
+                ..Default::default()
+            };
+
+            let (agents, warnings) = load_all_agents(&config, dir.path(), &fragments());
+            assert!(
+                warnings.is_empty(),
+                "listing the same agent twice must not warn: {warnings:?}"
+            );
+            assert!(
+                agents.iter().any(|a| a.name == "file-agent"),
+                "the twice-listed agent must still load: {agents:?}"
+            );
+            assert!(
+                agents.iter().any(|a| a.name == "core-specialist"),
+                "an unrelated declared agent must not be dropped as collateral \
+                 damage: {agents:?}"
             );
         });
     }

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -6,7 +6,7 @@
 //! that `resolve_agent` fails for one. This module is for callers that want the
 //! agent, not its file.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::agent::Agent;
 use crate::agent_decl;
@@ -50,24 +50,64 @@ pub fn load_agent(
 /// duplicated truth this format exists to remove, and you would edit a `.md`
 /// with no effect and nothing to tell you. Failing forces a choice.
 ///
+/// Two refinements over a naive `library.join(name + ".md")` existence
+/// check, both load-bearing:
+///
+/// - Names are compared as **slugs** (`agent::slugify`), not as raw
+///   strings. The linker projects every agent name through the same
+///   `slugify` to name its output file, so a declaration `Core-Specialist`
+///   and a file `core-specialist.md` — or a declaration `Agent (v2.0)` and
+///   a file `agent-v20.md` — land on the *same* filename at link time even
+///   though they are not byte-for-byte equal. Comparing raw names would
+///   pass both cases and let one silently overwrite the other later; only
+///   comparing slugs matches what actually happens on disk.
+/// - `libraries` takes **every** directory a file-backed agent can resolve
+///   from (see `project::resolve_agent`'s `Named` arm: `.armadai/agents/`,
+///   legacy `agents/`, and the user library), not just one. A caller that
+///   checks a single directory can believe the refusal is complete when it
+///   is not — and a later resolution step that tries file-backed agents
+///   first and declarations second, with no precedence rule, is only safe
+///   if a name shared with *any* of them has already failed here.
+///
+/// A library directory that does not exist is not an error — a project
+/// with no local `agents/` directory is normal. A directory that exists
+/// but cannot be read (permissions, not a directory after all) *is*
+/// propagated as an error: unlike "there is nothing there", "it would not
+/// tell me" is exactly the kind of silent gap this function exists to
+/// close.
+///
 /// Rule `C01` of the audit already reports name collisions; loading must
 /// refuse them.
-pub fn check_no_shadowing(project_root: &Path, library: &Path) -> anyhow::Result<()> {
+pub fn check_no_shadowing(project_root: &Path, libraries: &[PathBuf]) -> anyhow::Result<()> {
     let decls_path = declarations_path(project_root);
     if !decls_path.is_file() {
         return Ok(());
     }
     let decls = agent_decl::load(&decls_path)?;
     for decl in &decls.agents {
-        let file = library.join(format!("{}.md", decl.name));
-        if file.is_file() {
-            anyhow::bail!(
-                "agent '{}' is declared in {} and also written as {} — \
-                 remove one; there is deliberately no precedence between them",
-                decl.name,
-                decls_path.display(),
-                file.display()
-            );
+        let decl_slug = crate::agent::slugify(&decl.name);
+        for library in libraries {
+            if !library.is_dir() {
+                continue;
+            }
+            for entry in std::fs::read_dir(library)? {
+                let path = entry?.path();
+                if !path.extension().is_some_and(|ext| ext == "md") {
+                    continue;
+                }
+                let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                    continue;
+                };
+                if crate::agent::slugify(stem) == decl_slug {
+                    anyhow::bail!(
+                        "agent '{}' is declared in {} and also written as {} — \
+                         remove one; there is deliberately no precedence between them",
+                        decl.name,
+                        decls_path.display(),
+                        path.display()
+                    );
+                }
+            }
         }
     }
     Ok(())
@@ -234,12 +274,62 @@ agents:
         )
         .unwrap();
 
-        let err = check_no_shadowing(dir.path(), lib.path())
+        let err = check_no_shadowing(dir.path(), &[lib.path().to_path_buf()])
             .unwrap_err()
             .to_string();
         assert!(err.contains("core-specialist"), "must name it: {err}");
         // The point is that neither wins — say so, or the reader will assume
         // one does.
+        assert!(
+            err.contains("agents.yaml") && err.contains(".md"),
+            "must name both sources so the reader can pick one: {err}"
+        );
+    }
+
+    /// A declaration and a library file that only match once both are
+    /// lowercased — on a case-insensitive filesystem (macOS/Windows
+    /// default) a raw-filename existence check already caught this by
+    /// accident; on a case-sensitive one (Linux CI) it would not, and the
+    /// two would silently collide at link time instead. Comparing slugs
+    /// makes the outcome the same on every platform.
+    #[test]
+    fn a_declared_name_collides_with_a_file_that_only_differs_in_case() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path()); // declares `core-specialist`
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(lib.path().join("Core-Specialist.md"), "# Core").unwrap();
+
+        let err = check_no_shadowing(dir.path(), &[lib.path().to_path_buf()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("core-specialist"), "must name it: {err}");
+        assert!(
+            err.contains("agents.yaml") && err.contains(".md"),
+            "must name both sources so the reader can pick one: {err}"
+        );
+    }
+
+    /// A declaration and a library file that only collide once punctuation
+    /// and whitespace are folded to `-`, exactly as the linker's `slugify`
+    /// does when it names the output file. Neither a raw-name comparison
+    /// nor a case-insensitive one would catch this.
+    #[test]
+    fn a_declared_name_collides_with_a_file_only_after_slug_folding() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: \"Agent (v2.0)\"\n    description: d\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(lib.path().join("agent-v20.md"), "# Agent").unwrap();
+
+        let err = check_no_shadowing(dir.path(), &[lib.path().to_path_buf()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Agent (v2.0)"), "must name it: {err}");
         assert!(
             err.contains("agents.yaml") && err.contains(".md"),
             "must name both sources so the reader can pick one: {err}"
@@ -252,7 +342,7 @@ agents:
         project(dir.path());
         let lib = tempfile::tempdir().unwrap();
         std::fs::write(lib.path().join("other.md"), "# Other").unwrap();
-        assert!(check_no_shadowing(dir.path(), lib.path()).is_ok());
+        assert!(check_no_shadowing(dir.path(), &[lib.path().to_path_buf()]).is_ok());
     }
 
     #[test]
@@ -260,7 +350,46 @@ agents:
         let dir = tempfile::tempdir().unwrap();
         let lib = tempfile::tempdir().unwrap();
         std::fs::write(lib.path().join("a.md"), "# A").unwrap();
-        assert!(check_no_shadowing(dir.path(), lib.path()).is_ok());
+        assert!(check_no_shadowing(dir.path(), &[lib.path().to_path_buf()]).is_ok());
+    }
+
+    /// A directory that simply does not exist (no local `agents/` in this
+    /// project) must not be treated as an error — it is the common case.
+    #[test]
+    fn a_missing_library_directory_is_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let missing = dir.path().join("does-not-exist");
+        assert!(check_no_shadowing(dir.path(), &[missing]).is_ok());
+    }
+
+    /// The whole point of taking every candidate directory instead of one:
+    /// a fix that only checked `libraries[0]` would pass this test right up
+    /// until the collision moved to the second or third directory, which is
+    /// exactly the gap a name-resolution step with no precedence rule
+    /// cannot tolerate.
+    #[test]
+    fn a_collision_in_the_second_of_several_library_directories_is_caught() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path()); // declares `core-specialist`
+        let lib1 = tempfile::tempdir().unwrap();
+        std::fs::write(lib1.path().join("other.md"), "# Other").unwrap();
+        let lib2 = tempfile::tempdir().unwrap();
+        std::fs::write(lib2.path().join("core-specialist.md"), "# Core").unwrap();
+        let lib3 = tempfile::tempdir().unwrap();
+        std::fs::write(lib3.path().join("another.md"), "# Another").unwrap();
+
+        let err = check_no_shadowing(
+            dir.path(),
+            &[
+                lib1.path().to_path_buf(),
+                lib2.path().to_path_buf(),
+                lib3.path().to_path_buf(),
+            ],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("core-specialist"), "must name it: {err}");
     }
 
     /// Symmetric check: a `- declared: x` entry must resolve to `Declared`,

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -85,32 +85,57 @@ pub fn check_no_shadowing(project_root: &Path, libraries: &[PathBuf]) -> anyhow:
     }
     let decls = agent_decl::load(&decls_path)?;
     for decl in &decls.agents {
-        let decl_slug = crate::agent::slugify(&decl.name);
-        for library in libraries {
-            if !library.is_dir() {
-                continue;
-            }
-            for entry in std::fs::read_dir(library)? {
-                let path = entry?.path();
-                if !path.extension().is_some_and(|ext| ext == "md") {
-                    continue;
-                }
-                let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-                    continue;
-                };
-                if crate::agent::slugify(stem) == decl_slug {
-                    anyhow::bail!(
-                        "agent '{}' is declared in {} and also written as {} — \
-                         remove one; there is deliberately no precedence between them",
-                        decl.name,
-                        decls_path.display(),
-                        path.display()
-                    );
-                }
-            }
+        if let Some(collision) = shadowing_conflict(&decl.name, libraries)? {
+            anyhow::bail!(shadowing_message(&decl.name, &decls_path, &collision));
         }
     }
     Ok(())
+}
+
+/// Does `name` (compared as a slug) collide with a `.md` file in any of
+/// `libraries`? Returns the colliding file's path if so, `None` otherwise.
+///
+/// Factored out of `check_no_shadowing` so a single-name check —
+/// `load_agent_by_name` needs one for just the name it is resolving,
+/// `load_all_agents` needs one per declaration so a single collision costs
+/// only that declaration — and a whole-fleet check (`check_no_shadowing`
+/// itself, still used as a fast go/no-op reusable check) share one
+/// slug-comparison, one skip-missing-directory rule, and one skip-non-`.md`
+/// rule, rather than three copies that could drift.
+fn shadowing_conflict(name: &str, libraries: &[PathBuf]) -> anyhow::Result<Option<PathBuf>> {
+    let slug = crate::agent::slugify(name);
+    for library in libraries {
+        if !library.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(library)? {
+            let path = entry?.path();
+            if !path.extension().is_some_and(|ext| ext == "md") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if crate::agent::slugify(stem) == slug {
+                return Ok(Some(path));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// The message used whenever a declared name collides with a file-backed
+/// agent — shared by `check_no_shadowing`, `load_all_agents`, and
+/// `load_agent_by_name` so the wording (and the fact that neither side is
+/// given precedence) can't drift across the three collision-detection call
+/// sites.
+fn shadowing_message(decl_name: &str, decls_path: &Path, file_path: &Path) -> String {
+    format!(
+        "agent '{decl_name}' is declared in {} and also written as {} — \
+         remove one; there is deliberately no precedence between them",
+        decls_path.display(),
+        file_path.display()
+    )
 }
 
 /// Every prompt fragment a project's declarations can reference, gathered
@@ -126,13 +151,8 @@ pub fn check_no_shadowing(project_root: &Path, libraries: &[PathBuf]) -> anyhow:
 pub fn project_fragments(project_root: &Path) -> Vec<Prompt> {
     let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
-    let tiers = [
-        project_root.join(".armadai").join("prompts"),
-        project_root.join("prompts"),
-        crate::config::user_prompts_dir(),
-    ];
-    for dir in &tiers {
-        for p in crate::prompt::load_all_prompts(dir) {
+    for dir in crate::project::prompt_dirs(project_root) {
+        for p in crate::prompt::load_all_prompts(&dir) {
             if seen.insert(p.name.clone()) {
                 out.push(p);
             }
@@ -146,14 +166,14 @@ pub fn project_fragments(project_root: &Path) -> Vec<Prompt> {
 /// Same `(values, non-fatal errors)` shape as `resolve_all_agents`, so callers
 /// keep their existing warning loop. A broken declaration costs its own agent,
 /// never the whole fleet — a fleet that vanishes because one agent has a typo
-/// is worse than a fleet with a gap and a warning.
-///
-/// `check_no_shadowing` runs first, over `project::library_dirs` (the same
-/// list `resolve_agent` resolves file-backed agents from) — a name declared
-/// AND written as a file is refused outright rather than silently loaded
-/// twice or arbitrarily once. That refusal is what makes `load_agent_by_name`
-/// safe to try file-backed agents before declarations with no precedence
-/// rule: if both existed, loading already failed here.
+/// is worse than a fleet with a gap and a warning. **This is true of a
+/// shadowing collision too**: it costs only the colliding declaration (with a
+/// warning naming both sources, via `shadowing_message`), not every other
+/// declared agent — the first cut of this function bailed out of the whole
+/// declarations block on the first collision found, which meant one
+/// accidental collision (plausibly against a file the project doesn't even
+/// own, since the check spans the user's whole global library) silently
+/// dropped every other declared agent while callers kept exiting 0.
 pub fn load_all_agents(
     config: &crate::project::ProjectConfig,
     root: &Path,
@@ -170,13 +190,21 @@ pub fn load_all_agents(
 
     let decls_path = declarations_path(root);
     if decls_path.is_file() {
-        if let Err(e) = check_no_shadowing(root, &crate::project::library_dirs(root)) {
-            errors.push(format!("{e}"));
-            return (agents, errors);
-        }
+        let libraries = crate::project::library_dirs(root);
         match agent_decl::load(&decls_path) {
             Ok(decls) => {
                 for decl in &decls.agents {
+                    match shadowing_conflict(&decl.name, &libraries) {
+                        Ok(Some(collision)) => {
+                            errors.push(shadowing_message(&decl.name, &decls_path, &collision));
+                            continue;
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            errors.push(format!("{e}"));
+                            continue;
+                        }
+                    }
                     match agent_decl::to_agent(decl, &decls.defaults, fragments, decls_path.clone())
                     {
                         Ok(a) => agents.push(a),
@@ -196,10 +224,13 @@ pub fn load_all_agents(
 /// Resolution order: file-backed first — a config `AgentRef` matching `name`
 /// (mirroring `AgentResolution::Project`'s own ref-matching in `cli::run` and
 /// `cli::inspect`, which this replaces), or failing that a bare `Named`
-/// lookup — then the project's declarations. Because `check_no_shadowing`
-/// (wired into `load_all_agents`) refuses a name that exists in both, this
-/// order never has to arbitrate a real collision: if both existed, loading
-/// already failed elsewhere. There is deliberately no precedence rule here.
+/// lookup — then the project's declarations. There is deliberately no
+/// precedence rule for a name that resolves both ways: this function refuses
+/// it outright (see the `shadowing_conflict` check below), the same refusal
+/// `load_all_agents` applies per-declaration and `check_no_shadowing` applies
+/// fleet-wide — a name ambiguous enough to fail `link`/`list` must fail
+/// `run`/`inspect` too, not silently resolve to whichever side is tried
+/// first.
 ///
 /// A `config.agents` entry of `AgentRef::Declared` matching `name` is never
 /// handed to `resolve_agent` (which always refuses that variant) — it is
@@ -228,24 +259,49 @@ pub fn load_agent_by_name(
         ),
     };
 
-    let file_err = match file_result {
-        Ok(path) => return crate::parser::parse_agent_file(&path),
-        Err(e) => e,
-    };
-
     let decls_path = declarations_path(project_root);
-    if decls_path.is_file() {
-        let decls = agent_decl::load(&decls_path)?;
-        if let Some(decl) = decls.agents.iter().find(|a| a.name == name) {
-            return agent_decl::to_agent(decl, &decls.defaults, fragments, decls_path);
-        }
+    let decls = if decls_path.is_file() {
+        Some(agent_decl::load(&decls_path)?)
+    } else {
+        None
+    };
+    let declared = decls
+        .as_ref()
+        .and_then(|d| d.agents.iter().find(|a| a.name == name));
+
+    // Collision check scoped to just this one name — no need to scan the
+    // whole fleet the way `check_no_shadowing` does for `load_all_agents`.
+    // Checked against `project::library_dirs` directly, not against whether
+    // `file_result` happened to succeed: an explicit `path:`/`registry:` ref
+    // pointing outside those library dirs is not the ambiguity
+    // `check_no_shadowing` polices, and using `file_result` here would let
+    // `run`/`inspect` accept a name `link`/`list` refuse (or the reverse).
+    if declared.is_some()
+        && let Some(collision) =
+            shadowing_conflict(name, &crate::project::library_dirs(project_root))?
+    {
+        anyhow::bail!(shadowing_message(name, &decls_path, &collision));
     }
 
-    anyhow::bail!(
-        "agent '{name}' not found: not resolvable as a file ({file_err}), \
-         and not declared in {}",
-        decls_path.display()
-    );
+    match file_result {
+        Ok(path) => crate::parser::parse_agent_file(&path),
+        Err(file_err) => match declared {
+            Some(decl) => agent_decl::to_agent(
+                decl,
+                &decls
+                    .as_ref()
+                    .expect("declared borrows from decls")
+                    .defaults,
+                fragments,
+                decls_path,
+            ),
+            None => anyhow::bail!(
+                "agent '{name}' not found: not resolvable as a file ({file_err}), \
+                 and not declared in {}",
+                decls_path.display()
+            ),
+        },
+    }
 }
 
 #[cfg(test)]
@@ -545,6 +601,37 @@ agents:
     // load_all_agents
     // -----------------------------------------------------------------
 
+    /// Point the global agent library (`ARMADAI_CONFIG_DIR`) at an empty
+    /// temp dir for the duration of `f`.
+    ///
+    /// `load_all_agents`'s real `library_dirs(root)` always includes
+    /// `user_agents_dir()` — on a machine that has ever run `armadai
+    /// extract`/`init` from this very repo, that is a REAL directory
+    /// holding this project's own team agents (`core-specialist.md`
+    /// included). A test exercising `load_all_agents` without isolating
+    /// this can pass — or fail — for a reason that has nothing to do with
+    /// its own fixture, and would behave differently on a machine that has
+    /// never run those commands. Serialised via `ENV_MUTEX` since it
+    /// mutates a process-global env var.
+    fn with_isolated_global_library<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = crate::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        let empty = tempfile::tempdir().unwrap();
+        // SAFETY: serialised via ENV_MUTEX above.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", empty.path());
+        }
+        let result = f();
+        // SAFETY: restoring original env state, still under the guard.
+        unsafe {
+            match &orig {
+                Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
+                None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
+            }
+        }
+        result
+    }
+
     /// Build a `ProjectConfig` whose agent list holds one `AgentRef::Path`,
     /// following `project.rs`'s own `test_resolve_all_agents` construction
     /// rather than inventing a second way to build one.
@@ -563,30 +650,32 @@ agents:
     /// A project with one `.md` agent and one declared agent must yield both.
     #[test]
     fn declared_and_file_agents_are_loaded_together() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
-        std::fs::write(
-            dir.path().join(".armadai/agents.yaml"),
-            "defaults:\n  provider: claude\nagents:\n  - name: declared-one\n    prompt: [base]\n",
-        )
-        .unwrap();
-        let md_dir = dir.path().join("agents");
-        std::fs::create_dir_all(&md_dir).unwrap();
-        std::fs::write(
-            md_dir.join("file-one.md"),
-            "# file-one\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
-        )
-        .unwrap();
-        let config = config_listing_agent_path(dir.path(), "agents/file-one.md");
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+            std::fs::write(
+                dir.path().join(".armadai/agents.yaml"),
+                "defaults:\n  provider: claude\nagents:\n  - name: declared-one\n    prompt: [base]\n",
+            )
+            .unwrap();
+            let md_dir = dir.path().join("agents");
+            std::fs::create_dir_all(&md_dir).unwrap();
+            std::fs::write(
+                md_dir.join("file-one.md"),
+                "# file-one\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
+            )
+            .unwrap();
+            let config = config_listing_agent_path(dir.path(), "agents/file-one.md");
 
-        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
-        let mut names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
-        names.sort_unstable();
-        assert_eq!(
-            names,
-            vec!["declared-one", "file-one"],
-            "errors: {errors:?}"
-        );
+            let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+            let mut names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
+            names.sort_unstable();
+            assert_eq!(
+                names,
+                vec!["declared-one", "file-one"],
+                "errors: {errors:?}"
+            );
+        });
     }
 
     /// A project with no declarations must behave exactly as before.
@@ -635,24 +724,71 @@ agents:
 
     /// A declared agent and a same-named file must still refuse to load at
     /// all via `load_all_agents` — the shadowing check now actually runs.
+    /// The file that collides is local to the fixture (`agents/`), but the
+    /// check spans `library_dirs`, which also includes the real global
+    /// library — isolated here so THIS fixture is what makes the test pass,
+    /// not whatever happens to be installed on the machine running it.
     #[test]
     fn load_all_agents_refuses_a_shadowed_declaration() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path()); // declares `core-specialist`
-        let md_dir = dir.path().join("agents");
-        std::fs::create_dir_all(&md_dir).unwrap();
-        std::fs::write(md_dir.join("core-specialist.md"), "# Core").unwrap();
-        let config = crate::project::ProjectConfig::default();
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            project(dir.path()); // declares `core-specialist`
+            let md_dir = dir.path().join("agents");
+            std::fs::create_dir_all(&md_dir).unwrap();
+            std::fs::write(md_dir.join("core-specialist.md"), "# Core").unwrap();
+            let config = crate::project::ProjectConfig::default();
 
-        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
-        assert!(
-            agents.iter().all(|a| a.name != "core-specialist"),
-            "a shadowed name must not be silently loaded from either side: {agents:?}"
-        );
-        assert!(
-            errors.iter().any(|e| e.contains("core-specialist")),
-            "the collision must be reported: {errors:?}"
-        );
+            let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+            assert!(
+                agents.iter().all(|a| a.name != "core-specialist"),
+                "a shadowed name must not be silently loaded from either side: {agents:?}"
+            );
+            assert!(
+                errors.iter().any(|e| e.contains("core-specialist")),
+                "the collision must be reported: {errors:?}"
+            );
+        });
+    }
+
+    /// A collision must cost only the colliding declaration — every other
+    /// declared agent, including ones declared alongside it in the same
+    /// `agents.yaml`, must still load. This is the Finding-1 regression: the
+    /// first cut of `load_all_agents` bailed on the whole declarations block
+    /// at the first collision, dropping every declared agent, not just the
+    /// colliding one.
+    #[test]
+    fn a_shadowing_collision_costs_only_its_own_declaration_not_the_fleet() {
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+            std::fs::write(
+                dir.path().join(".armadai/agents.yaml"),
+                "defaults:\n  provider: claude\nagents:\n  \
+                 - name: shadowed-one\n    prompt: [base]\n  \
+                 - name: healthy-one\n    prompt: [base]\n",
+            )
+            .unwrap();
+            let md_dir = dir.path().join("agents");
+            std::fs::create_dir_all(&md_dir).unwrap();
+            std::fs::write(md_dir.join("shadowed-one.md"), "# Shadowed").unwrap();
+            let config = crate::project::ProjectConfig::default();
+
+            let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+            assert!(
+                agents.iter().any(|a| a.name == "healthy-one"),
+                "the un-shadowed declaration must survive: agents={agents:?} errors={errors:?}"
+            );
+            assert!(
+                agents.iter().all(|a| a.name != "shadowed-one"),
+                "the shadowed name must not load from either side: {agents:?}"
+            );
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.contains("shadowed-one") && e.contains("agents.yaml")),
+                "the collision must be reported, naming both sources: {errors:?}"
+            );
+        });
     }
 
     // -----------------------------------------------------------------
@@ -752,5 +888,33 @@ agents:
             err.contains("not found") || err.contains("not resolvable"),
             "must say it looked for a file too: {err}"
         );
+    }
+
+    /// The reachability premise ("files first, then declarations, no
+    /// precedence rule") only holds if a name shared by both has already
+    /// been refused. Before Finding 2's fix, `load_agent_by_name` never
+    /// checked, so `run`/`inspect` silently picked the file-backed side of
+    /// a name that `link`/`list` (via `check_no_shadowing`) already refuse —
+    /// two commands disagreeing about whether the exact same project is
+    /// valid.
+    #[test]
+    fn load_agent_by_name_refuses_a_shadowed_name() {
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            project(dir.path()); // declares `core-specialist`
+            let md_dir = dir.path().join("agents");
+            std::fs::create_dir_all(&md_dir).unwrap();
+            std::fs::write(md_dir.join("core-specialist.md"), "# Core").unwrap();
+            let config = crate::project::ProjectConfig::default();
+
+            let err = load_agent_by_name("core-specialist", &config, dir.path(), &fragments())
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("core-specialist"), "must name it: {err}");
+            assert!(
+                err.contains("agents.yaml") && err.contains(".md"),
+                "must name both sources so the reader can pick one: {err}"
+            );
+        });
     }
 }

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -46,13 +46,13 @@ pub fn load_agent(
 /// Does `name` (compared as a slug) collide with a `.md` file in any of
 /// `libraries`? Returns the colliding file's path if so, `None` otherwise.
 ///
-/// Factored out of `check_no_shadowing` so a single-name check —
-/// `load_agent_by_name` needs one for just the name it is resolving,
-/// `load_all_agents` needs one per declaration so a single collision costs
-/// only that declaration — and a whole-fleet check (`check_no_shadowing`
-/// itself, still used as a fast go/no-op reusable check) share one
-/// slug-comparison, one skip-missing-directory rule, and one skip-non-`.md`
-/// rule, rather than three copies that could drift.
+/// The one collision-detection primitive both real callers need, each at a
+/// different granularity: `load_agent_by_name` calls it once for just the
+/// name it is resolving; `load_all_agents` calls it once per declaration, so
+/// a single collision costs only that declaration rather than the whole
+/// fleet. One slug-comparison, one skip-missing-directory rule, and one
+/// skip-non-`.md` rule shared between them, rather than two copies that
+/// could drift.
 fn shadowing_conflict(name: &str, libraries: &[PathBuf]) -> anyhow::Result<Option<PathBuf>> {
     let slug = crate::agent::slugify(name);
     for library in libraries {
@@ -76,10 +76,9 @@ fn shadowing_conflict(name: &str, libraries: &[PathBuf]) -> anyhow::Result<Optio
 }
 
 /// The message used whenever a declared name collides with a file-backed
-/// agent — shared by `check_no_shadowing`, `load_all_agents`, and
-/// `load_agent_by_name` so the wording (and the fact that neither side is
-/// given precedence) can't drift across the three collision-detection call
-/// sites.
+/// agent — shared by `load_all_agents` and `load_agent_by_name` so the
+/// wording (and the fact that neither side is given precedence) can't drift
+/// across the two collision-detection call sites.
 fn shadowing_message(decl_name: &str, decls_path: &Path, file_path: &Path) -> String {
     format!(
         "agent '{decl_name}' is declared in {} and also written as {} — \
@@ -289,9 +288,12 @@ pub fn load_all_agents(
 /// An unreadable `.armadai/agents.yaml` does not fail this function on its
 /// own: it cannot declare `name`, so it cannot collide with a file-backed
 /// `name` either. When the file-backed lookup ALSO succeeds, that `.md` is
-/// unambiguous and is served, with a warning (`tracing::warn!`) so the
-/// broken yaml is not silently invisible. Only when the file-backed lookup
-/// fails too does the yaml error become the reason to fail — a working
+/// unambiguous and is served, alongside a [`LoadWarning`] so the broken yaml
+/// is not silently invisible — returned rather than printed here, so the
+/// CLI (`cli::run`/`cli::inspect`) renders it in its own voice
+/// (`cli::style::warn`) instead of core reaching a user's terminal directly
+/// with a bare `tracing::warn!` line. Only when the file-backed lookup fails
+/// too does the yaml error become the reason to fail — a working
 /// declaration could have provided this name, so its parse error, not a
 /// generic "not found", is what the caller needs to see.
 pub fn load_agent_by_name(
@@ -299,7 +301,7 @@ pub fn load_agent_by_name(
     config: &crate::project::ProjectConfig,
     project_root: &Path,
     fragments: &[Prompt],
-) -> anyhow::Result<Agent> {
+) -> anyhow::Result<(Agent, Option<LoadWarning>)> {
     let matched_ref = config.agents.iter().find(|r| match r {
         AgentRef::Named { name: n } => n == name,
         AgentRef::Path { path } => path.file_stem().is_some_and(|s| s == name),
@@ -330,12 +332,12 @@ pub fn load_agent_by_name(
     if let Some(decls_err) = decls_err {
         return match file_result {
             Ok(path) => {
-                tracing::warn!(
+                let warning = LoadWarning::DeclarationsUnreadable(format!(
                     "ignoring unparsable {}: {decls_err} (serving the file-backed agent \
                      '{name}' instead)",
                     decls_path.display()
-                );
-                crate::parser::parse_agent_file(&path)
+                ));
+                crate::parser::parse_agent_file(&path).map(|a| (a, Some(warning)))
             }
             Err(file_err) => Err(anyhow::anyhow!(
                 "agent '{name}' not found as a file ({file_err}), and {} could not be read: \
@@ -350,8 +352,8 @@ pub fn load_agent_by_name(
         .and_then(|d| d.agents.iter().find(|a| a.name == name));
 
     // Collision check scoped to just this one name — no need to scan the
-    // whole fleet the way `check_no_shadowing` does for a full project
-    // validation. Checked against `project::library_dirs` directly, not
+    // whole fleet the way `load_all_agents` does, one declaration at a
+    // time. Checked against `project::library_dirs` directly, not
     // against whether `file_result` happened to succeed: an explicit
     // `path:`/`registry:` ref pointing outside those library dirs is not
     // the ambiguity this collision check polices, and using `file_result`
@@ -365,7 +367,7 @@ pub fn load_agent_by_name(
     }
 
     match file_result {
-        Ok(path) => crate::parser::parse_agent_file(&path),
+        Ok(path) => crate::parser::parse_agent_file(&path).map(|a| (a, None)),
         Err(file_err) => match declared {
             Some(decl) => agent_decl::to_agent(
                 decl,
@@ -375,7 +377,8 @@ pub fn load_agent_by_name(
                     .defaults,
                 fragments,
                 decls_path,
-            ),
+            )
+            .map(|a| (a, None)),
             None => anyhow::bail!(
                 "agent '{name}' not found: not resolvable as a file ({file_err}), \
                  and not declared in {}",
@@ -968,9 +971,13 @@ agents:
         .unwrap();
         let config = crate::project::ProjectConfig::default();
 
-        let agent =
+        let (agent, warning) =
             load_agent_by_name("zzz-declared-only-agent", &config, dir.path(), &fragments())
                 .unwrap();
+        assert!(
+            warning.is_none(),
+            "a clean project must not warn: {warning:?}"
+        );
         assert_eq!(agent.name, "zzz-declared-only-agent");
         assert_eq!(agent.system_prompt, "You are zzz-declared-only-agent.");
         assert_eq!(agent.metadata.provider, "claude");
@@ -1004,7 +1011,11 @@ agents:
             ..Default::default()
         };
 
-        let agent = load_agent_by_name("sentinel", &config, dir.path(), &[]).unwrap();
+        let (agent, warning) = load_agent_by_name("sentinel", &config, dir.path(), &[]).unwrap();
+        assert!(
+            warning.is_none(),
+            "a clean project must not warn: {warning:?}"
+        );
         assert_eq!(agent.name, "Sentinel Prime");
         assert_eq!(agent.metadata.provider, "cli");
         assert_eq!(agent.metadata.command.as_deref(), Some("sentinel-cmd"));
@@ -1044,9 +1055,9 @@ agents:
     /// precedence rule") only holds if a name shared by both has already
     /// been refused. Before Finding 2's fix, `load_agent_by_name` never
     /// checked, so `run`/`inspect` silently picked the file-backed side of
-    /// a name that `link`/`list` (via `check_no_shadowing`) already refuse —
-    /// two commands disagreeing about whether the exact same project is
-    /// valid.
+    /// a name that `link`/`list` (via `load_all_agents`'s own per-declaration
+    /// check) already refuse — two commands disagreeing about whether the
+    /// exact same project is valid.
     #[test]
     fn load_agent_by_name_refuses_a_shadowed_name() {
         with_isolated_global_library(|| {
@@ -1106,7 +1117,12 @@ Guard the perimeter.
             ..Default::default()
         };
 
-        let agent = load_agent_by_name("sentinel", &config, dir.path(), &[]).unwrap();
+        let (agent, warning) = load_agent_by_name("sentinel", &config, dir.path(), &[]).unwrap();
+        assert!(
+            matches!(warning, Some(LoadWarning::DeclarationsUnreadable(_))),
+            "the malformed yaml must surface as a warning, not be silently \
+             dropped: {warning:?}"
+        );
         assert_eq!(agent.name, "Sentinel Prime");
         assert_eq!(agent.metadata.command.as_deref(), Some("sentinel-cmd"));
     }

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -18,29 +18,27 @@ pub fn declarations_path(project_root: &Path) -> std::path::PathBuf {
     project_root.join(".armadai").join("agents.yaml")
 }
 
-/// Load an agent, from a file or from the project's declarations.
-pub fn load_agent(
-    r: &AgentRef,
+/// Does this project count as declaring agents at all — via `armadai.yaml`'s
+/// `agents:` list, or via any declaration in `.armadai/agents.yaml`?
+///
+/// Every declared agent is included automatically (it does not need to be
+/// relisted in `agents:` — that would duplicate the declaration this format
+/// exists to remove), so a project relying purely on this format — an
+/// empty or absent `agents:` list — must still count as declaring agents,
+/// rather than being treated as having none.
+///
+/// The single boolean `link`, `list`, `run` and `unlink` each need for their
+/// own project-detection gate, kept in one place: `unlink` shipped as a
+/// fourth, un-widened copy of this exact check after the other three had
+/// already learned to widen it, which is how the false "no agents declared"
+/// message survived on the one command whose job is to undo `link`. A fifth
+/// call site forgetting to widen its own copy is the failure this function
+/// exists to make structurally impossible.
+pub fn project_declares_agents(
     project_root: &Path,
-    fragments: &[Prompt],
-) -> anyhow::Result<Agent> {
-    let AgentRef::Declared { declared } = r else {
-        // Unchanged path: resolve to a file, then parse it.
-        let path = resolve_agent(r, project_root)?;
-        return crate::parser::parse_agent_file(&path);
-    };
-
-    let path = declarations_path(project_root);
-    let decls = agent_decl::load(&path)?;
-    let decl = decls
-        .agents
-        .iter()
-        .find(|a| &a.name == declared)
-        .ok_or_else(|| {
-            anyhow::anyhow!("agent '{declared}' is not declared in {}", path.display())
-        })?;
-
-    agent_decl::to_agent(decl, &decls.defaults, fragments, path.clone())
+    config: &crate::project::ProjectConfig,
+) -> bool {
+    !config.agents.is_empty() || declarations_path(project_root).is_file()
 }
 
 /// Does `name` (compared as a slug) collide with a `.md` file in any of
@@ -265,6 +263,55 @@ pub fn load_all_agents(
         }
     }
 
+    // `shadowing_conflict` above only scans `library_dirs`, so two collision
+    // shapes reach here unchecked: a `path:`-ref `.md` living outside every
+    // library directory (the directory scan never visits it) that projects
+    // to the same slug as a declaration, and two declarations in the same
+    // `agents.yaml` sharing a `name:` (a bare `Vec`, with no uniqueness check
+    // of its own). Both would otherwise reach `link`, which writes one
+    // projection over the other silently — the exact overwrite Task 6 exists
+    // to prevent, reached by a different door. Same criterion as
+    // `shadowing_conflict`: the *slug*, because that is what names the file
+    // the linker writes, not the raw name — checked once the whole fleet
+    // above is assembled, since that is the earliest point both shapes exist
+    // to compare.
+    let mut by_slug: std::collections::HashMap<String, Vec<usize>> =
+        std::collections::HashMap::new();
+    for (i, a) in agents.iter().enumerate() {
+        by_slug
+            .entry(crate::agent::slugify(&a.name))
+            .or_default()
+            .push(i);
+    }
+    let mut colliding: Vec<usize> = Vec::new();
+    for idxs in by_slug.values() {
+        if idxs.len() < 2 {
+            continue;
+        }
+        for &i in idxs {
+            let others: Vec<String> = idxs
+                .iter()
+                .filter(|&&j| j != i)
+                .map(|&j| format!("'{}'", agents[j].name))
+                .collect();
+            warnings.push(LoadWarning::Dropped {
+                agent: agents[i].name.clone(),
+                message: format!(
+                    "agent '{}' projects to the same slug as {} — remove or \
+                     rename one; there is deliberately no precedence between them",
+                    agents[i].name,
+                    others.join(", ")
+                ),
+            });
+        }
+        colliding.extend(idxs);
+    }
+    colliding.sort_unstable();
+    colliding.dedup();
+    for i in colliding.into_iter().rev() {
+        agents.remove(i);
+    }
+
     (agents, warnings)
 }
 
@@ -392,6 +439,35 @@ pub fn load_agent_by_name(
 mod tests {
     use super::*;
 
+    /// I2's shared gate: a project relying purely on `.armadai/agents.yaml`
+    /// (an empty/absent `agents:` list) must still count as declaring
+    /// agents — the exact case `unlink.rs` got wrong before this helper
+    /// existed.
+    #[test]
+    fn project_declares_agents_is_true_for_a_declarations_only_project() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let config = crate::project::ProjectConfig::default();
+        assert!(project_declares_agents(dir.path(), &config));
+    }
+
+    #[test]
+    fn project_declares_agents_is_true_when_only_agents_lists_something() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = crate::project::ProjectConfig {
+            agents: vec![AgentRef::Named { name: "x".into() }],
+            ..Default::default()
+        };
+        assert!(project_declares_agents(dir.path(), &config));
+    }
+
+    #[test]
+    fn project_declares_agents_is_false_for_neither() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = crate::project::ProjectConfig::default();
+        assert!(!project_declares_agents(dir.path(), &config));
+    }
+
     /// A project with one declared agent and one fragment on disk.
     fn project(dir: &std::path::Path) {
         std::fs::create_dir_all(dir.join(".armadai")).unwrap();
@@ -414,52 +490,18 @@ mod tests {
         }]
     }
 
-    #[test]
-    fn a_declared_ref_yields_an_agent_without_touching_the_disk_for_it() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path());
-        let r = AgentRef::Declared {
-            declared: "core-specialist".into(),
-        };
-        let agent = load_agent(&r, dir.path(), &fragments()).unwrap();
-        assert_eq!(agent.name, "core-specialist");
-        assert_eq!(agent.system_prompt, "You are core-specialist.");
-        assert_eq!(agent.metadata.provider, "claude");
-        // `source` points at the declaration, which is where it came from.
-        assert!(agent.source.ends_with("agents.yaml"));
-    }
-
-    #[test]
-    fn a_declared_name_absent_from_the_yaml_is_an_error() {
-        let dir = tempfile::tempdir().unwrap();
-        project(dir.path());
-        let r = AgentRef::Declared {
-            declared: "ghost".into(),
-        };
-        let err = load_agent(&r, dir.path(), &fragments())
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("ghost"), "must name the missing agent: {err}");
-    }
-
-    #[test]
-    fn a_declared_ref_without_any_agents_yaml_is_an_error() {
-        let dir = tempfile::tempdir().unwrap();
-        let r = AgentRef::Declared {
-            declared: "x".into(),
-        };
-        assert!(load_agent(&r, dir.path(), &[]).is_err());
-    }
-
     /// Three declared agents with distinguishable metadata and prompts,
-    /// looked up by the middle name. `load_agent`'s
-    /// `.find(|a| &a.name == declared)` is correct by inspection against a
-    /// single-agent fixture, but that can't tell "found the right one" apart
-    /// from "returned the only one there was" — this fixture can, because
-    /// alpha's and gamma's values would make the assertions below fail just
-    /// as loudly as a completely wrong agent would.
+    /// looked up by the middle name via `load_agent_by_name` — the actual
+    /// production entry point for resolving one declared agent (this
+    /// scenario used to go through the now-deleted `load_agent`, which had
+    /// no production caller of its own). A single-agent fixture is correct
+    /// by inspection against `.find(|a| a.name == name)`, but that can't
+    /// tell "found the right one" apart from "returned the only one there
+    /// was" — this fixture can, because alpha's and gamma's values would
+    /// make the assertions below fail just as loudly as a completely wrong
+    /// agent would.
     #[test]
-    fn a_declared_ref_finds_the_middle_agent_among_several() {
+    fn load_agent_by_name_finds_the_middle_agent_among_several() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
         std::fs::write(
@@ -509,12 +551,14 @@ agents:
                 source: std::path::PathBuf::from("gamma.md"),
             },
         ];
+        let config = crate::project::ProjectConfig::default();
 
-        let r = AgentRef::Declared {
-            declared: "beta".into(),
-        };
-        let agent = load_agent(&r, dir.path(), &fragments).unwrap();
+        let (agent, warning) = load_agent_by_name("beta", &config, dir.path(), &fragments).unwrap();
 
+        assert!(
+            warning.is_none(),
+            "a clean project must not warn: {warning:?}"
+        );
         assert_eq!(agent.name, "beta");
         // Neither alpha's nor gamma's provider/model/prompt — beta's own.
         assert_eq!(agent.metadata.provider, "openai");
@@ -844,6 +888,80 @@ agents:
         });
     }
 
+    /// I4a: `shadowing_conflict` only scans `library_dirs`, so a `path:`-ref
+    /// `.md` living outside every one of them (here `custom/`, neither
+    /// `.armadai/agents/` nor the project-local `agents/` nor the global
+    /// library) was invisible to it — a declaration and that file could
+    /// share a slug and both silently reach `link`, which would write one
+    /// projection over the other. The post-assembly slug dedup must catch
+    /// what the directory scan cannot.
+    #[test]
+    fn load_all_agents_refuses_a_declaration_colliding_with_a_path_ref_outside_library_dirs() {
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            project(dir.path()); // declares `core-specialist`, prompt: [base]
+            let custom_dir = dir.path().join("custom");
+            std::fs::create_dir_all(&custom_dir).unwrap();
+            std::fs::write(
+                custom_dir.join("core-specialist.md"),
+                "# Core Specialist\n\n## Metadata\n- provider: claude\n\n\
+                 ## System Prompt\n\nHi\n",
+            )
+            .unwrap();
+            let config = config_listing_agent_path(dir.path(), "custom/core-specialist.md");
+
+            let (agents, warnings) = load_all_agents(&config, dir.path(), &fragments());
+            assert!(
+                agents
+                    .iter()
+                    .all(|a| crate::agent::slugify(&a.name) != "core-specialist"),
+                "neither side of the collision must silently win: {agents:?}"
+            );
+            assert!(
+                warnings
+                    .iter()
+                    .any(|w| w.message().to_lowercase().contains("core-specialist")),
+                "the collision must be reported: {warnings:?}"
+            );
+        });
+    }
+
+    /// I4b: two declarations in the same `agents.yaml` sharing a `name:` —
+    /// a bare `Vec`, with no uniqueness check of its own before this fix.
+    /// Compared as slugs, not raw strings, matching Task 6's own criterion:
+    /// `core-specialist` and `Core Specialist` project to the same file name.
+    #[test]
+    fn load_all_agents_refuses_two_declarations_sharing_a_slug() {
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+            std::fs::write(
+                dir.path().join(".armadai/agents.yaml"),
+                "defaults:\n  provider: claude\nagents:\n  \
+                 - name: core-specialist\n    prompt: [base]\n  \
+                 - name: Core Specialist\n    prompt: [base]\n",
+            )
+            .unwrap();
+            let config = crate::project::ProjectConfig::default();
+
+            let (agents, warnings) = load_all_agents(&config, dir.path(), &fragments());
+            assert!(
+                agents
+                    .iter()
+                    .all(|a| crate::agent::slugify(&a.name) != "core-specialist"),
+                "neither duplicate must silently win: {agents:?}"
+            );
+            assert_eq!(
+                warnings
+                    .iter()
+                    .filter(|w| matches!(w, LoadWarning::Dropped { .. }))
+                    .count(),
+                2,
+                "both sides of the collision must be reported: {warnings:?}"
+            );
+        });
+    }
+
     /// Task 7b review, Regression 2: `armadai.yaml`'s `agents:` may list a
     /// declared agent explicitly via `- declared: x` (for routes/teams to
     /// point at deliberately) — that must never make the agent unloadable.
@@ -981,6 +1099,8 @@ agents:
         assert_eq!(agent.name, "zzz-declared-only-agent");
         assert_eq!(agent.system_prompt, "You are zzz-declared-only-agent.");
         assert_eq!(agent.metadata.provider, "claude");
+        // `source` points at the declaration, which is where it came from.
+        assert!(agent.source.ends_with("agents.yaml"));
     }
 
     /// Regression guard on `run`/`inspect`'s most common path: a plain

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -43,6 +43,36 @@ pub fn load_agent(
     agent_decl::to_agent(decl, &decls.defaults, fragments, path.clone())
 }
 
+/// Refuse a name that exists both as a declaration and as a library file.
+///
+/// The obvious alternative is a precedence rule — local wins, as everywhere
+/// else. It is rejected on purpose: a silent precedence recreates the very
+/// duplicated truth this format exists to remove, and you would edit a `.md`
+/// with no effect and nothing to tell you. Failing forces a choice.
+///
+/// Rule `C01` of the audit already reports name collisions; loading must
+/// refuse them.
+pub fn check_no_shadowing(project_root: &Path, library: &Path) -> anyhow::Result<()> {
+    let decls_path = declarations_path(project_root);
+    if !decls_path.is_file() {
+        return Ok(());
+    }
+    let decls = agent_decl::load(&decls_path)?;
+    for decl in &decls.agents {
+        let file = library.join(format!("{}.md", decl.name));
+        if file.is_file() {
+            anyhow::bail!(
+                "agent '{}' is declared in {} and also written as {} — \
+                 remove one; there is deliberately no precedence between them",
+                decl.name,
+                decls_path.display(),
+                file.display()
+            );
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,6 +221,46 @@ agents:
             "expected Named, got {:?}",
             refs[0]
         );
+    }
+
+    #[test]
+    fn a_name_both_declared_and_written_as_a_file_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path()); // declares `core-specialist`
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(
+            lib.path().join("core-specialist.md"),
+            "# Core\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi",
+        )
+        .unwrap();
+
+        let err = check_no_shadowing(dir.path(), lib.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("core-specialist"), "must name it: {err}");
+        // The point is that neither wins — say so, or the reader will assume
+        // one does.
+        assert!(
+            err.contains("agents.yaml") && err.contains(".md"),
+            "must name both sources so the reader can pick one: {err}"
+        );
+    }
+
+    #[test]
+    fn distinct_names_are_fine() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(lib.path().join("other.md"), "# Other").unwrap();
+        assert!(check_no_shadowing(dir.path(), lib.path()).is_ok());
+    }
+
+    #[test]
+    fn a_project_without_declarations_never_shadows() {
+        let dir = tempfile::tempdir().unwrap();
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(lib.path().join("a.md"), "# A").unwrap();
+        assert!(check_no_shadowing(dir.path(), lib.path()).is_ok());
     }
 
     /// Symmetric check: a `- declared: x` entry must resolve to `Declared`,

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -113,6 +113,141 @@ pub fn check_no_shadowing(project_root: &Path, libraries: &[PathBuf]) -> anyhow:
     Ok(())
 }
 
+/// Every prompt fragment a project's declarations can reference, gathered
+/// from the same three tiers `project::resolve_prompt` searches by name:
+/// `.armadai/prompts/` (preferred), the legacy `prompts/`, then the user's
+/// global library. A name defined in more than one tier keeps its most
+/// local definition — the same "closer wins" rule the rest of resolution
+/// uses.
+///
+/// Every caller that turns declared agents into something usable (`link`,
+/// `list`, `run`, `inspect`) needs this fragment set, so it lives here
+/// rather than being reimplemented at each call site.
+pub fn project_fragments(project_root: &Path) -> Vec<Prompt> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    let tiers = [
+        project_root.join(".armadai").join("prompts"),
+        project_root.join("prompts"),
+        crate::config::user_prompts_dir(),
+    ];
+    for dir in &tiers {
+        for p in crate::prompt::load_all_prompts(dir) {
+            if seen.insert(p.name.clone()) {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// Every agent a project has: those resolved from files, plus those declared.
+///
+/// Same `(values, non-fatal errors)` shape as `resolve_all_agents`, so callers
+/// keep their existing warning loop. A broken declaration costs its own agent,
+/// never the whole fleet — a fleet that vanishes because one agent has a typo
+/// is worse than a fleet with a gap and a warning.
+///
+/// `check_no_shadowing` runs first, over `project::library_dirs` (the same
+/// list `resolve_agent` resolves file-backed agents from) — a name declared
+/// AND written as a file is refused outright rather than silently loaded
+/// twice or arbitrarily once. That refusal is what makes `load_agent_by_name`
+/// safe to try file-backed agents before declarations with no precedence
+/// rule: if both existed, loading already failed here.
+pub fn load_all_agents(
+    config: &crate::project::ProjectConfig,
+    root: &Path,
+    fragments: &[Prompt],
+) -> (Vec<Agent>, Vec<String>) {
+    let (paths, mut errors) = crate::project::resolve_all_agents(config, root);
+    let mut agents = Vec::new();
+    for path in &paths {
+        match crate::parser::parse_agent_file(path) {
+            Ok(a) => agents.push(a),
+            Err(e) => errors.push(format!("failed to parse {}: {e}", path.display())),
+        }
+    }
+
+    let decls_path = declarations_path(root);
+    if decls_path.is_file() {
+        if let Err(e) = check_no_shadowing(root, &crate::project::library_dirs(root)) {
+            errors.push(format!("{e}"));
+            return (agents, errors);
+        }
+        match agent_decl::load(&decls_path) {
+            Ok(decls) => {
+                for decl in &decls.agents {
+                    match agent_decl::to_agent(decl, &decls.defaults, fragments, decls_path.clone())
+                    {
+                        Ok(a) => agents.push(a),
+                        Err(e) => errors.push(format!("{e}")),
+                    }
+                }
+            }
+            Err(e) => errors.push(format!("{e}")),
+        }
+    }
+
+    (agents, errors)
+}
+
+/// Find one agent by name, whether it is declared or written as a file.
+///
+/// Resolution order: file-backed first — a config `AgentRef` matching `name`
+/// (mirroring `AgentResolution::Project`'s own ref-matching in `cli::run` and
+/// `cli::inspect`, which this replaces), or failing that a bare `Named`
+/// lookup — then the project's declarations. Because `check_no_shadowing`
+/// (wired into `load_all_agents`) refuses a name that exists in both, this
+/// order never has to arbitrate a real collision: if both existed, loading
+/// already failed elsewhere. There is deliberately no precedence rule here.
+///
+/// A `config.agents` entry of `AgentRef::Declared` matching `name` is never
+/// handed to `resolve_agent` (which always refuses that variant) — it is
+/// left unmatched here so resolution falls through to the declarations
+/// lookup below, which is what actually resolves it.
+pub fn load_agent_by_name(
+    name: &str,
+    config: &crate::project::ProjectConfig,
+    project_root: &Path,
+    fragments: &[Prompt],
+) -> anyhow::Result<Agent> {
+    let matched_ref = config.agents.iter().find(|r| match r {
+        AgentRef::Named { name: n } => n == name,
+        AgentRef::Path { path } => path.file_stem().is_some_and(|s| s == name),
+        AgentRef::Registry { registry } => registry.ends_with(name),
+        AgentRef::Declared { .. } => false,
+    });
+
+    let file_result = match matched_ref {
+        Some(agent_ref) => resolve_agent(agent_ref, project_root),
+        None => resolve_agent(
+            &AgentRef::Named {
+                name: name.to_string(),
+            },
+            project_root,
+        ),
+    };
+
+    let file_err = match file_result {
+        Ok(path) => return crate::parser::parse_agent_file(&path),
+        Err(e) => e,
+    };
+
+    let decls_path = declarations_path(project_root);
+    if decls_path.is_file() {
+        let decls = agent_decl::load(&decls_path)?;
+        if let Some(decl) = decls.agents.iter().find(|a| a.name == name) {
+            return agent_decl::to_agent(decl, &decls.defaults, fragments, decls_path);
+        }
+    }
+
+    anyhow::bail!(
+        "agent '{name}' not found: not resolvable as a file ({file_err}), \
+         and not declared in {}",
+        decls_path.display()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -403,6 +538,219 @@ agents:
             AgentRef::Declared {
                 declared: "core-specialist".to_string()
             }
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // load_all_agents
+    // -----------------------------------------------------------------
+
+    /// Build a `ProjectConfig` whose agent list holds one `AgentRef::Path`,
+    /// following `project.rs`'s own `test_resolve_all_agents` construction
+    /// rather than inventing a second way to build one.
+    fn config_listing_agent_path(
+        _project_root: &std::path::Path,
+        rel_path: &str,
+    ) -> crate::project::ProjectConfig {
+        crate::project::ProjectConfig {
+            agents: vec![AgentRef::Path {
+                path: std::path::PathBuf::from(rel_path),
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// A project with one `.md` agent and one declared agent must yield both.
+    #[test]
+    fn declared_and_file_agents_are_loaded_together() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  - name: declared-one\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let md_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&md_dir).unwrap();
+        std::fs::write(
+            md_dir.join("file-one.md"),
+            "# file-one\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
+        )
+        .unwrap();
+        let config = config_listing_agent_path(dir.path(), "agents/file-one.md");
+
+        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+        let mut names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["declared-one", "file-one"],
+            "errors: {errors:?}"
+        );
+    }
+
+    /// A project with no declarations must behave exactly as before.
+    #[test]
+    fn a_project_without_declarations_loads_only_its_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let md_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&md_dir).unwrap();
+        std::fs::write(
+            md_dir.join("only.md"),
+            "# only\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
+        )
+        .unwrap();
+        let config = config_listing_agent_path(dir.path(), "agents/only.md");
+
+        let (agents, _) = load_all_agents(&config, dir.path(), &[]);
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "only");
+    }
+
+    /// One bad declaration must not silence the good agents — the existing
+    /// callers print warnings and carry on, and that contract must hold.
+    #[test]
+    fn a_broken_declaration_becomes_an_error_string_not_a_lost_fleet() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        // `ghost` is not a known fragment -> composition fails for this agent.
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  - name: broken\n    prompt: [ghost]\n  \
+             - name: fine\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let config = config_listing_agent_path(dir.path(), "agents/none.md");
+
+        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+        assert!(
+            agents.iter().any(|a| a.name == "fine"),
+            "the healthy agent must survive: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("broken")),
+            "the broken one must be reported by name: {errors:?}"
+        );
+    }
+
+    /// A declared agent and a same-named file must still refuse to load at
+    /// all via `load_all_agents` — the shadowing check now actually runs.
+    #[test]
+    fn load_all_agents_refuses_a_shadowed_declaration() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path()); // declares `core-specialist`
+        let md_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&md_dir).unwrap();
+        std::fs::write(md_dir.join("core-specialist.md"), "# Core").unwrap();
+        let config = crate::project::ProjectConfig::default();
+
+        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+        assert!(
+            agents.iter().all(|a| a.name != "core-specialist"),
+            "a shadowed name must not be silently loaded from either side: {agents:?}"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("core-specialist")),
+            "the collision must be reported: {errors:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // load_agent_by_name
+    // -----------------------------------------------------------------
+
+    /// A declared agent must be reachable by name with no `AgentRef` at all
+    /// listing it in `armadai.yaml` — the whole point of "every agent in
+    /// `agents.yaml` is included automatically".
+    ///
+    /// Deliberately does NOT reuse the shared `project()`/`core-specialist`
+    /// fixture: `load_agent_by_name` tries a file-backed lookup first, which
+    /// walks the REAL `~/.config/armadai/agents/` on this machine (this very
+    /// repo's own `core-specialist` team agent is routinely extracted there).
+    /// A name that could plausibly exist globally would make this test pass
+    /// for the wrong reason on a dev box while still passing in CI — so this
+    /// uses a name no real global library will ever hold.
+    #[test]
+    fn load_agent_by_name_finds_a_declared_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: zzz-declared-only-agent\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let config = crate::project::ProjectConfig::default();
+
+        let agent =
+            load_agent_by_name("zzz-declared-only-agent", &config, dir.path(), &fragments())
+                .unwrap();
+        assert_eq!(agent.name, "zzz-declared-only-agent");
+        assert_eq!(agent.system_prompt, "You are zzz-declared-only-agent.");
+        assert_eq!(agent.metadata.provider, "claude");
+    }
+
+    /// Regression guard on `run`/`inspect`'s most common path: a plain
+    /// `.md` agent, referenced by a `path:` entry, must resolve to the SAME
+    /// agent it always did. Every assertion below is a value this test would
+    /// catch going wrong (wrong file loaded, empty metadata, wrong prompt) —
+    /// a bare "it loaded" assertion could not tell that apart from a bug
+    /// that returns some other agent, or a half-populated one.
+    #[test]
+    fn load_agent_by_name_still_resolves_a_file_backed_agent_exactly_as_before() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("sentinel.md"),
+            "# Sentinel Prime\n\n\
+             ## Metadata\n\
+             - provider: cli\n\
+             - command: sentinel-cmd\n\
+             - model: sentinel-model-x\n\
+             - tags: alpha-tag\n\n\
+             ## System Prompt\n\n\
+             Guard the perimeter, sentinel-style.\n",
+        )
+        .unwrap();
+        let config = crate::project::ProjectConfig {
+            agents: vec![AgentRef::Path {
+                path: std::path::PathBuf::from("sentinel.md"),
+            }],
+            ..Default::default()
+        };
+
+        let agent = load_agent_by_name("sentinel", &config, dir.path(), &[]).unwrap();
+        assert_eq!(agent.name, "Sentinel Prime");
+        assert_eq!(agent.metadata.provider, "cli");
+        assert_eq!(agent.metadata.command.as_deref(), Some("sentinel-cmd"));
+        assert_eq!(agent.metadata.model.as_deref(), Some("sentinel-model-x"));
+        assert_eq!(agent.metadata.tags, vec!["alpha-tag".to_string()]);
+        assert_eq!(
+            agent.system_prompt.trim(),
+            "Guard the perimeter, sentinel-style."
+        );
+    }
+
+    /// An unknown name must error, naming both places that were searched: the
+    /// file-backed resolution (via the underlying `resolve_agent` error) and
+    /// `agents.yaml` — a mistyped declared agent's name must not be reported
+    /// as though only one of the two had been consulted.
+    #[test]
+    fn an_unknown_name_errors_naming_both_places_searched() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path()); // .armadai/agents.yaml exists, declares core-specialist
+        let config = crate::project::ProjectConfig::default();
+
+        let err = load_agent_by_name("ghost-agent", &config, dir.path(), &fragments())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ghost-agent"), "must name the agent: {err}");
+        assert!(
+            err.contains("agents.yaml"),
+            "must say it looked in the declarations: {err}"
+        );
+        assert!(
+            err.contains("not found") || err.contains("not resolvable"),
+            "must say it looked for a file too: {err}"
         );
     }
 }

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -1,0 +1,147 @@
+//! Loading an `Agent`, whatever its origin.
+//!
+//! `project::resolve_agent` returns a **path**, which serves callers that
+//! manipulate files — `model_updater` and `pack_validation` rewrite deprecated
+//! models in place. A declared agent has no file of its own, so it is right
+//! that `resolve_agent` fails for one. This module is for callers that want the
+//! agent, not its file.
+
+use std::path::Path;
+
+use crate::agent::Agent;
+use crate::agent_decl;
+use crate::project::{AgentRef, resolve_agent};
+use crate::prompt::Prompt;
+
+/// Where a project's declarations live.
+pub fn declarations_path(project_root: &Path) -> std::path::PathBuf {
+    project_root.join(".armadai").join("agents.yaml")
+}
+
+/// Load an agent, from a file or from the project's declarations.
+pub fn load_agent(
+    r: &AgentRef,
+    project_root: &Path,
+    fragments: &[Prompt],
+) -> anyhow::Result<Agent> {
+    let AgentRef::Declared { declared } = r else {
+        // Unchanged path: resolve to a file, then parse it.
+        let path = resolve_agent(r, project_root)?;
+        return crate::parser::parse_agent_file(&path);
+    };
+
+    let path = declarations_path(project_root);
+    let decls = agent_decl::load(&path)?;
+    let decl = decls
+        .agents
+        .iter()
+        .find(|a| &a.name == declared)
+        .ok_or_else(|| {
+            anyhow::anyhow!("agent '{declared}' is not declared in {}", path.display())
+        })?;
+
+    Ok(Agent {
+        name: decl.name.clone(),
+        source: path.clone(),
+        metadata: agent_decl::merge_metadata(decl, &decls.defaults)?,
+        system_prompt: agent_decl::compose_prompt(&decl.prompt, decl, fragments)?,
+        instructions: None,
+        output_format: None,
+        pipeline: None,
+        context: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A project with one declared agent and one fragment on disk.
+    fn project(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir.join(".armadai")).unwrap();
+        std::fs::write(
+            dir.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\n  model: latest:pro\nagents:\n  \
+             - name: core-specialist\n    description: the core\n    \
+             prompt: [base]\n",
+        )
+        .unwrap();
+    }
+
+    fn fragments() -> Vec<crate::prompt::Prompt> {
+        vec![crate::prompt::Prompt {
+            name: "base".into(),
+            description: None,
+            apply_to: vec![],
+            body: "You are {{name}}.".into(),
+            source: std::path::PathBuf::from("base.md"),
+        }]
+    }
+
+    #[test]
+    fn a_declared_ref_yields_an_agent_without_touching_the_disk_for_it() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let r = AgentRef::Declared {
+            declared: "core-specialist".into(),
+        };
+        let agent = load_agent(&r, dir.path(), &fragments()).unwrap();
+        assert_eq!(agent.name, "core-specialist");
+        assert_eq!(agent.system_prompt, "You are core-specialist.");
+        assert_eq!(agent.metadata.provider, "claude");
+        // `source` points at the declaration, which is where it came from.
+        assert!(agent.source.ends_with("agents.yaml"));
+    }
+
+    #[test]
+    fn a_declared_name_absent_from_the_yaml_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let r = AgentRef::Declared {
+            declared: "ghost".into(),
+        };
+        let err = load_agent(&r, dir.path(), &fragments())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ghost"), "must name the missing agent: {err}");
+    }
+
+    #[test]
+    fn a_declared_ref_without_any_agents_yaml_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = AgentRef::Declared {
+            declared: "x".into(),
+        };
+        assert!(load_agent(&r, dir.path(), &[]).is_err());
+    }
+
+    /// `AgentRef` is `#[serde(untagged)]`. Adding `Declared` must not shift
+    /// how a plain `- name: x` entry resolves — untagged enums try each
+    /// variant in order and a missing required field is what actually
+    /// disambiguates them, but that is easy to get wrong when a fourth
+    /// variant with its own single required field joins the set.
+    #[test]
+    fn a_named_entry_still_deserialises_as_named_not_declared() {
+        let refs: Vec<AgentRef> = serde_yaml_ng::from_str("- name: core-specialist\n").unwrap();
+        assert_eq!(refs.len(), 1);
+        assert!(
+            matches!(refs[0], AgentRef::Named { .. }),
+            "expected Named, got {:?}",
+            refs[0]
+        );
+    }
+
+    /// Symmetric check: a `- declared: x` entry must resolve to `Declared`,
+    /// not to one of the other three variants.
+    #[test]
+    fn a_declared_entry_deserialises_as_declared() {
+        let refs: Vec<AgentRef> = serde_yaml_ng::from_str("- declared: core-specialist\n").unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(
+            refs[0],
+            AgentRef::Declared {
+                declared: "core-specialist".to_string()
+            }
+        );
+    }
+}

--- a/crates/armadai-core/src/lib.rs
+++ b/crates/armadai-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod agent_decl;
+pub mod agent_source;
 #[allow(dead_code)]
 pub mod config;
 pub mod dependency_resolver;

--- a/crates/armadai-core/src/lib.rs
+++ b/crates/armadai-core/src/lib.rs
@@ -19,3 +19,4 @@ pub mod registries;
 pub mod routing;
 pub mod skill;
 pub mod starter;
+pub mod template;

--- a/crates/armadai-core/src/lib.rs
+++ b/crates/armadai-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod agent_decl;
 #[allow(dead_code)]
 pub mod config;
 pub mod dependency_resolver;

--- a/crates/armadai-core/src/model_updater.rs
+++ b/crates/armadai-core/src/model_updater.rs
@@ -415,14 +415,42 @@ pub fn auto_check_and_prompt(project_root: &Path, interactive: bool) -> bool {
 
     if confirm {
         let decls_path = crate::agent_source::declarations_path(project_root);
-        let mut total = 0;
+        // Grouped by file, and passed to `apply_findings` a whole file at a
+        // time — one call per finding would split a file's occurrences
+        // across several independent calls, letting an earlier one's
+        // success land on disk before a later one's failure is even
+        // discovered. That defeats exactly the atomicity
+        // `update_declarations` exists to provide: this project shipped
+        // that guarantee once already and lost it right here, one call
+        // site later, by looping per finding instead of per file.
+        let mut by_file: std::collections::HashMap<PathBuf, Vec<DeprecationFinding>> =
+            std::collections::HashMap::new();
         for f in &findings {
-            if let Ok(n) = apply_finding(f, &decls_path) {
-                total += n;
+            by_file
+                .entry(f.agent_path.clone())
+                .or_default()
+                .push(f.clone());
+        }
+
+        let mut total = 0;
+        let mut any_failed = false;
+        for (path, file_findings) in &by_file {
+            match apply_findings(file_findings, &decls_path) {
+                Ok(n) => total += n,
+                Err(e) => {
+                    any_failed = true;
+                    eprintln!("  error: {}: {e}", path.display());
+                }
             }
         }
         if total > 0 {
             eprintln!("  Updated {total} model(s).\n");
+        }
+        if any_failed {
+            eprintln!(
+                "hint: one or more file(s) could not be fully updated (see error(s) above); \
+                 run `armadai models update` for details.\n"
+            );
         }
         return true;
     }
@@ -431,27 +459,41 @@ pub fn auto_check_and_prompt(project_root: &Path, interactive: bool) -> bool {
     false
 }
 
-/// Rewrite one finding in place, choosing the rewriter that matches where it
-/// came from.
+/// Rewrite every finding for ONE file in a single call, choosing the
+/// rewriter that matches where they came from.
 ///
-/// A finding whose `agent_path` is the project's `agents.yaml` came from
+/// Takes all of a file's findings at once and passes them through
+/// together — never split across several calls. `update_declarations`'s
+/// all-or-nothing guarantee (nothing is written unless every finding can be
+/// accounted for) only protects a caller that preserves this batching: one
+/// call per finding would let an earlier finding's fix land on disk before
+/// a later finding's failure in the SAME file is discovered, which is
+/// precisely the half-applied result the guarantee exists to rule out.
+///
+/// `findings` must all share one `agent_path` — callers group by file
+/// before calling this (`check_project`'s own results are always grouped
+/// for display, so this matches how a caller already has them). A finding
+/// whose `agent_path` is the project's `agents.yaml` came from
 /// [`check_declarations`] and must go through [`update_declarations`] —
-/// [`update_agent_file`]'s single `replacen(.., 1)` would only fix the first
-/// occurrence, and its raw `: <model>` pattern is not bounded to
+/// [`update_agent_file`]'s single `replacen(.., 1)` would only fix the
+/// first occurrence, and its raw `: <model>` pattern is not bounded to
 /// `model:`/`model_fallback:` lines the way the declarative rewrite is.
 ///
 /// Public, and used by two callers: `auto_check_and_prompt`'s own
-/// confirmation branch below, and `armadai models update`
-/// (`crates/armadai/src/cli/models.rs`) — the other place that turns a
-/// [`DeprecationFinding`] into an actual file edit. Both need the exact same
-/// routing decision; extracted here once so neither can drift from it (and
-/// so the decision itself has a direct test, independent of the interactive
-/// prompt one of its callers sits behind).
-pub fn apply_finding(finding: &DeprecationFinding, decls_path: &Path) -> anyhow::Result<usize> {
-    if finding.agent_path == decls_path {
-        update_declarations(&finding.agent_path, std::slice::from_ref(finding))
+/// confirmation branch above, and `armadai models update`
+/// (`crates/armadai/src/cli/models.rs`) — the other place that turns
+/// [`DeprecationFinding`]s into an actual file edit. Both need the exact
+/// same routing decision and the exact same batching; extracted here once
+/// so neither can drift from it.
+pub fn apply_findings(findings: &[DeprecationFinding], decls_path: &Path) -> anyhow::Result<usize> {
+    let Some(first) = findings.first() else {
+        return Ok(0);
+    };
+    let path = &first.agent_path;
+    if path == decls_path {
+        update_declarations(path, findings)
     } else {
-        update_agent_file(&finding.agent_path, std::slice::from_ref(finding))
+        update_agent_file(path, findings)
     }
 }
 
@@ -907,13 +949,14 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // `apply_finding` — the routing decision `auto_check_and_prompt` makes
-    // on confirmation. Tested directly, since exercising the surrounding
-    // `dialoguer::Confirm` prompt would need a real terminal.
+    // `apply_findings` — the routing AND batching decision
+    // `auto_check_and_prompt` makes on confirmation. Tested directly, since
+    // exercising the surrounding `dialoguer::Confirm` prompt would need a
+    // real terminal.
     // -----------------------------------------------------------------
 
     #[test]
-    fn apply_finding_routes_a_declarations_finding_to_update_declarations() {
+    fn apply_findings_routes_a_declarations_finding_to_update_declarations() {
         let (old, new) = a_deprecated_model();
         let dir = tempfile::tempdir().unwrap();
         let p = write_yaml(
@@ -930,13 +973,13 @@ mod tests {
 
         // `decls_path` equal to the finding's own path is what marks it as
         // declarations-sourced.
-        let n = apply_finding(&finding, &p).unwrap();
+        let n = apply_findings(&[finding], &p).unwrap();
         assert_eq!(n, 1);
         assert!(std::fs::read_to_string(&p).unwrap().contains(&new));
     }
 
     #[test]
-    fn apply_finding_routes_a_file_finding_to_update_agent_file() {
+    fn apply_findings_routes_a_file_finding_to_update_agent_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("agent.md");
         std::fs::write(&path, create_agent_md("Test", "gpt-4-turbo", &[])).unwrap();
@@ -951,12 +994,76 @@ mod tests {
         // so only the else-branch (`update_agent_file`) can produce a fix.
         let decls_path = dir.path().join("agents.yaml");
 
-        let n = apply_finding(&finding, &decls_path).unwrap();
+        let n = apply_findings(&[finding], &decls_path).unwrap();
         assert_eq!(n, 1);
         assert!(
             std::fs::read_to_string(&path)
                 .unwrap()
                 .contains("model: gpt-4o")
         );
+    }
+
+    #[test]
+    fn apply_findings_of_an_empty_slice_is_a_harmless_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let decls_path = dir.path().join("agents.yaml");
+        assert_eq!(apply_findings(&[], &decls_path).unwrap(), 0);
+    }
+
+    /// The regression this whole function exists to close: a file with
+    /// TWO findings, one reachable by the textual scan and one that is
+    /// not (a quoted key), must be treated as ONE atomic unit. A version
+    /// that calls the rewriter once per finding would let the first
+    /// finding's fix land on disk before the second finding's failure is
+    /// even discovered — this asserts all three properties a caller
+    /// needs to tell that apart from a real, honest failure: the file is
+    /// byte-identical to before, the reported count is 0, and the call
+    /// itself errors (so a caller — `models.rs` — has something to
+    /// propagate as a non-zero exit rather than a silent partial fix).
+    #[test]
+    fn apply_findings_is_atomic_across_a_files_own_findings() {
+        let (old, _new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "defaults:\n  provider: claude\n  model: {old}\nagents:\n  - name: a\n    \"model\": {old}\n"
+            ),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 2, "one plain, one quoted: {findings:?}");
+        let before = std::fs::read_to_string(&p).unwrap();
+
+        let err = apply_findings(&findings, &p).unwrap_err().to_string();
+        assert!(
+            err.contains("detection and rewrite disagree"),
+            "must surface update_declarations's own disagreement error: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&p).unwrap(),
+            before,
+            "the plain defaults.model fix must NOT land on disk just because the \
+             quoted-key finding in the SAME file failed — that is the exact bug \
+             this function exists to close"
+        );
+    }
+
+    /// The healthy twin of the atomicity test above: two or more findings
+    /// that CAN all be rewritten must all actually be, in one call —
+    /// batching must not lose any of them.
+    #[test]
+    fn apply_findings_fixes_every_finding_in_one_batched_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            "defaults:\n  provider: claude\n  model: gpt-4-turbo\nagents:\n  - name: a\n    model: gemini-1.5-flash\n",
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 2, "{findings:?}");
+
+        assert_eq!(apply_findings(&findings, &p).unwrap(), 2);
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(after.contains("gpt-4o") && !after.contains("gpt-4-turbo"));
+        assert!(after.contains("gemini-2.5-flash") && !after.contains("gemini-1.5-flash"));
     }
 }

--- a/crates/armadai-core/src/model_updater.rs
+++ b/crates/armadai-core/src/model_updater.rs
@@ -7,7 +7,7 @@ use crate::project::{self, ProjectConfig};
 // Data model
 // ---------------------------------------------------------------------------
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeprecationFinding {
     pub agent_path: PathBuf,
     pub agent_name: String,
@@ -179,6 +179,26 @@ pub fn check_declarations(path: &Path) -> Vec<DeprecationFinding> {
     out
 }
 
+/// Whether `value` (a line's content right after its `key:`, already
+/// trimmed) opens a YAML block scalar — `|` or `>`, optionally followed by
+/// a chomping indicator (`+`/`-`) and/or an explicit indentation indicator
+/// (`1`-`9`), the two in either order (`c-b-block-header` in the YAML
+/// spec: `|-`, `|+`, `|2`, `|2-`, `|-2`, and the `>` folded-scalar
+/// equivalents). A trailing comment after the header is allowed and
+/// ignored.
+fn opens_block_scalar(value: &str) -> bool {
+    let value = value.split('#').next().unwrap_or(value).trim();
+    let Some(rest) = value.strip_prefix(['|', '>']) else {
+        return false;
+    };
+    if rest.len() > 2 {
+        return false;
+    }
+    let digits = rest.chars().filter(|c| c.is_ascii_digit()).count();
+    let signs = rest.chars().filter(|c| *c == '+' || *c == '-').count();
+    digits <= 1 && signs <= 1 && digits + signs == rest.chars().count()
+}
+
 /// Rewrite deprecated models in an `agents.yaml`.
 ///
 /// Textual substitution, like `update_agent_file` — a `serde_yaml_ng`
@@ -199,6 +219,22 @@ pub fn check_declarations(path: &Path) -> Vec<DeprecationFinding> {
 /// name (e.g. `args: [--model, claude-3-sonnet-20240229]`, passed through
 /// to a `cli`-provider agent), and rewriting that would silently corrupt an
 /// argument, not fix a model.
+///
+/// The same enclosing-scope tracking covers block scalars (`description:
+/// |`, `>`, …): every line more indented than the key that opened one (or
+/// blank) belongs to that scalar's *value*, never to the mapping — `#` is
+/// literal there, not a comment, and a line that happens to start with
+/// `model:` is prose, not a key. Such lines are never rewrite candidates,
+/// whatever they start with.
+///
+/// Detection ([`check_declarations`]) is a structured YAML parse; this
+/// rewrite is textual, so the two can disagree on a form the parser
+/// accepts but this scan does not recognise (e.g. a quoted `"model":` key).
+/// Rather than let that surface as a silently-too-low count, this function
+/// insists the number of textual replacements it actually made equals
+/// `findings.len()` and returns an `Err` naming whatever finding(s) it
+/// could not locate otherwise — and, so a caller never has to reason about
+/// a half-applied fix, writes nothing at all when it errors.
 pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyhow::Result<usize> {
     if findings.is_empty() {
         return Ok(0);
@@ -209,8 +245,34 @@ pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyh
     // Indentation of the nearest `model:`/`model_fallback:` key that opened
     // a block list still in scope, if any.
     let mut active_list_indent: Option<usize> = None;
+    // Indentation of the key that opened a block scalar (`|`/`>`) still in
+    // scope, if any. Tracked separately: a block scalar can open under ANY
+    // key (`description: |`), not just `model:`/`model_fallback:`.
+    let mut block_scalar_indent: Option<usize> = None;
+    // How many findings still need a textual match, grouped by the exact
+    // deprecated value — several findings (e.g. `defaults.model` and an
+    // agent's own `model`) legitimately share the same `current` string, so
+    // this is decremented, not looked up by finding identity.
+    let mut remaining: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for f in findings {
+        *remaining.entry(f.current.as_str()).or_insert(0) += 1;
+    }
 
     for line in content.lines() {
+        let raw_indent = line.len() - line.trim_start().len();
+        let is_blank = line.trim().is_empty();
+
+        if let Some(bs_indent) = block_scalar_indent {
+            if is_blank || raw_indent > bs_indent {
+                // Still inside the scalar's value: copy through untouched,
+                // whatever this line looks like.
+                out.push_str(line);
+                out.push('\n');
+                continue;
+            }
+            block_scalar_indent = None; // dedented: the scalar just ended
+        }
+
         let code = line.split('#').next().unwrap_or(line);
         let trimmed = code.trim_start();
         let indent = code.len() - trimmed.len();
@@ -228,6 +290,15 @@ pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyh
                 (trimmed == "model:" || trimmed == "model_fallback:").then_some(indent);
         }
 
+        // Does THIS key's own value open a block scalar? Checked for every
+        // key, not just model/model_fallback — `description: |` is the
+        // case this exists for.
+        if let Some(colon) = trimmed.find(':')
+            && opens_block_scalar(&trimmed[colon + 1..])
+        {
+            block_scalar_indent = Some(indent);
+        }
+
         let is_model_key = is_model_line || is_active_list_item;
         let mut kept = line.to_string();
         if is_model_key {
@@ -235,11 +306,50 @@ pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyh
                 if kept.contains(&f.current) {
                     kept = kept.replace(&f.current, &f.replacement);
                     count += 1;
+                    if let Some(n) = remaining.get_mut(f.current.as_str()) {
+                        *n = n.saturating_sub(1);
+                    }
                 }
             }
         }
         out.push_str(&kept);
         out.push('\n');
+    }
+
+    if count != findings.len() {
+        // Attribute the shortfall to specific findings, deterministically:
+        // for each value still outstanding, the trailing findings that
+        // share it (findings sharing a `current` are textually
+        // interchangeable, so which exact one is named does not matter —
+        // only that the named count matches the real shortfall).
+        let mut left = remaining;
+        let mut unapplied: Vec<&DeprecationFinding> = Vec::new();
+        for f in findings.iter().rev() {
+            if let Some(n) = left.get_mut(f.current.as_str())
+                && *n > 0
+            {
+                *n -= 1;
+                unapplied.push(f);
+            }
+        }
+        unapplied.reverse();
+        let named = if unapplied.is_empty() {
+            "unable to attribute the mismatch to a specific finding".to_string()
+        } else {
+            unapplied
+                .iter()
+                .map(|f| format!("{} [{}]", f.agent_name, f.field))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        anyhow::bail!(
+            "detection and rewrite disagree on {}: parsing found {} deprecated model(s), the \
+             textual rewrite could only locate {} — left everything unfixed rather than guess \
+             (an unsupported form, such as a quoted `\"model\":` key, is the likely cause): {named}",
+            path.display(),
+            findings.len(),
+            count,
+        );
     }
 
     std::fs::write(path, out)?;
@@ -329,9 +439,15 @@ pub fn auto_check_and_prompt(project_root: &Path, interactive: bool) -> bool {
 /// [`update_agent_file`]'s single `replacen(.., 1)` would only fix the first
 /// occurrence, and its raw `: <model>` pattern is not bounded to
 /// `model:`/`model_fallback:` lines the way the declarative rewrite is.
-/// Extracted as its own function so the routing decision has a direct test,
-/// independent of the interactive prompt above it.
-fn apply_finding(finding: &DeprecationFinding, decls_path: &Path) -> anyhow::Result<usize> {
+///
+/// Public, and used by two callers: `auto_check_and_prompt`'s own
+/// confirmation branch below, and `armadai models update`
+/// (`crates/armadai/src/cli/models.rs`) — the other place that turns a
+/// [`DeprecationFinding`] into an actual file edit. Both need the exact same
+/// routing decision; extracted here once so neither can drift from it (and
+/// so the decision itself has a direct test, independent of the interactive
+/// prompt one of its callers sits behind).
+pub fn apply_finding(finding: &DeprecationFinding, decls_path: &Path) -> anyhow::Result<usize> {
     if finding.agent_path == decls_path {
         update_declarations(&finding.agent_path, std::slice::from_ref(finding))
     } else {
@@ -671,6 +787,81 @@ mod tests {
         let after = std::fs::read_to_string(&p).unwrap();
         assert!(after.contains("gpt-4o") && !after.contains("gpt-4-turbo"));
         assert!(after.contains("gemini-2.5-flash") && !after.contains("gemini-1.5-flash"));
+    }
+
+    /// A `description: |` block scalar whose indented continuation line
+    /// itself starts with `model:` must not be mistaken for a real `model:`
+    /// key — it is prose inside the scalar's value, not a mapping key. The
+    /// sibling agent's real `model:` field, outside the scalar, must still
+    /// be fixed.
+    #[test]
+    fn a_block_scalar_is_left_byte_identical_while_a_real_model_field_is_still_fixed() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let body = format!(
+            "agents:\n  - name: a\n    description: |\n      notes:\n      model: {old}\n      \
+             more prose about {old}\n    model: {old}\n"
+        );
+        let p = write_yaml(dir.path(), &body);
+
+        let findings = check_declarations(&p);
+        assert_eq!(
+            findings.len(),
+            1,
+            "only the real `model:` field is a finding: {findings:?}"
+        );
+        assert_eq!(update_declarations(&p, &findings).unwrap(), 1);
+
+        let after = std::fs::read_to_string(&p).unwrap();
+        let block_scalar_lines = "      notes:\n      model: {old}\n      more prose about {old}\n"
+            .replace("{old}", &old);
+        assert!(
+            after.contains(&block_scalar_lines),
+            "the block scalar's content must survive byte-identical:\n{after}"
+        );
+        assert!(
+            after.contains(&format!("\n    model: {new}\n")),
+            "the real, sibling model: field must still be fixed:\n{after}"
+        );
+    }
+
+    /// `is_model_key`'s textual scan does not recognise a quoted key
+    /// (`"model":`), while `check_declarations`'s structured parse does —
+    /// a genuine detection/rewrite disagreement. `update_declarations` must
+    /// refuse rather than silently under-report, and must leave the file
+    /// completely untouched (no partial rewrite the caller never asked
+    /// for).
+    #[test]
+    fn a_quoted_key_is_detected_but_not_textually_matched_and_the_disagreement_is_a_hard_error() {
+        let (old, _new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!("defaults:\n  provider: claude\n  \"model\": {old}\nagents:\n  - name: a\n"),
+        );
+
+        let findings = check_declarations(&p);
+        assert_eq!(
+            findings.len(),
+            1,
+            "the structured parse must still find it: {findings:?}"
+        );
+
+        let before = std::fs::read_to_string(&p).unwrap();
+        let err = update_declarations(&p, &findings).unwrap_err().to_string();
+        assert!(
+            err.contains("detection and rewrite disagree"),
+            "must name what kind of failure this is: {err}"
+        );
+        assert!(
+            err.contains("defaults [defaults.model]"),
+            "must name the specific finding that could not be applied: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&p).unwrap(),
+            before,
+            "a disagreement must leave the file completely untouched, not partially rewritten"
+        );
     }
 
     #[test]

--- a/crates/armadai-core/src/model_updater.rs
+++ b/crates/armadai-core/src/model_updater.rs
@@ -57,6 +57,12 @@ pub fn check_agent_file(path: &Path) -> Vec<DeprecationFinding> {
 }
 
 /// Check all agents in a project for deprecated models.
+///
+/// Covers both formats: `.md` files (via [`check_agent_file`]) and, when the
+/// project has one, `.armadai/agents.yaml` (via [`check_declarations`]).
+/// Without the latter, a declaration file would be the one place in a
+/// project where a dead model goes unnoticed while every `.md` around it
+/// gets fixed.
 pub fn check_project(project_root: &Path) -> anyhow::Result<Vec<DeprecationFinding>> {
     let config = load_project_config(project_root)?;
     let (paths, _errors) = project::resolve_all_agents(&config, project_root);
@@ -64,6 +70,11 @@ pub fn check_project(project_root: &Path) -> anyhow::Result<Vec<DeprecationFindi
     let mut all_findings = Vec::new();
     for path in &paths {
         all_findings.extend(check_agent_file(path));
+    }
+
+    let decls_path = crate::agent_source::declarations_path(project_root);
+    if decls_path.is_file() {
+        all_findings.extend(check_declarations(&decls_path));
     }
 
     Ok(all_findings)
@@ -109,6 +120,129 @@ pub fn update_agent_file(path: &Path, findings: &[DeprecationFinding]) -> anyhow
         std::fs::write(path, content)?;
     }
 
+    Ok(count)
+}
+
+// ---------------------------------------------------------------------------
+// Declarative agents (`.armadai/agents.yaml`)
+// ---------------------------------------------------------------------------
+
+/// Deprecated models declared in an `agents.yaml`.
+///
+/// One finding **per occurrence**: unlike a `.md` agent, which declares
+/// `model` once, a declaration file carries it in `defaults` and in every
+/// agent that deviates. `field` distinguishes them (`defaults.model`,
+/// `<agent>.model`, `<agent>.model_fallback[i]`) so the rewrite can target
+/// each one.
+///
+/// Detection walks the parsed declaration, so it can only ever see real
+/// `model` / `model_fallback` values — never prose in a comment or a
+/// `description`.
+pub fn check_declarations(path: &Path) -> Vec<DeprecationFinding> {
+    let Ok(decls) = crate::agent_decl::load(path) else {
+        return Vec::new(); // unreadable: not this function's problem
+    };
+    let mut out = Vec::new();
+    let mut push = |field: String, agent_name: String, current: &str| {
+        if let Some(replacement) = resolve_alias(current) {
+            out.push(DeprecationFinding {
+                agent_path: path.to_path_buf(),
+                agent_name,
+                field,
+                current: current.to_string(),
+                replacement,
+            });
+        }
+    };
+    if let Some(m) = &decls.defaults.model {
+        push("defaults.model".into(), "defaults".into(), m);
+    }
+    for (i, fb) in decls.defaults.model_fallback.iter().enumerate() {
+        push(
+            format!("defaults.model_fallback[{i}]"),
+            "defaults".into(),
+            fb,
+        );
+    }
+    for a in &decls.agents {
+        if let Some(m) = &a.model {
+            push(format!("{}.model", a.name), a.name.clone(), m);
+        }
+        for (i, fb) in a.model_fallback.iter().flatten().enumerate() {
+            push(
+                format!("{}.model_fallback[{i}]", a.name),
+                a.name.clone(),
+                fb,
+            );
+        }
+    }
+    out
+}
+
+/// Rewrite deprecated models in an `agents.yaml`.
+///
+/// Textual substitution, like `update_agent_file` — a `serde_yaml_ng`
+/// round-trip would silently drop every comment and reorder keys.
+///
+/// Bounded to lines whose key is `model:`/`model_fallback:`, or which are
+/// list items belonging to one of those keys' own block list. A raw
+/// `: <model>` pattern would also match inside a comment or a
+/// `description`, and correcting a configuration must not rewrite prose.
+///
+/// A bare `- ` line is only a candidate while it is at or below the
+/// indentation of the nearest preceding `model:`/`model_fallback:` key that
+/// opened a block list (i.e. a line that is *only* that key, with the
+/// values on the following, indented lines) — any other line, whatever its
+/// own indentation, closes that scope. Without tracking the enclosing key,
+/// any `- ` line anywhere would be a candidate: a declared agent's `args:`
+/// block list happens to be able to hold a string that is itself a model
+/// name (e.g. `args: [--model, claude-3-sonnet-20240229]`, passed through
+/// to a `cli`-provider agent), and rewriting that would silently corrupt an
+/// argument, not fix a model.
+pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyhow::Result<usize> {
+    if findings.is_empty() {
+        return Ok(0);
+    }
+    let content = std::fs::read_to_string(path)?;
+    let mut count = 0;
+    let mut out = String::with_capacity(content.len());
+    // Indentation of the nearest `model:`/`model_fallback:` key that opened
+    // a block list still in scope, if any.
+    let mut active_list_indent: Option<usize> = None;
+
+    for line in content.lines() {
+        let code = line.split('#').next().unwrap_or(line);
+        let trimmed = code.trim_start();
+        let indent = code.len() - trimmed.len();
+
+        let is_model_line = trimmed.starts_with("model:") || trimmed.starts_with("model_fallback:");
+        let is_active_list_item = trimmed.starts_with("- ")
+            && active_list_indent.is_some_and(|key_indent| indent >= key_indent);
+
+        if !trimmed.is_empty() && !is_active_list_item {
+            // Not a continuation of the active list: a bare `model:`/
+            // `model_fallback:` key (no inline value) opens a new one — its
+            // values are the following, more-indented `- ` lines — and any
+            // other line closes whatever scope was open.
+            active_list_indent =
+                (trimmed == "model:" || trimmed == "model_fallback:").then_some(indent);
+        }
+
+        let is_model_key = is_model_line || is_active_list_item;
+        let mut kept = line.to_string();
+        if is_model_key {
+            for f in findings {
+                if kept.contains(&f.current) {
+                    kept = kept.replace(&f.current, &f.replacement);
+                    count += 1;
+                }
+            }
+        }
+        out.push_str(&kept);
+        out.push('\n');
+    }
+
+    std::fs::write(path, out)?;
     Ok(count)
 }
 
@@ -170,9 +304,10 @@ pub fn auto_check_and_prompt(project_root: &Path, interactive: bool) -> bool {
         .unwrap_or(false);
 
     if confirm {
+        let decls_path = crate::agent_source::declarations_path(project_root);
         let mut total = 0;
         for f in &findings {
-            if let Ok(n) = update_agent_file(&f.agent_path, std::slice::from_ref(f)) {
+            if let Ok(n) = apply_finding(f, &decls_path) {
                 total += n;
             }
         }
@@ -184,6 +319,24 @@ pub fn auto_check_and_prompt(project_root: &Path, interactive: bool) -> bool {
 
     eprintln!("hint: run `armadai models update` when ready.\n");
     false
+}
+
+/// Rewrite one finding in place, choosing the rewriter that matches where it
+/// came from.
+///
+/// A finding whose `agent_path` is the project's `agents.yaml` came from
+/// [`check_declarations`] and must go through [`update_declarations`] —
+/// [`update_agent_file`]'s single `replacen(.., 1)` would only fix the first
+/// occurrence, and its raw `: <model>` pattern is not bounded to
+/// `model:`/`model_fallback:` lines the way the declarative rewrite is.
+/// Extracted as its own function so the routing decision has a direct test,
+/// independent of the interactive prompt above it.
+fn apply_finding(finding: &DeprecationFinding, decls_path: &Path) -> anyhow::Result<usize> {
+    if finding.agent_path == decls_path {
+        update_declarations(&finding.agent_path, std::slice::from_ref(finding))
+    } else {
+        update_agent_file(&finding.agent_path, std::slice::from_ref(finding))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -316,5 +469,303 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].current, "gpt-3.5-turbo");
         assert_eq!(findings[0].replacement, "gpt-4o-mini");
+    }
+
+    // -----------------------------------------------------------------
+    // Declarative agents (`.armadai/agents.yaml`)
+    // -----------------------------------------------------------------
+
+    /// Take a real deprecated model from the alias registry, so the test
+    /// does not encode a value that may stop being deprecated.
+    ///
+    /// The two Claude names are tried first, in case the registry ever
+    /// grows Anthropic entries, but `embedded_aliases()` (in
+    /// `model_aliases.rs`) carries none today — verified by reading it, and
+    /// by this helper actually panicking on an unpatched version of itself
+    /// that tried only those two. The fallback candidates ARE in that map
+    /// today, so this stays deterministic without depending on a machine's
+    /// optional `~/.config/armadai/model-aliases.json` override.
+    fn a_deprecated_model() -> (String, String) {
+        for candidate in [
+            "claude-3-sonnet-20240229",
+            "claude-3-opus-20240229",
+            "gpt-4-turbo",
+            "gpt-3.5-turbo",
+            "gemini-1.5-flash",
+            "gemini-3.0-pro",
+        ] {
+            if let Some(r) = resolve_alias(candidate) {
+                return (candidate.to_string(), r);
+            }
+        }
+        panic!("no known deprecated model in the alias registry — update this helper");
+    }
+
+    fn write_yaml(dir: &Path, body: &str) -> std::path::PathBuf {
+        let p = dir.join("agents.yaml");
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn a_deprecated_model_in_defaults_is_found_and_fixed() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!("defaults:\n  model: {old}\nagents:\n  - name: a\n"),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(update_declarations(&p, &findings).unwrap(), 1);
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(after.contains(&new) && !after.contains(&old));
+    }
+
+    /// A `.md` agent declares `model` once; `agents.yaml` carries it in
+    /// `defaults` and in every agent that deviates. `replacen(.., 1)` would
+    /// fix only the first.
+    #[test]
+    fn the_same_deprecated_model_is_fixed_at_every_occurrence() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "defaults:\n  model: {old}\nagents:\n  \
+                 - name: a\n    model: {old}\n  - name: b\n    model: {old}\n"
+            ),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 3, "one per occurrence: {findings:?}");
+        update_declarations(&p, &findings).unwrap();
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(
+            !after.contains(&old),
+            "every occurrence must be fixed:\n{after}"
+        );
+        assert_eq!(after.matches(&new).count(), 3);
+    }
+
+    /// A raw `: <model>` pattern would also match inside prose. Correcting a
+    /// configuration is one thing; rewriting a comment is another.
+    #[test]
+    fn a_deprecated_model_named_in_a_comment_or_description_is_left_alone() {
+        let (old, _new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "# we used to run {old} here\nagents:\n  - name: a\n    \
+                 description: migrated away from {old}\n"
+            ),
+        );
+        assert!(
+            check_declarations(&p).is_empty(),
+            "no `model:` key carries it, so there is nothing to fix"
+        );
+        let before = std::fs::read_to_string(&p).unwrap();
+        update_declarations(&p, &[]).unwrap();
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), before);
+    }
+
+    #[test]
+    fn comments_and_key_order_survive_the_rewrite() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "# fleet defaults\ndefaults:\n  model: {old}\n  \
+                 temperature: 0.3   # deliberately warm\nagents:\n  - name: a\n"
+            ),
+        );
+        let findings = check_declarations(&p);
+        update_declarations(&p, &findings).unwrap();
+        let after = std::fs::read_to_string(&p).unwrap();
+        // The rewrite must actually have happened — otherwise "comments and
+        // key order survive" would pass just as well for a no-op that never
+        // touched the file at all.
+        assert!(
+            after.contains(&new) && !after.contains(&old),
+            "the model must actually be rewritten:\n{after}"
+        );
+        assert!(after.contains("# fleet defaults"), "comment lost:\n{after}");
+        assert!(
+            after.contains("# deliberately warm"),
+            "inline comment lost:\n{after}"
+        );
+        assert!(
+            after.find("model:").unwrap() < after.find("temperature:").unwrap(),
+            "key order changed — a serde round-trip would do this:\n{after}"
+        );
+    }
+
+    #[test]
+    fn a_deprecated_model_in_model_fallback_is_fixed() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!("agents:\n  - name: a\n    model_fallback: [{old}]\n"),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        update_declarations(&p, &findings).unwrap();
+        assert!(std::fs::read_to_string(&p).unwrap().contains(&new));
+    }
+
+    /// `is_model_key` must not treat every `- ` line as a candidate. An
+    /// `args:` block list — added alongside `command` so a declared
+    /// `provider: cli` agent can be expressed — can perfectly well hold a
+    /// value that is itself a deprecated model name, e.g. `--model
+    /// <name>` passed straight through to the CLI. Rewriting that would
+    /// corrupt an argument instead of fixing a model, while the real
+    /// `model:` field on the same agent must still be fixed.
+    #[test]
+    fn a_list_item_under_an_unrelated_key_is_left_alone() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "agents:\n  - name: a\n    provider: cli\n    model: {old}\n    \
+                 args:\n      - --model\n      - {old}\n"
+            ),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(
+            findings.len(),
+            1,
+            "only the `model:` field is a finding: {findings:?}"
+        );
+        update_declarations(&p, &findings).unwrap();
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(
+            after.contains(&format!("model: {new}")),
+            "the real model field must still be fixed:\n{after}"
+        );
+        assert!(
+            after.contains(&format!("- {old}")),
+            "the args list item must survive untouched:\n{after}"
+        );
+    }
+
+    /// `model_fallback` written as a block list (each value on its own,
+    /// indented `- ` line) rather than the inline `[a, b]` form used
+    /// elsewhere in this file — both are valid YAML, and both must be
+    /// fixed. Two distinct deprecated models (rather than
+    /// `a_deprecated_model`'s single pair) so a mutation that only fixes
+    /// the first occurrence cannot hide behind two identical strings.
+    #[test]
+    fn a_block_style_model_fallback_list_is_fixed() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            "agents:\n  - name: a\n    model_fallback:\n      - gpt-4-turbo\n      \
+             - gemini-1.5-flash\n",
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 2, "{findings:?}");
+        assert_eq!(update_declarations(&p, &findings).unwrap(), 2);
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(after.contains("gpt-4o") && !after.contains("gpt-4-turbo"));
+        assert!(after.contains("gemini-2.5-flash") && !after.contains("gemini-1.5-flash"));
+    }
+
+    #[test]
+    fn check_declarations_of_an_unreadable_file_is_empty_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("does-not-exist.yaml");
+        assert!(check_declarations(&p).is_empty());
+    }
+
+    #[test]
+    fn update_declarations_with_no_findings_leaves_the_file_untouched() {
+        let (old, _new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(dir.path(), &format!("defaults:\n  model: {old}\n"));
+        let before = std::fs::read_to_string(&p).unwrap();
+        assert_eq!(update_declarations(&p, &[]).unwrap(), 0);
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), before);
+    }
+
+    /// `check_project` must also see `.armadai/agents.yaml` — the wiring
+    /// this task exists to add (see also `auto_check_and_prompt`, verified
+    /// by hand rather than here since it drives an interactive prompt).
+    /// Same project-fixture shape as `test_check_project_with_agents`, but
+    /// the deprecated model lives in the declaration file instead of a
+    /// `.md`.
+    #[test]
+    fn check_project_also_scans_the_declarations_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let armadai_dir = dir.path().join(".armadai");
+        std::fs::create_dir_all(&armadai_dir).unwrap();
+        std::fs::write(armadai_dir.join("config.yaml"), "agents: []\n").unwrap();
+        let (old, new) = a_deprecated_model();
+        std::fs::write(
+            armadai_dir.join("agents.yaml"),
+            format!("defaults:\n  provider: claude\n  model: {old}\nagents:\n  - name: a\n"),
+        )
+        .unwrap();
+
+        let findings = check_project(dir.path()).unwrap();
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].current, old);
+        assert_eq!(findings[0].replacement, new);
+    }
+
+    // -----------------------------------------------------------------
+    // `apply_finding` — the routing decision `auto_check_and_prompt` makes
+    // on confirmation. Tested directly, since exercising the surrounding
+    // `dialoguer::Confirm` prompt would need a real terminal.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn apply_finding_routes_a_declarations_finding_to_update_declarations() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!("defaults:\n  model: {old}\nagents:\n  - name: a\n"),
+        );
+        let finding = DeprecationFinding {
+            agent_path: p.clone(),
+            agent_name: "defaults".into(),
+            field: "defaults.model".into(),
+            current: old,
+            replacement: new.clone(),
+        };
+
+        // `decls_path` equal to the finding's own path is what marks it as
+        // declarations-sourced.
+        let n = apply_finding(&finding, &p).unwrap();
+        assert_eq!(n, 1);
+        assert!(std::fs::read_to_string(&p).unwrap().contains(&new));
+    }
+
+    #[test]
+    fn apply_finding_routes_a_file_finding_to_update_agent_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.md");
+        std::fs::write(&path, create_agent_md("Test", "gpt-4-turbo", &[])).unwrap();
+        let finding = DeprecationFinding {
+            agent_path: path.clone(),
+            agent_name: "Test".into(),
+            field: "model".into(),
+            current: "gpt-4-turbo".into(),
+            replacement: "gpt-4o".into(),
+        };
+        // `decls_path` deliberately different from the finding's own path,
+        // so only the else-branch (`update_agent_file`) can produce a fix.
+        let decls_path = dir.path().join("agents.yaml");
+
+        let n = apply_finding(&finding, &decls_path).unwrap();
+        assert_eq!(n, 1);
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("model: gpt-4o")
+        );
     }
 }

--- a/crates/armadai-core/src/model_updater.rs
+++ b/crates/armadai-core/src/model_updater.rs
@@ -787,36 +787,47 @@ mod tests {
             dir.path(),
             "agents:\n  - name: a\n    model: dep\n  - name: b\n    model: dep-longer\n",
         );
+        // Replacements chosen so an unanchored rewrite CANNOT recompose the
+        // right answer by accident: `dep` -> `new` and `dep-longer` ->
+        // `new-longer` would let an unanchored replace of `dep` inside
+        // `dep-longer` produce `new` + `-longer` = `new-longer`, the exact
+        // string the second finding was also going to write — the mutation
+        // would be invisible. `alpha`/`beta` share no structure with each
+        // other or with `dep`/`dep-longer`, so the ONLY way `model:
+        // dep-longer` ends up as `model: beta` is the longer finding
+        // matching its own whole token; an unanchored replace of `dep` ->
+        // `alpha` inside `dep-longer` produces `alpha-longer`, which is
+        // asserted against below.
         let findings = vec![
             DeprecationFinding {
                 agent_path: p.clone(),
                 agent_name: "a".into(),
                 field: "model".into(),
                 current: "dep".into(),
-                replacement: "new".into(),
+                replacement: "alpha".into(),
             },
             DeprecationFinding {
                 agent_path: p.clone(),
                 agent_name: "b".into(),
                 field: "model".into(),
                 current: "dep-longer".into(),
-                replacement: "new-longer".into(),
+                replacement: "beta".into(),
             },
         ];
 
         assert_eq!(update_declarations(&p, &findings).unwrap(), 2);
         let after = std::fs::read_to_string(&p).unwrap();
         assert!(
-            after.contains("model: new\n"),
+            after.contains("model: alpha\n"),
             "the shorter deprecated name must be fixed on its own line:\n{after}"
         );
         assert!(
-            after.contains("model: new-longer\n"),
+            after.contains("model: beta\n"),
             "the longer line must be fixed to its OWN replacement, not \
              corrupted by the shorter finding's rewrite:\n{after}"
         );
         assert!(
-            !after.contains("new-dep-longer"),
+            !after.contains("alpha-longer"),
             "the shorter finding must not have rewritten inside the longer \
              line's value: {after}"
         );

--- a/crates/armadai-core/src/model_updater.rs
+++ b/crates/armadai-core/src/model_updater.rs
@@ -199,6 +199,65 @@ fn opens_block_scalar(value: &str) -> bool {
     digits <= 1 && signs <= 1 && digits + signs == rest.chars().count()
 }
 
+/// Does `c` belong to a model-identifier token (letters, digits, `-`, `_`,
+/// `.`)? Model names routinely contain hyphens and digits (`claude-3-5-
+/// sonnet-20241022`), so a plain word-boundary check (alphanumeric only)
+/// would not stop at the hyphen between a shorter name and a longer one that
+/// starts with it.
+fn is_model_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
+}
+/// Replace every occurrence of `needle` in `haystack` that is a whole
+/// model-name token — not merely a substring — with `replacement`, and
+/// report how many were replaced.
+///
+/// A single forward pass: once an occurrence (matching or not) is behind the
+/// cursor, it is never revisited, so a `replacement` that happens to start
+/// with `needle` (e.g. `gpt-4` deprecated in favour of `gpt-4-turbo`) cannot
+/// loop — the newly written text is simply not rescanned. `needle ==
+/// replacement` is treated as already-a-no-op for the same reason (nothing
+/// to gain by "replacing" a value with itself, and it would otherwise never
+/// terminate).
+fn replace_model_name_all(haystack: &str, needle: &str, replacement: &str) -> (String, usize) {
+    if needle.is_empty() || needle == replacement {
+        return (haystack.to_string(), 0);
+    }
+    let mut out = String::with_capacity(haystack.len());
+    let mut rest = haystack;
+    let mut count = 0;
+    loop {
+        let Some(rel) = rest.find(needle) else {
+            out.push_str(rest);
+            break;
+        };
+        let before_ok = rest[..rel]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_model_name_char(c));
+        let end = rel + needle.len();
+        let after_ok = rest[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_model_name_char(c));
+        if before_ok && after_ok {
+            out.push_str(&rest[..rel]);
+            out.push_str(replacement);
+            count += 1;
+            rest = &rest[end..];
+        } else {
+            // Not a whole-token match (`needle` is a substring of a longer
+            // identifier) — copy past just this occurrence's first
+            // character and keep scanning; guarantees forward progress.
+            let mut chars = rest[rel..].chars();
+            let c = chars.next().expect("find() returned a valid offset");
+            out.push_str(&rest[..rel]);
+            out.push(c);
+            rest = &rest[rel + c.len_utf8()..];
+        }
+    }
+    (out, count)
+}
+
 /// Rewrite deprecated models in an `agents.yaml`.
 ///
 /// Textual substitution, like `update_agent_file` — a `serde_yaml_ng`
@@ -235,6 +294,13 @@ fn opens_block_scalar(value: &str) -> bool {
 /// `findings.len()` and returns an `Err` naming whatever finding(s) it
 /// could not locate otherwise — and, so a caller never has to reason about
 /// a half-applied fix, writes nothing at all when it errors.
+///
+/// Every replacement on a model-key line goes through
+/// [`replace_model_name_all`], anchored on the model name's own boundaries —
+/// not a raw `contains`/`replace` — so one deprecated name that happens to
+/// be a prefix of another (a future `claude-3-5-sonnet` next to
+/// `claude-3-5-sonnet-20241022`, or `gpt-4` next to `gpt-4-turbo`) cannot
+/// have the shorter finding's rewrite corrupt the line the longer one owns.
 pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyhow::Result<usize> {
     if findings.is_empty() {
         return Ok(0);
@@ -303,11 +369,12 @@ pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyh
         let mut kept = line.to_string();
         if is_model_key {
             for f in findings {
-                if kept.contains(&f.current) {
-                    kept = kept.replace(&f.current, &f.replacement);
-                    count += 1;
-                    if let Some(n) = remaining.get_mut(f.current.as_str()) {
-                        *n = n.saturating_sub(1);
+                let (rewritten, n) = replace_model_name_all(&kept, &f.current, &f.replacement);
+                if n > 0 {
+                    kept = rewritten;
+                    count += n;
+                    if let Some(rem) = remaining.get_mut(f.current.as_str()) {
+                        *rem = rem.saturating_sub(n);
                     }
                 }
             }
@@ -703,6 +770,56 @@ mod tests {
             "every occurrence must be fixed:\n{after}"
         );
         assert_eq!(after.matches(&new).count(), 3);
+    }
+
+    /// m6 / F11: `contains`/`replace` on the raw line is unanchored, so two
+    /// deprecated models where one name is a prefix of the other used to
+    /// corrupt each other — the shorter finding's rewrite would land inside
+    /// the longer line too, and the per-line count still balanced (1 match
+    /// each), so `update_declarations` reported success on a mangled value.
+    /// Findings are built by hand rather than through `check_declarations`,
+    /// since no pair in the real alias registry happens to share a prefix
+    /// today — this fixture manufactures the exact shape regardless.
+    #[test]
+    fn a_deprecated_model_that_is_a_prefix_of_another_does_not_corrupt_the_longer_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            "agents:\n  - name: a\n    model: dep\n  - name: b\n    model: dep-longer\n",
+        );
+        let findings = vec![
+            DeprecationFinding {
+                agent_path: p.clone(),
+                agent_name: "a".into(),
+                field: "model".into(),
+                current: "dep".into(),
+                replacement: "new".into(),
+            },
+            DeprecationFinding {
+                agent_path: p.clone(),
+                agent_name: "b".into(),
+                field: "model".into(),
+                current: "dep-longer".into(),
+                replacement: "new-longer".into(),
+            },
+        ];
+
+        assert_eq!(update_declarations(&p, &findings).unwrap(), 2);
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(
+            after.contains("model: new\n"),
+            "the shorter deprecated name must be fixed on its own line:\n{after}"
+        );
+        assert!(
+            after.contains("model: new-longer\n"),
+            "the longer line must be fixed to its OWN replacement, not \
+             corrupted by the shorter finding's rewrite:\n{after}"
+        );
+        assert!(
+            !after.contains("new-dep-longer"),
+            "the shorter finding must not have rewritten inside the longer \
+             line's value: {after}"
+        );
     }
 
     /// A raw `: <model>` pattern would also match inside prose. Correcting a

--- a/crates/armadai-core/src/pack_validation.rs
+++ b/crates/armadai-core/src/pack_validation.rs
@@ -246,6 +246,9 @@ pub fn validate_project_config(project_root: &Path) -> Vec<ValidationIssue> {
             super::project::AgentRef::Registry { registry } => {
                 agent_names.insert(registry.clone());
             }
+            super::project::AgentRef::Declared { declared } => {
+                agent_names.insert(declared.clone());
+            }
         }
     }
 

--- a/crates/armadai-core/src/pack_validation.rs
+++ b/crates/armadai-core/src/pack_validation.rs
@@ -252,6 +252,23 @@ pub fn validate_project_config(project_root: &Path) -> Vec<ValidationIssue> {
         }
     }
 
+    // Every agent in `.armadai/agents.yaml` is included automatically — it
+    // does not need to be relisted in `agents:` (the `Declared` arm above
+    // only fires for that redundant `- declared: x` spelling) — so an
+    // orchestration `coordinator`/`teams[].lead`/`teams[].agents` naming a
+    // declared-but-not-relisted agent must count as known here too, or this
+    // reports a project `list`, `link`, `inspect` and `run --orchestrate`
+    // all resolve fine as invalid. Guarded the same way
+    // `model_updater::check_project` guards its own declarations scan.
+    let decls_path = super::agent_source::declarations_path(project_root);
+    if decls_path.is_file()
+        && let Ok(decls) = super::agent_decl::load(&decls_path)
+    {
+        for decl in &decls.agents {
+            agent_names.insert(decl.name.clone());
+        }
+    }
+
     // R1 + R2: Validate orchestration config (teams + coordinator)
     if let Some(orch) = &config.orchestration {
         validate_orchestration_config(orch, &agent_names, &config_path, &mut issues);
@@ -676,6 +693,45 @@ orchestration:
         assert!(issues.iter().any(|i| i.severity == Severity::Error
             && i.message.contains("missing-coordinator")
             && i.message.contains("not found")));
+    }
+
+    /// I1: an agent declared only in `.armadai/agents.yaml` — never relisted
+    /// in `armadai.yaml`'s `agents:`, which is the whole point of the format
+    /// — must count as known to `orchestration.coordinator`/`teams[].lead`/
+    /// `teams[].agents`. Before this fix, `agent_names` was built from
+    /// `config.agents` alone, so this reported three false ERRORs for a
+    /// project `list`/`link`/`inspect`/`run --orchestrate` all resolve fine.
+    #[test]
+    fn test_validate_project_config_resolves_declared_only_orchestration_agents() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("armadai.yaml"),
+            r#"
+orchestration:
+  enabled: true
+  coordinator: zzz-lead
+  teams:
+    - lead: zzz-worker
+      agents:
+        - zzz-worker2
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: zzz-lead\n    prompt: []\n  \
+             - name: zzz-worker\n    prompt: []\n  \
+             - name: zzz-worker2\n    prompt: []\n",
+        )
+        .unwrap();
+
+        let issues = validate_project_config(dir.path());
+        assert!(
+            issues.iter().all(|i| i.severity != Severity::Error),
+            "every named agent is declared and must resolve: {issues:?}"
+        );
     }
 
     #[test]

--- a/crates/armadai-core/src/parser/metadata.rs
+++ b/crates/armadai-core/src/parser/metadata.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 
-use crate::agent::{AgentMetadata, AgentMode};
+use crate::agent::{AgentMetadata, AgentMode, default_temperature};
 use crate::orchestration::OrchestrationPattern;
 
 /// Parse the Metadata section content (YAML-like list format) into AgentMetadata.
@@ -9,7 +9,7 @@ pub fn parse_metadata(raw: &str) -> anyhow::Result<AgentMetadata> {
     let mut model = None;
     let mut command = None;
     let mut args = None;
-    let mut temperature = 0.7_f32;
+    let mut temperature = default_temperature();
     let mut max_tokens = None;
     let mut timeout = None;
     let mut tags = Vec::new();

--- a/crates/armadai-core/src/project.rs
+++ b/crates/armadai-core/src/project.rs
@@ -291,6 +291,22 @@ fn check_dotarmadai_migration_hint(project_root: &Path, legacy_filename: &str) {
 // Agent resolution
 // ---------------------------------------------------------------------------
 
+/// Every directory a `.md` agent can be resolved from, in resolution order.
+///
+/// The single source of truth for that list: `resolve_agent`'s `Named` arm
+/// and `agent_source::check_no_shadowing` both call this rather than each
+/// keeping their own copy, so the two can never drift apart.
+pub fn library_dirs(project_root: &Path) -> Vec<PathBuf> {
+    vec![
+        // 1. .armadai/agents/ (preferred)
+        project_root.join(PROJECT_DIR).join("agents"),
+        // 2. Project-local agents/ (legacy)
+        project_root.join("agents"),
+        // 3. User library ~/.config/armadai/agents/
+        user_agents_dir(),
+    ]
+}
+
 /// Resolve a single `AgentRef` to an absolute path.
 pub fn resolve_agent(agent_ref: &AgentRef, project_root: &Path) -> anyhow::Result<PathBuf> {
     match agent_ref {
@@ -313,32 +329,19 @@ pub fn resolve_agent(agent_ref: &AgentRef, project_root: &Path) -> anyhow::Resul
                 format!("{name}.md")
             };
 
-            // 1. .armadai/agents/ (preferred)
-            let dotarmadai = project_root
-                .join(PROJECT_DIR)
-                .join("agents")
-                .join(&filename);
-            if dotarmadai.exists() {
-                return Ok(dotarmadai);
-            }
-
-            // 2. Project-local agents/ (legacy)
-            let local = project_root.join("agents").join(&filename);
-            if local.exists() {
-                return Ok(local);
-            }
-
-            // 3. User library ~/.config/armadai/agents/
-            let global = user_agents_dir().join(&filename);
-            if global.exists() {
-                return Ok(global);
+            let dirs = library_dirs(project_root);
+            for dir in &dirs {
+                let candidate = dir.join(&filename);
+                if candidate.exists() {
+                    return Ok(candidate);
+                }
             }
 
             anyhow::bail!(
                 "Agent '{name}' not found in {}, {} or {}",
-                dotarmadai.display(),
-                local.display(),
-                global.display()
+                dirs[0].join(&filename).display(),
+                dirs[1].join(&filename).display(),
+                dirs[2].join(&filename).display(),
             );
         }
         AgentRef::Registry { registry } => {

--- a/crates/armadai-core/src/project.rs
+++ b/crates/armadai-core/src/project.rs
@@ -294,8 +294,9 @@ fn check_dotarmadai_migration_hint(project_root: &Path, legacy_filename: &str) {
 /// Every directory a `.md` agent can be resolved from, in resolution order.
 ///
 /// The single source of truth for that list: `resolve_agent`'s `Named` arm
-/// and `agent_source::check_no_shadowing` both call this rather than each
-/// keeping their own copy, so the two can never drift apart.
+/// and `agent_source::shadowing_conflict` (the collision check
+/// `load_all_agents`/`load_agent_by_name` each call) both use this rather
+/// than keeping their own copy, so the two can never drift apart.
 pub fn library_dirs(project_root: &Path) -> Vec<PathBuf> {
     vec![
         // 1. .armadai/agents/ (preferred)

--- a/crates/armadai-core/src/project.rs
+++ b/crates/armadai-core/src/project.rs
@@ -161,9 +161,12 @@ pub enum AgentRef {
         path: PathBuf,
     },
     /// An agent declared in `.armadai/agents.yaml` rather than written as a
-    /// file. See `agent_source::load_agent`, which is the only way to turn
-    /// this variant into an `Agent` — `resolve_agent` below refuses it,
-    /// because a declared agent has no file of its own.
+    /// file. `resolve_agent` below refuses this variant, because a declared
+    /// agent has no file of its own — `agent_source::load_all_agents` (a
+    /// whole project's fleet) and `agent_source::load_agent_by_name` (one
+    /// agent by name) are what actually turn it into an `Agent`, by
+    /// resolving it through the project's declarations directly rather than
+    /// through this function.
     Declared {
         declared: String,
     },

--- a/crates/armadai-core/src/project.rs
+++ b/crates/armadai-core/src/project.rs
@@ -394,6 +394,22 @@ pub fn resolve_all_agents(
 // ---------------------------------------------------------------------------
 
 /// Resolve a single `PromptRef` to an absolute path.
+/// Every directory a `.md` prompt fragment can be resolved from, in
+/// resolution order — the prompt-side twin of `library_dirs`, so
+/// `resolve_prompt`'s `Named` arm and `agent_source::project_fragments`
+/// (which needs the same three tiers to gather fragments a declared agent
+/// can reference) share one list instead of each keeping its own copy.
+pub fn prompt_dirs(project_root: &Path) -> Vec<PathBuf> {
+    vec![
+        // 1. .armadai/prompts/ (preferred)
+        project_root.join(PROJECT_DIR).join("prompts"),
+        // 2. Project-local prompts/ (legacy)
+        project_root.join("prompts"),
+        // 3. User library ~/.config/armadai/prompts/
+        user_prompts_dir(),
+    ]
+}
+
 pub fn resolve_prompt(prompt_ref: &PromptRef, project_root: &Path) -> anyhow::Result<PathBuf> {
     match prompt_ref {
         PromptRef::Path { path } => {
@@ -415,32 +431,19 @@ pub fn resolve_prompt(prompt_ref: &PromptRef, project_root: &Path) -> anyhow::Re
                 format!("{name}.md")
             };
 
-            // 1. .armadai/prompts/ (preferred)
-            let dotarmadai = project_root
-                .join(PROJECT_DIR)
-                .join("prompts")
-                .join(&filename);
-            if dotarmadai.exists() {
-                return Ok(dotarmadai);
-            }
-
-            // 2. Project-local prompts/ (legacy)
-            let local = project_root.join("prompts").join(&filename);
-            if local.exists() {
-                return Ok(local);
-            }
-
-            // 3. User library ~/.config/armadai/prompts/
-            let global = user_prompts_dir().join(&filename);
-            if global.exists() {
-                return Ok(global);
+            let dirs = prompt_dirs(project_root);
+            for dir in &dirs {
+                let candidate = dir.join(&filename);
+                if candidate.exists() {
+                    return Ok(candidate);
+                }
             }
 
             anyhow::bail!(
                 "Prompt '{name}' not found in {}, {} or {}",
-                dotarmadai.display(),
-                local.display(),
-                global.display()
+                dirs[0].join(&filename).display(),
+                dirs[1].join(&filename).display(),
+                dirs[2].join(&filename).display(),
             );
         }
     }

--- a/crates/armadai-core/src/project.rs
+++ b/crates/armadai-core/src/project.rs
@@ -361,9 +361,15 @@ pub fn resolve_agent(agent_ref: &AgentRef, project_root: &Path) -> anyhow::Resul
             }
         }
         AgentRef::Declared { declared } => {
+            // User-facing text: this is reachable from `link`/`list`'s
+            // warning loop whenever `agents:` lists `- declared: x`
+            // explicitly (`resolve_all_agents` iterates every ref), so it
+            // must read as a fact about the project, never as an internal
+            // pointer to a different function — an earlier version named
+            // `agent_source::load_agent` here, which a user has no reason to
+            // know about and cannot act on.
             anyhow::bail!(
-                "agent '{declared}' is declared in {}, not a file — use \
-                 `agent_source::load_agent` instead of `resolve_agent`",
+                "agent '{declared}' is declared in {} rather than written as a file",
                 agent_source::declarations_path(project_root).display()
             );
         }

--- a/crates/armadai-core/src/project.rs
+++ b/crates/armadai-core/src/project.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use super::agent::AgentMode;
+use super::agent_source;
 use super::config::{registry_cache_dir, user_agents_dir, user_prompts_dir, user_skills_dir};
 use super::orchestration::OrchestrationConfig;
 
@@ -150,9 +151,22 @@ impl ShellConfig {
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum AgentRef {
-    Named { name: String },
-    Registry { registry: String },
-    Path { path: PathBuf },
+    Named {
+        name: String,
+    },
+    Registry {
+        registry: String,
+    },
+    Path {
+        path: PathBuf,
+    },
+    /// An agent declared in `.armadai/agents.yaml` rather than written as a
+    /// file. See `agent_source::load_agent`, which is the only way to turn
+    /// this variant into an `Agent` — `resolve_agent` below refuses it,
+    /// because a declared agent has no file of its own.
+    Declared {
+        declared: String,
+    },
 }
 
 /// Reference to a prompt fragment.
@@ -342,6 +356,13 @@ pub fn resolve_agent(agent_ref: &AgentRef, project_root: &Path) -> anyhow::Resul
                     path.display()
                 );
             }
+        }
+        AgentRef::Declared { declared } => {
+            anyhow::bail!(
+                "agent '{declared}' is declared in {}, not a file — use \
+                 `agent_source::load_agent` instead of `resolve_agent`",
+                agent_source::declarations_path(project_root).display()
+            );
         }
     }
 }

--- a/crates/armadai-core/src/template.rs
+++ b/crates/armadai-core/src/template.rs
@@ -1,0 +1,168 @@
+//! `{{var}}` substitution, shared by agent templates and prompt fragments.
+//!
+//! Extracted from `cli/new.rs`, which substituted inline and hand-rolled its
+//! own leftover scan.
+//!
+//! Two policies over one scan. `render` refuses a leftover: a prompt
+//! containing a literal `{{module}}` is text the model will try to interpret,
+//! and an agent built from it is quietly wrong. `render_lenient` substitutes
+//! what it can and hands the leftovers back, which is what `armadai new`
+//! needs — most templates carry `{{description}}`, and `new` warns rather
+//! than refusing.
+
+use std::collections::BTreeMap;
+
+/// A template could not be fully rendered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplateError {
+    /// Placeholder names with no value supplied, in order of appearance.
+    Unsubstituted(Vec<String>),
+}
+
+impl std::fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsubstituted(names) => write!(
+                f,
+                "no value supplied for {}",
+                names
+                    .iter()
+                    .map(|n| format!("{{{{{n}}}}}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TemplateError {}
+
+/// Every `{{name}}` placeholder in `template`, in order, without duplicates.
+fn placeholders(template: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        let after = &rest[start + 2..];
+        let Some(end) = after.find("}}") else {
+            break; // unterminated: not a placeholder
+        };
+        let name = after[..end].trim().to_string();
+        if !name.is_empty() && !found.contains(&name) {
+            found.push(name);
+        }
+        rest = &after[end + 2..];
+    }
+    found
+}
+
+/// Substitute every `{{name}}` with its value.
+///
+/// Errors when a placeholder has no value: see the module docs.
+pub fn render(template: &str, vars: &BTreeMap<String, String>) -> Result<String, TemplateError> {
+    let missing: Vec<String> = placeholders(template)
+        .into_iter()
+        .filter(|n| !vars.contains_key(n))
+        .collect();
+    if !missing.is_empty() {
+        return Err(TemplateError::Unsubstituted(missing));
+    }
+    let mut out = template.to_string();
+    for (name, value) in vars {
+        out = out.replace(&format!("{{{{{name}}}}}"), value);
+    }
+    Ok(out)
+}
+
+/// Substitute what the variables cover, and report what is left.
+///
+/// For callers that must not fail on a leftover — `armadai new` warns about
+/// them instead, because most templates legitimately carry a `{{description}}`
+/// the user did not supply.
+pub fn render_lenient(template: &str, vars: &BTreeMap<String, String>) -> (String, Vec<String>) {
+    let left: Vec<String> = placeholders(template)
+        .into_iter()
+        .filter(|n| !vars.contains_key(n))
+        .collect();
+    let mut out = template.to_string();
+    for (name, value) in vars {
+        out = out.replace(&format!("{{{{{name}}}}}"), value);
+    }
+    (out, left)
+}
+
+/// Values supplied that the template never uses — almost always a typo.
+pub fn unused_vars(template: &str, vars: &BTreeMap<String, String>) -> Vec<String> {
+    let used = placeholders(template);
+    vars.keys().filter(|k| !used.contains(k)).cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn substitutes_every_occurrence() {
+        let out = render(
+            "{{a}} then {{b}} then {{a}}",
+            &vars(&[("a", "1"), ("b", "2")]),
+        )
+        .unwrap();
+        assert_eq!(out, "1 then 2 then 1");
+    }
+
+    #[test]
+    fn a_template_without_variables_is_returned_as_is() {
+        assert_eq!(render("plain text", &vars(&[])).unwrap(), "plain text");
+    }
+
+    /// A prompt still containing `{{module}}` is text the model will try to
+    /// interpret. Refusing to build the agent is the whole point.
+    #[test]
+    fn an_unsubstituted_variable_is_an_error_naming_it() {
+        let err = render("hello {{who}} and {{whom}}", &vars(&[])).unwrap_err();
+        match err {
+            TemplateError::Unsubstituted(names) => {
+                assert_eq!(names, vec!["who".to_string(), "whom".to_string()])
+            }
+        }
+    }
+
+    #[test]
+    fn a_provided_but_unused_variable_is_reported_not_fatal() {
+        // Almost always a typo — worth saying, never worth failing.
+        assert!(render("nothing here", &vars(&[("spare", "x")])).is_ok());
+        assert_eq!(
+            unused_vars("nothing here", &vars(&[("spare", "x")])),
+            vec!["spare".to_string()]
+        );
+    }
+
+    /// `armadai new` must keep working on the 10 templates that carry
+    /// `{{description}}`: substitute what we have, hand back the rest.
+    #[test]
+    fn lenient_rendering_substitutes_what_it_can_and_returns_the_rest() {
+        let (out, left) = render_lenient("{{a}} and {{b}}", &vars(&[("a", "1")]));
+        assert_eq!(out, "1 and {{b}}");
+        assert_eq!(left, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn lenient_rendering_reports_nothing_left_when_all_are_supplied() {
+        let (out, left) = render_lenient("{{a}}", &vars(&[("a", "1")]));
+        assert_eq!(out, "1");
+        assert!(left.is_empty());
+    }
+
+    #[test]
+    fn an_unterminated_placeholder_is_left_alone() {
+        // `{{` with no closing `}}` is not a placeholder, just text.
+        assert_eq!(render("a {{ b", &vars(&[])).unwrap(), "a {{ b");
+    }
+}

--- a/crates/armadai-core/src/template.rs
+++ b/crates/armadai-core/src/template.rs
@@ -9,8 +9,17 @@
 //! what it can and hands the leftovers back, which is what `armadai new`
 //! needs — most templates carry `{{description}}`, and `new` warns rather
 //! than refusing.
+//!
+//! `placeholders()` and substitution share one scan (see `scan()` below), so
+//! they cannot disagree on which occurrences a template contains — including
+//! `{{ name }}` written with inner whitespace, which is trimmed and treated
+//! exactly like `{{name}}` by both the missing-value check and the
+//! substitution itself. A value is inserted literally and is never rescanned
+//! for placeholders of its own, so substitution is single-pass and
+//! order-independent.
 
 use std::collections::BTreeMap;
+use std::ops::Range;
 
 /// A template could not be fully rendered.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -37,22 +46,69 @@ impl std::fmt::Display for TemplateError {
 
 impl std::error::Error for TemplateError {}
 
+/// One `{{name}}` occurrence, with the byte range of the whole `{{...}}` span
+/// (inner whitespace included) so a caller can replace exactly that text.
+struct Occurrence {
+    name: String,
+    span: Range<usize>,
+}
+
+/// Scan `template` once for `{{name}}` placeholders, trimming inner
+/// whitespace so `{{ name }}` and `{{name}}` are the same placeholder. An
+/// unterminated `{{` (no matching `}}` anywhere after it) is not a
+/// placeholder and stops the scan, matching the pre-existing "left alone"
+/// behaviour for trailing garbage.
+fn scan(template: &str) -> Vec<Occurrence> {
+    let mut found = Vec::new();
+    let mut pos = 0;
+    while let Some(rel_start) = template[pos..].find("{{") {
+        let start = pos + rel_start;
+        let after = start + 2;
+        let Some(rel_end) = template[after..].find("}}") else {
+            break; // unterminated: not a placeholder
+        };
+        let inner_end = after + rel_end;
+        let end = inner_end + 2;
+        let name = template[after..inner_end].trim().to_string();
+        if !name.is_empty() {
+            found.push(Occurrence {
+                name,
+                span: start..end,
+            });
+        }
+        pos = end;
+    }
+    found
+}
+
 /// Every `{{name}}` placeholder in `template`, in order, without duplicates.
 fn placeholders(template: &str) -> Vec<String> {
     let mut found = Vec::new();
-    let mut rest = template;
-    while let Some(start) = rest.find("{{") {
-        let after = &rest[start + 2..];
-        let Some(end) = after.find("}}") else {
-            break; // unterminated: not a placeholder
-        };
-        let name = after[..end].trim().to_string();
-        if !name.is_empty() && !found.contains(&name) {
-            found.push(name);
+    for occurrence in scan(template) {
+        if !found.contains(&occurrence.name) {
+            found.push(occurrence.name);
         }
-        rest = &after[end + 2..];
     }
     found
+}
+
+/// Replace every recognised occurrence that has a value, in one pass over
+/// `template`. An occurrence with no value is copied through verbatim
+/// (original spacing included), so a caller can inspect what is still
+/// missing without the output silently losing that placeholder's text.
+fn substitute(template: &str, vars: &BTreeMap<String, String>) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut last = 0;
+    for occurrence in scan(template) {
+        out.push_str(&template[last..occurrence.span.start]);
+        match vars.get(&occurrence.name) {
+            Some(value) => out.push_str(value),
+            None => out.push_str(&template[occurrence.span.clone()]),
+        }
+        last = occurrence.span.end;
+    }
+    out.push_str(&template[last..]);
+    out
 }
 
 /// Substitute every `{{name}}` with its value.
@@ -66,11 +122,7 @@ pub fn render(template: &str, vars: &BTreeMap<String, String>) -> Result<String,
     if !missing.is_empty() {
         return Err(TemplateError::Unsubstituted(missing));
     }
-    let mut out = template.to_string();
-    for (name, value) in vars {
-        out = out.replace(&format!("{{{{{name}}}}}"), value);
-    }
-    Ok(out)
+    Ok(substitute(template, vars))
 }
 
 /// Substitute what the variables cover, and report what is left.
@@ -83,11 +135,7 @@ pub fn render_lenient(template: &str, vars: &BTreeMap<String, String>) -> (Strin
         .into_iter()
         .filter(|n| !vars.contains_key(n))
         .collect();
-    let mut out = template.to_string();
-    for (name, value) in vars {
-        out = out.replace(&format!("{{{{{name}}}}}"), value);
-    }
-    (out, left)
+    (substitute(template, vars), left)
 }
 
 /// Values supplied that the template never uses — almost always a typo.
@@ -164,5 +212,60 @@ mod tests {
     fn an_unterminated_placeholder_is_left_alone() {
         // `{{` with no closing `}}` is not a placeholder, just text.
         assert_eq!(render("a {{ b", &vars(&[])).unwrap(), "a {{ b");
+    }
+
+    /// C1: `{{ name }}` (spaced) must be substituted, not shipped literally.
+    /// `placeholders()` already trimmed the inner name for the missing-value
+    /// check; substitution has to agree or a spaced placeholder passes as
+    /// "present" and then never gets replaced.
+    #[test]
+    fn a_placeholder_with_inner_whitespace_is_substituted() {
+        assert_eq!(
+            render(
+                "You are {{ name }}, spaced.",
+                &vars(&[("name", "core-specialist")])
+            )
+            .unwrap(),
+            "You are core-specialist, spaced."
+        );
+    }
+
+    #[test]
+    fn a_placeholder_with_extra_inner_whitespace_is_substituted() {
+        assert_eq!(
+            render("Hi {{  name  }}!", &vars(&[("name", "Ada")])).unwrap(),
+            "Hi Ada!"
+        );
+    }
+
+    /// `render` and `render_lenient` must agree on exactly the same set of
+    /// occurrences, spaced or not — they share one scan for that reason.
+    #[test]
+    fn render_and_render_lenient_agree_on_spaced_placeholders() {
+        let template = "You are {{ name }}, a {{ role }}.";
+        let complete = vars(&[("name", "Ada"), ("role", "engineer")]);
+
+        let strict = render(template, &complete).unwrap();
+        let (lenient, left) = render_lenient(template, &complete);
+        assert_eq!(strict, lenient);
+        assert!(left.is_empty());
+
+        let partial = vars(&[("name", "Ada")]);
+        let err = render(template, &partial).unwrap_err();
+        let (lenient_out, left) = render_lenient(template, &partial);
+        match err {
+            TemplateError::Unsubstituted(names) => assert_eq!(names, left),
+        }
+        // The missing placeholder is left exactly as written, spacing included.
+        assert_eq!(lenient_out, "You are Ada, a {{ role }}.");
+    }
+
+    /// A substituted value is inserted literally, never rescanned for
+    /// placeholders of its own — otherwise substitution order (BTreeMap key
+    /// order today) would change the result.
+    #[test]
+    fn a_substituted_value_is_not_rescanned_for_nested_placeholders() {
+        let out = render("{{a}}", &vars(&[("a", "{{b}}"), ("b", "BOOM")])).unwrap();
+        assert_eq!(out, "{{b}}");
     }
 }

--- a/crates/armadai/src/cli/inspect.rs
+++ b/crates/armadai/src/cli/inspect.rs
@@ -140,20 +140,29 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
 
 /// Resolve an agent by name: check the project first (file-backed or
 /// declared in `.armadai/agents.yaml`, via `agent_source::load_agent_by_name`),
-/// then fall back to the default global agents directory — mirroring the
-/// same two-tier fallback the previous path-only version used, just with a
-/// richer project-side lookup that also covers declared agents.
+/// else the default global agents directory when no project was found at all.
+///
+/// Once a project IS found, its `load_agent_by_name` result — success or
+/// failure — is final: it is returned directly, never silently swallowed in
+/// favour of a fallback. An earlier version discarded any error from it via
+/// `if let Ok(agent) = ...`, which defeated the by-name amendment's own
+/// requirement in two ways measured on a real project: a name ambiguous
+/// between a declaration and a file was reported as the generic "not found
+/// in agents/" from the branch below instead of naming both `agents.yaml`
+/// and the colliding file, and a name matching an explicit, broken `path:`
+/// ref in the project config no longer propagated that specific failure
+/// either.
 fn load_named_agent(agent_name: &str) -> anyhow::Result<Agent> {
     if let Some((root, config)) = project::find_project_config() {
         let fragments = armadai_core::agent_source::project_fragments(&root);
-        if let Ok(agent) =
-            armadai_core::agent_source::load_agent_by_name(agent_name, &config, &root, &fragments)
-        {
-            return Ok(agent);
-        }
+        return armadai_core::agent_source::load_agent_by_name(
+            agent_name, &config, &root, &fragments,
+        );
     }
 
-    // Fallback to default paths
+    // No project config found at all — fall back to the default global
+    // agents directory (the only fallback tier that remains once a project
+    // IS found is `load_agent_by_name`'s own file-then-declarations order).
     let paths = AppPaths::resolve();
     let path = Agent::find_file(&paths.agents_dir, agent_name).ok_or_else(|| {
         anyhow::anyhow!(

--- a/crates/armadai/src/cli/inspect.rs
+++ b/crates/armadai/src/cli/inspect.rs
@@ -1,11 +1,10 @@
 use armadai_core::agent::Agent;
 use armadai_core::config::AppPaths;
 use armadai_core::parser::parse_agent_file;
-use armadai_core::project::{self, AgentRef};
+use armadai_core::project;
 
 pub async fn execute(agent_name: String) -> anyhow::Result<()> {
-    let path = resolve_agent_file(&agent_name)?;
-    let agent = parse_agent_file(&path)?;
+    let agent = load_named_agent(&agent_name)?;
 
     // Header
     let h = crate::cli::style::header();
@@ -139,37 +138,28 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Resolve an agent by name: check project config first, then default paths.
-fn resolve_agent_file(agent_name: &str) -> anyhow::Result<std::path::PathBuf> {
+/// Resolve an agent by name: check the project first (file-backed or
+/// declared in `.armadai/agents.yaml`, via `agent_source::load_agent_by_name`),
+/// then fall back to the default global agents directory — mirroring the
+/// same two-tier fallback the previous path-only version used, just with a
+/// richer project-side lookup that also covers declared agents.
+fn load_named_agent(agent_name: &str) -> anyhow::Result<Agent> {
     if let Some((root, config)) = project::find_project_config() {
-        // Try to find the agent in the project config
-        if let Some(agent_ref) = config.agents.iter().find(|r| match r {
-            AgentRef::Named { name } => name == agent_name,
-            AgentRef::Path { path } => path.file_stem().is_some_and(|s| s == agent_name),
-            AgentRef::Registry { registry } => registry.ends_with(agent_name),
-            // Matched by name so a later step can report the ref by name;
-            // `resolve_agent` below refuses it because it has no file to
-            // return a path for.
-            AgentRef::Declared { declared } => declared == agent_name,
-        }) {
-            return project::resolve_agent(agent_ref, &root);
-        }
-
-        // Not in config, but try resolving as Named from project root
-        let fallback = AgentRef::Named {
-            name: agent_name.to_string(),
-        };
-        if let Ok(path) = project::resolve_agent(&fallback, &root) {
-            return Ok(path);
+        let fragments = armadai_core::agent_source::project_fragments(&root);
+        if let Ok(agent) =
+            armadai_core::agent_source::load_agent_by_name(agent_name, &config, &root, &fragments)
+        {
+            return Ok(agent);
         }
     }
 
     // Fallback to default paths
     let paths = AppPaths::resolve();
-    Agent::find_file(&paths.agents_dir, agent_name).ok_or_else(|| {
+    let path = Agent::find_file(&paths.agents_dir, agent_name).ok_or_else(|| {
         anyhow::anyhow!(
             "Agent '{agent_name}' not found in {}/ (looked for {agent_name}.md)",
             paths.agents_dir.display()
         )
-    })
+    })?;
+    parse_agent_file(&path)
 }

--- a/crates/armadai/src/cli/inspect.rs
+++ b/crates/armadai/src/cli/inspect.rs
@@ -147,6 +147,10 @@ fn resolve_agent_file(agent_name: &str) -> anyhow::Result<std::path::PathBuf> {
             AgentRef::Named { name } => name == agent_name,
             AgentRef::Path { path } => path.file_stem().is_some_and(|s| s == agent_name),
             AgentRef::Registry { registry } => registry.ends_with(agent_name),
+            // Matched by name so a later step can report the ref by name;
+            // `resolve_agent` below refuses it because it has no file to
+            // return a path for.
+            AgentRef::Declared { declared } => declared == agent_name,
         }) {
             return project::resolve_agent(agent_ref, &root);
         }

--- a/crates/armadai/src/cli/inspect.rs
+++ b/crates/armadai/src/cli/inspect.rs
@@ -155,9 +155,17 @@ pub async fn execute(agent_name: String) -> anyhow::Result<()> {
 fn load_named_agent(agent_name: &str) -> anyhow::Result<Agent> {
     if let Some((root, config)) = project::find_project_config() {
         let fragments = armadai_core::agent_source::project_fragments(&root);
-        return armadai_core::agent_source::load_agent_by_name(
-            agent_name, &config, &root, &fragments,
-        );
+        let (agent, warning) =
+            armadai_core::agent_source::load_agent_by_name(agent_name, &config, &root, &fragments)?;
+        // Core returns the warning rather than printing it (see
+        // `load_agent_by_name`'s own doc) precisely so it renders here, in
+        // the CLI's own voice, instead of a bare `tracing::warn!` line
+        // reaching the user's terminal directly from core.
+        if let Some(w) = warning {
+            let s = crate::cli::style::warn();
+            anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
+        }
+        return Ok(agent);
     }
 
     // No project config found at all — fall back to the default global

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use crate::linker::model_resolution::{self, TargetKind};
 use crate::linker::{self, LinkAgent};
-use armadai_core::parser;
 use armadai_core::project;
 
 pub async fn execute(
@@ -28,7 +27,13 @@ pub async fn execute(
     }
     armadai_core::model_updater::auto_check_and_prompt(&root, std::io::stdin().is_terminal());
 
-    if config.agents.is_empty() {
+    // Every agent in `.armadai/agents.yaml` is included automatically (it
+    // does not need to be relisted in `agents:` — that would duplicate the
+    // declaration this format exists to remove), so an otherwise-empty
+    // `agents:` list is only a real error when there is no declarations
+    // file either.
+    let has_declarations = armadai_core::agent_source::declarations_path(&root).is_file();
+    if config.agents.is_empty() && !has_declarations {
         anyhow::bail!("No agents declared in project config.");
     }
 
@@ -48,23 +53,15 @@ pub async fn execute(
         );
     }
 
-    // 2. Resolve and parse agents
-    let (paths, errors) = project::resolve_all_agents(&config, &root);
+    // 2. Resolve and load agents — file-backed and declared alike.
+    let fragments = armadai_core::agent_source::project_fragments(&root);
+    let (agents, errors) = armadai_core::agent_source::load_all_agents(&config, &root, &fragments);
     for err in &errors {
         let w = crate::cli::style::warn();
         anstream::eprintln!("{w}  warn: {err}{w:#}");
     }
 
-    let mut link_agents: Vec<LinkAgent> = Vec::new();
-    for path in &paths {
-        match parser::parse_agent_file(path) {
-            Ok(agent) => link_agents.push(LinkAgent::from(&agent)),
-            Err(e) => {
-                let w = crate::cli::style::warn();
-                anstream::eprintln!("{w}  warn: failed to parse {}: {e}{w:#}", path.display());
-            }
-        }
-    }
+    let mut link_agents: Vec<LinkAgent> = agents.iter().map(LinkAgent::from).collect();
 
     if link_agents.is_empty() {
         anyhow::bail!("No agents could be resolved. Check your project config.");

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -61,6 +61,19 @@ pub async fn execute(
         anstream::eprintln!("{w}  warn: {err}{w:#}");
     }
 
+    // `link` writes config that other tools then trust — unlike `list`
+    // (read-only), it must never silently ship a fleet smaller than the one
+    // declared. Any drop (a parse failure, a broken declaration, a
+    // shadowing collision — "whatever the reason") is refused here, even
+    // though the warnings above already named each one, and even if enough
+    // agents survived to be individually non-empty below.
+    if !errors.is_empty() {
+        anyhow::bail!(
+            "{} agent(s) could not be loaded (see warning(s) above) — refusing to link a smaller fleet than declared. Fix the issue(s), or rerun once resolved.",
+            errors.len()
+        );
+    }
+
     let mut link_agents: Vec<LinkAgent> = agents.iter().map(LinkAgent::from).collect();
 
     if link_agents.is_empty() {

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -55,23 +55,11 @@ pub async fn execute(
 
     // 2. Resolve and load agents — file-backed and declared alike.
     let fragments = armadai_core::agent_source::project_fragments(&root);
-    let (agents, errors) = armadai_core::agent_source::load_all_agents(&config, &root, &fragments);
-    for err in &errors {
-        let w = crate::cli::style::warn();
-        anstream::eprintln!("{w}  warn: {err}{w:#}");
-    }
-
-    // `link` writes config that other tools then trust — unlike `list`
-    // (read-only), it must never silently ship a fleet smaller than the one
-    // declared. Any drop (a parse failure, a broken declaration, a
-    // shadowing collision — "whatever the reason") is refused here, even
-    // though the warnings above already named each one, and even if enough
-    // agents survived to be individually non-empty below.
-    if !errors.is_empty() {
-        anyhow::bail!(
-            "{} agent(s) could not be loaded (see warning(s) above) — refusing to link a smaller fleet than declared. Fix the issue(s), or rerun once resolved.",
-            errors.len()
-        );
+    let (agents, warnings) =
+        armadai_core::agent_source::load_all_agents(&config, &root, &fragments);
+    for w in &warnings {
+        let s = crate::cli::style::warn();
+        anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
     }
 
     let mut link_agents: Vec<LinkAgent> = agents.iter().map(LinkAgent::from).collect();
@@ -95,6 +83,26 @@ pub async fn execute(
         if link_agents.is_empty() {
             anyhow::bail!("No agents match the given filter: {}", filter.join(", "));
         }
+    }
+
+    // 3a. `link` writes config that other tools then trust — unlike `list`
+    // (read-only), it must never silently ship a fleet smaller than the one
+    // declared. But only when THIS chantier's format is the reason (a
+    // dropped declaration, or a shadowing collision): a pre-existing
+    // failure (an unparseable `.md`, an unresolvable ref) keeps its exact
+    // old behaviour — warn above, link what did load, exit 0 — since that
+    // behaviour predates this format and was never wrong.
+    //
+    // Checked AFTER `--agents` filtering, and scoped to it: a loss outside
+    // what was actually requested (`--agents good` when only `bad` was
+    // dropped) must not refuse a link that never intended to write `bad` in
+    // the first place. `--dry-run` reaches this exact same check with no
+    // special-casing either way, further down — a preview must refuse
+    // exactly when the real link would.
+    if armadai_core::agent_source::blocks_a_write(&warnings, agents_filter.as_deref()) {
+        anyhow::bail!(
+            "one or more agents could not be loaded (see warning(s) above) — refusing to link              a smaller fleet than declared. Fix the issue(s), or rerun once resolved."
+        );
     }
 
     // 3b. Extract coordinator if configured (CLI flag takes priority over config)

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -101,7 +101,7 @@ pub async fn execute(
     // exactly when the real link would.
     if armadai_core::agent_source::blocks_a_write(&warnings, agents_filter.as_deref()) {
         anyhow::bail!(
-            "one or more agents could not be loaded (see warning(s) above) — refusing to link              a smaller fleet than declared. Fix the issue(s), or rerun once resolved."
+            "one or more agents could not be loaded (see warning(s) above) — refusing to link a smaller fleet than declared. Fix the issue(s), or rerun once resolved."
         );
     }
 

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -32,8 +32,7 @@ pub async fn execute(
     // declaration this format exists to remove), so an otherwise-empty
     // `agents:` list is only a real error when there is no declarations
     // file either.
-    let has_declarations = armadai_core::agent_source::declarations_path(&root).is_file();
-    if config.agents.is_empty() && !has_declarations {
+    if !armadai_core::agent_source::project_declares_agents(&root, &config) {
         anyhow::bail!("No agents declared in project config.");
     }
 

--- a/crates/armadai/src/cli/list.rs
+++ b/crates/armadai/src/cli/list.rs
@@ -1,6 +1,5 @@
 use armadai_core::agent::Agent;
 use armadai_core::config::AppPaths;
-use armadai_core::parser;
 use armadai_core::project;
 
 pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow::Result<()> {
@@ -92,28 +91,28 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
     Ok(())
 }
 
-/// Load agents: if a project config is found, resolve only declared agents.
-/// Otherwise, load all agents from the default directory.
-/// When `--global` is active, always load from the global library.
+/// Load agents: if a project config is found, resolve project agents
+/// (file-backed and declared alike). Otherwise, load all agents from the
+/// default directory. When `--global` is active, always load from the
+/// global library.
+///
+/// A project counts as having agents when `agents:` lists any, OR
+/// `.armadai/agents.yaml` declares any — every declared agent is included
+/// automatically, so a project that only uses that format (an empty/absent
+/// `agents:` list) must still take the project branch instead of falling
+/// through to the global library.
 fn load_agents() -> anyhow::Result<Vec<Agent>> {
     if !armadai_core::config::is_force_global()
         && let Some((root, config)) = project::find_project_config()
-        && !config.agents.is_empty()
+        && (!config.agents.is_empty()
+            || armadai_core::agent_source::declarations_path(&root).is_file())
     {
-        let (paths, errors) = project::resolve_all_agents(&config, &root);
+        let fragments = armadai_core::agent_source::project_fragments(&root);
+        let (agents, errors) =
+            armadai_core::agent_source::load_all_agents(&config, &root, &fragments);
         for err in &errors {
             let w = crate::cli::style::warn();
             anstream::eprintln!("{w}  warn: {err}{w:#}");
-        }
-        let mut agents = Vec::new();
-        for path in &paths {
-            match parser::parse_agent_file(path) {
-                Ok(agent) => agents.push(agent),
-                Err(e) => {
-                    let w = crate::cli::style::warn();
-                    anstream::eprintln!("{w}  warn: failed to parse {}: {e}{w:#}", path.display());
-                }
-            }
         }
         return Ok(agents);
     }

--- a/crates/armadai/src/cli/list.rs
+++ b/crates/armadai/src/cli/list.rs
@@ -108,11 +108,14 @@ fn load_agents() -> anyhow::Result<Vec<Agent>> {
             || armadai_core::agent_source::declarations_path(&root).is_file())
     {
         let fragments = armadai_core::agent_source::project_fragments(&root);
-        let (agents, errors) =
+        let (agents, warnings) =
             armadai_core::agent_source::load_all_agents(&config, &root, &fragments);
-        for err in &errors {
-            let w = crate::cli::style::warn();
-            anstream::eprintln!("{w}  warn: {err}{w:#}");
+        // Read-only: unlike `link`, `list` never refuses over a drop
+        // (pre-existing or new to this chantier's format alike) -- it warns
+        // and shows whatever did load.
+        for w in &warnings {
+            let s = crate::cli::style::warn();
+            anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
         }
         return Ok(agents);
     }

--- a/crates/armadai/src/cli/list.rs
+++ b/crates/armadai/src/cli/list.rs
@@ -104,8 +104,7 @@ pub async fn execute(tags: Option<Vec<String>>, stack: Option<String>) -> anyhow
 fn load_agents() -> anyhow::Result<Vec<Agent>> {
     if !armadai_core::config::is_force_global()
         && let Some((root, config)) = project::find_project_config()
-        && (!config.agents.is_empty()
-            || armadai_core::agent_source::declarations_path(&root).is_file())
+        && armadai_core::agent_source::project_declares_agents(&root, &config)
     {
         let fragments = armadai_core::agent_source::project_fragments(&root);
         let (agents, warnings) =

--- a/crates/armadai/src/cli/models.rs
+++ b/crates/armadai/src/cli/models.rs
@@ -1,5 +1,6 @@
 use clap::Subcommand;
 
+use armadai_core::agent_source;
 use armadai_core::model_updater;
 use armadai_core::project;
 use armadai_core::project_registry;
@@ -136,43 +137,7 @@ fn update(all: bool) -> anyhow::Result<()> {
                 continue;
             }
 
-            // Group findings by file path
-            let mut by_file: std::collections::HashMap<
-                std::path::PathBuf,
-                Vec<&model_updater::DeprecationFinding>,
-            > = std::collections::HashMap::new();
-            for f in &findings {
-                by_file.entry(f.agent_path.clone()).or_default().push(f);
-            }
-
-            for (path, file_findings) in &by_file {
-                let owned: Vec<_> = file_findings
-                    .iter()
-                    .map(|f| model_updater::DeprecationFinding {
-                        agent_path: f.agent_path.clone(),
-                        agent_name: f.agent_name.clone(),
-                        field: f.field.clone(),
-                        current: f.current.clone(),
-                        replacement: f.replacement.clone(),
-                    })
-                    .collect();
-                match model_updater::update_agent_file(path, &owned) {
-                    Ok(n) => {
-                        if n > 0 {
-                            let o = crate::cli::style::ok();
-                            anstream::println!(
-                                "{o}  updated {}: {n} replacement(s){o:#}",
-                                path.display()
-                            );
-                            total_updated += n;
-                        }
-                    }
-                    Err(e) => {
-                        let er = crate::cli::style::err();
-                        anstream::eprintln!("{er}  error: {}: {e}{er:#}", path.display());
-                    }
-                }
-            }
+            total_updated += apply_and_report(&findings, &agent_source::declarations_path(root));
         }
 
         let o = crate::cli::style::ok();
@@ -189,50 +154,69 @@ fn update(all: bool) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        // Group findings by file path
-        let mut by_file: std::collections::HashMap<
-            std::path::PathBuf,
-            Vec<&model_updater::DeprecationFinding>,
-        > = std::collections::HashMap::new();
-        for f in &findings {
-            by_file.entry(f.agent_path.clone()).or_default().push(f);
-        }
-
-        let mut total = 0;
-        for (path, file_findings) in &by_file {
-            let owned: Vec<_> = file_findings
-                .iter()
-                .map(|f| model_updater::DeprecationFinding {
-                    agent_path: f.agent_path.clone(),
-                    agent_name: f.agent_name.clone(),
-                    field: f.field.clone(),
-                    current: f.current.clone(),
-                    replacement: f.replacement.clone(),
-                })
-                .collect();
-            match model_updater::update_agent_file(path, &owned) {
-                Ok(n) => {
-                    if n > 0 {
-                        let o = crate::cli::style::ok();
-                        anstream::println!(
-                            "{o}  updated {}: {n} replacement(s){o:#}",
-                            path.display()
-                        );
-                        total += n;
-                    }
-                }
-                Err(e) => {
-                    let er = crate::cli::style::err();
-                    anstream::eprintln!("{er}  error: {}: {e}{er:#}", path.display());
-                }
-            }
-        }
+        let total = apply_and_report(&findings, &agent_source::declarations_path(&root));
 
         let o = crate::cli::style::ok();
         anstream::println!("{o}\n{total} model(s) updated.{o:#}");
     }
 
     Ok(())
+}
+
+/// Apply every finding, grouped by the file it came from, and print one
+/// status line per file — the shared body of both branches above.
+///
+/// `decls_path` (the project's `agents.yaml`, whether or not it exists) is
+/// what routes a finding to the right rewriter: [`model_updater::apply_finding`]
+/// sends anything whose `agent_path` matches it through
+/// `update_declarations`, and everything else through `update_agent_file`.
+/// Applying a whole file's findings through the wrong one is exactly the
+/// bug this exists to avoid — `update_agent_file`'s single
+/// `replacen(.., 1)` and unbounded `: <model>` pattern can rewrite a
+/// comment in `agents.yaml` while leaving the real deprecated field
+/// untouched, all while reporting success.
+fn apply_and_report(
+    findings: &[model_updater::DeprecationFinding],
+    decls_path: &std::path::Path,
+) -> usize {
+    let mut by_file: std::collections::HashMap<
+        std::path::PathBuf,
+        Vec<&model_updater::DeprecationFinding>,
+    > = std::collections::HashMap::new();
+    for f in findings {
+        by_file.entry(f.agent_path.clone()).or_default().push(f);
+    }
+
+    let mut total = 0;
+    for (path, file_findings) in &by_file {
+        let mut file_total = 0;
+        let mut file_err = None;
+        for f in file_findings {
+            match model_updater::apply_finding(f, decls_path) {
+                Ok(n) => file_total += n,
+                Err(e) => {
+                    file_err = Some(e);
+                    break;
+                }
+            }
+        }
+        match file_err {
+            Some(e) => {
+                let er = crate::cli::style::err();
+                anstream::eprintln!("{er}  error: {}: {e}{er:#}", path.display());
+            }
+            None if file_total > 0 => {
+                let o = crate::cli::style::ok();
+                anstream::println!(
+                    "{o}  updated {}: {file_total} replacement(s){o:#}",
+                    path.display()
+                );
+                total += file_total;
+            }
+            None => {}
+        }
+    }
+    total
 }
 
 fn list() -> anyhow::Result<()> {

--- a/crates/armadai/src/cli/models.rs
+++ b/crates/armadai/src/cli/models.rs
@@ -113,6 +113,8 @@ fn check(all: bool, prune: bool) -> anyhow::Result<()> {
 }
 
 fn update(all: bool) -> anyhow::Result<()> {
+    let mut any_failed = false;
+
     if all {
         let registry = project_registry::load();
         if registry.projects.is_empty() {
@@ -137,7 +139,9 @@ fn update(all: bool) -> anyhow::Result<()> {
                 continue;
             }
 
-            total_updated += apply_and_report(&findings, &agent_source::declarations_path(root));
+            let (n, failed) = apply_and_report(&findings, &agent_source::declarations_path(root));
+            total_updated += n;
+            any_failed |= failed;
         }
 
         let o = crate::cli::style::ok();
@@ -154,10 +158,27 @@ fn update(all: bool) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let total = apply_and_report(&findings, &agent_source::declarations_path(&root));
+        let (total, failed) = apply_and_report(&findings, &agent_source::declarations_path(&root));
+        any_failed = failed;
 
         let o = crate::cli::style::ok();
         anstream::println!("{o}\n{total} model(s) updated.{o:#}");
+    }
+
+    // Every group/project is processed to the end regardless of an earlier
+    // one's failure — a problem isolated to one file must not stop this
+    // command from fixing every other file/project that is fine, the same
+    // reasoning already applied above to a `check_project` error. But the
+    // command as a whole must not exit 0 when something was left broken: a
+    // caller that only checks the exit code (a script, CI, `--all` from a
+    // cron job) needs to be able to tell "everything fixed" from "some
+    // file(s) still need a look", and the summary line above already
+    // reports the true (partial) count rather than lying about it.
+    if any_failed {
+        anyhow::bail!(
+            "one or more file(s) could not be fully updated (see error(s) above) — nothing in \
+             those files was rewritten"
+        );
     }
 
     Ok(())
@@ -166,57 +187,63 @@ fn update(all: bool) -> anyhow::Result<()> {
 /// Apply every finding, grouped by the file it came from, and print one
 /// status line per file — the shared body of both branches above.
 ///
+/// One [`model_updater::apply_findings`] call per file, carrying that
+/// file's ENTIRE finding set — never split into one call per finding. A
+/// prior version of this function did split per finding, which silently
+/// broke `update_declarations`'s own all-or-nothing guarantee one layer up:
+/// a `defaults.model` fix could land on disk from one call, immediately
+/// before a second call — for the SAME file, a finding the textual rewrite
+/// could not locate — errored, leaving a half-fixed file reported as "0
+/// model(s) updated" with a plain `eprintln` and no effect on the exit
+/// code. Batching restores the guarantee: either the whole file is fixed
+/// and counted, or nothing in it changes and the caller sees an `Err`.
+///
 /// `decls_path` (the project's `agents.yaml`, whether or not it exists) is
-/// what routes a finding to the right rewriter: [`model_updater::apply_finding`]
-/// sends anything whose `agent_path` matches it through
-/// `update_declarations`, and everything else through `update_agent_file`.
-/// Applying a whole file's findings through the wrong one is exactly the
-/// bug this exists to avoid — `update_agent_file`'s single
-/// `replacen(.., 1)` and unbounded `: <model>` pattern can rewrite a
+/// what routes a file's findings to the right rewriter:
+/// [`model_updater::apply_findings`] sends anything whose `agent_path`
+/// matches it through `update_declarations`, and everything else through
+/// `update_agent_file`. Applying a whole file's findings through the wrong
+/// one is exactly the bug this exists to avoid — `update_agent_file`'s
+/// single `replacen(.., 1)` and unbounded `: <model>` pattern can rewrite a
 /// comment in `agents.yaml` while leaving the real deprecated field
 /// untouched, all while reporting success.
+///
+/// Returns `(replacements actually made, whether any file failed)` — never
+/// invents a non-zero count for a file that errored.
 fn apply_and_report(
     findings: &[model_updater::DeprecationFinding],
     decls_path: &std::path::Path,
-) -> usize {
+) -> (usize, bool) {
     let mut by_file: std::collections::HashMap<
         std::path::PathBuf,
-        Vec<&model_updater::DeprecationFinding>,
+        Vec<model_updater::DeprecationFinding>,
     > = std::collections::HashMap::new();
     for f in findings {
-        by_file.entry(f.agent_path.clone()).or_default().push(f);
+        by_file
+            .entry(f.agent_path.clone())
+            .or_default()
+            .push(f.clone());
     }
 
     let mut total = 0;
+    let mut any_failed = false;
     for (path, file_findings) in &by_file {
-        let mut file_total = 0;
-        let mut file_err = None;
-        for f in file_findings {
-            match model_updater::apply_finding(f, decls_path) {
-                Ok(n) => file_total += n,
-                Err(e) => {
-                    file_err = Some(e);
-                    break;
+        match model_updater::apply_findings(file_findings, decls_path) {
+            Ok(n) => {
+                if n > 0 {
+                    let o = crate::cli::style::ok();
+                    anstream::println!("{o}  updated {}: {n} replacement(s){o:#}", path.display());
                 }
+                total += n;
             }
-        }
-        match file_err {
-            Some(e) => {
+            Err(e) => {
+                any_failed = true;
                 let er = crate::cli::style::err();
                 anstream::eprintln!("{er}  error: {}: {e}{er:#}", path.display());
             }
-            None if file_total > 0 => {
-                let o = crate::cli::style::ok();
-                anstream::println!(
-                    "{o}  updated {}: {file_total} replacement(s){o:#}",
-                    path.display()
-                );
-                total += file_total;
-            }
-            None => {}
         }
     }
-    total
+    (total, any_failed)
 }
 
 fn list() -> anyhow::Result<()> {

--- a/crates/armadai/src/cli/new.rs
+++ b/crates/armadai/src/cli/new.rs
@@ -260,12 +260,21 @@ async fn interactive_create() -> anyhow::Result<()> {
         let template_path = templates_dir.join(format!("{tpl_name}.md"));
         let mut content = std::fs::read_to_string(&template_path)?;
         let title = slug_to_title(&name);
-        content = content.replace("{{name}}", &title);
-        content = content.replace("{{description}}", &system_prompt);
-        // Replace stacks placeholder
-        if !stacks.is_empty() {
-            content = content.replace("{{stack}}", &stacks[0]);
+        // Through the shared `template` module, not a hand-rolled
+        // `replace("{{name}}", ..)` — that exact shape is what let a
+        // `{{ name }}` (spaced) placeholder in a template ship
+        // unsubstituted (see `template.rs`'s `render`/`render_lenient`):
+        // building the literal `{{name}}` string to search for agrees with
+        // neither a template author's spacing nor with how
+        // `placeholders()`/`render` itself recognises a placeholder.
+        let mut vars = std::collections::BTreeMap::new();
+        vars.insert("name".to_string(), title);
+        vars.insert("description".to_string(), system_prompt.clone());
+        if let Some(first_stack) = stacks.first() {
+            vars.insert("stack".to_string(), first_stack.clone());
         }
+        let (rendered, _remaining) = armadai_core::template::render_lenient(&content, &vars);
+        content = rendered;
         // Overwrite metadata section with user choices
         overwrite_metadata(
             &content,

--- a/crates/armadai/src/cli/new.rs
+++ b/crates/armadai/src/cli/new.rs
@@ -52,30 +52,21 @@ fn template_create(
     }
 
     // Read and replace placeholders
-    let mut content = std::fs::read_to_string(&template_path)?;
+    let content = std::fs::read_to_string(&template_path)?;
 
     let title = slug_to_title(name);
-    content = content.replace("{{name}}", &title);
-
+    let mut vars = std::collections::BTreeMap::new();
+    vars.insert("name".to_string(), title.clone());
+    // Replace model placeholder with default
+    vars.insert("model".to_string(), "latest:pro".to_string());
     if let Some(desc) = description {
-        content = content.replace("{{description}}", desc);
+        vars.insert("description".to_string(), desc.to_string());
     }
     if let Some(s) = stack {
-        content = content.replace("{{stack}}", s);
+        vars.insert("stack".to_string(), s.to_string());
     }
 
-    // Replace model placeholder with default
-    content = content.replace("{{model}}", "latest:pro");
-
-    // Check for remaining placeholders
-    let remaining: Vec<&str> = content
-        .match_indices("{{")
-        .filter_map(|(start, _)| {
-            content[start..]
-                .find("}}")
-                .map(|end| &content[start..start + end + 2])
-        })
-        .collect();
+    let (content, remaining) = armadai_core::template::render_lenient(&content, &vars);
 
     // Ensure agents directory exists
     std::fs::create_dir_all(agents_dir)?;
@@ -91,16 +82,13 @@ fn template_create(
     anstream::println!("{m}  Name:{m:#} {a}{title}{a:#}");
 
     if !remaining.is_empty() {
-        let unique: Vec<&str> = {
-            let mut seen = std::collections::HashSet::new();
-            remaining.into_iter().filter(|p| seen.insert(*p)).collect()
-        };
         let w = crate::cli::style::warn();
         anstream::println!(
             "\n{w}  Note: the following placeholders need to be filled in manually:{w:#}"
         );
-        for p in &unique {
-            anstream::println!("{w}    - {p}{w:#}");
+        for placeholder_name in &remaining {
+            let placeholder = format!("{{{{{placeholder_name}}}}}");
+            anstream::println!("{w}    - {placeholder}{w:#}");
         }
     }
 

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -471,8 +471,7 @@ async fn resume_run(
         Arc<dyn armadai_core::provider::Provider>,
     > = std::collections::BTreeMap::new();
     for name in &state.agents {
-        let agent_path = resolve_agent_path(&resolution, name)?;
-        let mut agent = armadai_core::parser::parse_agent_file(&agent_path)?;
+        let mut agent = load_agent_for_run(&resolution, name)?;
         armadai_core::model_aliases::resolve_model_deprecations(
             &mut agent.metadata.model,
             &mut agent.metadata.model_fallback,
@@ -896,11 +895,19 @@ fn resolve_agent_path(resolution: &AgentResolution, agent_name: &str) -> anyhow:
 /// [`resolve_agent_path`], used where the loaded [`Agent`] itself is needed
 /// rather than a file path to hand to a lower-level step.
 ///
-/// Only the single-agent path (`chain.len() == 1`, the common `armadai run
-/// <name>` invocation) calls this. `--pipe`'s legacy chain loop and
-/// `--resume`'s roster reload still call [`resolve_agent_path`] directly and
-/// so still hard-fail on a declared agent — extending them is separate
-/// follow-up work, not this fix (see the task report).
+/// Called from the single-agent path (`chain.len() == 1`, the common
+/// `armadai run <name>` invocation), the `--orchestrate` roster loader
+/// (`run_orchestrated`), and `--resume`'s roster reload (`resume_run`) —
+/// each of those three already parsed the path into an `Agent` immediately
+/// after resolving it, so swapping in the by-name load was a same-shape
+/// change at each site (task 7b review, Finding 7).
+///
+/// `--pipe`'s legacy chain loop (`run_inner`'s multi-agent branch, which
+/// still calls [`resolve_agent_path`] directly into the older
+/// `run_single_agent`) is NOT wired here: `run_single_agent` loads by path
+/// internally rather than accepting an already-loaded `Agent`, so extending
+/// it needs the same signature change `run_single_agent_es` already got —
+/// real, separate follow-up work, reported rather than done here.
 fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow::Result<Agent> {
     match resolution {
         AgentResolution::Project { root, config } => {
@@ -1643,8 +1650,7 @@ async fn run_orchestrated(
     };
 
     for name in agent_names {
-        let agent_path = resolve_agent_path(resolution, name)?;
-        let mut agent = armadai_core::parser::parse_agent_file(&agent_path)?;
+        let mut agent = load_agent_for_run(resolution, name)?;
 
         let model_before = agent.metadata.model.clone();
         armadai_core::model_aliases::resolve_model_deprecations(

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -912,7 +912,18 @@ fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow:
     match resolution {
         AgentResolution::Project { root, config } => {
             let fragments = armadai_core::agent_source::project_fragments(root);
-            armadai_core::agent_source::load_agent_by_name(agent_name, config, root, &fragments)
+            let (agent, warning) = armadai_core::agent_source::load_agent_by_name(
+                agent_name, config, root, &fragments,
+            )?;
+            // Core returns the warning rather than printing it (see
+            // `load_agent_by_name`'s own doc) precisely so it renders here,
+            // in the CLI's own voice, instead of a bare `tracing::warn!`
+            // line reaching the user's terminal directly from core.
+            if let Some(w) = warning {
+                let s = crate::cli::style::warn();
+                anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
+            }
+            Ok(agent)
         }
         AgentResolution::Default(agents_dir) => {
             let path = Agent::find_file(agents_dir, agent_name).ok_or_else(|| {

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -1506,8 +1506,7 @@ fn resolve_agents_dir(headless: bool) -> AgentResolution {
     // must still take the project branch instead of silently falling
     // through to the no-project default below.
     if let Some((root, config)) = project::find_project_config()
-        && (!config.agents.is_empty()
-            || armadai_core::agent_source::declarations_path(&root).is_file())
+        && armadai_core::agent_source::project_declares_agents(&root, &config)
     {
         tracing::info!(
             "Using project config from {} ({} agent(s))",

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -870,6 +870,10 @@ fn resolve_agent_path(resolution: &AgentResolution, agent_name: &str) -> anyhow:
                 AgentRef::Named { name } => name == agent_name,
                 AgentRef::Path { path } => path.file_stem().is_some_and(|s| s == agent_name),
                 AgentRef::Registry { registry } => registry.ends_with(agent_name),
+                // Matched by name so a later step can report the ref by
+                // name; `resolve_agent` below refuses it because it has no
+                // file to return a path for.
+                AgentRef::Declared { declared } => declared == agent_name,
             }) {
                 return project::resolve_agent(agent_ref, root);
             }

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -762,10 +762,10 @@ async fn run_inner(
     // scopes this bascule to the single-agent case only.
     if chain.len() == 1 {
         let name = &chain[0];
-        let agent_path = resolve_agent_path(&resolution, name)?;
+        let agent = load_agent_for_run(&resolution, name)?;
         let (content, tin, tout, cost) = run_single_agent_es(
             &run_id,
-            &agent_path,
+            agent,
             name,
             &current_input,
             project_defaults,
@@ -888,6 +888,31 @@ fn resolve_agent_path(resolution: &AgentResolution, agent_name: &str) -> anyhow:
             .ok_or_else(|| {
                 anyhow::anyhow!("Agent '{agent_name}' not found in {}", agents_dir.display())
             }),
+    }
+}
+
+/// Load the primary agent for a run, whether it is written as a file or
+/// declared in `.armadai/agents.yaml` — the by-name counterpart to
+/// [`resolve_agent_path`], used where the loaded [`Agent`] itself is needed
+/// rather than a file path to hand to a lower-level step.
+///
+/// Only the single-agent path (`chain.len() == 1`, the common `armadai run
+/// <name>` invocation) calls this. `--pipe`'s legacy chain loop and
+/// `--resume`'s roster reload still call [`resolve_agent_path`] directly and
+/// so still hard-fail on a declared agent — extending them is separate
+/// follow-up work, not this fix (see the task report).
+fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow::Result<Agent> {
+    match resolution {
+        AgentResolution::Project { root, config } => {
+            let fragments = armadai_core::agent_source::project_fragments(root);
+            armadai_core::agent_source::load_agent_by_name(agent_name, config, root, &fragments)
+        }
+        AgentResolution::Default(agents_dir) => {
+            let path = Agent::find_file(agents_dir, agent_name).ok_or_else(|| {
+                anyhow::anyhow!("Agent '{agent_name}' not found in {}", agents_dir.display())
+            })?;
+            armadai_core::parser::parse_agent_file(&path)
+        }
     }
 }
 
@@ -1276,10 +1301,15 @@ async fn dispatch_direct_es(
 /// order on a "model not found" error). `quiet`/`max_content` *are* honored
 /// (via [`QuietMaxContentSink`] in [`dispatch_direct_es`]), matching
 /// `run_single_agent`'s step 6.
+///
+/// Takes an already-loaded `agent` rather than a path (unlike
+/// `run_single_agent`, which still loads from a path): the caller resolves
+/// it via [`load_agent_for_run`], which — unlike a bare path — also covers an
+/// agent declared in `.armadai/agents.yaml`.
 #[allow(clippy::too_many_arguments)]
 async fn run_single_agent_es(
     run_id: &str,
-    agent_path: &Path,
+    mut agent: Agent,
     agent_key: &str,
     input: &str,
     project_defaults: Option<&ProjectDefaults>,
@@ -1291,9 +1321,6 @@ async fn run_single_agent_es(
 ) -> anyhow::Result<(String, u32, u32, f64)> {
     #[cfg(not(feature = "storage"))]
     let _ = project;
-
-    // 1. Load agent (mirrors `run_single_agent` steps 1-1c).
-    let mut agent = armadai_core::parser::parse_agent_file(agent_path)?;
 
     let model_before = agent.metadata.model.clone();
     armadai_core::model_aliases::resolve_model_deprecations(
@@ -1452,9 +1479,17 @@ fn atty_is_pipe() -> bool {
 /// Resolve agent source: walk up for `armadai.yaml`, detect format,
 /// and return the appropriate resolution strategy.
 fn resolve_agents_dir(headless: bool) -> AgentResolution {
-    // 1. Walk-up search for project config (new or legacy format)
+    // 1. Walk-up search for project config (new or legacy format).
+    //
+    // A project counts as having agents when `agents:` lists any, OR
+    // `.armadai/agents.yaml` declares any: every declared agent is included
+    // automatically (it does not need to be relisted in `agents:`), so a
+    // project that only uses that format — an empty/absent `agents:` list —
+    // must still take the project branch instead of silently falling
+    // through to the no-project default below.
     if let Some((root, config)) = project::find_project_config()
-        && !config.agents.is_empty()
+        && (!config.agents.is_empty()
+            || armadai_core::agent_source::declarations_path(&root).is_file())
     {
         tracing::info!(
             "Using project config from {} ({} agent(s))",

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use crate::linker::{self, LinkAgent};
-use armadai_core::parser;
 use armadai_core::project;
 
 pub async fn execute(
@@ -20,27 +19,30 @@ pub async fn execute(
         )
     })?;
 
-    if config.agents.is_empty() {
+    // Every agent in `.armadai/agents.yaml` is included automatically (it
+    // does not need to be relisted in `agents:`), the same gate `link`,
+    // `list` and `run` all widened for this format: an otherwise-empty
+    // `agents:` list is only a real error when there is no declarations file
+    // either. Without this, `unlink` reports the false "No agents declared in
+    // project config." for exactly the project `link` just wrote three files
+    // for, and removes nothing.
+    if !armadai_core::agent_source::project_declares_agents(&root, &config) {
         anyhow::bail!("No agents declared in project config.");
     }
 
-    // 2. Resolve and parse agents
-    let (paths, errors) = project::resolve_all_agents(&config, &root);
-    for err in &errors {
-        let w = crate::cli::style::warn();
-        anstream::eprintln!("{w}  warn: {err}{w:#}");
+    // 2. Resolve and load agents — file-backed and declared alike.
+    let fragments = armadai_core::agent_source::project_fragments(&root);
+    let (agents, warnings) =
+        armadai_core::agent_source::load_all_agents(&config, &root, &fragments);
+    // `unlink` writes no config — it only removes files `link` would have
+    // written — so unlike `link` it never needs to refuse over a drop: warn
+    // and remove whatever can still be resolved, same policy as `list`.
+    for w in &warnings {
+        let s = crate::cli::style::warn();
+        anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
     }
 
-    let mut link_agents: Vec<LinkAgent> = Vec::new();
-    for path in &paths {
-        match parser::parse_agent_file(path) {
-            Ok(agent) => link_agents.push(LinkAgent::from(&agent)),
-            Err(e) => {
-                let w = crate::cli::style::warn();
-                anstream::eprintln!("{w}  warn: failed to parse {}: {e}{w:#}", path.display());
-            }
-        }
-    }
+    let mut link_agents: Vec<LinkAgent> = agents.iter().map(LinkAgent::from).collect();
 
     if link_agents.is_empty() {
         anyhow::bail!("No agents could be resolved. Check your project config.");

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -206,4 +206,169 @@ mod tests {
     fn test_create_linker_unknown() {
         assert!(create_linker("unknown").is_err());
     }
+
+    /// A declared agent and its hand-written `.md` twin must produce the same
+    /// native projection. If they diverge, the declaration format is a second
+    /// source of truth rather than an alternative spelling of the first —
+    /// exactly what it exists to avoid.
+    ///
+    /// Run against **every** target, not just claude: a divergence that only
+    /// shows in the codex projection is still a divergence.
+    ///
+    /// Both twins carry a model, a temperature, tags and a scope (beyond the
+    /// bare minimum) so the comparison actually exercises the metadata path
+    /// `LinkAgent::from(&Agent)` walks, not just the system prompt.
+    #[test]
+    fn a_declared_agent_and_its_md_twin_project_identically() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The fragment both versions share.
+        let fragments = vec![armadai_core::prompt::Prompt {
+            name: "base".into(),
+            description: None,
+            apply_to: vec![],
+            body: "You own the core domain.".into(),
+            source: std::path::PathBuf::from("base.md"),
+        }];
+
+        // Declared version.
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
+             agents:\n  - name: core-specialist\n    description: Core domain\n    \
+             tags: [rust, domain]\n    scope: [src/core/**]\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let declared = armadai_core::agent_source::load_agent(
+            &armadai_core::project::AgentRef::Declared {
+                declared: "core-specialist".into(),
+            },
+            dir.path(),
+            &fragments,
+        )
+        .unwrap();
+
+        // Hand-written twin, same values.
+        let md = dir.path().join("core-specialist.md");
+        std::fs::write(
+            &md,
+            "# core-specialist\n\n## Metadata\n\
+             - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
+             - tags: [rust, domain]\n- scope: [src/core/**]\n\n## System Prompt\n\nYou own the core domain.\n",
+        )
+        .unwrap();
+        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+
+        // Sanity check before comparing projections: if the two agents are not
+        // actually equivalent, an equal projection would prove nothing.
+        assert_eq!(declared.system_prompt, written.system_prompt);
+        assert_eq!(declared.metadata.model, written.metadata.model);
+        assert_eq!(declared.metadata.temperature, written.metadata.temperature);
+        assert_eq!(declared.metadata.tags, written.metadata.tags);
+        assert_eq!(declared.metadata.scope, written.metadata.scope);
+
+        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
+            let linker = create_linker(target).unwrap();
+            let a = linker.generate(&[LinkAgent::from(&declared)], None, &[]);
+            let b = linker.generate(&[LinkAgent::from(&written)], None, &[]);
+
+            // An empty projection on both sides would satisfy every assertion
+            // below without proving anything.
+            assert!(
+                !a.is_empty(),
+                "target {target} produced no output file — the comparison \
+                 below would be vacuous"
+            );
+            assert_eq!(a.len(), b.len(), "target {target}: file count differs");
+            for (x, y) in a.iter().zip(b.iter()) {
+                assert_eq!(x.path, y.path, "target {target}: paths differ");
+                assert_eq!(
+                    x.content, y.content,
+                    "target {target}: projection diverged — the declaration is \
+                     not an alternative spelling but a second source of truth"
+                );
+            }
+        }
+    }
+
+    /// Same invariant as above, for a `provider: cli` agent carrying
+    /// `command`/`args` — fields added to the declaration format specifically
+    /// so this class of agent could be declared. Nothing had yet proven a
+    /// declared CLI agent projects like its `.md` twin; this is that proof.
+    #[test]
+    fn a_declared_cli_agent_and_its_md_twin_project_identically() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let fragments = vec![armadai_core::prompt::Prompt {
+            name: "base".into(),
+            description: None,
+            apply_to: vec![],
+            body: "You wrap a CLI tool for scripted tasks.".into(),
+            source: std::path::PathBuf::from("base.md"),
+        }];
+
+        // Declared version.
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: cli\n  temperature: 0.5\n\
+             agents:\n  - name: shell-runner\n    description: Wraps a CLI tool\n    \
+             command: echo\n    args: [hello, world]\n    model: local-llm\n    \
+             tags: [ops, shell]\n    scope: [scripts/**]\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let declared = armadai_core::agent_source::load_agent(
+            &armadai_core::project::AgentRef::Declared {
+                declared: "shell-runner".into(),
+            },
+            dir.path(),
+            &fragments,
+        )
+        .unwrap();
+
+        // Hand-written twin, same values.
+        let md = dir.path().join("shell-runner.md");
+        std::fs::write(
+            &md,
+            "# shell-runner\n\n## Metadata\n\
+             - provider: cli\n- command: echo\n- args: [hello, world]\n\
+             - model: local-llm\n- temperature: 0.5\n- tags: [ops, shell]\n\
+             - scope: [scripts/**]\n\n## System Prompt\n\nYou wrap a CLI tool for scripted tasks.\n",
+        )
+        .unwrap();
+        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+
+        // Sanity check before comparing projections: if the two agents are not
+        // actually equivalent, an equal projection would prove nothing.
+        assert_eq!(declared.system_prompt, written.system_prompt);
+        assert_eq!(declared.metadata.provider, written.metadata.provider);
+        assert_eq!(declared.metadata.command, written.metadata.command);
+        assert_eq!(declared.metadata.args, written.metadata.args);
+        assert_eq!(declared.metadata.model, written.metadata.model);
+        assert_eq!(declared.metadata.temperature, written.metadata.temperature);
+        assert_eq!(declared.metadata.tags, written.metadata.tags);
+        assert_eq!(declared.metadata.scope, written.metadata.scope);
+
+        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
+            let linker = create_linker(target).unwrap();
+            let a = linker.generate(&[LinkAgent::from(&declared)], None, &[]);
+            let b = linker.generate(&[LinkAgent::from(&written)], None, &[]);
+
+            assert!(
+                !a.is_empty(),
+                "target {target} produced no output file — the comparison \
+                 below would be vacuous"
+            );
+            assert_eq!(a.len(), b.len(), "target {target}: file count differs");
+            for (x, y) in a.iter().zip(b.iter()) {
+                assert_eq!(x.path, y.path, "target {target}: paths differ");
+                assert_eq!(
+                    x.content, y.content,
+                    "target {target}: projection diverged — the declaration is \
+                     not an alternative spelling but a second source of truth"
+                );
+            }
+        }
+    }
 }

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -151,6 +151,7 @@ Follow this protocol for all responses:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use armadai_core::agent::AgentMetadata;
 
     #[test]
     fn test_slugify_simple() {
@@ -207,13 +208,168 @@ mod tests {
         assert!(create_linker("unknown").is_err());
     }
 
+    /// Assert every field of two `Agent`s that this invariant is responsible
+    /// for is equal: every field of `AgentMetadata`, plus `system_prompt`,
+    /// `instructions`, `output_format`, `context`. Deliberately **not**
+    /// `Agent::source` — it differs by construction (one is a `.yaml`, one is
+    /// a `.md`) and no projection reads it, so a difference there is not a
+    /// divergence this invariant cares about.
+    ///
+    /// This exists because the five-target projection comparison
+    /// (`assert_projections_equal_across_targets`) is blind to a real class of
+    /// divergence: grepping all five linkers for `tags`/`scope`/`stacks` finds
+    /// zero hits, and `LinkAgent` does not carry `command`/`args` at all, so a
+    /// bug in how those fields are merged would never show up in any
+    /// projection. Both checks matter — this one for what the projection
+    /// cannot see, the projection one for what actually ships to the CLIs.
+    ///
+    /// Uses a destructuring pattern rather than a single `assert_eq!` on the
+    /// two `AgentMetadata` values because `AgentMetadata` does not derive
+    /// `PartialEq` (nor do two of its optional fields, `TriggerConfig` and
+    /// `AgentRingConfig`), and adding that derive to a shared domain type just
+    /// to shorten this test was judged not worth the production-code touch.
+    /// The destructuring gets the same guarantee a derive would have given —
+    /// and then some: a field added to `AgentMetadata` later is a **compile
+    /// error** here (the pattern stops being exhaustive) rather than a
+    /// silently-skipped comparison, which forces this test to be updated
+    /// instead of quietly missing the new field.
+    fn assert_agents_equivalent(declared: &Agent, written: &Agent) {
+        assert_eq!(declared.name, written.name, "agent name diverged");
+
+        let AgentMetadata {
+            provider: d_provider,
+            model: d_model,
+            command: d_command,
+            args: d_args,
+            temperature: d_temperature,
+            max_tokens: d_max_tokens,
+            timeout: d_timeout,
+            tags: d_tags,
+            stacks: d_stacks,
+            scope: d_scope,
+            model_fallback: d_model_fallback,
+            cost_limit: d_cost_limit,
+            rate_limit: d_rate_limit,
+            context_window: d_context_window,
+            mode: d_mode,
+            orchestration: d_orchestration,
+            triggers: d_triggers,
+            ring_config: d_ring_config,
+        } = declared.metadata.clone();
+        let AgentMetadata {
+            provider: w_provider,
+            model: w_model,
+            command: w_command,
+            args: w_args,
+            temperature: w_temperature,
+            max_tokens: w_max_tokens,
+            timeout: w_timeout,
+            tags: w_tags,
+            stacks: w_stacks,
+            scope: w_scope,
+            model_fallback: w_model_fallback,
+            cost_limit: w_cost_limit,
+            rate_limit: w_rate_limit,
+            context_window: w_context_window,
+            mode: w_mode,
+            orchestration: w_orchestration,
+            triggers: w_triggers,
+            ring_config: w_ring_config,
+        } = written.metadata.clone();
+
+        assert_eq!(d_provider, w_provider, "metadata.provider diverged");
+        assert_eq!(d_model, w_model, "metadata.model diverged");
+        assert_eq!(d_command, w_command, "metadata.command diverged");
+        assert_eq!(d_args, w_args, "metadata.args diverged");
+        assert_eq!(
+            d_temperature, w_temperature,
+            "metadata.temperature diverged"
+        );
+        assert_eq!(d_max_tokens, w_max_tokens, "metadata.max_tokens diverged");
+        assert_eq!(d_timeout, w_timeout, "metadata.timeout diverged");
+        assert_eq!(d_tags, w_tags, "metadata.tags diverged");
+        assert_eq!(d_stacks, w_stacks, "metadata.stacks diverged");
+        assert_eq!(d_scope, w_scope, "metadata.scope diverged");
+        assert_eq!(
+            d_model_fallback, w_model_fallback,
+            "metadata.model_fallback diverged"
+        );
+        assert_eq!(d_cost_limit, w_cost_limit, "metadata.cost_limit diverged");
+        assert_eq!(d_rate_limit, w_rate_limit, "metadata.rate_limit diverged");
+        assert_eq!(
+            d_context_window, w_context_window,
+            "metadata.context_window diverged"
+        );
+        assert_eq!(d_mode, w_mode, "metadata.mode diverged");
+        assert_eq!(
+            d_orchestration, w_orchestration,
+            "metadata.orchestration diverged"
+        );
+        // Neither format has a way to declare `triggers`/`ring_config` — both
+        // are always `None` here regardless of source — and their types lack
+        // `PartialEq`, so `Debug` equality is exact for what these fixtures
+        // can produce without adding a derive to production code for it.
+        assert_eq!(
+            format!("{d_triggers:?}"),
+            format!("{w_triggers:?}"),
+            "metadata.triggers diverged"
+        );
+        assert_eq!(
+            format!("{d_ring_config:?}"),
+            format!("{w_ring_config:?}"),
+            "metadata.ring_config diverged"
+        );
+
+        assert_eq!(
+            declared.system_prompt, written.system_prompt,
+            "system_prompt diverged"
+        );
+        assert_eq!(
+            declared.instructions, written.instructions,
+            "instructions diverged"
+        );
+        assert_eq!(
+            declared.output_format, written.output_format,
+            "output_format diverged"
+        );
+        assert_eq!(declared.context, written.context, "context diverged");
+    }
+
+    /// Assert the two agents project identically on every link target. This
+    /// is what actually catches a divergence in what ships to the CLIs —
+    /// complementary to, not a substitute for, `assert_agents_equivalent`.
+    ///
+    /// Run against **every** target, not just claude: a divergence that only
+    /// shows in the codex projection is still a divergence.
+    fn assert_projections_equal_across_targets(declared: &Agent, written: &Agent) {
+        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
+            let linker = create_linker(target).unwrap();
+            let a = linker.generate(&[LinkAgent::from(declared)], None, &[]);
+            let b = linker.generate(&[LinkAgent::from(written)], None, &[]);
+
+            // An empty projection on both sides would satisfy every assertion
+            // below without proving anything.
+            assert!(
+                !a.is_empty(),
+                "target {target} produced no output file — the comparison \
+                 below would be vacuous"
+            );
+            assert_eq!(a.len(), b.len(), "target {target}: file count differs");
+            for (x, y) in a.iter().zip(b.iter()) {
+                assert_eq!(x.path, y.path, "target {target}: paths differ");
+                assert_eq!(
+                    x.content, y.content,
+                    "target {target}: projection diverged — the declaration is \
+                     not an alternative spelling but a second source of truth"
+                );
+            }
+        }
+    }
+
     /// A declared agent and its hand-written `.md` twin must produce the same
     /// native projection. If they diverge, the declaration format is a second
     /// source of truth rather than an alternative spelling of the first —
     /// exactly what it exists to avoid.
-    ///
-    /// Run against **every** target, not just claude: a divergence that only
-    /// shows in the codex projection is still a divergence.
     ///
     /// Both twins carry a model, a temperature, tags and a scope (beyond the
     /// bare minimum) so the comparison actually exercises the metadata path
@@ -260,42 +416,21 @@ mod tests {
         .unwrap();
         let written = armadai_core::parser::parse_agent_file(&md).unwrap();
 
-        // Sanity check before comparing projections: if the two agents are not
-        // actually equivalent, an equal projection would prove nothing.
-        assert_eq!(declared.system_prompt, written.system_prompt);
-        assert_eq!(declared.metadata.model, written.metadata.model);
-        assert_eq!(declared.metadata.temperature, written.metadata.temperature);
-        assert_eq!(declared.metadata.tags, written.metadata.tags);
-        assert_eq!(declared.metadata.scope, written.metadata.scope);
-
-        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
-            let linker = create_linker(target).unwrap();
-            let a = linker.generate(&[LinkAgent::from(&declared)], None, &[]);
-            let b = linker.generate(&[LinkAgent::from(&written)], None, &[]);
-
-            // An empty projection on both sides would satisfy every assertion
-            // below without proving anything.
-            assert!(
-                !a.is_empty(),
-                "target {target} produced no output file — the comparison \
-                 below would be vacuous"
-            );
-            assert_eq!(a.len(), b.len(), "target {target}: file count differs");
-            for (x, y) in a.iter().zip(b.iter()) {
-                assert_eq!(x.path, y.path, "target {target}: paths differ");
-                assert_eq!(
-                    x.content, y.content,
-                    "target {target}: projection diverged — the declaration is \
-                     not an alternative spelling but a second source of truth"
-                );
-            }
-        }
+        assert_agents_equivalent(&declared, &written);
+        assert_projections_equal_across_targets(&declared, &written);
     }
 
     /// Same invariant as above, for a `provider: cli` agent carrying
     /// `command`/`args` — fields added to the declaration format specifically
-    /// so this class of agent could be declared. Nothing had yet proven a
-    /// declared CLI agent projects like its `.md` twin; this is that proof.
+    /// so this class of agent could be declared.
+    ///
+    /// Neither field reaches any linker's output (no target emits `command`
+    /// or `args` into generated content), so the real coverage this case adds
+    /// is at the `Agent`/`AgentMetadata` level via `assert_agents_equivalent`
+    /// — it proves the declared-agent metadata merge is CLI-safe, not that a
+    /// declared CLI agent's `command`/`args` show up anywhere a linked config
+    /// file's content diverges. The five-target projection comparison is kept
+    /// anyway for the fields it *does* cover (model, temperature, prompt).
     #[test]
     fn a_declared_cli_agent_and_its_md_twin_project_identically() {
         let dir = tempfile::tempdir().unwrap();
@@ -339,36 +474,68 @@ mod tests {
         .unwrap();
         let written = armadai_core::parser::parse_agent_file(&md).unwrap();
 
-        // Sanity check before comparing projections: if the two agents are not
-        // actually equivalent, an equal projection would prove nothing.
-        assert_eq!(declared.system_prompt, written.system_prompt);
-        assert_eq!(declared.metadata.provider, written.metadata.provider);
-        assert_eq!(declared.metadata.command, written.metadata.command);
-        assert_eq!(declared.metadata.args, written.metadata.args);
-        assert_eq!(declared.metadata.model, written.metadata.model);
-        assert_eq!(declared.metadata.temperature, written.metadata.temperature);
-        assert_eq!(declared.metadata.tags, written.metadata.tags);
-        assert_eq!(declared.metadata.scope, written.metadata.scope);
+        assert_agents_equivalent(&declared, &written);
+        assert_projections_equal_across_targets(&declared, &written);
+    }
 
-        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
-            let linker = create_linker(target).unwrap();
-            let a = linker.generate(&[LinkAgent::from(&declared)], None, &[]);
-            let b = linker.generate(&[LinkAgent::from(&written)], None, &[]);
+    /// Same invariant again, for a declared agent composed from **two**
+    /// prompt fragments rather than one. `compose_prompt` joins fragment
+    /// bodies with a blank line — a single-fragment fixture (the two tests
+    /// above) never exercises that join at all, which would make it dead code
+    /// as far as this file's coverage goes.
+    #[test]
+    fn a_declared_agent_composed_from_two_fragments_projects_like_its_md_twin() {
+        let dir = tempfile::tempdir().unwrap();
 
-            assert!(
-                !a.is_empty(),
-                "target {target} produced no output file — the comparison \
-                 below would be vacuous"
-            );
-            assert_eq!(a.len(), b.len(), "target {target}: file count differs");
-            for (x, y) in a.iter().zip(b.iter()) {
-                assert_eq!(x.path, y.path, "target {target}: paths differ");
-                assert_eq!(
-                    x.content, y.content,
-                    "target {target}: projection diverged — the declaration is \
-                     not an alternative spelling but a second source of truth"
-                );
-            }
-        }
+        let fragments = vec![
+            armadai_core::prompt::Prompt {
+                name: "role".into(),
+                description: None,
+                apply_to: vec![],
+                body: "You own the core domain.".into(),
+                source: std::path::PathBuf::from("role.md"),
+            },
+            armadai_core::prompt::Prompt {
+                name: "constraints".into(),
+                description: None,
+                apply_to: vec![],
+                body: "Never touch generated code by hand.".into(),
+                source: std::path::PathBuf::from("constraints.md"),
+            },
+        ];
+
+        // Declared version: two prompt steps.
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
+             agents:\n  - name: core-specialist\n    description: Core domain\n    \
+             tags: [rust, domain]\n    scope: [src/core/**]\n    prompt: [role, constraints]\n",
+        )
+        .unwrap();
+        let declared = armadai_core::agent_source::load_agent(
+            &armadai_core::project::AgentRef::Declared {
+                declared: "core-specialist".into(),
+            },
+            dir.path(),
+            &fragments,
+        )
+        .unwrap();
+
+        // Hand-written twin: the same two bodies, joined by a blank line —
+        // the equivalent of what `compose_prompt` produces.
+        let md = dir.path().join("core-specialist.md");
+        std::fs::write(
+            &md,
+            "# core-specialist\n\n## Metadata\n\
+             - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
+             - tags: [rust, domain]\n- scope: [src/core/**]\n\n## System Prompt\n\n\
+             You own the core domain.\n\nNever touch generated code by hand.\n",
+        )
+        .unwrap();
+        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+
+        assert_agents_equivalent(&declared, &written);
+        assert_projections_equal_across_targets(&declared, &written);
     }
 }

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -95,24 +95,13 @@ pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
 }
 
 /// Convert an agent name to a kebab-case slug suitable for filenames.
-pub fn slugify(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
-                c.to_ascii_lowercase()
-            } else if c == ' ' || c == '_' {
-                '-'
-            } else {
-                '\0'
-            }
-        })
-        .filter(|c| *c != '\0')
-        .collect::<String>()
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("-")
-}
+///
+/// Moved to `armadai_core::agent` — normalising a name into a filename-safe
+/// slug is agent-domain-model territory, and `agent_source::check_no_shadowing`
+/// needs the exact same normalisation to catch a declaration/file collision
+/// that only matches after folding. Re-exported here so no call site in this
+/// crate has to change.
+pub use armadai_core::agent::slugify;
 
 impl From<&Agent> for LinkAgent {
     fn from(agent: &Agent) -> Self {

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -97,7 +97,7 @@ pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
 /// Convert an agent name to a kebab-case slug suitable for filenames.
 ///
 /// Moved to `armadai_core::agent` — normalising a name into a filename-safe
-/// slug is agent-domain-model territory, and `agent_source::check_no_shadowing`
+/// slug is agent-domain-model territory, and `agent_source::shadowing_conflict`
 /// needs the exact same normalisation to catch a declaration/file collision
 /// that only matches after folding. Re-exported here so no call site in this
 /// crate has to change.

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -379,6 +379,41 @@ mod tests {
         }
     }
 
+    /// Point the global agent library (`ARMADAI_CONFIG_DIR`) at an empty temp
+    /// dir for the duration of `f`.
+    ///
+    /// The three parity tests below load their declared side through
+    /// `load_agent_by_name`, the real production entry point — unlike the
+    /// now-deleted `load_agent`, that function's file-backed lookup walks
+    /// `library_dirs`, which always includes the REAL
+    /// `~/.config/armadai/agents/`. On a machine that has ever run `armadai
+    /// extract`/`init` from this very repo, that directory holds this
+    /// project's own team agents (`core-specialist.md` included) — without
+    /// this isolation, a parity test could silently resolve the wrong agent
+    /// from a dev box's real global library instead of the fixture below,
+    /// and pass or fail for a reason that has nothing to do with its own
+    /// fixture. Mirrors `agent_source.rs`'s own
+    /// `with_isolated_global_library`; serialised via `ENV_MUTEX` since it
+    /// mutates a process-global env var.
+    fn with_isolated_global_library<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        let empty = tempfile::tempdir().unwrap();
+        // SAFETY: serialised via ENV_MUTEX above.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", empty.path());
+        }
+        let result = f();
+        // SAFETY: restoring original env state, still under the guard.
+        unsafe {
+            match &orig {
+                Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
+                None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
+            }
+        }
+        result
+    }
+
     /// A declared agent and its hand-written `.md` twin must produce the same
     /// native projection. If they diverge, the declaration format is a second
     /// source of truth rather than an alternative spelling of the first —
@@ -389,50 +424,59 @@ mod tests {
     /// `LinkAgent::from(&Agent)` walks, not just the system prompt.
     #[test]
     fn a_declared_agent_and_its_md_twin_project_identically() {
-        let dir = tempfile::tempdir().unwrap();
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
 
-        // The fragment both versions share.
-        let fragments = vec![armadai_core::prompt::Prompt {
-            name: "base".into(),
-            description: None,
-            apply_to: vec![],
-            body: "You own the core domain.".into(),
-            source: std::path::PathBuf::from("base.md"),
-        }];
+            // The fragment both versions share.
+            let fragments = vec![armadai_core::prompt::Prompt {
+                name: "base".into(),
+                description: None,
+                apply_to: vec![],
+                body: "You own the core domain.".into(),
+                source: std::path::PathBuf::from("base.md"),
+            }];
 
-        // Declared version.
-        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
-        std::fs::write(
-            dir.path().join(".armadai/agents.yaml"),
-            "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
-             agents:\n  - name: core-specialist\n    description: Core domain\n    \
-             tags: [rust, domain]\n    scope: [src/core/**]\n    max_tokens: 8192\n    \
-             timeout: 45\n    model_fallback: [latest:fast]\n    prompt: [base]\n",
-        )
-        .unwrap();
-        let declared = armadai_core::agent_source::load_agent(
-            &armadai_core::project::AgentRef::Declared {
-                declared: "core-specialist".into(),
-            },
-            dir.path(),
-            &fragments,
-        )
-        .unwrap();
+            // Declared version.
+            std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+            std::fs::write(
+                dir.path().join(".armadai/agents.yaml"),
+                "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
+                 agents:\n  - name: core-specialist\n    description: Core domain\n    \
+                 tags: [rust, domain]\n    scope: [src/core/**]\n    max_tokens: 8192\n    \
+                 timeout: 45\n    model_fallback: [latest:fast]\n    prompt: [base]\n",
+            )
+            .unwrap();
+            // Loaded through `load_agent_by_name`, the actual production
+            // entry point for one declared agent — not the now-deleted
+            // `load_agent`, which had no production caller of its own.
+            let config = armadai_core::project::ProjectConfig::default();
+            let (declared, warning) = armadai_core::agent_source::load_agent_by_name(
+                "core-specialist",
+                &config,
+                dir.path(),
+                &fragments,
+            )
+            .unwrap();
+            assert!(
+                warning.is_none(),
+                "a clean project must not warn: {warning:?}"
+            );
 
-        // Hand-written twin, same values.
-        let md = dir.path().join("core-specialist.md");
-        std::fs::write(
-            &md,
-            "# core-specialist\n\n## Metadata\n\
-             - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
-             - tags: [rust, domain]\n- scope: [src/core/**]\n- max_tokens: 8192\n\
-             - timeout: 45\n- model_fallback: [latest:fast]\n\n## System Prompt\n\nYou own the core domain.\n",
-        )
-        .unwrap();
-        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+            // Hand-written twin, same values.
+            let md = dir.path().join("core-specialist.md");
+            std::fs::write(
+                &md,
+                "# core-specialist\n\n## Metadata\n\
+                 - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
+                 - tags: [rust, domain]\n- scope: [src/core/**]\n- max_tokens: 8192\n\
+                 - timeout: 45\n- model_fallback: [latest:fast]\n\n## System Prompt\n\nYou own the core domain.\n",
+            )
+            .unwrap();
+            let written = armadai_core::parser::parse_agent_file(&md).unwrap();
 
-        assert_agents_equivalent(&declared, &written);
-        assert_projections_equal_across_targets(&declared, &written);
+            assert_agents_equivalent(&declared, &written);
+            assert_projections_equal_across_targets(&declared, &written);
+        });
     }
 
     /// Same invariant as above, for a `provider: cli` agent carrying
@@ -448,49 +492,55 @@ mod tests {
     /// anyway for the fields it *does* cover (model, temperature, prompt).
     #[test]
     fn a_declared_cli_agent_and_its_md_twin_project_identically() {
-        let dir = tempfile::tempdir().unwrap();
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
 
-        let fragments = vec![armadai_core::prompt::Prompt {
-            name: "base".into(),
-            description: None,
-            apply_to: vec![],
-            body: "You wrap a CLI tool for scripted tasks.".into(),
-            source: std::path::PathBuf::from("base.md"),
-        }];
+            let fragments = vec![armadai_core::prompt::Prompt {
+                name: "base".into(),
+                description: None,
+                apply_to: vec![],
+                body: "You wrap a CLI tool for scripted tasks.".into(),
+                source: std::path::PathBuf::from("base.md"),
+            }];
 
-        // Declared version.
-        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
-        std::fs::write(
-            dir.path().join(".armadai/agents.yaml"),
-            "defaults:\n  provider: cli\n  temperature: 0.5\n\
-             agents:\n  - name: shell-runner\n    description: Wraps a CLI tool\n    \
-             command: echo\n    args: [hello, world]\n    model: local-llm\n    \
-             tags: [ops, shell]\n    stacks: [devops]\n    scope: [scripts/**]\n    prompt: [base]\n",
-        )
-        .unwrap();
-        let declared = armadai_core::agent_source::load_agent(
-            &armadai_core::project::AgentRef::Declared {
-                declared: "shell-runner".into(),
-            },
-            dir.path(),
-            &fragments,
-        )
-        .unwrap();
+            // Declared version.
+            std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+            std::fs::write(
+                dir.path().join(".armadai/agents.yaml"),
+                "defaults:\n  provider: cli\n  temperature: 0.5\n\
+                 agents:\n  - name: shell-runner\n    description: Wraps a CLI tool\n    \
+                 command: echo\n    args: [hello, world]\n    model: local-llm\n    \
+                 tags: [ops, shell]\n    stacks: [devops]\n    scope: [scripts/**]\n    prompt: [base]\n",
+            )
+            .unwrap();
+            let config = armadai_core::project::ProjectConfig::default();
+            let (declared, warning) = armadai_core::agent_source::load_agent_by_name(
+                "shell-runner",
+                &config,
+                dir.path(),
+                &fragments,
+            )
+            .unwrap();
+            assert!(
+                warning.is_none(),
+                "a clean project must not warn: {warning:?}"
+            );
 
-        // Hand-written twin, same values.
-        let md = dir.path().join("shell-runner.md");
-        std::fs::write(
-            &md,
-            "# shell-runner\n\n## Metadata\n\
-             - provider: cli\n- command: echo\n- args: [hello, world]\n\
-             - model: local-llm\n- temperature: 0.5\n- tags: [ops, shell]\n\
-             - stacks: [devops]\n- scope: [scripts/**]\n\n## System Prompt\n\nYou wrap a CLI tool for scripted tasks.\n",
-        )
-        .unwrap();
-        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+            // Hand-written twin, same values.
+            let md = dir.path().join("shell-runner.md");
+            std::fs::write(
+                &md,
+                "# shell-runner\n\n## Metadata\n\
+                 - provider: cli\n- command: echo\n- args: [hello, world]\n\
+                 - model: local-llm\n- temperature: 0.5\n- tags: [ops, shell]\n\
+                 - stacks: [devops]\n- scope: [scripts/**]\n\n## System Prompt\n\nYou wrap a CLI tool for scripted tasks.\n",
+            )
+            .unwrap();
+            let written = armadai_core::parser::parse_agent_file(&md).unwrap();
 
-        assert_agents_equivalent(&declared, &written);
-        assert_projections_equal_across_targets(&declared, &written);
+            assert_agents_equivalent(&declared, &written);
+            assert_projections_equal_across_targets(&declared, &written);
+        });
     }
 
     /// Same invariant again, for a declared agent composed from **two**
@@ -500,57 +550,63 @@ mod tests {
     /// as far as this file's coverage goes.
     #[test]
     fn a_declared_agent_composed_from_two_fragments_projects_like_its_md_twin() {
-        let dir = tempfile::tempdir().unwrap();
+        with_isolated_global_library(|| {
+            let dir = tempfile::tempdir().unwrap();
 
-        let fragments = vec![
-            armadai_core::prompt::Prompt {
-                name: "role".into(),
-                description: None,
-                apply_to: vec![],
-                body: "You own the core domain.".into(),
-                source: std::path::PathBuf::from("role.md"),
-            },
-            armadai_core::prompt::Prompt {
-                name: "constraints".into(),
-                description: None,
-                apply_to: vec![],
-                body: "Never touch generated code by hand.".into(),
-                source: std::path::PathBuf::from("constraints.md"),
-            },
-        ];
+            let fragments = vec![
+                armadai_core::prompt::Prompt {
+                    name: "role".into(),
+                    description: None,
+                    apply_to: vec![],
+                    body: "You own the core domain.".into(),
+                    source: std::path::PathBuf::from("role.md"),
+                },
+                armadai_core::prompt::Prompt {
+                    name: "constraints".into(),
+                    description: None,
+                    apply_to: vec![],
+                    body: "Never touch generated code by hand.".into(),
+                    source: std::path::PathBuf::from("constraints.md"),
+                },
+            ];
 
-        // Declared version: two prompt steps.
-        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
-        std::fs::write(
-            dir.path().join(".armadai/agents.yaml"),
-            "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
-             agents:\n  - name: core-specialist\n    description: Core domain\n    \
-             tags: [rust, domain]\n    scope: [src/core/**]\n    prompt: [role, constraints]\n",
-        )
-        .unwrap();
-        let declared = armadai_core::agent_source::load_agent(
-            &armadai_core::project::AgentRef::Declared {
-                declared: "core-specialist".into(),
-            },
-            dir.path(),
-            &fragments,
-        )
-        .unwrap();
+            // Declared version: two prompt steps.
+            std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+            std::fs::write(
+                dir.path().join(".armadai/agents.yaml"),
+                "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
+                 agents:\n  - name: core-specialist\n    description: Core domain\n    \
+                 tags: [rust, domain]\n    scope: [src/core/**]\n    prompt: [role, constraints]\n",
+            )
+            .unwrap();
+            let config = armadai_core::project::ProjectConfig::default();
+            let (declared, warning) = armadai_core::agent_source::load_agent_by_name(
+                "core-specialist",
+                &config,
+                dir.path(),
+                &fragments,
+            )
+            .unwrap();
+            assert!(
+                warning.is_none(),
+                "a clean project must not warn: {warning:?}"
+            );
 
-        // Hand-written twin: the same two bodies, joined by a blank line —
-        // the equivalent of what `compose_prompt` produces.
-        let md = dir.path().join("core-specialist.md");
-        std::fs::write(
-            &md,
-            "# core-specialist\n\n## Metadata\n\
-             - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
-             - tags: [rust, domain]\n- scope: [src/core/**]\n\n## System Prompt\n\n\
-             You own the core domain.\n\nNever touch generated code by hand.\n",
-        )
-        .unwrap();
-        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+            // Hand-written twin: the same two bodies, joined by a blank line —
+            // the equivalent of what `compose_prompt` produces.
+            let md = dir.path().join("core-specialist.md");
+            std::fs::write(
+                &md,
+                "# core-specialist\n\n## Metadata\n\
+                 - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
+                 - tags: [rust, domain]\n- scope: [src/core/**]\n\n## System Prompt\n\n\
+                 You own the core domain.\n\nNever touch generated code by hand.\n",
+            )
+            .unwrap();
+            let written = armadai_core::parser::parse_agent_file(&md).unwrap();
 
-        assert_agents_equivalent(&declared, &written);
-        assert_projections_equal_across_targets(&declared, &written);
+            assert_agents_equivalent(&declared, &written);
+            assert_projections_equal_across_targets(&declared, &written);
+        });
     }
 }

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -294,6 +294,19 @@ mod tests {
             d_model_fallback, w_model_fallback,
             "metadata.model_fallback diverged"
         );
+        // `cost_limit`, `rate_limit`, `context_window`, `mode`,
+        // `orchestration`, `triggers` and `ring_config` are fields the
+        // declarative format (`AgentDecl`/`AgentDefaults` in
+        // `agent_decl.rs`) has no way to express at all — `to_agent` always
+        // produces `None`/default for every one of them, regardless of what
+        // a `.md` twin's `## Metadata` might otherwise be able to set. Both
+        // sides of every fixture in this file are therefore `None` here by
+        // construction, and these seven assertions are vacuous: they can
+        // never fail while the format stays as it is. That is legitimate,
+        // not a gap in this test — but if the declarative format ever grows
+        // one of these seven, this comment is where the next reader learns
+        // that its fixture also needs a non-default value added, the same
+        // way `model_fallback` did after the mutation that found it unused.
         assert_eq!(d_cost_limit, w_cost_limit, "metadata.cost_limit diverged");
         assert_eq!(d_rate_limit, w_rate_limit, "metadata.rate_limit diverged");
         assert_eq!(
@@ -305,10 +318,10 @@ mod tests {
             d_orchestration, w_orchestration,
             "metadata.orchestration diverged"
         );
-        // Neither format has a way to declare `triggers`/`ring_config` — both
-        // are always `None` here regardless of source — and their types lack
-        // `PartialEq`, so `Debug` equality is exact for what these fixtures
-        // can produce without adding a derive to production code for it.
+        // `triggers`/`ring_config` additionally lack `PartialEq` on their
+        // types, so `Debug` equality is used instead — exact for what these
+        // fixtures can ever produce (always `None`), without adding a
+        // derive to production code for it.
         assert_eq!(
             format!("{d_triggers:?}"),
             format!("{w_triggers:?}"),
@@ -393,7 +406,8 @@ mod tests {
             dir.path().join(".armadai/agents.yaml"),
             "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
              agents:\n  - name: core-specialist\n    description: Core domain\n    \
-             tags: [rust, domain]\n    scope: [src/core/**]\n    prompt: [base]\n",
+             tags: [rust, domain]\n    scope: [src/core/**]\n    max_tokens: 8192\n    \
+             timeout: 45\n    model_fallback: [latest:fast]\n    prompt: [base]\n",
         )
         .unwrap();
         let declared = armadai_core::agent_source::load_agent(
@@ -411,7 +425,8 @@ mod tests {
             &md,
             "# core-specialist\n\n## Metadata\n\
              - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
-             - tags: [rust, domain]\n- scope: [src/core/**]\n\n## System Prompt\n\nYou own the core domain.\n",
+             - tags: [rust, domain]\n- scope: [src/core/**]\n- max_tokens: 8192\n\
+             - timeout: 45\n- model_fallback: [latest:fast]\n\n## System Prompt\n\nYou own the core domain.\n",
         )
         .unwrap();
         let written = armadai_core::parser::parse_agent_file(&md).unwrap();
@@ -450,7 +465,7 @@ mod tests {
             "defaults:\n  provider: cli\n  temperature: 0.5\n\
              agents:\n  - name: shell-runner\n    description: Wraps a CLI tool\n    \
              command: echo\n    args: [hello, world]\n    model: local-llm\n    \
-             tags: [ops, shell]\n    scope: [scripts/**]\n    prompt: [base]\n",
+             tags: [ops, shell]\n    stacks: [devops]\n    scope: [scripts/**]\n    prompt: [base]\n",
         )
         .unwrap();
         let declared = armadai_core::agent_source::load_agent(
@@ -469,7 +484,7 @@ mod tests {
             "# shell-runner\n\n## Metadata\n\
              - provider: cli\n- command: echo\n- args: [hello, world]\n\
              - model: local-llm\n- temperature: 0.5\n- tags: [ops, shell]\n\
-             - scope: [scripts/**]\n\n## System Prompt\n\nYou wrap a CLI tool for scripted tasks.\n",
+             - stacks: [devops]\n- scope: [scripts/**]\n\n## System Prompt\n\nYou wrap a CLI tool for scripted tasks.\n",
         )
         .unwrap();
         let written = armadai_core::parser::parse_agent_file(&md).unwrap();

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1097,9 +1097,46 @@ async fn execute_tandem(
     Ok(())
 }
 
-/// Resolve an agent file path by name from the current project config.
-fn resolve_project_agent(name: &str) -> Option<std::path::PathBuf> {
-    let (root, config) = armadai_core::project::find_project_config()?;
+/// Outcome of looking an agent name up against the project config.
+///
+/// Plain `Option<PathBuf>` used to stand in for this, but that collapses two
+/// different truths into one `None`: "no such agent" and "that agent exists,
+/// declared in `agents.yaml`, but has no file to run from the shell relay".
+/// Only the first one means "not found in project config" — saying that for
+/// the second sends the user hunting through `armadai.yaml` for something
+/// that is, in fact, correctly declared.
+#[derive(Debug, PartialEq)]
+enum AgentLookup {
+    /// Resolved to a file, exactly as the three pre-existing `AgentRef`
+    /// variants (`Named`, `Path`, `Registry`) always have.
+    Path(std::path::PathBuf),
+    /// Declared in `.armadai/agents.yaml`, not file-backed. The shell relay
+    /// only runs file-backed agents today — wiring it to `load_agent` for
+    /// declared agents is a later task's job.
+    Declared,
+    /// No ref in the project config matches this name at all.
+    NotFound,
+}
+
+/// Message shown when a step's `--agent` name resolves to a declared
+/// (non-file) agent. Kept as its own function so both the shell and its
+/// tests say the exact same thing.
+fn declared_agent_not_runnable_message(agent_name: &str) -> String {
+    format!(
+        "Agent '{agent_name}' is declared in .armadai/agents.yaml but has no \
+         file — declarative agents can't be run from the shell yet"
+    )
+}
+
+/// Look `name` up against a project config already resolved to `root`. Pure
+/// with respect to the filesystem beyond what `resolve_agent` itself touches
+/// — split out from `resolve_project_agent` so it can be tested without
+/// depending on (and mutating) the process's current directory.
+fn lookup_agent_in_config(
+    config: &armadai_core::project::ProjectConfig,
+    root: &std::path::Path,
+    name: &str,
+) -> AgentLookup {
     for agent_ref in &config.agents {
         let agent_name = match agent_ref {
             armadai_core::project::AgentRef::Named { name: n } => n.clone(),
@@ -1108,19 +1145,29 @@ fn resolve_project_agent(name: &str) -> Option<std::path::PathBuf> {
                 .and_then(|s| s.to_str())
                 .map(|s| s.to_string())
                 .unwrap_or_default(),
-            // Matched by name like the other file-backed variants; the
-            // shell relay wants a file path, which a declared agent has
-            // none of, so `resolve_agent` below turns this into a clean
-            // `None` rather than a path. Wiring the shell to `load_agent`
-            // for declared agents is a later task's job.
             armadai_core::project::AgentRef::Declared { declared } => declared.clone(),
             _ => continue,
         };
-        if agent_name == name {
-            return armadai_core::project::resolve_agent(agent_ref, &root).ok();
+        if agent_name != name {
+            continue;
         }
+        if matches!(agent_ref, armadai_core::project::AgentRef::Declared { .. }) {
+            return AgentLookup::Declared;
+        }
+        return match armadai_core::project::resolve_agent(agent_ref, root) {
+            Ok(path) => AgentLookup::Path(path),
+            Err(_) => AgentLookup::NotFound,
+        };
     }
-    None
+    AgentLookup::NotFound
+}
+
+/// Resolve an agent file path by name from the current project config.
+fn resolve_project_agent(name: &str) -> AgentLookup {
+    let Some((root, config)) = armadai_core::project::find_project_config() else {
+        return AgentLookup::NotFound;
+    };
+    lookup_agent_in_config(&config, &root, name)
 }
 
 /// Resolved step data: command, args, combined prompt, display label.
@@ -1171,7 +1218,7 @@ async fn execute_pipeline_steps(
         {
             // Agent mode: load the agent from project config
             match resolve_project_agent(agent_name) {
-                Some(path) => match armadai_core::parser::parse_agent_file(&path) {
+                AgentLookup::Path(path) => match armadai_core::parser::parse_agent_file(&path) {
                     Ok(agent) => {
                         let cmd = agent.metadata.provider.clone();
                         let args = super::detect::args_for_provider(&cmd);
@@ -1185,7 +1232,11 @@ async fn execute_pipeline_steps(
                         continue;
                     }
                 },
-                None => {
+                AgentLookup::Declared => {
+                    app.add_system_message(&declared_agent_not_runnable_message(agent_name));
+                    continue;
+                }
+                AgentLookup::NotFound => {
                     app.add_system_message(&format!(
                         "Agent '{agent_name}' not found in project config"
                     ));
@@ -1668,5 +1719,56 @@ mod tests {
         assert_eq!(tokens_in, Some(42));
         assert_eq!(tokens_out, 7);
         assert!((cost - 0.1).abs() < f64::EPSILON);
+    }
+
+    // -----------------------------------------------------------------
+    // AgentLookup: distinguishing "no such agent" from "declared, not
+    // file-backed" so the shell's message stays true. `lookup_agent_in_config`
+    // takes the project config directly, so these don't touch the process's
+    // current directory the way `resolve_project_agent` itself does.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_declared_ref_is_looked_up_as_declared_not_as_a_missing_file() {
+        let config = armadai_core::project::ProjectConfig {
+            agents: vec![armadai_core::project::AgentRef::Declared {
+                declared: "core-specialist".to_string(),
+            }],
+            ..Default::default()
+        };
+        let root = std::path::Path::new("/does/not/matter");
+
+        assert_eq!(
+            lookup_agent_in_config(&config, root, "core-specialist"),
+            AgentLookup::Declared
+        );
+    }
+
+    #[test]
+    fn a_name_absent_from_the_config_is_not_found() {
+        let config = armadai_core::project::ProjectConfig {
+            agents: vec![armadai_core::project::AgentRef::Declared {
+                declared: "core-specialist".to_string(),
+            }],
+            ..Default::default()
+        };
+        let root = std::path::Path::new("/does/not/matter");
+
+        assert_eq!(
+            lookup_agent_in_config(&config, root, "ghost"),
+            AgentLookup::NotFound
+        );
+    }
+
+    #[test]
+    fn the_declared_agent_message_is_true_and_names_the_agent() {
+        // Pins the exact wording so a future edit can't silently regress it
+        // back to the false "not found in project config" message this
+        // fix replaced.
+        assert_eq!(
+            declared_agent_not_runnable_message("core-specialist"),
+            "Agent 'core-specialist' is declared in .armadai/agents.yaml but has no \
+             file — declarative agents can't be run from the shell yet"
+        );
     }
 }

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1111,8 +1111,9 @@ enum AgentLookup {
     /// variants (`Named`, `Path`, `Registry`) always have.
     Path(std::path::PathBuf),
     /// Declared in `.armadai/agents.yaml`, not file-backed. The shell relay
-    /// only runs file-backed agents today — wiring it to `load_agent` for
-    /// declared agents is a later task's job.
+    /// only runs file-backed agents today — wiring it to
+    /// `agent_source::load_agent_by_name` for declared agents is a later
+    /// task's job.
     Declared,
     /// No ref in the project config matches this name at all.
     NotFound,

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1108,6 +1108,12 @@ fn resolve_project_agent(name: &str) -> Option<std::path::PathBuf> {
                 .and_then(|s| s.to_str())
                 .map(|s| s.to_string())
                 .unwrap_or_default(),
+            // Matched by name like the other file-backed variants; the
+            // shell relay wants a file path, which a declared agent has
+            // none of, so `resolve_agent` below turns this into a clean
+            // `None` rather than a path. Wiring the shell to `load_agent`
+            // for declared agents is a later task's job.
+            armadai_core::project::AgentRef::Declared { declared } => declared.clone(),
             _ => continue,
         };
         if agent_name == name {

--- a/crates/armadai/tests/cases/declarations-only-project.yaml
+++ b/crates/armadai/tests/cases/declarations-only-project.yaml
@@ -17,6 +17,12 @@ expect:
   events:
     - { t: run_start }
     - { t: agent_start, agent: t-declared }
-    - { t: result }
+    # Proves the declared agent's prompt was actually composed (the
+    # `fake-base` fragment's `{{name}}` substituted to `t-declared`), not
+    # just that SOME agent ran: the scenario's catch-all rule (which fires
+    # on any prompt fake-claude cannot match to `t-declared`) responds with
+    # a different, unmistakable string, so this would fail if composition
+    # silently broke and the catch-all fired instead.
+    - { t: result, content: "done" }
   event_counts: { agent_start: 1, agent_end: 1, result: 1 }
   invariants: [agent_start_end_symmetric, prov_non_empty, model_non_empty, single_result, no_orphan_events]

--- a/crates/armadai/tests/cases/declarations-only-project.yaml
+++ b/crates/armadai/tests/cases/declarations-only-project.yaml
@@ -1,0 +1,22 @@
+name: declarations-only-project
+weight: 6
+setup:
+  pattern: direct
+  agents: [t-declared]
+  declared_agents: [t-declared]
+  flags: ["--json"]
+  input: "hi"
+  scenario:
+    rules:
+      - match: { agent: t-declared }
+        respond: "done"
+      - match: {}
+        respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    - { t: run_start }
+    - { t: agent_start, agent: t-declared }
+    - { t: result }
+  event_counts: { agent_start: 1, agent_end: 1, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_non_empty, model_non_empty, single_result, no_orphan_events]

--- a/crates/armadai/tests/cases/declared-agents-orchestrated.yaml
+++ b/crates/armadai/tests/cases/declared-agents-orchestrated.yaml
@@ -1,0 +1,47 @@
+name: declared-agents-orchestrated
+weight: 6
+setup:
+  pattern: blackboard
+  agents: [t-a, t-b]
+  declared_agents: [t-a, t-b]
+  flags: ["--json"]
+  input: "assess the caching layer"
+  scenario:
+    rules:
+      - match: { agent: t-a, call: 1 }
+        respond: "ACTION: FINDING\nCONFIDENCE: 0.9\nCONTENT: caching layer looks sound"
+      - match: { agent: t-b, call: 1 }
+        respond: "ACTION: FINDING\nCONFIDENCE: 0.85\nCONTENT: cache TTLs look reasonable"
+      - match: { agent: t-a, call: 2 }
+        respond: "ACTION: CONFIRMATION\nTARGET: 0\nCONFIDENCE: 0.95\nCONTENT: agreed, no issues found"
+      - match: { agent: t-b, call: 2 }
+        respond: "ACTION: CONFIRMATION\nTARGET: 0\nCONFIDENCE: 0.9\nCONTENT: agreed, confirming the finding"
+      - match: {}
+        respond: "unexpected — catch-all should never be hit in this case"
+expect:
+  exit_code: 0
+  events:
+    # Proves task 7b review Finding 7's `run_orchestrated` roster-loader
+    # swap (`resolve_agent_path` -> `load_agent_for_run`): BOTH agents here
+    # are declared in `.armadai/agents.yaml`, not written as `.md` files —
+    # a project with none at all. Matching `agent_start`/`board` on each
+    # (rather than just `run_start`) also proves each declared agent's
+    # composed prompt reached the fake correctly (the catch-all fires on a
+    # mismatch, and its response would break the round-2 convergence this
+    # case relies on to reach `result` with exit 0).
+    - { t: run_start }
+    - { t: agent_start, agent: t-a }
+    - { t: board, agent: t-a, kind: finding }
+    - { t: agent_end, agent: t-a }
+    - { t: agent_start, agent: t-b }
+    - { t: board, agent: t-b, kind: finding }
+    - { t: agent_end, agent: t-b }
+    - { t: agent_start, agent: t-a }
+    - { t: board, agent: t-a, kind: confirmation }
+    - { t: agent_end, agent: t-a }
+    - { t: agent_start, agent: t-b }
+    - { t: board, agent: t-b, kind: confirmation }
+    - { t: agent_end, agent: t-b }
+    - { t: result }
+  event_counts: { agent_start: 4, agent_end: 4, board: 4, result: 1 }
+  invariants: [agent_start_end_symmetric, prov_non_empty, model_non_empty, single_result, no_orphan_events]

--- a/crates/armadai/tests/cases/no-agents-project-still-errors.yaml
+++ b/crates/armadai/tests/cases/no-agents-project-still-errors.yaml
@@ -1,0 +1,16 @@
+name: no-agents-project-still-errors
+weight: 6
+setup:
+  pattern: direct
+  agents: [ghost]
+  no_project_agents: true
+  flags: ["--json"]
+  input: "hi"
+  scenario:
+    rules: []
+expect:
+  exit_code: 1
+  events:
+    - { t: error, code: agent_failed }
+  stdout:
+    contains: ["ghost", "not found"]

--- a/crates/armadai/tests/cases/no-agents-project-still-errors.yaml
+++ b/crates/armadai/tests/cases/no-agents-project-still-errors.yaml
@@ -13,4 +13,4 @@ expect:
   events:
     - { t: error, code: agent_failed }
   stdout:
-    contains: ["ghost", "not found"]
+    contains: ["not found in agents"]

--- a/crates/armadai/tests/gaveldrop.rs
+++ b/crates/armadai/tests/gaveldrop.rs
@@ -534,10 +534,11 @@ fn all_cases_load() {
         }
     }
     assert_eq!(
-        n, 12,
+        n, 13,
         "expected 9 migrated cases + the direct-replay steps case + 2 task-7b-review \
          project-detection-gate cases (declarations-only-project, \
-         no-agents-project-still-errors)"
+         no-agents-project-still-errors) + 1 task-7b-review-round-2 case proving \
+         --orchestrate loads declared agents (declared-agents-orchestrated)"
     );
 }
 
@@ -582,13 +583,15 @@ fn armadai_adapter_is_conformant() {
     assert!(report.is_conformant(), "\n{}", report.render());
 }
 
-/// Runs the full 12-case suite through `gaveldrop::runner::run_all_with`, the same entry point
+/// Runs the full 13-case suite through `gaveldrop::runner::run_all_with`, the same entry point
 /// `armadai`'s own e2e binary would use in production, with the `Armadai` adapter prepended to
 /// gaveldrop's built-in registry. This is the decisive migration gate: it proves the original 10
 /// cases reach the SAME verdicts the old hand-rolled harness produced (deleted in T3), now
 /// evaluated entirely by gaveldrop's `verdict::evaluate` instead of bespoke assertion code — plus
 /// 2 more added for the task-7b review's Finding 5 (the `resolve_agents_dir`/`link`/`list`
-/// project-detection gate fix: a declarations-only project vs. a project with no agents at all).
+/// project-detection gate fix: a declarations-only project vs. a project with no agents at all),
+/// plus 1 more added for that review's follow-up round, proving Finding 7's `--orchestrate`
+/// roster-loader swap actually loads declared agents (`declared-agents-orchestrated`).
 #[test]
 fn e2e_suite_passes_through_gaveldrop() {
     use gaveldrop::Tee;
@@ -622,8 +625,8 @@ fn e2e_suite_passes_through_gaveldrop() {
     // trivially true if the `cases:` glob or `root` path silently stopped matching anything.
     assert_eq!(
         report.summary().total,
-        12,
-        "expected 12 cases to run, got {}",
+        13,
+        "expected 13 cases to run, got {}",
         report.summary().total
     );
     assert!(

--- a/crates/armadai/tests/gaveldrop.rs
+++ b/crates/armadai/tests/gaveldrop.rs
@@ -101,6 +101,32 @@ fn arr_field(case: &Case, key: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Reads a bool from `case.setup.extra`, `false` when the key is missing.
+fn bool_field(case: &Case, key: &str) -> bool {
+    case.setup
+        .extra
+        .get(key)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// The `.armadai/prompts/` fragment every `declared_agents` entry composes its
+/// system prompt from — carries the SAME `FAKE_AGENT_ID: {{name}}` marker
+/// `agent_markdown` writes literally for a file-backed agent, so `fake-claude`
+/// identifies a declared agent's calls exactly the same way (see
+/// `armadai_fake::lib.rs`'s `AGENT_ID_MARKER`). `{{name}}` is substituted by
+/// `agent_decl::compose_prompt` from the declaration's own name — one fragment
+/// serves every declared agent in a case, whatever it's called.
+const DECLARED_FAKE_FRAGMENT: &str = "FAKE_AGENT_ID: {{name}}\n\n\
+You are `{{name}}`, a deterministic test agent used by the e2e harness. Respond \
+concisely to the task given.\n";
+
+/// A minimal, valid `.armadai/agents.yaml` entry for `agent`, composing from
+/// [`DECLARED_FAKE_FRAGMENT`] — the declared-agent twin of [`agent_markdown`].
+fn declared_agent_yaml(agent: &str) -> String {
+    format!("  - name: {agent}\n    prompt: [fake-base]\n")
+}
+
 /// `setup.nested_team` (C9): the sub-team a `hierarchical` case's lead runs instead of flat
 /// delegation. Ported from the old typed `NestedTeamSetup` (`tests/e2e/case.rs`, deleted in
 /// T3) — see `project_yaml`.
@@ -132,16 +158,46 @@ fn io_err(case: &Case, action: &str, source: std::io::Error) -> AdapterError {
 fn write_project(case: &Case, iso: &Isolation) -> Result<PathBuf, AdapterError> {
     let root = iso.root();
     let agents = arr_field(case, "agents");
+    let declared_agents = arr_field(case, "declared_agents");
+    let no_project_agents = bool_field(case, "no_project_agents");
 
     std::fs::create_dir_all(root.join("agents"))
         .map_err(|e| io_err(case, "creating agents/ dir", e))?;
     std::fs::write(root.join("armadai.yaml"), project_yaml(case))
         .map_err(|e| io_err(case, "writing armadai.yaml", e))?;
 
+    // `declared_agents`/`no_project_agents` (Finding 5, task 7b review): a
+    // name in either of these must resolve to NOTHING written as a `.md`
+    // file — the whole point is exercising the project-detection gate for a
+    // declarations-only project, or a project with no agents at all, rather
+    // than the ordinary file-backed path every other case exercises.
     for agent in &agents {
+        if no_project_agents || declared_agents.contains(agent) {
+            continue;
+        }
         let path = root.join("agents").join(format!("{agent}.md"));
         std::fs::write(&path, agent_markdown(agent))
             .map_err(|e| io_err(case, &format!("writing {}", path.display()), e))?;
+    }
+
+    if !declared_agents.is_empty() {
+        std::fs::create_dir_all(root.join(".armadai").join("prompts"))
+            .map_err(|e| io_err(case, "creating .armadai/prompts/ dir", e))?;
+        std::fs::write(
+            root.join(".armadai/prompts/fake-base.md"),
+            DECLARED_FAKE_FRAGMENT,
+        )
+        .map_err(|e| io_err(case, "writing .armadai/prompts/fake-base.md", e))?;
+
+        let decls_block: String = declared_agents
+            .iter()
+            .map(|a| declared_agent_yaml(a))
+            .collect();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            format!("defaults:\n  provider: claude\n  model: fake-model\nagents:\n{decls_block}"),
+        )
+        .map_err(|e| io_err(case, "writing .armadai/agents.yaml", e))?;
     }
 
     let scenario_value = case
@@ -168,9 +224,12 @@ fn write_project(case: &Case, iso: &Isolation) -> Result<PathBuf, AdapterError> 
     Ok(scenario_path)
 }
 
-/// Renders `armadai.yaml` for `case`. The `agents:` list is always required (an empty list
+/// Renders `armadai.yaml` for `case`. The `agents:` list is normally required (an empty list
 /// makes `armadai` fall back to the global agent library instead of resolving this project's
-/// `agents/*.md` — see `resolve_agents_dir` in `src/cli/run.rs`).
+/// `agents/*.md` — see `resolve_agents_dir` in `src/cli/run.rs`) — UNLESS the project also has
+/// `.armadai/agents.yaml` declarations (task 7b), in which case an empty `agents:` list is the
+/// whole point of the case: `declared_agents`/`no_project_agents` (Finding 5) both force it
+/// empty here, deliberately, to exercise that gate.
 ///
 /// Only `hierarchical` gets a top-level `orchestration:` block: it's the only pattern selected
 /// via project config rather than a `--orchestrate` CLI flag (see `build_command`). When
@@ -182,9 +241,19 @@ fn write_project(case: &Case, iso: &Isolation) -> Result<PathBuf, AdapterError> 
 /// `Setup`.
 fn project_yaml(case: &Case) -> String {
     let agents = arr_field(case, "agents");
+    let declared_agents = arr_field(case, "declared_agents");
+    let no_project_agents = bool_field(case, "no_project_agents");
     let pattern = str_field(case, "pattern").unwrap_or_default();
 
-    let agents_block: String = agents.iter().map(|a| format!("  - name: {a}\n")).collect();
+    let agents_block: String = if no_project_agents {
+        String::new()
+    } else {
+        agents
+            .iter()
+            .filter(|a| !declared_agents.contains(a))
+            .map(|a| format!("  - name: {a}\n"))
+            .collect()
+    };
     let mut yaml = format!("agents:\n{agents_block}");
 
     if pattern == "hierarchical" {
@@ -465,8 +534,10 @@ fn all_cases_load() {
         }
     }
     assert_eq!(
-        n, 10,
-        "expected 9 migrated cases + the direct-replay steps case"
+        n, 12,
+        "expected 9 migrated cases + the direct-replay steps case + 2 task-7b-review \
+         project-detection-gate cases (declarations-only-project, \
+         no-agents-project-still-errors)"
     );
 }
 
@@ -511,11 +582,13 @@ fn armadai_adapter_is_conformant() {
     assert!(report.is_conformant(), "\n{}", report.render());
 }
 
-/// Runs the full 10-case suite through `gaveldrop::runner::run_all_with`, the same entry point
+/// Runs the full 12-case suite through `gaveldrop::runner::run_all_with`, the same entry point
 /// `armadai`'s own e2e binary would use in production, with the `Armadai` adapter prepended to
-/// gaveldrop's built-in registry. This is the decisive migration gate: it proves the 10 cases
-/// reach the SAME verdicts the old hand-rolled harness produced (deleted in T3), now evaluated
-/// entirely by gaveldrop's `verdict::evaluate` instead of bespoke assertion code.
+/// gaveldrop's built-in registry. This is the decisive migration gate: it proves the original 10
+/// cases reach the SAME verdicts the old hand-rolled harness produced (deleted in T3), now
+/// evaluated entirely by gaveldrop's `verdict::evaluate` instead of bespoke assertion code — plus
+/// 2 more added for the task-7b review's Finding 5 (the `resolve_agents_dir`/`link`/`list`
+/// project-detection gate fix: a declarations-only project vs. a project with no agents at all).
 #[test]
 fn e2e_suite_passes_through_gaveldrop() {
     use gaveldrop::Tee;
@@ -549,8 +622,8 @@ fn e2e_suite_passes_through_gaveldrop() {
     // trivially true if the `cases:` glob or `root` path silently stopped matching anything.
     assert_eq!(
         report.summary().total,
-        10,
-        "expected 10 cases to run, got {}",
+        12,
+        "expected 12 cases to run, got {}",
         report.summary().total
     );
     assert!(

--- a/crates/armadai/tests/link_list_gate.rs
+++ b/crates/armadai/tests/link_list_gate.rs
@@ -160,4 +160,79 @@ mod tests {
             assert!(!stderr.trim().is_empty(), "list must still warn: {stderr}");
         }
     }
+
+    /// A project with only declared agents — no `agents:` entries at all,
+    /// relying entirely on `.armadai/agents.yaml` — the layout the format
+    /// exists to enable.
+    fn project_all_declared() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai/prompts")).unwrap();
+        std::fs::write(root.join("armadai.yaml"), "link:\n  target: claude\n").unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: zzz-declared-one\n    prompt: [base]\n  \
+             - name: zzz-declared-two\n    prompt: [base]\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".armadai/prompts/base.md"), "You are {{name}}.\n").unwrap();
+        dir
+    }
+
+    /// I2: `unlink.rs` was the fourth copy of the `config.agents.is_empty()`
+    /// gate that `link`/`list`/`run` all widened to also check
+    /// `.armadai/agents.yaml` — and it was the one copy that got missed.
+    /// Before the fix, `unlink --target claude` on this exact project
+    /// answered the false "No agents declared in project config." right
+    /// after `link` had written its files, and removed nothing.
+    #[test]
+    fn unlink_removes_what_link_generated_for_a_declarations_only_project() {
+        let dir = project_all_declared();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let mut link_cmd = Command::cargo_bin("armadai").unwrap();
+        link_cmd
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["link", "--target", "claude"]);
+        let link_output = link_cmd.output().unwrap();
+        assert!(
+            link_output.status.success(),
+            "link must succeed for an all-declared project: stdout={} stderr={}",
+            String::from_utf8_lossy(&link_output.stdout),
+            String::from_utf8_lossy(&link_output.stderr)
+        );
+
+        let generated = root.join(".claude/agents/zzz-declared-one.md");
+        assert!(
+            generated.is_file(),
+            "link must have written the declared agent's projection: {}",
+            generated.display()
+        );
+
+        let mut unlink_cmd = Command::cargo_bin("armadai").unwrap();
+        unlink_cmd
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["unlink", "--target", "claude"]);
+        let unlink_output = unlink_cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&unlink_output.stdout);
+        let stderr = String::from_utf8_lossy(&unlink_output.stderr);
+
+        assert!(
+            unlink_output.status.success(),
+            "unlink must not refuse an all-declared project: stdout={stdout} stderr={stderr}"
+        );
+        assert!(
+            !stderr.contains("No agents declared in project config"),
+            "must not report the false message link's own output already disproves: {stderr}"
+        );
+        assert!(
+            !generated.exists(),
+            "unlink must have removed what link generated: {}",
+            generated.display()
+        );
+    }
 }

--- a/crates/armadai/tests/link_list_gate.rs
+++ b/crates/armadai/tests/link_list_gate.rs
@@ -119,9 +119,19 @@ mod tests {
             !output.status.success(),
             "a dropped declaration must refuse the link: stdout={stdout} stderr={stderr}"
         );
+        // Full message, not just a prefix: round 2's edit introduced 14
+        // literal stray spaces mid-string ("link              a smaller")
+        // via a rustfmt-collapsed backslash-continuation, and a
+        // prefix-only `contains("refusing to link")` check was blind to
+        // it -- the whole gate passed with the damaged string still
+        // reaching a user's terminal. Asserting the exact text is what
+        // makes a reflow accident fail the suite instead of shipping.
         assert!(
-            stderr.contains("refusing to link"),
-            "must say why it refused: {stderr}"
+            stderr.contains(
+                "one or more agents could not be loaded (see warning(s) above) — refusing to \
+                 link a smaller fleet than declared. Fix the issue(s), or rerun once resolved."
+            ),
+            "must say why it refused, verbatim: {stderr}"
         );
     }
 

--- a/crates/armadai/tests/link_list_gate.rs
+++ b/crates/armadai/tests/link_list_gate.rs
@@ -1,0 +1,153 @@
+//! Black-box regressions for the `link`/`list` refusal policy (task 7b
+//! review, "Missing coverage"): `link`'s refuse-to-write and `list`'s
+//! warn-and-continue had zero automated coverage — a refuse-unconditionally
+//! implementation would have passed every existing test. Spawns the real
+//! binary (like `audit_usage.rs`) since the policy is wired in
+//! `cli::link::execute`/`cli::list::execute`, end to end.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+
+    /// Every project directory in this file gets its own isolated
+    /// `ARMADAI_CONFIG_DIR` — without it, `link`'s `project_registry`
+    /// write lands in the developer's real `~/.config/armadai/`, and the
+    /// shadowing check would scan the developer's real global agent
+    /// library (which, on a machine that has ever run `armadai extract`
+    /// from this repo, holds a real `core-specialist.md` — see the task's
+    /// own unit-test regressions for the same trap).
+    fn isolated_config(dir: &std::path::Path) -> std::path::PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(&config).unwrap();
+        config
+    }
+
+    /// A project with one broken `.md` (missing `## System Prompt`, so
+    /// `parse_agent_file` fails) and one healthy `.md` — a failure that
+    /// predates the declarative format entirely and has nothing to do with
+    /// `.armadai/agents.yaml`.
+    fn project_with_a_pre_existing_md_failure() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let agents = root.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: broken\n  - name: good\nlink:\n  target: claude\n",
+        )
+        .unwrap();
+        // Missing `## System Prompt` -> parse_agent_file fails.
+        std::fs::write(
+            agents.join("broken.md"),
+            "# broken\n\n## Metadata\n- provider: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("good.md"),
+            "# good\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// A project with no file-backed agents at all, and one declared agent
+    /// whose prompt composition fails (`missing-fragment` does not exist) —
+    /// a loss this chantier's format is directly responsible for.
+    fn project_with_a_dropped_declaration() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai/prompts")).unwrap();
+        std::fs::write(root.join("armadai.yaml"), "link:\n  target: claude\n").unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: good-declared\n    prompt: [base]\n  \
+             - name: bad-declared\n    prompt: [missing-fragment]\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".armadai/prompts/base.md"), "You are {{name}}.\n").unwrap();
+        dir
+    }
+
+    /// Regression guard for Finding 1's own regression: a pre-existing
+    /// `.md` failure keeps its EXACT old behaviour through `link` — warn,
+    /// link what did load, exit 0. A refuse-to-write policy applied
+    /// unconditionally on any warning would fail this test.
+    #[test]
+    fn link_survives_a_pre_existing_md_failure() {
+        let dir = project_with_a_pre_existing_md_failure();
+        let root = dir.path().join("project");
+
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .args(["link", "--target", "claude", "--dry-run"]);
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "a pre-existing .md failure must not refuse the link: stdout={stdout} stderr={stderr}"
+        );
+        assert!(
+            stderr.contains("broken"),
+            "must still warn about it: {stderr}"
+        );
+        assert!(
+            stdout.contains("good"),
+            "the healthy agent must still be projected: {stdout}"
+        );
+    }
+
+    /// The actual Finding 1 fix: a declaration this chantier's format
+    /// dropped DOES refuse the write.
+    #[test]
+    fn link_refuses_on_a_dropped_declaration() {
+        let dir = project_with_a_dropped_declaration();
+        let root = dir.path().join("project");
+
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .args(["link", "--target", "claude", "--dry-run"]);
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            !output.status.success(),
+            "a dropped declaration must refuse the link: stdout={stdout} stderr={stderr}"
+        );
+        assert!(
+            stderr.contains("refusing to link"),
+            "must say why it refused: {stderr}"
+        );
+    }
+
+    /// `list` is read-only: it must warn and continue in BOTH scenarios
+    /// above, never refusing — the distinction Finding 1 draws only applies
+    /// to a command that writes config.
+    #[test]
+    fn list_warns_and_continues_for_both_scenarios() {
+        for dir in [
+            project_with_a_pre_existing_md_failure(),
+            project_with_a_dropped_declaration(),
+        ] {
+            let root = dir.path().join("project");
+            let mut cmd = Command::cargo_bin("armadai").unwrap();
+            cmd.current_dir(&root)
+                .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+                .arg("list");
+            let output = cmd.output().unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            assert!(
+                output.status.success(),
+                "list must never refuse, being read-only: stdout={stdout} stderr={stderr}"
+            );
+            assert!(!stderr.trim().is_empty(), "list must still warn: {stderr}");
+        }
+    }
+}

--- a/crates/armadai/tests/models_update_declarations.rs
+++ b/crates/armadai/tests/models_update_declarations.rs
@@ -1,0 +1,119 @@
+//! Black-box regression: `armadai models update` (both the single-project
+//! and `--all` branches, `crates/armadai/src/cli/models.rs`) must route an
+//! `agents.yaml` finding through the declarative rewriter
+//! (`model_updater::update_declarations`, via `model_updater::
+//! apply_finding`), not the `.md` one (`update_agent_file`). The latter's
+//! single `replacen(.., 1)` and unbounded `: <model>` pattern can rewrite a
+//! comment that happens to contain the deprecated model string, while
+//! leaving the real `model:` field untouched — and still report success.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+
+    /// Every project directory in this file gets its own isolated
+    /// `ARMADAI_CONFIG_DIR` — without it, `models update --all`'s registry
+    /// read/write would land in the developer's real `~/.config/armadai/`.
+    fn isolated_config(dir: &std::path::Path) -> std::path::PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(&config).unwrap();
+        config
+    }
+
+    /// A project whose `agents.yaml` carries a deprecated model both as the
+    /// real `defaults.model` value AND, deliberately positioned earlier in
+    /// the file, inside a comment containing the exact same string right
+    /// after a colon (`": gpt-4-turbo"`) — the substring
+    /// `update_agent_file`'s textual rewrite (wrongly applied to a
+    /// declaration file before this fix) matches first, since it scans the
+    /// whole file top to bottom with no notion of which key a line
+    /// belongs to.
+    fn project_with_a_deprecated_model_and_a_lookalike_comment() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai")).unwrap();
+        std::fs::write(root.join(".armadai/config.yaml"), "agents: []\n").unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "# fallback note: gpt-4-turbo was our old default\n\
+             defaults:\n  provider: claude\n  model: gpt-4-turbo\n\
+             agents:\n  - name: demo-agent\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    fn assert_fixed_correctly(root: &std::path::Path, stdout: &str, stderr: &str) {
+        assert!(
+            stdout.contains("1 replacement(s)") && stdout.contains("1 model(s) updated"),
+            "the reported count must be truthful: stdout={stdout} stderr={stderr}"
+        );
+        let after = std::fs::read_to_string(root.join(".armadai/agents.yaml")).unwrap();
+        assert!(
+            after.contains("model: gpt-4o"),
+            "the real deprecated field must actually be fixed:\n{after}"
+        );
+        assert!(
+            after.contains("# fallback note: gpt-4-turbo was our old default"),
+            "the comment must survive untouched — this is the corruption this fix \
+             prevents:\n{after}"
+        );
+    }
+
+    #[test]
+    fn models_update_fixes_the_real_field_and_reports_a_truthful_count() {
+        let dir = project_with_a_deprecated_model_and_a_lookalike_comment();
+        let root = dir.path().join("project");
+
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .arg("models")
+            .arg("update");
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "a clean single-occurrence fix must not error: stdout={stdout} stderr={stderr}"
+        );
+        assert_fixed_correctly(&root, &stdout, &stderr);
+    }
+
+    /// Same fix, the other cited call site: `models update --all`, driven
+    /// off the project registry rather than the current directory.
+    #[test]
+    fn models_update_all_fixes_the_real_field_and_reports_a_truthful_count() {
+        let dir = project_with_a_deprecated_model_and_a_lookalike_comment();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+        std::fs::write(
+            config.join("projects.json"),
+            format!(
+                r#"{{"projects":[{{"path":"{}","last_seen":"2026-01-01T00:00:00Z"}}]}}"#,
+                root.display()
+            ),
+        )
+        .unwrap();
+
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.env("ARMADAI_CONFIG_DIR", &config)
+            .arg("models")
+            .arg("update")
+            .arg("--all");
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "a clean single-occurrence fix must not error: stdout={stdout} stderr={stderr}"
+        );
+        assert!(
+            stdout.contains("1 model(s) updated across all projects"),
+            "the --all summary must be truthful too: {stdout}"
+        );
+        assert_fixed_correctly(&root, &stdout, &stderr);
+    }
+}

--- a/crates/armadai/tests/models_update_declarations.rs
+++ b/crates/armadai/tests/models_update_declarations.rs
@@ -2,7 +2,7 @@
 //! and `--all` branches, `crates/armadai/src/cli/models.rs`) must route an
 //! `agents.yaml` finding through the declarative rewriter
 //! (`model_updater::update_declarations`, via `model_updater::
-//! apply_finding`), not the `.md` one (`update_agent_file`). The latter's
+//! apply_findings`), not the `.md` one (`update_agent_file`). The latter's
 //! single `replacen(.., 1)` and unbounded `: <model>` pattern can rewrite a
 //! comment that happens to contain the deprecated model string, while
 //! leaving the real `model:` field untouched — and still report success.
@@ -115,5 +115,58 @@ mod tests {
             "the --all summary must be truthful too: {stdout}"
         );
         assert_fixed_correctly(&root, &stdout, &stderr);
+    }
+
+    /// A project whose `agents.yaml` carries TWO findings for the same
+    /// file: a plain `defaults.model` (which the textual rewrite can fix)
+    /// and a quoted `"model":` key on an agent (which it cannot — a
+    /// structured-parse-vs-textual-scan disagreement). Regression for the
+    /// bug a prior fix round reintroduced one layer up: looping
+    /// `apply_findings` once per finding let the plain fix land on disk
+    /// before the quoted one's failure was discovered, reporting "0
+    /// model(s) updated." with exit 0 while the file sat half-rewritten.
+    fn project_with_one_fixable_and_one_unfixable_finding() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai")).unwrap();
+        std::fs::write(root.join(".armadai/config.yaml"), "agents: []\n").unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\n  model: gpt-4-turbo\nagents:\n  - name: a\n    \"model\": gpt-4-turbo\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn models_update_leaves_the_file_untouched_and_exits_non_zero_on_a_partial_failure() {
+        let dir = project_with_one_fixable_and_one_unfixable_finding();
+        let root = dir.path().join("project");
+        let agents_yaml = root.join(".armadai/agents.yaml");
+        let before = std::fs::read_to_string(&agents_yaml).unwrap();
+
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .arg("models")
+            .arg("update");
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            !output.status.success(),
+            "a file that could not be fully fixed must not exit 0: stdout={stdout}              stderr={stderr}"
+        );
+        assert!(
+            stdout.contains("0 model(s) updated"),
+            "the reported count must not claim a fix that did not happen: {stdout}"
+        );
+        assert!(!stderr.trim().is_empty(), "must report why: {stderr}");
+        assert_eq!(
+            std::fs::read_to_string(&agents_yaml).unwrap(),
+            before,
+            "the plain defaults.model fix must NOT land on disk just because the              quoted-key finding in the SAME file failed"
+        );
     }
 }

--- a/docs/superpowers/plans/2026-08-20-declarative-agents.md
+++ b/docs/superpowers/plans/2026-08-20-declarative-agents.md
@@ -1,0 +1,1670 @@
+# Agents déclaratifs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare agents in `.armadai/agents.yaml` — metadata inherited from defaults, system prompt composed from named fragments with substituted variables — producing an `Agent` in memory with no intermediate `.md` on disk.
+
+**Architecture:** `AgentRef` gains a `Declared` variant; a new `load_agent()` returns an `Agent` where `resolve_agent()` returns a path. The variable substitution currently inline in `cli/new.rs` is extracted into `armadai-core` so templates and fragments behave identically. The linker is untouched — it consumes `Agent`, and the origin is indifferent to it.
+
+**Tech Stack:** Rust edition 2024, `serde` / `serde_yaml_ng` (both already dependencies), `anyhow`.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-declarative-agents-design.md`
+
+## Global Constraints
+
+- No new dependency, no new feature flag, nothing feature-gated.
+- Clippy must pass in the **4 CI modes**, each `--all-targets ... -- -D warnings`: `tui` / `tui,providers-api` / `tui,web,storage` / `tui,storage,e2e-fake`.
+- Tests: `cargo test --no-default-features --features tui` and `--features tui,storage,e2e-fake`.
+- `cargo fmt --all` before every commit.
+- Code, comments and commit messages in **English**. Conventional Commits, **a single type** per message.
+- Commit trailer: `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`
+- **The 77 existing `.md` agents keep working.** YAML is an additional input, never a replacement.
+- **No intermediate artefact.** Nothing in this plan writes a generated `.md` to disk.
+- **Composition fails hard**: a missing fragment or an unsubstituted `{{var}}` is an error, not a degradation. This is the deliberate inverse of the policy gate's degrade-to-allow — degrading here ships an agent with amputated instructions that hallucinates rather than complains.
+- rust-analyzer is unreliable in this repo (false "mismatched ABI", stale snapshots). **Always verify at the compiler.**
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `crates/armadai-core/src/template.rs` — **new** | Variable substitution, extracted from `cli/new.rs`. One job: `{{var}}` → value, error on leftovers. |
+| `crates/armadai-core/src/agent_decl.rs` — **new** | The `agents.yaml` format: deserialisation, defaults merge, fragment composition → `Agent`. |
+| `crates/armadai-core/src/agent_source.rs` — **new** | `load_agent()`: dispatch between file-backed refs and declared ones. |
+| `crates/armadai-core/src/project.rs` — modify | `AgentRef::Declared` variant. |
+| `crates/armadai-core/src/model_updater.rs` — modify | Deprecated-model detection and rewrite for YAML-declared agents. |
+| `crates/armadai/src/cli/new.rs` — modify | Consume `template.rs` instead of its inline `replace` chain. |
+
+Three new files rather than one: substitution is reusable on its own, the YAML format is the bulk of the logic, and the dispatch is a thin seam. Keeping them apart means Task 1 is testable before the format exists.
+
+---
+
+### Task 1: Extract variable substitution into `armadai-core`
+
+`cli/new.rs:55-78` substitutes `{{name}}`, `{{description}}`, `{{stack}}`, `{{model}}` with a chain of `replace` calls, then computes the leftover placeholders into a `remaining` vector **and does nothing with it**. Fragments need the same substitution, and the spec requires leftovers to be an error.
+
+**Files:**
+- Create: `crates/armadai-core/src/template.rs`
+- Modify: `crates/armadai-core/src/lib.rs` (declare the module), `crates/armadai/src/cli/new.rs:55-78`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `pub fn render(template: &str, vars: &BTreeMap<String, String>) -> Result<String, TemplateError>`
+  - `pub fn unused_vars(template: &str, vars: &BTreeMap<String, String>) -> Vec<String>`
+  - `pub enum TemplateError { Unsubstituted(Vec<String>) }` (implements `std::error::Error`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/armadai-core/src/template.rs` with only its test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn substitutes_every_occurrence() {
+        let out = render("{{a}} then {{b}} then {{a}}", &vars(&[("a", "1"), ("b", "2")])).unwrap();
+        assert_eq!(out, "1 then 2 then 1");
+    }
+
+    #[test]
+    fn a_template_without_variables_is_returned_as_is() {
+        assert_eq!(render("plain text", &vars(&[])).unwrap(), "plain text");
+    }
+
+    /// A prompt still containing `{{module}}` is text the model will try to
+    /// interpret. Refusing to build the agent is the whole point.
+    #[test]
+    fn an_unsubstituted_variable_is_an_error_naming_it() {
+        let err = render("hello {{who}} and {{whom}}", &vars(&[])).unwrap_err();
+        match err {
+            TemplateError::Unsubstituted(names) => {
+                assert_eq!(names, vec!["who".to_string(), "whom".to_string()])
+            }
+        }
+    }
+
+    #[test]
+    fn a_provided_but_unused_variable_is_reported_not_fatal() {
+        // Almost always a typo — worth saying, never worth failing.
+        assert!(render("nothing here", &vars(&[("spare", "x")])).is_ok());
+        assert_eq!(
+            unused_vars("nothing here", &vars(&[("spare", "x")])),
+            vec!["spare".to_string()]
+        );
+    }
+
+    #[test]
+    fn an_unterminated_placeholder_is_left_alone() {
+        // `{{` with no closing `}}` is not a placeholder, just text.
+        assert_eq!(render("a {{ b", &vars(&[])).unwrap(), "a {{ b");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core template`
+Expected: FAIL — `render`, `unused_vars` and `TemplateError` do not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Above the test module in `crates/armadai-core/src/template.rs`:
+
+```rust
+//! `{{var}}` substitution, shared by agent templates and prompt fragments.
+//!
+//! Extracted from `cli/new.rs`, which substituted inline and computed the
+//! leftover placeholders without acting on them. Leftovers are an error here:
+//! a prompt containing a literal `{{module}}` is text the model will try to
+//! interpret, and an agent built from it is quietly wrong.
+
+use std::collections::BTreeMap;
+
+/// A template could not be fully rendered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplateError {
+    /// Placeholder names with no value supplied, in order of appearance.
+    Unsubstituted(Vec<String>),
+}
+
+impl std::fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsubstituted(names) => write!(
+                f,
+                "no value supplied for {}",
+                names
+                    .iter()
+                    .map(|n| format!("{{{{{n}}}}}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TemplateError {}
+
+/// Every `{{name}}` placeholder in `template`, in order, without duplicates.
+fn placeholders(template: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        let after = &rest[start + 2..];
+        let Some(end) = after.find("}}") else {
+            break; // unterminated: not a placeholder
+        };
+        let name = after[..end].trim().to_string();
+        if !name.is_empty() && !found.contains(&name) {
+            found.push(name);
+        }
+        rest = &after[end + 2..];
+    }
+    found
+}
+
+/// Substitute every `{{name}}` with its value.
+///
+/// Errors when a placeholder has no value: see the module docs.
+pub fn render(
+    template: &str,
+    vars: &BTreeMap<String, String>,
+) -> Result<String, TemplateError> {
+    let missing: Vec<String> = placeholders(template)
+        .into_iter()
+        .filter(|n| !vars.contains_key(n))
+        .collect();
+    if !missing.is_empty() {
+        return Err(TemplateError::Unsubstituted(missing));
+    }
+    let mut out = template.to_string();
+    for (name, value) in vars {
+        out = out.replace(&format!("{{{{{name}}}}}"), value);
+    }
+    Ok(out)
+}
+
+/// Values supplied that the template never uses — almost always a typo.
+pub fn unused_vars(template: &str, vars: &BTreeMap<String, String>) -> Vec<String> {
+    let used = placeholders(template);
+    vars.keys()
+        .filter(|k| !used.contains(k))
+        .cloned()
+        .collect()
+}
+```
+
+Declare the module in `crates/armadai-core/src/lib.rs`, in alphabetical order among the existing `pub mod` lines.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core template`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Make `cli/new.rs` consume it**
+
+Replace the `replace` chain at `crates/armadai/src/cli/new.rs:55-78` with a `vars` map plus one `render` call. Keep `new.rs`'s current behaviour: a missing `--description` or `--stack` means those placeholders stay unsupplied, so a template using them would now **error** instead of silently keeping `{{description}}`. That is the intended improvement; confirm the existing `new.rs` tests still pass, and if one relied on the silent behaviour, report it rather than weakening it.
+
+- [ ] **Step 6: Run the affected tests**
+
+Run: `cargo test --no-default-features --features tui new`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/template.rs crates/armadai-core/src/lib.rs crates/armadai/src/cli/new.rs
+git commit -m "refactor(core): extract {{var}} substitution into armadai-core
+
+cli/new.rs substituted inline and computed leftover placeholders without
+acting on them. Prompt fragments need the same substitution, and a leftover
+is now an error: a prompt containing a literal {{module}} is text the model
+will try to interpret."
+```
+
+---
+
+### Task 2: Deserialise `agents.yaml`
+
+**Files:**
+- Create: `crates/armadai-core/src/agent_decl.rs`
+- Modify: `crates/armadai-core/src/lib.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `pub struct DeclaredAgents { pub defaults: AgentDefaults, pub agents: Vec<AgentDecl> }`
+  - `pub struct AgentDefaults` — every field `Option`/`Vec`, mirroring `AgentMetadata`'s scalar subset
+  - `pub struct AgentDecl { pub name: String, pub description: Option<String>, pub prompt: Vec<PromptStep>, … }`
+  - `pub enum PromptStep { Plain(String), Parameterised { fragment: String, vars: BTreeMap<String, String> } }`
+  - `pub fn load(path: &Path) -> anyhow::Result<DeclaredAgents>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+defaults:
+  provider: claude
+  model: latest:pro
+  temperature: 0.3
+  max_tokens: 8192
+
+agents:
+  - name: core-specialist
+    description: Core domain and orchestration engine
+    scope: [src/core/**, src/parser/**]
+    tags: [rust, domain]
+    prompt:
+      - specialist-base
+      - { armadai-architecture: { module: core } }
+
+  - name: ui-specialist
+    temperature: 0.4
+    prompt: [specialist-base]
+"#;
+
+    fn parsed() -> DeclaredAgents {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, SAMPLE).unwrap();
+        load(&p).unwrap()
+    }
+
+    #[test]
+    fn reads_defaults_and_agents() {
+        let d = parsed();
+        assert_eq!(d.defaults.provider.as_deref(), Some("claude"));
+        assert_eq!(d.defaults.temperature, Some(0.3));
+        assert_eq!(d.agents.len(), 2);
+        assert_eq!(d.agents[0].name, "core-specialist");
+    }
+
+    #[test]
+    fn a_plain_prompt_step_is_a_bare_fragment_name() {
+        let d = parsed();
+        assert_eq!(
+            d.agents[0].prompt[0],
+            PromptStep::Plain("specialist-base".into())
+        );
+    }
+
+    #[test]
+    fn a_parameterised_step_carries_its_fragment_and_vars() {
+        let d = parsed();
+        match &d.agents[0].prompt[1] {
+            PromptStep::Parameterised { fragment, vars } => {
+                assert_eq!(fragment, "armadai-architecture");
+                assert_eq!(vars.get("module").map(String::as_str), Some("core"));
+            }
+            other => panic!("expected a parameterised step, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_step_with_several_keys_is_rejected() {
+        // `{ a: {...}, b: {...} }` is ambiguous: which fragment is it?
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(
+            &p,
+            "agents:\n  - name: x\n    prompt:\n      - { a: {}, b: {} }\n",
+        )
+        .unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("exactly one fragment"),
+            "the error must say what is wrong: {err}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_file_reports_where() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(&p, "agents:\n  - name: [unclosed\n").unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("agents.yaml"),
+            "the error must name the file: {err}"
+        );
+    }
+
+    #[test]
+    fn a_missing_file_is_an_error_not_an_empty_set() {
+        // Silently treating it as empty would hide a typo'd path.
+        assert!(load(std::path::Path::new("/nonexistent/agents.yaml")).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core agent_decl`
+Expected: FAIL — nothing exists yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+//! The `.armadai/agents.yaml` format: agents declared rather than written as
+//! Markdown files.
+//!
+//! This module only *reads* the format. Turning a declaration into an `Agent`
+//! (defaults merge, fragment composition) is the rest of this file's job, and
+//! the dispatch between declared and file-backed agents lives in
+//! `agent_source`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// One entry of an agent's `prompt:` list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptStep {
+    /// `- specialist-base`
+    Plain(String),
+    /// `- { armadai-architecture: { module: core } }`
+    Parameterised {
+        fragment: String,
+        vars: BTreeMap<String, String>,
+    },
+}
+
+/// Raw shape accepted by serde before validation.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawPromptStep {
+    Plain(String),
+    Parameterised(BTreeMap<String, BTreeMap<String, String>>),
+}
+
+/// Values every agent inherits unless it says otherwise.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentDefaults {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub timeout: Option<u64>,
+    pub model_fallback: Vec<String>,
+    pub tags: Vec<String>,
+    pub stacks: Vec<String>,
+}
+
+/// One declared agent.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentDecl {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub timeout: Option<u64>,
+    #[serde(default)]
+    pub model_fallback: Option<Vec<String>>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub stacks: Option<Vec<String>>,
+    #[serde(default)]
+    pub scope: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "de_prompt")]
+    pub prompt: Vec<PromptStep>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DeclaredAgents {
+    pub defaults: AgentDefaults,
+    pub agents: Vec<AgentDecl>,
+}
+
+fn de_prompt<'de, D>(d: D) -> Result<Vec<PromptStep>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let raw: Vec<RawPromptStep> = Vec::deserialize(d)?;
+    raw.into_iter()
+        .map(|step| match step {
+            RawPromptStep::Plain(name) => Ok(PromptStep::Plain(name)),
+            RawPromptStep::Parameterised(map) => {
+                // One key means one fragment. Two keys leave no way to know
+                // which fragment the entry is about.
+                let mut it = map.into_iter();
+                match (it.next(), it.next()) {
+                    (Some((fragment, vars)), None) => {
+                        Ok(PromptStep::Parameterised { fragment, vars })
+                    }
+                    _ => Err(D::Error::custom(
+                        "a prompt step must name exactly one fragment",
+                    )),
+                }
+            }
+        })
+        .collect()
+}
+
+/// Read and validate an `agents.yaml`.
+///
+/// A missing file is an error, not an empty set: treating it as empty would
+/// hide a mistyped path behind a fleet that silently has no agents.
+pub fn load(path: &Path) -> anyhow::Result<DeclaredAgents> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+    serde_yaml_ng::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("cannot parse {}: {e}", path.display()))
+}
+```
+
+Declare `pub mod agent_decl;` in `lib.rs`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core agent_decl`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/agent_decl.rs crates/armadai-core/src/lib.rs
+git commit -m "feat(core): read the .armadai/agents.yaml declaration format
+
+deny_unknown_fields throughout: a mistyped key in a fleet declaration should
+fail loudly, not be ignored. A prompt step naming several fragments is
+rejected — there would be no way to know which one it means."
+```
+
+---
+
+### Task 3: Merge defaults into `AgentMetadata`
+
+**Files:**
+- Modify: `crates/armadai-core/src/agent_decl.rs`
+
+**Interfaces:**
+- Consumes: Task 2 (`AgentDecl`, `AgentDefaults`).
+- Produces: `pub fn merge_metadata(decl: &AgentDecl, defaults: &AgentDefaults) -> anyhow::Result<AgentMetadata>`
+
+**Two facts read from the code, not assumed** — the whole task turns on them:
+1. `AgentMetadata` has **no `Default`** (`agent.rs:40` derives only `Debug, Clone, Serialize, Deserialize`). Do not add one: `String::default()` for `provider` and `0.0` for `temperature` are both wrong values that would then propagate silently.
+2. `provider` is **required** in the `.md` format — `parser/metadata.rs:83` does `provider.context("Missing 'provider' in Metadata")?`. YAML must be just as strict, hence the `Result`. Defaulting it to `"claude"` here would make the two formats disagree on what a valid agent is.
+
+`temperature`'s real default is `0.7` (`agent.rs:85-87`, `fn default_temperature`, currently private). Make it `pub` and call it rather than writing `0.7` in a second place.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    fn decl(name: &str) -> AgentDecl {
+        AgentDecl {
+            name: name.into(),
+            description: None,
+            provider: None,
+            model: None,
+            temperature: None,
+            max_tokens: None,
+            timeout: None,
+            model_fallback: None,
+            tags: None,
+            stacks: None,
+            scope: None,
+            prompt: vec![],
+        }
+    }
+
+    fn defaults() -> AgentDefaults {
+        AgentDefaults {
+            provider: Some("claude".into()),
+            model: Some("latest:pro".into()),
+            temperature: Some(0.3),
+            max_tokens: Some(8192),
+            timeout: None,
+            model_fallback: vec!["latest:fast".into()],
+            tags: vec!["shared".into()],
+            stacks: vec![],
+        }
+    }
+
+    #[test]
+    fn an_agent_without_overrides_takes_every_default() {
+        let m = merge_metadata(&decl("a"), &defaults()).unwrap();
+        assert_eq!(m.provider, "claude");
+        assert_eq!(m.model.as_deref(), Some("latest:pro"));
+        assert_eq!(m.temperature, 0.3);
+        assert_eq!(m.max_tokens, Some(8192));
+        assert_eq!(m.tags, vec!["shared".to_string()]);
+    }
+
+    #[test]
+    fn a_scalar_override_wins() {
+        let mut d = decl("a");
+        d.temperature = Some(0.9);
+        assert_eq!(merge_metadata(&d, &defaults()).unwrap().temperature, 0.9);
+    }
+
+    /// Lists are replaced, never merged: an agent that declares its tags has
+    /// exactly those, and does not silently inherit a wider set.
+    #[test]
+    fn a_declared_list_replaces_the_default_rather_than_extending_it() {
+        let mut d = decl("a");
+        d.tags = Some(vec!["own".into()]);
+        let m = merge_metadata(&d, &defaults()).unwrap();
+        assert_eq!(m.tags, vec!["own".to_string()]);
+        assert!(!m.tags.contains(&"shared".to_string()));
+    }
+
+    #[test]
+    fn an_empty_declared_list_means_empty_not_inherit() {
+        let mut d = decl("a");
+        d.tags = Some(vec![]);
+        assert!(merge_metadata(&d, &defaults()).unwrap().tags.is_empty());
+    }
+
+    /// The `.md` parser refuses an agent with no provider
+    /// (`parser/metadata.rs:83`). YAML must refuse it too, or the two formats
+    /// disagree on what a valid agent is.
+    #[test]
+    fn a_provider_declared_nowhere_is_an_error() {
+        let err = merge_metadata(&decl("a"), &AgentDefaults::default())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("provider"), "must say what is missing: {err}");
+        assert!(err.contains("a"), "must name the agent: {err}");
+    }
+
+    #[test]
+    fn temperature_falls_back_to_the_parsers_own_default() {
+        let mut d = decl("a");
+        d.provider = Some("claude".into());
+        let m = merge_metadata(&d, &AgentDefaults::default()).unwrap();
+        // Call the shared function rather than writing 0.7 in a second place:
+        // this test must follow the default, not pin a copy of it.
+        assert_eq!(m.temperature, crate::agent::default_temperature());
+    }
+
+    /// An agent may supply the provider itself with no defaults block at all.
+    #[test]
+    fn an_agent_can_carry_the_provider_alone() {
+        let mut d = decl("a");
+        d.provider = Some("cli".into());
+        assert_eq!(
+            merge_metadata(&d, &AgentDefaults::default())
+                .unwrap()
+                .provider,
+            "cli"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core agent_decl::tests::an_agent_without_overrides`
+Expected: FAIL — `merge_metadata` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+First make the parser's own default reachable — in `crates/armadai-core/src/agent.rs:85`, change `fn default_temperature()` to `pub fn default_temperature()`. It stays the single definition of that value.
+
+Then, in `agent_decl.rs`:
+
+```rust
+use crate::agent::{AgentMetadata, default_temperature};
+
+/// Build an agent's metadata from its declaration and the shared defaults.
+///
+/// Shallow merge: a field absent from the declaration takes the default's
+/// value. Lists are **replaced, never merged** — less expressive, but an agent
+/// that declares a `scope` has exactly that scope, rather than silently
+/// inheriting a wider one.
+///
+/// Fails when no `provider` is declared at either level. The `.md` parser
+/// refuses that too (`parser/metadata.rs`), and the two formats must agree on
+/// what a valid agent is. Every remaining field is written out explicitly:
+/// `AgentMetadata` has no `Default`, and giving it one would mean `provider:
+/// ""` and `temperature: 0.0` — two wrong values free to propagate.
+pub fn merge_metadata(
+    decl: &AgentDecl,
+    defaults: &AgentDefaults,
+) -> anyhow::Result<AgentMetadata> {
+    let provider = decl
+        .provider
+        .clone()
+        .or_else(|| defaults.provider.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "agent '{}': no provider declared, and none in defaults",
+                decl.name
+            )
+        })?;
+
+    Ok(AgentMetadata {
+        provider,
+        model: decl.model.clone().or_else(|| defaults.model.clone()),
+        command: None,
+        args: None,
+        temperature: decl
+            .temperature
+            .or(defaults.temperature)
+            .unwrap_or_else(default_temperature),
+        max_tokens: decl.max_tokens.or(defaults.max_tokens),
+        timeout: decl.timeout.or(defaults.timeout),
+        tags: decl.tags.clone().unwrap_or_else(|| defaults.tags.clone()),
+        stacks: decl
+            .stacks
+            .clone()
+            .unwrap_or_else(|| defaults.stacks.clone()),
+        scope: decl.scope.clone().unwrap_or_default(),
+        model_fallback: decl
+            .model_fallback
+            .clone()
+            .unwrap_or_else(|| defaults.model_fallback.clone()),
+        cost_limit: None,
+        rate_limit: None,
+        context_window: None,
+        mode: None,
+        orchestration: None,
+        triggers: None,
+        ring_config: None,
+    })
+}
+```
+
+The fields left at `None` are the ones the format does not yet expose (`command`/`args` belong to the `cli` provider, `mode`/`orchestration`/`triggers`/`ring_config` to features out of this scope). The compiler will tell you if a field is missing — that is why the struct is written out in full rather than closed with `..Default::default()`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core agent_decl`
+Expected: PASS (11 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/agent_decl.rs crates/armadai-core/src/agent.rs
+git commit -m "feat(core): merge declared agent metadata over shared defaults
+
+Shallow merge, lists replaced rather than extended: an agent that declares a
+scope has exactly that scope. Inheriting a wider one silently is how a
+specialist ends up allowed everywhere.
+
+Fails when no provider is declared at either level, as the .md parser already
+does — the two formats must agree on what a valid agent is. default_temperature
+becomes pub so the value stays defined in one place."
+```
+
+---
+
+### Task 4: Compose the system prompt from fragments
+
+**Files:**
+- Modify: `crates/armadai-core/src/agent_decl.rs`
+
+**Interfaces:**
+- Consumes: Task 1 (`template::render`, `template::unused_vars`), Task 2 (`PromptStep`), and the existing `crate::prompt::{Prompt, load_all_prompts}`.
+- Produces: `pub fn compose_prompt(steps: &[PromptStep], decl: &AgentDecl, fragments: &[Prompt]) -> anyhow::Result<String>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    use crate::prompt::Prompt;
+
+    fn fragment(name: &str, body: &str) -> Prompt {
+        Prompt {
+            name: name.into(),
+            description: None,
+            apply_to: vec![],
+            body: body.into(),
+            source: std::path::PathBuf::from(format!("{name}.md")),
+        }
+    }
+
+    #[test]
+    fn fragments_are_concatenated_in_declared_order() {
+        let frags = vec![fragment("a", "first"), fragment("b", "second")];
+        let steps = vec![
+            PromptStep::Plain("b".into()),
+            PromptStep::Plain("a".into()),
+        ];
+        let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();
+        assert_eq!(out, "second\n\nfirst");
+    }
+
+    #[test]
+    fn a_parameterised_fragment_gets_its_variables() {
+        let frags = vec![fragment("arch", "module is {{module}}")];
+        let steps = vec![PromptStep::Parameterised {
+            fragment: "arch".into(),
+            vars: [("module".to_string(), "core".to_string())]
+                .into_iter()
+                .collect(),
+        }];
+        let out = compose_prompt(&steps, &decl("x"), &frags).unwrap();
+        assert_eq!(out, "module is core");
+    }
+
+    /// The agent's own fields are available to every fragment, with the same
+    /// names `cli/new.rs` uses for templates.
+    #[test]
+    fn the_agents_name_and_description_are_implicit_variables() {
+        let frags = vec![fragment("greet", "I am {{name}}: {{description}}")];
+        let mut d = decl("core-specialist");
+        d.description = Some("the core".into());
+        let out = compose_prompt(
+            &[PromptStep::Plain("greet".into())],
+            &d,
+            &frags,
+        )
+        .unwrap();
+        assert_eq!(out, "I am core-specialist: the core");
+    }
+
+    #[test]
+    fn a_missing_fragment_is_an_error_naming_it_and_the_agent() {
+        let err = compose_prompt(
+            &[PromptStep::Plain("nope".into())],
+            &decl("core-specialist"),
+            &[],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("nope"), "must name the fragment: {err}");
+        assert!(
+            err.contains("core-specialist"),
+            "must name the agent, or you cannot find it in a 77-agent fleet: {err}"
+        );
+    }
+
+    /// An agent whose prompt still contains `{{module}}` is quietly wrong.
+    #[test]
+    fn an_unsubstituted_variable_fails_the_composition() {
+        let frags = vec![fragment("arch", "module is {{module}}")];
+        let err = compose_prompt(&[PromptStep::Plain("arch".into())], &decl("x"), &frags)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("module"), "must name the variable: {err}");
+    }
+
+    #[test]
+    fn an_empty_prompt_list_yields_an_empty_system_prompt() {
+        assert_eq!(compose_prompt(&[], &decl("x"), &[]).unwrap(), "");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core agent_decl::tests::fragments_are_concatenated`
+Expected: FAIL — `compose_prompt` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+/// Assemble an agent's system prompt from its declared fragments.
+///
+/// Fails on a missing fragment or an unsubstituted variable. That is the
+/// deliberate inverse of the policy gate, where uncertainty allows: degrading
+/// here would ship an agent whose instructions are amputated, and such an
+/// agent fills the gaps instead of complaining.
+pub fn compose_prompt(
+    steps: &[PromptStep],
+    decl: &AgentDecl,
+    fragments: &[crate::prompt::Prompt],
+) -> anyhow::Result<String> {
+    let mut parts = Vec::new();
+    for step in steps {
+        let (name, extra) = match step {
+            PromptStep::Plain(n) => (n.as_str(), BTreeMap::new()),
+            PromptStep::Parameterised { fragment, vars } => (fragment.as_str(), vars.clone()),
+        };
+        let frag = fragments
+            .iter()
+            .find(|f| f.name == name)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "agent '{}' references prompt fragment '{name}', which was not found",
+                    decl.name
+                )
+            })?;
+
+        // The agent's own fields, then the step's variables — a step may
+        // override an implicit value deliberately.
+        let mut vars: BTreeMap<String, String> = BTreeMap::new();
+        vars.insert("name".into(), decl.name.clone());
+        vars.insert(
+            "description".into(),
+            decl.description.clone().unwrap_or_default(),
+        );
+        vars.extend(extra);
+
+        let rendered = crate::template::render(&frag.body, &vars).map_err(|e| {
+            anyhow::anyhow!("agent '{}', fragment '{name}': {e}", decl.name)
+        })?;
+        parts.push(rendered);
+    }
+    Ok(parts.join("\n\n"))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core agent_decl`
+Expected: PASS (17 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/agent_decl.rs
+git commit -m "feat(core): compose a declared agent's prompt from fragments
+
+Fails on a missing fragment or an unsubstituted variable, naming both the
+fragment and the agent — in a 77-agent fleet an error without the agent name
+is a search. This hard failure is the inverse of the policy gate's
+degrade-to-allow, and deliberately so: an agent with amputated instructions
+hallucinates rather than complains."
+```
+
+---
+
+### Task 5: `load_agent` — the dispatch, and `AgentRef::Declared`
+
+**Files:**
+- Create: `crates/armadai-core/src/agent_source.rs`
+- Modify: `crates/armadai-core/src/project.rs:152-156` (the `AgentRef` enum), `crates/armadai-core/src/lib.rs`
+
+**Interfaces:**
+- Consumes: Tasks 2-4 (`load`, `merge_metadata`, `compose_prompt`), and the existing `project::resolve_agent`, `parser::parse_agent_file`, `prompt::load_all_prompts`.
+- Produces: `pub fn load_agent(r: &AgentRef, project_root: &Path, fragments: &[Prompt]) -> anyhow::Result<Agent>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A project with one declared agent and one fragment on disk.
+    fn project(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir.join(".armadai")).unwrap();
+        std::fs::write(
+            dir.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\n  model: latest:pro\nagents:\n  \
+             - name: core-specialist\n    description: the core\n    \
+             prompt: [base]\n",
+        )
+        .unwrap();
+    }
+
+    fn fragments() -> Vec<crate::prompt::Prompt> {
+        vec![crate::prompt::Prompt {
+            name: "base".into(),
+            description: None,
+            apply_to: vec![],
+            body: "You are {{name}}.".into(),
+            source: std::path::PathBuf::from("base.md"),
+        }]
+    }
+
+    #[test]
+    fn a_declared_ref_yields_an_agent_without_touching_the_disk_for_it() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let r = AgentRef::Declared {
+            declared: "core-specialist".into(),
+        };
+        let agent = load_agent(&r, dir.path(), &fragments()).unwrap();
+        assert_eq!(agent.name, "core-specialist");
+        assert_eq!(agent.system_prompt, "You are core-specialist.");
+        assert_eq!(agent.metadata.provider, "claude");
+        // `source` points at the declaration, which is where it came from.
+        assert!(agent.source.ends_with("agents.yaml"));
+    }
+
+    #[test]
+    fn a_declared_name_absent_from_the_yaml_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let r = AgentRef::Declared {
+            declared: "ghost".into(),
+        };
+        let err = load_agent(&r, dir.path(), &fragments())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ghost"), "must name the missing agent: {err}");
+    }
+
+    #[test]
+    fn a_declared_ref_without_any_agents_yaml_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = AgentRef::Declared {
+            declared: "x".into(),
+        };
+        assert!(load_agent(&r, dir.path(), &[]).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core agent_source`
+Expected: FAIL — neither `load_agent` nor `AgentRef::Declared` exists.
+
+- [ ] **Step 3: Add the enum variant**
+
+In `crates/armadai-core/src/project.rs`, extend `AgentRef` (it is `#[serde(untagged)]`, so the new variant must have a distinct key — `declared` — to stay unambiguous):
+
+```rust
+pub enum AgentRef {
+    Named { name: String },
+    Registry { registry: String },
+    Path { path: PathBuf },
+    /// An agent declared in `.armadai/agents.yaml` rather than written as a file.
+    Declared { declared: String },
+}
+```
+
+- [ ] **Step 4: Write the dispatch**
+
+```rust
+//! Loading an `Agent`, whatever its origin.
+//!
+//! `project::resolve_agent` returns a **path**, which serves callers that
+//! manipulate files — `model_updater` and `pack_validation` rewrite deprecated
+//! models in place. A declared agent has no file of its own, so it is right
+//! that `resolve_agent` fails for one. This module is for callers that want the
+//! agent, not its file.
+
+use std::path::Path;
+
+use crate::agent::Agent;
+use crate::agent_decl;
+use crate::project::{AgentRef, resolve_agent};
+use crate::prompt::Prompt;
+
+/// Where a project's declarations live.
+pub fn declarations_path(project_root: &Path) -> std::path::PathBuf {
+    project_root.join(".armadai").join("agents.yaml")
+}
+
+/// Load an agent, from a file or from the project's declarations.
+pub fn load_agent(
+    r: &AgentRef,
+    project_root: &Path,
+    fragments: &[Prompt],
+) -> anyhow::Result<Agent> {
+    let AgentRef::Declared { declared } = r else {
+        // Unchanged path: resolve to a file, then parse it.
+        let path = resolve_agent(r, project_root)?;
+        return crate::parser::parse_agent_file(&path);
+    };
+
+    let path = declarations_path(project_root);
+    let decls = agent_decl::load(&path)?;
+    let decl = decls
+        .agents
+        .iter()
+        .find(|a| &a.name == declared)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "agent '{declared}' is not declared in {}",
+                path.display()
+            )
+        })?;
+
+    Ok(Agent {
+        name: decl.name.clone(),
+        source: path.clone(),
+        metadata: agent_decl::merge_metadata(decl, &decls.defaults)?,
+        system_prompt: agent_decl::compose_prompt(&decl.prompt, decl, fragments)?,
+        instructions: None,
+        output_format: None,
+        pipeline: None,
+        context: None,
+    })
+}
+```
+
+Declare `pub mod agent_source;` in `lib.rs`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core agent_source`
+Expected: PASS (3 tests). The compiler will also flag every exhaustive `match` on `AgentRef` — fix each by handling `Declared` explicitly rather than with a catch-all, so a future variant is caught too.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/agent_source.rs crates/armadai-core/src/project.rs crates/armadai-core/src/lib.rs
+git commit -m "feat(core): load an agent from a declaration or from a file
+
+resolve_agent returns a path, which is right for callers that rewrite files
+in place. A declared agent has no file, so load_agent returns the Agent
+itself and dispatches on the ref."
+```
+
+---
+
+### Task 6: Reject a name declared twice
+
+**Files:**
+- Modify: `crates/armadai-core/src/agent_source.rs`
+
+**Interfaces:**
+- Consumes: Task 5 (`load_agent`, `declarations_path`).
+- Produces: `pub fn check_no_shadowing(project_root: &Path, library: &Path) -> anyhow::Result<()>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn a_name_both_declared_and_written_as_a_file_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path()); // declares `core-specialist`
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(
+            lib.path().join("core-specialist.md"),
+            "# Core\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi",
+        )
+        .unwrap();
+
+        let err = check_no_shadowing(dir.path(), lib.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("core-specialist"), "must name it: {err}");
+        // The point is that neither wins — say so, or the reader will assume
+        // one does.
+        assert!(
+            err.contains("agents.yaml") && err.contains(".md"),
+            "must name both sources so the reader can pick one: {err}"
+        );
+    }
+
+    #[test]
+    fn distinct_names_are_fine() {
+        let dir = tempfile::tempdir().unwrap();
+        project(dir.path());
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(lib.path().join("other.md"), "# Other").unwrap();
+        assert!(check_no_shadowing(dir.path(), lib.path()).is_ok());
+    }
+
+    #[test]
+    fn a_project_without_declarations_never_shadows() {
+        let dir = tempfile::tempdir().unwrap();
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(lib.path().join("a.md"), "# A").unwrap();
+        assert!(check_no_shadowing(dir.path(), lib.path()).is_ok());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core check_no_shadowing`
+Expected: FAIL — the function does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+/// Refuse a name that exists both as a declaration and as a library file.
+///
+/// The obvious alternative is a precedence rule — local wins, as everywhere
+/// else. It is rejected on purpose: a silent precedence recreates the very
+/// duplicated truth this format exists to remove, and you would edit a `.md`
+/// with no effect and nothing to tell you. Failing forces a choice.
+///
+/// Rule `C01` of the audit already reports name collisions; loading must
+/// refuse them.
+pub fn check_no_shadowing(project_root: &Path, library: &Path) -> anyhow::Result<()> {
+    let decls_path = declarations_path(project_root);
+    if !decls_path.is_file() {
+        return Ok(());
+    }
+    let decls = agent_decl::load(&decls_path)?;
+    for decl in &decls.agents {
+        let file = library.join(format!("{}.md", decl.name));
+        if file.is_file() {
+            anyhow::bail!(
+                "agent '{}' is declared in {} and also written as {} — \
+                 remove one; there is deliberately no precedence between them",
+                decl.name,
+                decls_path.display(),
+                file.display()
+            );
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core agent_source`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/agent_source.rs
+git commit -m "feat(core): refuse an agent name that is both declared and a file
+
+No precedence, deliberately. A silent local-wins rule recreates the
+duplicated truth this format removes: you would edit a .md with no effect and
+nothing would tell you."
+```
+
+---
+
+### Task 7: The invariant — a declared agent projects like its `.md` twin
+
+This is the task that proves there are not two divergent paths. It is also the property easiest to verify badly, so it gets its own test file.
+
+**Files:**
+- Modify: `crates/armadai/src/linker/mod.rs` — add to the existing `#[cfg(test)] mod tests` (the one holding `test_slugify_*`)
+
+**Where the test lives, and why it is not in `tests/`:** `crates/armadai` is **bin-only** — no `src/lib.rs`, no `[lib]` section, two `[[bin]]` targets. An integration test under `tests/` therefore cannot `use armadai::linker`; the existing `tests/*.rs` drive the compiled binary instead. This test needs the trait directly, so it belongs in the crate as a unit test.
+
+**Interfaces:**
+- Consumes: Tasks 1-5, plus the real linker API read from `linker/mod.rs`:
+  - `pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>>`
+  - `Linker::generate(&self, agents: &[LinkAgent], coordinator: Option<&LinkAgent>, sources: &[String]) -> Vec<OutputFile>`
+  - `pub struct OutputFile { pub path: PathBuf, pub content: String }`
+  - `impl From<&Agent> for LinkAgent` — note it derives `description` from the **first non-empty line of `system_prompt`**, not from any declared description. Two agents with the same prompt therefore get the same description, which is part of what this test pins.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    /// A declared agent and its hand-written `.md` twin must produce the same
+    /// native projection. If they diverge, the declaration format is a second
+    /// source of truth rather than an alternative spelling of the first —
+    /// exactly what it exists to avoid.
+    ///
+    /// Run against **every** target, not just claude: a divergence that only
+    /// shows in the codex projection is still a divergence.
+    #[test]
+    fn a_declared_agent_and_its_md_twin_project_identically() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The fragment both versions share.
+        let fragments = vec![armadai_core::prompt::Prompt {
+            name: "base".into(),
+            description: None,
+            apply_to: vec![],
+            body: "You own the core domain.".into(),
+            source: std::path::PathBuf::from("base.md"),
+        }];
+
+        // Declared version.
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\n  model: latest:pro\n  temperature: 0.3\n\
+             agents:\n  - name: core-specialist\n    description: Core domain\n    \
+             scope: [src/core/**]\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let declared = armadai_core::agent_source::load_agent(
+            &armadai_core::project::AgentRef::Declared {
+                declared: "core-specialist".into(),
+            },
+            dir.path(),
+            &fragments,
+        )
+        .unwrap();
+
+        // Hand-written twin, same values.
+        let md = dir.path().join("core-specialist.md");
+        std::fs::write(
+            &md,
+            "# core-specialist\n\n## Metadata\n\
+             - provider: claude\n- model: latest:pro\n- temperature: 0.3\n\
+             - scope: [src/core/**]\n\n## System Prompt\n\nYou own the core domain.\n",
+        )
+        .unwrap();
+        let written = armadai_core::parser::parse_agent_file(&md).unwrap();
+
+        // Sanity check before comparing projections: if the two agents are not
+        // actually equivalent, an equal projection would prove nothing.
+        assert_eq!(declared.system_prompt, written.system_prompt);
+        assert_eq!(declared.metadata.model, written.metadata.model);
+        assert_eq!(declared.metadata.scope, written.metadata.scope);
+
+        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
+            let linker = create_linker(target).unwrap();
+            let a = linker.generate(&[LinkAgent::from(&declared)], None, &[]);
+            let b = linker.generate(&[LinkAgent::from(&written)], None, &[]);
+
+            // An empty projection on both sides would satisfy every assertion
+            // below without proving anything.
+            assert!(
+                !a.is_empty(),
+                "target {target} produced no output file — the comparison \
+                 below would be vacuous"
+            );
+            assert_eq!(a.len(), b.len(), "target {target}: file count differs");
+            for (x, y) in a.iter().zip(b.iter()) {
+                assert_eq!(x.path, y.path, "target {target}: paths differ");
+                assert_eq!(
+                    x.content, y.content,
+                    "target {target}: projection diverged — the declaration is \
+                     not an alternative spelling but a second source of truth"
+                );
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --no-default-features --features tui a_declared_agent_and_its_md_twin`
+Expected: FAIL. `tempfile` must be a dev-dependency of `crates/armadai` — check, and add it if absent.
+
+- [ ] **Step 3: Make it pass**
+
+Do **not** weaken the assertions, and do not drop a target from the loop to make it green. If the projections differ, the difference **is** the finding: report which field diverges, on which target, and why.
+
+`Agent::source` differs by construction (one is a `.yaml`, one a `.md`), and the test does not compare it because `LinkAgent` does not carry it. Verify that rather than assume it: if `From<&Agent> for LinkAgent` does read `source`, say so — the invariant then cannot hold as written and the spec needs revisiting.
+
+Any divergence in `metadata` or `system_prompt` is a real defect in Tasks 3-4 — fix it there, not here.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test --no-default-features --features tui`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai/src/linker/mod.rs crates/armadai/Cargo.toml
+git commit -m "test: a declared agent must project like its hand-written twin
+
+The invariant that keeps the declaration format an alternative spelling of
+the .md rather than a second source of truth."
+```
+
+---
+
+### Task 8: Deprecated models in `agents.yaml`
+
+`model_updater` fixes deprecated models in place and is called automatically by `run`, `link` and `init`. Without this, `agents.yaml` becomes the one place in a project where a dead model goes unnoticed.
+
+**Files:**
+- Modify: `crates/armadai-core/src/model_updater.rs` (add beside `check_agent_file:24` and `update_agent_file:78`)
+
+**Interfaces:**
+- Consumes: Task 2 (`agent_decl::load`), and the existing `DeprecationFinding { agent_path, agent_name, field, current, replacement }` plus `resolve_alias`.
+- Produces:
+  - `pub fn check_declarations(path: &Path) -> Vec<DeprecationFinding>`
+  - `pub fn update_declarations(path: &Path, findings: &[DeprecationFinding]) -> anyhow::Result<usize>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    /// Take a real deprecated model from the alias registry, so the test does
+    /// not encode a value that may stop being deprecated.
+    fn a_deprecated_model() -> (String, String) {
+        // `resolve_alias` returns Some(replacement) for a deprecated name.
+        for candidate in ["claude-3-sonnet-20240229", "claude-3-opus-20240229"] {
+            if let Some(r) = resolve_alias(candidate) {
+                return (candidate.to_string(), r);
+            }
+        }
+        panic!("no known deprecated model in the alias registry — update this helper");
+    }
+
+    fn write_yaml(dir: &Path, body: &str) -> std::path::PathBuf {
+        let p = dir.join("agents.yaml");
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn a_deprecated_model_in_defaults_is_found_and_fixed() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!("defaults:\n  model: {old}\nagents:\n  - name: a\n"),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(update_declarations(&p, &findings).unwrap(), 1);
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(after.contains(&new) && !after.contains(&old));
+    }
+
+    /// A `.md` agent declares `model` once; `agents.yaml` carries it in
+    /// `defaults` and in every agent that deviates. `replacen(.., 1)` would
+    /// fix only the first.
+    #[test]
+    fn the_same_deprecated_model_is_fixed_at_every_occurrence() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "defaults:\n  model: {old}\nagents:\n  \
+                 - name: a\n    model: {old}\n  - name: b\n    model: {old}\n"
+            ),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 3, "one per occurrence: {findings:?}");
+        update_declarations(&p, &findings).unwrap();
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(!after.contains(&old), "every occurrence must be fixed:\n{after}");
+        assert_eq!(after.matches(&new).count(), 3);
+    }
+
+    /// A raw `: <model>` pattern would also match inside prose. Correcting a
+    /// configuration is one thing; rewriting a comment is another.
+    #[test]
+    fn a_deprecated_model_named_in_a_comment_or_description_is_left_alone() {
+        let (old, _new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "# we used to run {old} here\nagents:\n  - name: a\n    \
+                 description: migrated away from {old}\n"
+            ),
+        );
+        assert!(
+            check_declarations(&p).is_empty(),
+            "no `model:` key carries it, so there is nothing to fix"
+        );
+        let before = std::fs::read_to_string(&p).unwrap();
+        update_declarations(&p, &[]).unwrap();
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), before);
+    }
+
+    #[test]
+    fn comments_and_key_order_survive_the_rewrite() {
+        let (old, _new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!(
+                "# fleet defaults\ndefaults:\n  model: {old}\n  \
+                 temperature: 0.3   # deliberately warm\nagents:\n  - name: a\n"
+            ),
+        );
+        let findings = check_declarations(&p);
+        update_declarations(&p, &findings).unwrap();
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(after.contains("# fleet defaults"), "comment lost:\n{after}");
+        assert!(
+            after.contains("# deliberately warm"),
+            "inline comment lost:\n{after}"
+        );
+        assert!(
+            after.find("model:").unwrap() < after.find("temperature:").unwrap(),
+            "key order changed — a serde round-trip would do this:\n{after}"
+        );
+    }
+
+    #[test]
+    fn a_deprecated_model_in_model_fallback_is_fixed() {
+        let (old, new) = a_deprecated_model();
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_yaml(
+            dir.path(),
+            &format!("agents:\n  - name: a\n    model_fallback: [{old}]\n"),
+        );
+        let findings = check_declarations(&p);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        update_declarations(&p, &findings).unwrap();
+        assert!(std::fs::read_to_string(&p).unwrap().contains(&new));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core check_declarations`
+Expected: FAIL — the functions do not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Detection walks the parsed declaration, so it can only ever see real `model` / `model_fallback` values — never prose:
+
+```rust
+/// Deprecated models declared in an `agents.yaml`.
+///
+/// One finding **per occurrence**: unlike a `.md` agent, which declares
+/// `model` once, a declaration file carries it in `defaults` and in every
+/// agent that deviates. `field` distinguishes them (`defaults.model`,
+/// `<agent>.model`, `<agent>.model_fallback[i]`) so the rewrite can target
+/// each one.
+pub fn check_declarations(path: &Path) -> Vec<DeprecationFinding> {
+    let Ok(decls) = crate::agent_decl::load(path) else {
+        return Vec::new(); // unreadable: not this function's problem
+    };
+    let mut out = Vec::new();
+    let mut push = |field: String, agent_name: String, current: &str| {
+        if let Some(replacement) = resolve_alias(current) {
+            out.push(DeprecationFinding {
+                agent_path: path.to_path_buf(),
+                agent_name,
+                field,
+                current: current.to_string(),
+                replacement,
+            });
+        }
+    };
+    if let Some(m) = &decls.defaults.model {
+        push("defaults.model".into(), "defaults".into(), m);
+    }
+    for (i, fb) in decls.defaults.model_fallback.iter().enumerate() {
+        push(format!("defaults.model_fallback[{i}]"), "defaults".into(), fb);
+    }
+    for a in &decls.agents {
+        if let Some(m) = &a.model {
+            push(format!("{}.model", a.name), a.name.clone(), m);
+        }
+        for (i, fb) in a.model_fallback.iter().flatten().enumerate() {
+            push(
+                format!("{}.model_fallback[{i}]", a.name),
+                a.name.clone(),
+                fb,
+            );
+        }
+    }
+    out
+}
+
+/// Rewrite deprecated models in an `agents.yaml`.
+///
+/// Textual substitution, like `update_agent_file` — a `serde_yaml_ng`
+/// round-trip would silently drop every comment and reorder keys.
+///
+/// Bounded to lines whose key is `model`/`model_fallback`, or which are list
+/// items: a raw `: <model>` pattern would also match inside a comment or a
+/// `description`, and correcting a configuration must not rewrite prose.
+pub fn update_declarations(
+    path: &Path,
+    findings: &[DeprecationFinding],
+) -> anyhow::Result<usize> {
+    if findings.is_empty() {
+        return Ok(0);
+    }
+    let content = std::fs::read_to_string(path)?;
+    let mut count = 0;
+    let mut out = String::with_capacity(content.len());
+    for line in content.lines() {
+        let code = line.split('#').next().unwrap_or(line);
+        let trimmed = code.trim_start();
+        let is_model_key = trimmed.starts_with("model:")
+            || trimmed.starts_with("model_fallback:")
+            || trimmed.starts_with("- ");
+        let mut kept = line.to_string();
+        if is_model_key {
+            for f in findings {
+                if kept.contains(&f.current) {
+                    kept = kept.replace(&f.current, &f.replacement);
+                    count += 1;
+                }
+            }
+        }
+        out.push_str(&kept);
+        out.push('\n');
+    }
+    std::fs::write(path, out)?;
+    Ok(count)
+}
+```
+
+Note for the implementer: `model_fallback: [a, b]` on one line and `- a` on its own line are both handled by the `is_model_key` test above. A `- ` list item under some *other* key could be touched — if any of the tests shows that, narrow the check by tracking the enclosing key rather than loosening the test.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core model_updater`
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into the automatic check**
+
+`auto_check_and_prompt` (`model_updater.rs:145`) and `check_project` (`:60`) walk agent files. Extend them to also call `check_declarations` on `.armadai/agents.yaml` when it exists, and `update_declarations` on acceptance. Verify by hand that `armadai validate` on a project whose `agents.yaml` holds a deprecated model reports it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/model_updater.rs
+git commit -m "feat(core): fix deprecated models in agents.yaml too
+
+Otherwise the declaration file is the one place in a project where a dead
+model goes unnoticed, while run/link/init keep fixing every .md.
+
+One finding per occurrence: a .md declares model once, a declaration carries
+it in defaults and in every deviating agent, so replacen(.., 1) would fix
+only the first. Substitution is bounded to model/model_fallback lines — a raw
+pattern would also match inside a comment or a description, and correcting a
+configuration must not rewrite prose. Textual rewrite, so comments and key
+order survive; a serde round-trip would drop both."
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Create: `docs/wiki/declarative-agents.md`
+- Modify: `docs/wiki/SUMMARY.md`, `CLAUDE.md` (the `core/` bullet), `docs/wiki/agent-format.md`
+
+- [ ] **Step 1: Write the page**
+
+Cover, in this order: what a declaration looks like (the spec's example); that the `.md` format stays fully valid and this is an additional input; the defaults merge with **lists replaced, not merged**; fragment composition and `{{var}}` substitution; that a missing fragment or unsubstituted variable **fails** rather than degrades, and why; that a name both declared and written as a file is an error with no precedence; and that `A05` flags an over-composed prompt.
+
+State plainly what it does **not** buy — no token saving, no reduced context saturation, no guaranteed improvement in agent quality — with the spec's numbers. A reader who adopts it expecting a smaller context will be disappointed, and better disappointed by the doc than by the tool.
+
+- [ ] **Step 2: Cross-reference the existing format page**
+
+`docs/wiki/agent-format.md` documents the `.md` format. Add a short pointer to the declaration format there, so a reader landing on one finds the other.
+
+- [ ] **Step 3: Update `CLAUDE.md`**
+
+Add to the `core/` module list, in the file's terse style:
+
+```markdown
+- `core/agent_decl.rs` + `core/agent_source.rs` — declarative agents: `.armadai/agents.yaml` declares agents (defaults merge + prompt composed from fragments with `{{var}}` substitution); `load_agent()` returns an `Agent` where `resolve_agent()` returns a path. `core/template.rs` holds the substitution, shared with `cli/new.rs`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ CLAUDE.md
+git commit -m "docs: document declarative agents"
+```
+
+---
+
+### Task 10: Gate and PR
+
+- [ ] **Step 1: Run the full local gate**
+
+```bash
+cargo fmt --all -- --check
+for f in "tui" "tui,providers-api" "tui,web,storage" "tui,storage,e2e-fake"; do
+  cargo clippy --all-targets --no-default-features --features "$f" -- -D warnings || break
+done
+cargo test --no-default-features --features tui
+cargo test --no-default-features --features tui,storage,e2e-fake
+```
+Expected: all green. **Do not open the PR otherwise.**
+
+- [ ] **Step 2: Verify against the real library**
+
+Declare two of this project's own specialists in a throwaway `agents.yaml`, referencing the real fragments in `~/.config/armadai/prompts/`, and confirm `armadai link --target claude --dry-run` produces projections equivalent to today's. Capture the output. Every serious defect on this project's recent branches was found by running the real binary against real data, not by unit tests.
+
+- [ ] **Step 3: Push and open the PR**
+
+Body should carry: what it does; that the 77 `.md` agents keep working; the measured section of the spec on what it does *not* buy; the hard-failure rationale; and the limits (no `.md` → YAML converter, list-replacement semantics).
+
+- [ ] **Step 4: Independent review**
+
+Green CI is not sufficient on this project. Request an independent review before merge, and ask it explicitly to hunt for tautological tests — four separate reviews have found one on recent branches.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| `.armadai/agents.yaml` format, two prompt-step forms | 2 |
+| Defaults merge, lists replaced not merged | 3 |
+| Fragment composition, `{{var}}` substitution | 1, 4 |
+| Substitution extracted from `cli/new.rs`, not rewritten | 1 |
+| `AgentRef::Declared` + `load_agent()` returning an `Agent` | 5 |
+| `resolve_agent` untouched for file-backed refs | 5 |
+| Hard failure on missing fragment / unsubstituted variable | 1, 4 |
+| Unused variable = warning, not error | 1 |
+| Name collision = error, no precedence | 6 |
+| Malformed YAML reports position | 2 |
+| Orphan `Declared` reference errors | 5 |
+| Identical projection invariant | 7 |
+| Deprecated models in YAML, per occurrence, bounded to model keys, comments survive | 8 |
+| `provider` as strict in YAML as in `.md` | 3 — derived from `parser/metadata.rs`, not from the spec; noted here because it tightens the format |
+| `A05` measures composed prompts (no new limit) | — inherited: composed agents become `Agent`, so `A05` applies without code |
+| No intermediate `.md` | 5 (constructs `Agent` directly) |
+| 77 `.md` agents keep working | 5, 7 |
+| Docs, including what it does not buy | 9 |
+
+Two spec points deliberately carry no task: **the lot-2 extension to prompt fragments** and **the absence of a `.md` → YAML converter**, both listed as out of scope.
+
+**Type consistency:** `PromptStep` is defined in Task 2 and consumed in Task 4 with the same variants. `AgentDefaults`/`AgentDecl` field names are identical across Tasks 2, 3 and 8. `load_agent`'s third parameter is `&[Prompt]` in Tasks 5, 6 and 7. `DeprecationFinding` is reused as-is in Task 8 — no new type.
+
+**Signatures verified at the source, not assumed** — four of them changed the plan:
+
+| Read | Consequence |
+|---|---|
+| `AgentMetadata` has no `Default` (`agent.rs:40`) | Task 3 writes every field out; adding a `Default` would mean `provider: ""` and `temperature: 0.0`. |
+| `provider` is required (`parser/metadata.rs:83`) | `merge_metadata` returns `Result`; YAML is as strict as `.md`. |
+| `crates/armadai` is bin-only (no `lib.rs`, no `[lib]`) | Task 7's test moved from `tests/` into the crate — `tests/` cannot `use armadai::linker`. |
+| `Linker::generate(&[LinkAgent], Option<&LinkAgent>, &[String]) -> Vec<OutputFile>`, via `create_linker(target)` | Task 7 uses the trait across all five targets, not a fictional `linker::claude::generate`. |
+
+**One risk the plan does not remove:** Task 7 asserts equal projections across five targets. If a target's projection legitimately depends on something a declared agent cannot carry, that assertion fails for a good reason. The step says to report it rather than drop the target — a green test bought by narrowing the loop proves nothing.

--- a/docs/superpowers/plans/2026-08-20-declarative-agents.md
+++ b/docs/superpowers/plans/2026-08-20-declarative-agents.md
@@ -40,7 +40,13 @@ Three new files rather than one: substitution is reusable on its own, the YAML f
 
 ### Task 1: Extract variable substitution into `armadai-core`
 
-`cli/new.rs:55-78` substitutes `{{name}}`, `{{description}}`, `{{stack}}`, `{{model}}` with a chain of `replace` calls, then computes the leftover placeholders into a `remaining` vector **and does nothing with it**. Fragments need the same substitution, and the spec requires leftovers to be an error.
+`cli/new.rs:55-78` substitutes `{{name}}`, `{{description}}`, `{{stack}}`, `{{model}}` with a chain of `replace` calls, then hand-rolls a `{{`/`}}` scan into a `remaining` vector and **prints it as a warning** (`new.rs:70-95`). Fragments need the same substitution; the difference is what happens to a leftover.
+
+**Two callers, two policies — this is deliberate:**
+- **Fragments** (Task 4) need a **hard failure**: an agent whose prompt still contains `{{module}}` ships amputated instructions and hallucinates rather than complains.
+- **`armadai new`** must keep today's behaviour. **10 of the 12 templates in `crates/armadai/templates/` carry `{{description}}` or `{{stack}}`**, so failing hard would break `armadai new <name>` without `--description` for almost every template. That is a regression in the product's most-used command, not an improvement.
+
+So this task ships **two** functions over one implementation of the scan: `render` (strict) and `render_lenient` (substitutes what it can, returns the leftovers). `new.rs` switches to `render_lenient` and feeds its existing warning from the returned list, deleting its hand-rolled scan. Behaviour preserved, detection defined once.
 
 **Files:**
 - Create: `crates/armadai-core/src/template.rs`
@@ -50,6 +56,7 @@ Three new files rather than one: substitution is reusable on its own, the YAML f
 - Consumes: nothing.
 - Produces:
   - `pub fn render(template: &str, vars: &BTreeMap<String, String>) -> Result<String, TemplateError>`
+  - `pub fn render_lenient(template: &str, vars: &BTreeMap<String, String>) -> (String, Vec<String>)` — the rendered text, plus the placeholder names left unsubstituted
   - `pub fn unused_vars(template: &str, vars: &BTreeMap<String, String>) -> Vec<String>`
   - `pub enum TemplateError { Unsubstituted(Vec<String>) }` (implements `std::error::Error`)
 
@@ -102,6 +109,22 @@ mod tests {
         );
     }
 
+    /// `armadai new` must keep working on the 10 templates that carry
+    /// `{{description}}`: substitute what we have, hand back the rest.
+    #[test]
+    fn lenient_rendering_substitutes_what_it_can_and_returns_the_rest() {
+        let (out, left) = render_lenient("{{a}} and {{b}}", &vars(&[("a", "1")]));
+        assert_eq!(out, "1 and {{b}}");
+        assert_eq!(left, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn lenient_rendering_reports_nothing_left_when_all_are_supplied() {
+        let (out, left) = render_lenient("{{a}}", &vars(&[("a", "1")]));
+        assert_eq!(out, "1");
+        assert!(left.is_empty());
+    }
+
     #[test]
     fn an_unterminated_placeholder_is_left_alone() {
         // `{{` with no closing `}}` is not a placeholder, just text.
@@ -122,10 +145,15 @@ Above the test module in `crates/armadai-core/src/template.rs`:
 ```rust
 //! `{{var}}` substitution, shared by agent templates and prompt fragments.
 //!
-//! Extracted from `cli/new.rs`, which substituted inline and computed the
-//! leftover placeholders without acting on them. Leftovers are an error here:
-//! a prompt containing a literal `{{module}}` is text the model will try to
-//! interpret, and an agent built from it is quietly wrong.
+//! Extracted from `cli/new.rs`, which substituted inline and hand-rolled its
+//! own leftover scan.
+//!
+//! Two policies over one scan. `render` refuses a leftover: a prompt
+//! containing a literal `{{module}}` is text the model will try to interpret,
+//! and an agent built from it is quietly wrong. `render_lenient` substitutes
+//! what it can and hands the leftovers back, which is what `armadai new`
+//! needs — most templates carry `{{description}}`, and `new` warns rather
+//! than refusing.
 
 use std::collections::BTreeMap;
 
@@ -193,6 +221,26 @@ pub fn render(
     Ok(out)
 }
 
+/// Substitute what the variables cover, and report what is left.
+///
+/// For callers that must not fail on a leftover — `armadai new` warns about
+/// them instead, because most templates legitimately carry a `{{description}}`
+/// the user did not supply.
+pub fn render_lenient(
+    template: &str,
+    vars: &BTreeMap<String, String>,
+) -> (String, Vec<String>) {
+    let left: Vec<String> = placeholders(template)
+        .into_iter()
+        .filter(|n| !vars.contains_key(n))
+        .collect();
+    let mut out = template.to_string();
+    for (name, value) in vars {
+        out = out.replace(&format!("{{{{{name}}}}}"), value);
+    }
+    (out, left)
+}
+
 /// Values supplied that the template never uses — almost always a typo.
 pub fn unused_vars(template: &str, vars: &BTreeMap<String, String>) -> Vec<String> {
     let used = placeholders(template);
@@ -212,7 +260,15 @@ Expected: PASS (5 tests).
 
 - [ ] **Step 5: Make `cli/new.rs` consume it**
 
-Replace the `replace` chain at `crates/armadai/src/cli/new.rs:55-78` with a `vars` map plus one `render` call. Keep `new.rs`'s current behaviour: a missing `--description` or `--stack` means those placeholders stay unsupplied, so a template using them would now **error** instead of silently keeping `{{description}}`. That is the intended improvement; confirm the existing `new.rs` tests still pass, and if one relied on the silent behaviour, report it rather than weakening it.
+Replace the `replace` chain at `crates/armadai/src/cli/new.rs:55-68` with a `vars` map plus one `render_lenient` call, inserting only the variables actually supplied (`name` and `model` always; `description` and `stack` only when `Some`). Then delete the hand-rolled `{{`/`}}` scan at `new.rs:70-78` and feed the existing warning block from `render_lenient`'s second return value.
+
+`new.rs`'s warning currently prints whole placeholders (`{{description}}`) while `render_lenient` returns bare names (`description`). Keep the printed form identical to today's — wrap each name back into `{{…}}` at the print site. Changing user-visible output is out of scope for this task.
+
+Verify by hand and put the output in your report:
+```bash
+cargo run --bin armadai -- new scratch-check --template basic
+```
+Expected: the command **succeeds** and warns about the unsubstituted placeholders, exactly as before. Delete the generated file afterwards. A failure here means the strict path leaked into `new` — 10 of the 12 templates carry `{{description}}`.
 
 - [ ] **Step 6: Run the affected tests**
 
@@ -226,10 +282,13 @@ cargo fmt --all
 git add crates/armadai-core/src/template.rs crates/armadai-core/src/lib.rs crates/armadai/src/cli/new.rs
 git commit -m "refactor(core): extract {{var}} substitution into armadai-core
 
-cli/new.rs substituted inline and computed leftover placeholders without
-acting on them. Prompt fragments need the same substitution, and a leftover
-is now an error: a prompt containing a literal {{module}} is text the model
-will try to interpret."
+Two policies over one scan. render() refuses a leftover: a prompt containing a
+literal {{module}} is text the model will try to interpret, and the agent built
+from it is quietly wrong. render_lenient() hands leftovers back, which is what
+armadai new needs — 10 of the 12 templates carry {{description}}, so failing
+hard there would break the command for almost every template.
+
+cli/new.rs keeps its behaviour and drops its hand-rolled scan."
 ```
 
 ---
@@ -1309,6 +1368,204 @@ the .md rather than a second source of truth."
 
 ---
 
+### Task 7b: Wire declared agents into `link` and `list`
+
+Without this task the feature is unreachable: `link.rs:52` calls `resolve_all_agents`, which returns `Vec<PathBuf>`, then parses each file. A declared agent has no file, so `armadai link` would ignore `agents.yaml` entirely — and `link` is precisely the moment the duplication this format removes shows up.
+
+**Files:**
+- Modify: `crates/armadai-core/src/agent_source.rs` (add `load_all_agents`)
+- Modify: `crates/armadai/src/cli/link.rs:52-68`, `crates/armadai/src/cli/list.rs:103`
+
+**Interfaces:**
+- Consumes: Tasks 5-6 (`load_agent`, `declarations_path`, `check_no_shadowing`), plus the existing `project::resolve_all_agents(config, root) -> (Vec<PathBuf>, Vec<String>)` and `prompt::load_all_prompts`.
+- Produces: `pub fn load_all_agents(config: &ProjectConfig, root: &Path, fragments: &[Prompt]) -> (Vec<Agent>, Vec<String>)` — same `(values, non-fatal errors)` shape as `resolve_all_agents`, so callers keep their existing warning loop.
+
+**Decision, already made — do not re-litigate it:** every agent in `agents.yaml` is included automatically. Requiring them to be relisted in `armadai.yaml` would duplicate the declaration this format exists to remove. `AgentRef::Declared` stays useful for pointing at one deliberately (routes, teams), not as an opt-in gate.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `agent_source.rs`'s test module:
+
+```rust
+    /// A project with one `.md` agent and one declared agent must yield both.
+    #[test]
+    fn declared_and_file_agents_are_loaded_together() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  - name: declared-one\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let md_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&md_dir).unwrap();
+        std::fs::write(
+            md_dir.join("file-one.md"),
+            "# file-one\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
+        )
+        .unwrap();
+        let config = config_listing_agent_path(dir.path(), "agents/file-one.md");
+
+        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+        let mut names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["declared-one", "file-one"], "errors: {errors:?}");
+    }
+
+    /// A project with no declarations must behave exactly as before.
+    #[test]
+    fn a_project_without_declarations_loads_only_its_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let md_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&md_dir).unwrap();
+        std::fs::write(
+            md_dir.join("only.md"),
+            "# only\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi\n",
+        )
+        .unwrap();
+        let config = config_listing_agent_path(dir.path(), "agents/only.md");
+
+        let (agents, _) = load_all_agents(&config, dir.path(), &[]);
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "only");
+    }
+
+    /// One bad declaration must not silence the good agents — the existing
+    /// callers print warnings and carry on, and that contract must hold.
+    #[test]
+    fn a_broken_declaration_becomes_an_error_string_not_a_lost_fleet() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        // `ghost` is not a known fragment -> composition fails for this agent.
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  - name: broken\n    prompt: [ghost]\n  \
+             - name: fine\n    prompt: [base]\n",
+        )
+        .unwrap();
+        let config = config_listing_agent_path(dir.path(), "agents/none.md");
+
+        let (agents, errors) = load_all_agents(&config, dir.path(), &fragments());
+        assert!(
+            agents.iter().any(|a| a.name == "fine"),
+            "the healthy agent must survive: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("broken")),
+            "the broken one must be reported by name: {errors:?}"
+        );
+    }
+```
+
+`config_listing_agent_path` is a helper you write: build a `ProjectConfig` whose agent list holds one `AgentRef::Path`. Read `project.rs`'s own tests (`test_resolve_all_agents`, around `project.rs:822`) for how they construct a `ProjectConfig` and copy that, rather than inventing a second way.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p armadai-core load_all_agents`
+Expected: FAIL — the function does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+/// Every agent a project has: those resolved from files, plus those declared.
+///
+/// Same `(values, non-fatal errors)` shape as `resolve_all_agents`, so callers
+/// keep their existing warning loop. A broken declaration costs its own agent,
+/// never the whole fleet — a fleet that vanishes because one agent has a typo
+/// is worse than a fleet with a gap and a warning.
+pub fn load_all_agents(
+    config: &crate::project::ProjectConfig,
+    root: &Path,
+    fragments: &[Prompt],
+) -> (Vec<Agent>, Vec<String>) {
+    let (paths, mut errors) = crate::project::resolve_all_agents(config, root);
+    let mut agents = Vec::new();
+    for path in &paths {
+        match crate::parser::parse_agent_file(path) {
+            Ok(a) => agents.push(a),
+            Err(e) => errors.push(format!("failed to parse {}: {e}", path.display())),
+        }
+    }
+
+    let decls_path = declarations_path(root);
+    if decls_path.is_file() {
+        match crate::agent_decl::load(&decls_path) {
+            Ok(decls) => {
+                for decl in &decls.agents {
+                    let built = crate::agent_decl::merge_metadata(decl, &decls.defaults).and_then(
+                        |metadata| {
+                            Ok(Agent {
+                                name: decl.name.clone(),
+                                source: decls_path.clone(),
+                                metadata,
+                                system_prompt: crate::agent_decl::compose_prompt(
+                                    &decl.prompt,
+                                    decl,
+                                    fragments,
+                                )?,
+                                instructions: None,
+                                output_format: None,
+                                pipeline: None,
+                                context: None,
+                            })
+                        },
+                    );
+                    match built {
+                        Ok(a) => agents.push(a),
+                        Err(e) => errors.push(format!("{e}")),
+                    }
+                }
+            }
+            Err(e) => errors.push(format!("{e}")),
+        }
+    }
+
+    (agents, errors)
+}
+```
+
+Note the duplication with `load_agent`'s construction of `Agent`. Extract the shared part into one private `fn build(decl, defaults, fragments, source) -> anyhow::Result<Agent>` and have **both** call it — two places building an `Agent` from a declaration is exactly how the two drift apart later.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p armadai-core`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `link` and `list`**
+
+In `crates/armadai/src/cli/link.rs`, replace the `resolve_all_agents` + `parse_agent_file` loop (lines 52-68) with one `load_all_agents` call, mapping through `LinkAgent::from(&agent)`. Keep the existing warning loop and the `link_agents.is_empty()` bail exactly as they are. The fragments argument comes from the project's prompts — use whatever `link.rs` already loads if it loads them, and `prompt::load_all_prompts` otherwise.
+
+Do the same at `crates/armadai/src/cli/list.rs:103`.
+
+- [ ] **Step 6: Answer one question in your report**
+
+`unlink` (`cli/unlink.rs:28`) also calls `resolve_all_agents`. Read it and state in your report whether it needs declared agents to remove the files `link` generated for them. Do not change it in this task — report the verdict, with the line that decides it. If it does need them, that is a follow-up, and your report is what makes it visible.
+
+Six other callers keep using paths (`tui/app.rs:417`, `web/api.rs:199`, `shell/wizard.rs:319`, `unlink.rs:28`, `model_updater.rs:62`, plus `project.rs`'s own tests). Leave them: a declared agent will not appear in the TUI or Web lists yet, which is a documented limit, not a defect to fix here.
+
+- [ ] **Step 7: Verify on a real project**
+
+```bash
+cargo run --bin armadai -- link --target claude --dry-run
+```
+Run it in a throwaway project that declares one agent in `.armadai/agents.yaml` and lists none in `armadai.yaml`. Expected: the declared agent appears in the projection. Put the output in your report. This is the check that proves the feature is reachable at all.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt --all
+git add crates/armadai-core/src/agent_source.rs crates/armadai/src/cli/link.rs crates/armadai/src/cli/list.rs
+git commit -m "feat(cli): link and list see declared agents
+
+Without this the format is unreachable: link resolved agents to paths and
+parsed each file, so an agent declared in agents.yaml was invisible to the one
+command that matters most for it.
+
+A broken declaration costs its own agent and a warning, never the whole fleet."
+```
+
+---
+
 ### Task 8: Deprecated models in `agents.yaml`
 
 `model_updater` fixes deprecated models in place and is called automatically by `run`, `link` and `init`. Without this, `agents.yaml` becomes the one place in a project where a dead model goes unnoticed.
@@ -1651,6 +1908,7 @@ Green CI is not sufficient on this project. Request an independent review before
 | `provider` as strict in YAML as in `.md` | 3 — derived from `parser/metadata.rs`, not from the spec; noted here because it tightens the format |
 | `A05` measures composed prompts (no new limit) | — inherited: composed agents become `Agent`, so `A05` applies without code |
 | No intermediate `.md` | 5 (constructs `Agent` directly) |
+| A declared agent is actually reachable from `link` | 7b — added by the pre-flight scan; the plan as first written produced code no command called |
 | 77 `.md` agents keep working | 5, 7 |
 | Docs, including what it does not buy | 9 |
 

--- a/docs/superpowers/specs/2026-08-20-declarative-agents-design.md
+++ b/docs/superpowers/specs/2026-08-20-declarative-agents-design.md
@@ -1,0 +1,242 @@
+# Agents déclaratifs — le YAML comme source d'`Agent` — Design
+
+**Date** : 2026-08-20
+**Statut** : validé (design), à implémenter
+**Cible** : lot 1 d'un moteur déclaratif. Les agents ; les fragments de prompt viennent au lot 2.
+
+## Contexte : ce qui existe déjà, et ce qui manque
+
+L'idée « config comme source de vérité » est capturée depuis le 2026-07-17 (mémoire
+`project_vision_declarative`, idée B). Ce spec la reprend avec deux éléments qu'elle n'avait pas.
+
+**Les briques sont là, en pièces détachées** :
+
+| Brique | Où | Ce qu'elle fait déjà |
+|---|---|---|
+| Substitution de variables | `crates/armadai/templates/*.md` + `cli/new.rs` | `{{name}}`, `{{description}}`, `{{stack}}`, `{{model}}` |
+| Fragments composables | `armadai-core/src/prompt.rs` | frontmatter YAML + prose, sélection par `apply_to` |
+| Projection native | `linker/` | un `Agent` → 5 formats (claude, codex, copilot, gemini, opencode) |
+| Rendu d'agent | `audit/proposal.rs` | `Agent` → `.md` au format ArmadAI |
+
+**Le linker projette déjà.** `armadai link --target claude` *génère* `.claude/agents/{slug}.md`
+(`linker/claude.rs:43`) — les fichiers d'un projet lié ne sont pas une copie maintenue à la main,
+c'est une projection régénérable. Le mécanisme « source unique → projections » de l'idée B **tourne
+donc déjà**. Ce qui manque n'est pas la génération : c'est que la source soit 77 fichiers Markdown.
+
+**Ce chantier n'est donc pas un nouveau sous-système**, mais un format d'entrée qui assemble
+l'existant.
+
+### Mesures sur la bibliothèque (2026-08-20)
+
+77 fichiers dans `~/.config/armadai/agents/`, dont 76 déclarent `provider` et `model`, et 72
+`temperature` et `max_tokens`. Sur ceux qui déclarent la clé, une valeur domine largement :
+
+| Clé | Valeur dominante | Occurrences | Sur combien de déclarations |
+|---|---|---|---|
+| `model` | `latest:pro` | 60 | 76 |
+| `max_tokens` | `8192` | 57 | 72 |
+| `temperature` | `0.3` | 49 | 72 |
+| `provider` | `claude` | 47 | 76 (3 valeurs distinctes) |
+
+## Ce que ce chantier ne fait PAS gagner
+
+Établi par mesure, pour qu'on ne conçoive pas sur une prémisse fausse.
+
+**Aucune économie de tokens.** Les métadonnées ne partent jamais au modèle : ArmadAI les parse pour
+choisir provider/modèle/température. Les 5 152 tokens de blocs `## Metadata` de la bibliothèque
+pèsent sur le disque et sur les yeux, pas sur la facture. Ce qui coûte, ce sont les ~52 460 tokens
+de prose d'instruction, et un YAML n'y change rien puisque cette prose doit exister quelque part.
+
+**Aucune réduction de la saturation de contexte** pour la même raison. Et la composition peut
+l'aggraver : ~680 tokens de prompt par agent en moyenne, avec des fragments de 66 lignes — un agent
+qui compose quatre fragments a un prompt plus long qu'un prompt écrit sur mesure. On échange de la
+duplication sur disque contre de l'inclusion au runtime.
+
+**Aucune garantie d'amélioration de la qualité des agents.** Un prompt assemblé de fragments
+génériques est moins spécifique qu'un prompt taillé, et un agent aux instructions vagues comble les
+vides. Le gain en cohérence peut se payer en précision. Seul un comparatif sur tâche réelle le
+dira — mesurable, comme la prose l'a été pour le policy gate.
+
+## Le gain réel : une seule vérité
+
+Le seul mécanisme par lequel ce chantier réduit les hallucinations est la **suppression des vérités
+en double**, et il est démontré sur ce projet même : `.claude/CLAUDE.md` contredisait le `CLAUDE.md`
+racine, et le modèle a suivi la version actionnable tout en citant l'autre mot pour mot
+(mémoire `project_orchestration_policy_gate`). Deux specs de ce dépôt ont affirmé des faits erronés
+(« vaut pour l'équipe », « chaque sous-agent ») nés de la même information vivant à deux endroits.
+
+C'est l'argument décisif de l'approche retenue.
+
+## Décisions de cadrage (Dimitri, 2026-08-20)
+
+1. **Le YAML porte les métadonnées et compose le prompt depuis des fragments**, avec paramètres.
+   La prose reste écrite à la main, une fois, dans des fragments réutilisés.
+2. **Prompt « généré » = substitution dans des fragments humains**, jamais rédaction depuis des
+   énumérés. Un `role: reviewer, strictness: high` produirait des instructions fades, et un prompt
+   fade fait un agent médiocre.
+3. **Extension du moteur aux fragments de prompt** : souhaitée, reportée au lot 2. Concevoir les
+   deux à la fois, c'est concevoir mal les deux.
+4. **Aucun artefact intermédiaire.** Le YAML produit un `Agent` en mémoire, pas un `.md` sur disque.
+
+## Approches écartées
+
+**Le YAML génère des `.md` dans la bibliothèque.** Plus simple (réutilise `render_agent` tel quel),
+et le résultat est inspectable. Écartée : elle crée un fichier éditable de plus, donc une seconde
+source, donc la divergence — exactement le problème que ce chantier traite. La première fois qu'on
+générera un `.md` « pour inspection », on l'aura réintroduit.
+
+**Le YAML remplace le format `.md`.** Cohérent à terme, mais ArmadAI se présente comme un
+orchestrateur d'agents Markdown : le standard passerait d'interface à format d'export. Décision
+trop lourde pour un lot 1, et rien n'oblige à la prendre maintenant.
+
+## Architecture
+
+La chaîne actuelle est `AgentRef → resolve_agent() → PathBuf → parse_agent_file() → Agent`. Le
+goulot est que `resolve_agent` (`armadai-core/src/project.rs:281`) rend un **chemin**, ce qui
+suppose un fichier.
+
+```
+.armadai/agents.yaml
+        │
+        ▼  AgentRef::Declared
+armadai_core::agent_source::load_agent(&AgentRef, root) -> Agent
+        │   ├─ Named / Registry / Path → resolve_agent() + parse_agent_file()   (inchangé)
+        │   └─ Declared                → defaults + composition + substitution
+        ▼
+     Agent (en mémoire)
+        │
+        ▼  inchangé
+linker/  → .claude/agents/, .github/agents/, … (5 cibles)
+```
+
+`AgentRef` gagne un variant `Declared { declared: String }`. Une nouvelle fonction
+`load_agent(&AgentRef, &Path) -> anyhow::Result<Agent>` rend un `Agent` là où `resolve_agent` rend
+un chemin.
+
+**Cette séparation est sémantique, pas une commodité.** `resolve_agent` sert ceux qui *manipulent
+des fichiers* — `model_updater` et `pack_validation` réécrivent les modèles dépréciés en place ;
+`load_agent` sert ceux qui *exécutent*. Un agent déclaré en YAML n'a pas de fichier, et il est juste
+que `resolve_agent` échoue pour lui.
+
+**Non touché** : le parseur `.md`, le linker (il consomme des `Agent`, l'origine lui est
+indifférente), les 77 agents existants, `audit --propose`.
+
+## Le format
+
+```yaml
+# .armadai/agents.yaml
+defaults:
+  provider: claude
+  model: latest:pro
+  temperature: 0.3
+  max_tokens: 8192
+
+agents:
+  - name: core-specialist
+    description: Core domain and orchestration engine
+    scope: [src/core/**, src/parser/**]
+    tags: [rust, domain]
+    prompt:
+      - specialist-base
+      - { armadai-architecture: { module: core } }
+
+  - name: ui-specialist
+    description: TUI and Web dashboards
+    temperature: 0.4          # le seul écart aux défauts
+    scope: [src/tui/**, src/web/**]
+    prompt: [specialist-base, ratatui-conventions]
+```
+
+**Fusion des défauts, peu profonde** : un champ absent prend la valeur de `defaults`. Les listes
+(`tags`, `scope`) sont **remplacées, jamais fusionnées** — moins expressif, mais prévisible : un
+agent qui déclare son `scope` a exactement celui-là, sans hériter silencieusement d'un périmètre
+plus large.
+
+## Composition et substitution
+
+`prompt:` accepte deux formes, chaîne ou map à une clé — YAML idiomatique, sans niveau d'imbrication
+superflu. Le `system_prompt` est la concaténation des corps de fragments, dans l'ordre déclaré,
+séparés d'une ligne vide.
+
+La substitution remplace `{{module}}` par sa valeur, plus les variables implicites de l'agent
+(`{{name}}`, `{{description}}`). Le code existe : `cli/new.rs:58-68` fait déjà
+`content.replace("{{name}}", …)`. Il est **extrait dans `armadai-core`** pour que templates et
+fragments se comportent identiquement — pas réécrit.
+
+`prompt.rs` garde son mécanisme `apply_to` pour les agents `.md`. Les deux coexistent : `apply_to`
+est piloté par le fragment, le YAML est piloté par l'agent.
+
+## Où l'on échoue — et pourquoi c'est l'inverse du policy gate
+
+Un fragment introuvable, ou une variable `{{x}}` restée non substituée, sont des **erreurs dures**.
+C'est l'exact opposé du principe du policy gate, où toute incertitude autorise. L'inversion est
+délibérée :
+
+| | Effet d'une défaillance |
+|---|---|
+| Policy gate | dégrader = laisser passer du travail légitime |
+| Composition de prompt | dégrader = livrer un agent aux instructions incomplètes |
+
+Un agent au prompt amputé ne signale rien : il comble les vides, c'est-à-dire qu'il hallucine. Et un
+prompt contenant littéralement `{{module}}` est un texte que le modèle va tenter d'interpréter.
+Mieux vaut refuser de construire l'agent.
+
+Une variable fournie mais jamais utilisée reste un **avertissement** : c'est presque toujours une
+faute de frappe, mais elle ne casse rien.
+
+**Un nom présent à la fois dans `agents.yaml` et dans la bibliothèque `.md` est une erreur**, pas
+une précédence. La tentation serait de faire gagner le local, comme partout — mais ce chantier
+existe pour supprimer les vérités en double, et une précédence silencieuse en crée une : on
+éditerait un `.md` sans effet, sans rien pour le signaler. La règle `C01` de l'audit détecte déjà
+les collisions de noms ; le chargement, lui, doit refuser.
+
+Un YAML malformé remonte la position que `serde_yaml_ng` fournit. Une référence `Declared` sans
+entrée correspondante échoue.
+
+## Frugalité : rien à inventer
+
+La règle `A05` (`audit/rules/assets.rs:44`) flaggue déjà tout agent dont le prompt dépasse
+`prompt_token_threshold` (défaut 4000, réglable par projet). Les agents composés devenant des
+`Agent` comme les autres, le garde-fou existant dit quand une composition a trop gonflé — au lieu
+d'une limite arbitraire dans le générateur.
+
+Réserve : `A05` mesure aujourd'hui les agents importés depuis `.claude/`. Pour qu'il voie un agent
+déclaré en YAML, l'audit devra le charger ; sinon la frugalité n'est mesurée que sur les
+projections, ce qui reste utile mais indirect.
+
+## Tests
+
+Du plus mécanique au plus porteur :
+
+- **Fusion des défauts** : scalaire surchargé ; liste remplacée et non fusionnée ; agent sans aucun
+  écart prenant tous les défauts.
+- **Composition** : ordre déclaré respecté ; séparateur entre fragments ; fragment unique.
+- **Substitution** : variable substituée ; variable manquante → erreur ; variable fournie mais
+  inutilisée → avertissement, pas erreur.
+- **Erreurs de chargement** : fragment introuvable ; nom en collision avec un `.md` de la
+  bibliothèque ; référence `Declared` orpheline ; YAML malformé.
+- **L'invariant qui garantit le reste** : un agent déclaré en YAML et son équivalent `.md`
+  produisent une **projection linker identique**. C'est la preuve qu'il n'existe pas deux chemins
+  divergents, et c'est la propriété la plus facile à mal vérifier.
+
+## Limites assumées
+
+- **`model_updater` ne verra pas les modèles dépréciés d'un agent YAML.** Il réécrit les fichiers en
+  place ; un agent déclaré n'a pas de fichier. À étendre, hors de ce lot.
+- **La composition peut allonger les prompts** plutôt que les raccourcir (voir « ce que ce chantier
+  ne fait pas gagner »). `A05` le mesure ; rien ne l'empêche.
+- **Aucun convertisseur `.md` → YAML.** Migrer un agent, c'est le déclarer et supprimer son `.md`, à
+  la main. Outiller une migration vers un format non encore éprouvé est le meilleur moyen de figer
+  une erreur.
+- **Le vrai levier contre le mauvais routage est ailleurs** : la similarité des descriptions
+  d'activation, que la règle `C03` mesure déjà (Jaccard, seuil `activation_similarity`, défaut 0.6).
+  Elle ne trouve rien sur les 6 agents de ce projet ; elle parlerait sur trente. Indépendant du
+  format.
+
+## Hors périmètre
+
+- L'extension du moteur aux fragments de prompt — lot 2, souhaité par Dimitri.
+- La génération de prose depuis des énumérés (`role`, `strictness`) — écartée en cadrage.
+- Le remplacement du format `.md` — les 77 agents restent valides, le YAML est une entrée
+  supplémentaire.
+- Un convertisseur `.md` → YAML.

--- a/docs/superpowers/specs/2026-08-20-declarative-agents-design.md
+++ b/docs/superpowers/specs/2026-08-20-declarative-agents-design.md
@@ -204,6 +204,34 @@ Réserve : `A05` mesure aujourd'hui les agents importés depuis `.claude/`. Pour
 déclaré en YAML, l'audit devra le charger ; sinon la frugalité n'est mesurée que sur les
 projections, ce qui reste utile mais indirect.
 
+## Mise à jour des modèles dépréciés
+
+`model_updater` détecte les modèles dépréciés et les corrige en place, et il est appelé
+automatiquement par `run`, `link` et `init`. Un agent déclaré doit en bénéficier comme les autres,
+sinon le YAML devient le seul endroit du projet où un modèle mort passe inaperçu.
+
+**La réécriture est déjà format-agnostique.** `update_agent_file`
+(`armadai-core/src/model_updater.rs:78`) opère par substitution textuelle — `content.replacen(": old",
+": new", 1)` — et non par round-trip de parseur. Elle s'applique donc au YAML sans rien réécrire, et
+surtout **sans effacer les commentaires**, ce qu'un aller-retour `serde_yaml_ng` ferait
+inévitablement.
+
+Deux pièges propres au YAML, à traiter explicitement :
+
+**Occurrences multiples.** Dans un `.md` un agent déclare son `model` une fois ; dans `agents.yaml`
+la clé apparaît dans `defaults` et dans chaque agent qui s'en écarte. Le `replacen(…, 1)` actuel ne
+corrigerait que la première. La détection doit donc rendre un finding **par occurrence**, avec sa
+position, et la réécriture les traiter toutes.
+
+**Substitution accidentelle.** Un motif `: latest:pro` brut apparaîtrait aussi dans un commentaire ou
+dans une `description`. La substitution doit être **bornée aux lignes dont la clé est `model` ou qui
+sont un élément de `model_fallback`**, jamais appliquée au texte libre. C'est la différence entre
+corriger une configuration et corriger de la prose.
+
+**Tests dédiés** : un modèle déprécié dans `defaults` est corrigé ; un modèle déprécié dans deux
+agents distincts est corrigé aux deux endroits ; un modèle déprécié cité dans un commentaire ou une
+`description` n'est **pas** touché ; les commentaires et l'ordre des clés survivent à la réécriture.
+
 ## Tests
 
 Du plus mécanique au plus porteur :
@@ -221,8 +249,6 @@ Du plus mécanique au plus porteur :
 
 ## Limites assumées
 
-- **`model_updater` ne verra pas les modèles dépréciés d'un agent YAML.** Il réécrit les fichiers en
-  place ; un agent déclaré n'a pas de fichier. À étendre, hors de ce lot.
 - **La composition peut allonger les prompts** plutôt que les raccourcir (voir « ce que ce chantier
   ne fait pas gagner »). `A05` le mesure ; rien ne l'empêche.
 - **Aucun convertisseur `.md` → YAML.** Migrer un agent, c'est le déclarer et supprimer son `.md`, à

--- a/docs/wiki/SUMMARY.md
+++ b/docs/wiki/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [Getting Started](getting-started.md)
 - [Agent format](agent-format.md)
+- [Declarative agents](declarative-agents.md)
 - [Orchestration](orchestration-guide.md)
   - [Reference](orchestration.md)
 - [Providers](providers.md)

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -2,6 +2,11 @@
 
 Agents are defined as Markdown files in the `agents/` directory. Each file represents one specialized agent.
 
+A project can also declare agents in `.armadai/agents.yaml` instead of writing this file by hand —
+see [Declarative agents](declarative-agents.md) for that format, including the one rule that
+surprises people (a name that collides with a `.md` file, anywhere in your agent libraries, is
+refused with no precedence either way) and an honest read on what it does and doesn't buy you.
+
 ## File Structure
 
 ```markdown

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -1,0 +1,225 @@
+# Declarative agents
+
+A project can declare its agents in `.armadai/agents.yaml` instead of writing each one as a
+Markdown file. The YAML is parsed into the same `Agent` struct the `.md` parser produces — same
+provider factory, same linker, same everything downstream. Nothing changes for a project that
+never creates the file.
+
+## What this does not buy
+
+Measured on the 77 agents in `~/.config/armadai/agents/` (2026-08-20), before writing a line of
+this format:
+
+- **No token saving.** Metadata never reaches the model — ArmadAI parses it locally to pick a
+  provider, model and temperature. The 5,152 tokens of `## Metadata` blocks across that library
+  cost disk space and eyestrain, not API spend. What actually costs money is the ~52,460 tokens of
+  instruction prose, and moving it into YAML changes nothing about that: the prose still has to
+  exist somewhere, in full, for the model to read it.
+- **No reduction in context saturation**, for the same reason — and composition can make it worse.
+  Fragments in this library average ~66 lines and a composed prompt averages ~680 tokens; an agent
+  that composes four of them ends up with a longer system prompt than one written to fit, not a
+  shorter one. You are trading duplication on disk for inclusion at runtime, not eliminating either.
+- **No guaranteed improvement in agent quality.** A prompt assembled from generic, reusable
+  fragments is less specific than one written for exactly one agent, and an agent left with vague
+  instructions fills in the gaps itself. Whatever consistency you gain this way may cost you
+  precision. Only a real task comparison would say — this chantier didn't run one.
+
+The one real gain is structural, not computational: a fact that used to live in one `.md` file now
+has exactly one place to be wrong in, instead of a `.md` file and whatever someone remembers about
+it. If you're adopting this expecting a smaller or cheaper context, don't — that expectation is
+what this section exists to correct before you build on it.
+
+## What a declaration looks like
+
+```yaml
+# .armadai/agents.yaml
+defaults:
+  provider: claude
+  model: latest:pro
+  temperature: 0.3
+  max_tokens: 8192
+
+agents:
+  - name: core-specialist
+    description: Core domain and orchestration engine
+    scope: [src/core/**, src/parser/**]
+    tags: [rust, domain]
+    prompt:
+      - specialist-base
+      - { armadai-architecture: { module: core } }
+
+  - name: ui-specialist
+    description: TUI and Web dashboards
+    temperature: 0.4          # the only deviation from defaults
+    prompt: [specialist-base]
+```
+
+`defaults` supplies values every agent inherits unless it overrides them. `provider` is required —
+at agent or `defaults` level — exactly like the `.md` format: an agent with no provider anywhere
+fails to load, on both sides. `command`/`args` are also expressible, so a `provider: cli` agent
+(wrapping `claude`, `gemini`, or any other command-line tool) can be declared, not just an API one.
+`defaults` has no `scope` field — there is no fleet-wide default scope; `scope` is per-agent only,
+and an agent that omits it simply has none.
+
+## The `.md` format is not going away
+
+This is an additional input, not a replacement. `.md` agents keep working exactly as before, and a
+project can mix both: some agents declared, some written by hand, loaded together by every command
+that resolves a fleet (see the [Agent format](agent-format.md) page for the `.md` side).
+
+## Defaults merge; lists replace, never merge
+
+Every field a declared agent omits falls back to `defaults`. Scalars (`temperature`, `model`,
+`max_tokens`, …) behave the way you'd expect. **Lists do not.** An agent that declares `tags: [own]`
+has exactly `[own]` — the default's tags are not appended. An agent that declares `tags: []` has no
+tags at all, not "inherit whatever `defaults` set." This is the one rule most likely to surprise a
+reader coming from a format where lists usually merge — say it plainly: they don't, here, ever
+(`tags`, `stacks`, `model_fallback`, `args` all follow the same rule).
+
+## Composing a prompt from fragments
+
+`prompt:` is a list of steps. A step is either a bare fragment name:
+
+```yaml
+prompt: [specialist-base]
+```
+
+or a single-key map naming a fragment and the variables to substitute into it:
+
+```yaml
+prompt:
+  - { armadai-architecture: { module: core } }
+```
+
+Each fragment body goes through the same `{{var}}` substitution `armadai new` uses
+(`core/template.rs`), then the rendered fragments are joined with a blank line, in the order
+declared. Every fragment body is trimmed first, so a fragment file's own trailing newline doesn't
+pile up into two or three blank lines at the join. Two variables are always available implicitly:
+`name` (the agent's own name) and `description` (the agent's own `description:`, when it declares
+one) — a step's own variables win if it supplies the same name.
+
+## Failure is the default, not degradation
+
+A missing fragment, or a fragment left with an unsubstituted `{{variable}}`, **fails agent loading**
+— it does not ship a shorter or blanker prompt. The same applies to `description`: if a fragment
+references `{{description}}` and the agent declares none, loading fails, naming both the agent and
+the fragment. This is deliberate: an agent shipped with amputated instructions doesn't complain
+about it, it fills the gaps itself, and a hard failure is the only way to make that visible before a
+model ever sees the result. If you genuinely need a fragment's `{{description}}` filled without the
+agent declaring one, a prompt step can supply it directly as one of its own variables — that's the
+escape hatch, not a default.
+
+Deprecated model names are checked and fixed in `agents.yaml` too — `defaults.model` and every
+deviating agent's own `model`/`model_fallback`, one finding per occurrence — the same textual
+in-place rewrite `armadai models update` already does for `.md` files, chosen so comments and key
+order survive. Two forms are refused rather than half-fixed: a quoted `"model":` key, and any case
+where the structured YAML parse and the textual rewrite disagree about what needs changing. The
+tool would rather stop and tell you than guess at a partial fix.
+
+## A name both declared and written as a file: no precedence
+
+If a name in `agents.yaml` collides with a `.md` file — compared as a slug, so `Core Specialist`,
+`core-specialist` and `core_specialist` all collide with each other — **the declaration is
+refused**, and neither side is given precedence.
+
+This check runs against **all three** directories ArmadAI already searches for agent files:
+`.armadai/agents/` (project-local, preferred), `agents/` (project-local, legacy), and
+**`~/.config/armadai/agents/` — your personal library**, which the project doesn't own and may not
+even know about. On a machine with a large accumulated personal library, this is the first thing a
+new user is likely to hit: you write `name: code-reviewer` in a fresh project's `agents.yaml`, and
+loading refuses because you happen to have a `code-reviewer.md` sitting in your global agents
+directory from an unrelated project.
+
+The reasoning: a silent "the local file wins" (or the reverse) would recreate exactly the duplicated
+truth this format exists to remove. You'd edit the `.md`, see no effect because the YAML quietly
+took precedence, and have nothing on screen telling you why — the same failure mode as two
+`CLAUDE.md` files disagreeing and the model citing one while acting on the other. Refusing outright,
+by contrast, tells you immediately and by name. The message looks like this:
+
+```
+agent 'code-reviewer' is declared in .armadai/agents.yaml and also written as
+/Users/you/.config/armadai/agents/code-reviewer.md — remove one; there is
+deliberately no precedence between them
+```
+
+What to do: rename or delete one side — whichever is actually stale. There is no flag to suppress
+the check or to force one side to win; a suppression flag would just be the silent precedence rule
+in disguise.
+
+The blast radius is scoped, though: a collision costs only the colliding declaration, never the
+rest of the fleet — every other declared agent, and the colliding `.md` file itself, still load
+fine elsewhere. `armadai list` and `armadai inspect` (read-only) print a warning and carry on with
+whatever did load. `armadai link` is different: because it writes files other tools then trust, it
+refuses to write **anything** when the collision falls inside what you asked it to link (the whole
+fleet by default, or the names passed to `--agents`) — a command that writes config must not
+silently ship a smaller fleet than the one you declared.
+
+## Long compositions still get audited
+
+Composing several fragments is easy to do without noticing how long the result got. `armadai
+audit`'s existing rule `A05` (system prompt exceeds a configurable token estimate, default 4000,
+`audit.prompt_token_threshold` in project config) doesn't care where a prompt came from — once a
+declared agent is linked into a native config, `armadai audit` reads that generated file exactly
+like a hand-written one. A four-fragment composition is exactly as likely to trip it as an
+over-written `.md`.
+
+## What's wired, and what isn't
+
+Every command that resolves a project's agent fleet was updated to see declared agents alongside
+file-backed ones — except where noted:
+
+| Surface | Sees declared agents? |
+|---|---|
+| `armadai run <name>` (single agent) | Yes |
+| `armadai run --orchestrate` | Yes |
+| `armadai run --resume` | Yes |
+| `armadai run --pipe` (multi-agent chain) | **No** — the legacy chain loop still resolves purely by file path |
+| `armadai link` | Yes (and refuses to write on an unresolved collision, see above) |
+| `armadai list` | Yes |
+| `armadai inspect` | Yes |
+| `armadai models check` / `armadai models update` | Yes — including the deprecated-model rewrite described above |
+| `armadai unlink` | **No** |
+| TUI dashboard | **No** |
+| Web API | **No** |
+| `armadai shell` | **No** |
+
+The `unlink` gap has a sharp edge worth calling out on its own: `link` can generate native config
+files for a declared agent, but `unlink` has no way to know that agent exists, so it will not clean
+those files up. Removing them is a manual step until `unlink` is updated to match.
+
+Do not assume any of the four "No" rows will discover a declared agent by some other path — they
+were simply not touched by this chantier, and hitting one of them is the way to find out the hard
+way if this table goes unread.
+
+## Parity with the `.md` format — and its limits
+
+A declared agent and its hand-written `.md` twin are proven, by test
+(`crates/armadai/src/linker/mod.rs`), to project **byte-identical native output** on all five link
+targets (claude, codex, copilot, gemini, opencode) — same file paths, same content — and to carry
+identical values for every field the declarative format is able to express. That's a real, tested
+guarantee, covering a plain API agent, a `provider: cli` agent with `command`/`args`, and an agent
+composed from two fragments.
+
+It is narrower than "the two formats are interchangeable," though, in two ways worth knowing before
+you rely on it:
+
+- **The linker doesn't emit every field it merges.** No target's generated file includes
+  `command`, `args`, `tags`, `scope` or `stacks` in its content — the five-target comparison is
+  real, but it cannot fail on a divergence in a field none of the five linkers ever write out. Those
+  fields are checked separately, at the `Agent`/`AgentMetadata` level, by a second test — necessary
+  precisely because the projection check can't see them.
+- **Seven `AgentMetadata` fields have no declarative equivalent at all**: `cost_limit`,
+  `rate_limit`, `context_window`, `mode`, `orchestration`, `triggers`, `ring_config`. A declared
+  agent always resolves these to `None`/default, whatever it says — there is no key for them in the
+  format. The parity test's assertions on these seven are true by construction, not by
+  demonstration: both sides are always `None`, so they can never fail while the format stays as it
+  is. If your `.md` agent uses any of these seven, declaring it means losing that capability, not
+  preserving it under a different spelling.
+
+So: identical projection, for what both formats can actually say. Not identical expressiveness.
+
+## See also
+
+[Agent format](agent-format.md) documents the `.md` side — required sections, the full metadata
+table, provider types. Anything not covered here (Instructions, Output Format, Pipeline, Triggers,
+Ring Config) is `.md`-only for now; a declared agent has no way to set any of them.

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -92,11 +92,14 @@ prompt:
 ```
 
 Each fragment body goes through the same `{{var}}` substitution `armadai new` uses
-(`core/template.rs`), then the rendered fragments are joined with a blank line, in the order
-declared. Every fragment body is trimmed first, so a fragment file's own trailing newline doesn't
-pile up into two or three blank lines at the join. Two variables are always available implicitly:
-`name` (the agent's own name) and `description` (the agent's own `description:`, when it declares
-one) — a step's own variables win if it supplies the same name.
+(`crates/armadai-core/src/template.rs`), then the rendered fragments are joined with a blank line,
+in the order declared. Every fragment body is trimmed first, so a fragment file's own trailing
+newline doesn't pile up into two or three blank lines at the join. Two variables are always
+available implicitly: `name` (the agent's own name) and `description` (the agent's own
+`description:`, when it declares one) — a step's own variables win if it supplies the same name.
+`{{ name }}` (inner whitespace, either side or both) is the same placeholder as `{{name}}` — the
+missing-value check and the substitution agree on that by construction, so a spaced placeholder is
+never left in the rendered prompt unsubstituted.
 
 ## Failure is the default, not degradation
 
@@ -189,18 +192,15 @@ file-backed ones — except where noted:
 | `armadai list` | Yes |
 | `armadai inspect` | Yes |
 | `armadai models check` / `armadai models update` | Yes — including the deprecated-model rewrite described above |
-| `armadai unlink` | **No** |
+| `armadai unlink` | Yes |
+| `armadai validate` | Yes — a declared agent named as an `orchestration.coordinator`/`teams[].lead`/`teams[].agents` entry resolves, even when never relisted in `armadai.yaml`'s `agents:` |
 | TUI dashboard | **No** |
 | Web API | **No** |
 | `armadai shell` | **No** |
 
-The `unlink` gap has a sharp edge worth calling out on its own: `link` can generate native config
-files for a declared agent, but `unlink` has no way to know that agent exists, so it will not clean
-those files up. Removing them is a manual step until `unlink` is updated to match.
-
-Do not assume any of the four "No" rows will discover a declared agent by some other path — they
-were simply not touched by this chantier, and hitting one of them is the way to find out the hard
-way if this table goes unread.
+Do not assume any of the three remaining "No" rows will discover a declared agent by some other
+path — they were simply not touched by this chantier, and hitting one of them is the way to find
+out the hard way if this table goes unread.
 
 ## Parity with the `.md` format — and its limits
 

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -148,11 +148,22 @@ in disguise.
 
 The blast radius is scoped, though: a collision costs only the colliding declaration, never the
 rest of the fleet — every other declared agent, and the colliding `.md` file itself, still load
-fine elsewhere. `armadai list` and `armadai inspect` (read-only) print a warning and carry on with
-whatever did load. `armadai link` is different: because it writes files other tools then trust, it
-refuses to write **anything** when the collision falls inside what you asked it to link (the whole
-fleet by default, or the names passed to `--agents`) — a command that writes config must not
-silently ship a smaller fleet than the one you declared.
+fine elsewhere. But the three commands that can hit one don't all react the same way:
+
+- `armadai list` is read-only over the whole fleet: it prints a warning for the colliding name and
+  carries on, showing every other agent that did load.
+- `armadai run <name>` and `armadai inspect <name>` are about one specific agent, and refuse to
+  guess which side of a collision you meant: naming a colliding agent **hard-fails** (exit 1),
+  naming both `agents.yaml` and the colliding `.md` file. A command that is about to execute or
+  describe one agent must not silently pick a winner between a declaration and a file.
+- Because that check is scoped to just the one name you asked for, `armadai inspect
+  <some-other-name>` says **nothing** about an unrelated collision sitting elsewhere in the fleet —
+  it doesn't scan the whole project the way `list` does. Don't rely on `inspect` to surface
+  collisions in general; only `armadai list` (or `armadai link`) looks at the whole fleet at once.
+- `armadai link` is different again: because it writes files other tools then trust, it refuses to
+  write **anything** when the collision falls inside what you asked it to link (the whole fleet by
+  default, or the names passed to `--agents`) — a command that writes config must not silently ship
+  a smaller fleet than the one you declared.
 
 ## Long compositions still get audited
 
@@ -221,5 +232,6 @@ So: identical projection, for what both formats can actually say. Not identical 
 ## See also
 
 [Agent format](agent-format.md) documents the `.md` side — required sections, the full metadata
-table, provider types. Anything not covered here (Instructions, Output Format, Pipeline, Triggers,
-Ring Config) is `.md`-only for now; a declared agent has no way to set any of them.
+table, provider types. Anything not covered here (Instructions, Output Format, Pipeline, Context,
+Triggers, Ring Config) is `.md`-only for now; a declared agent has no way to set any of them —
+`to_agent()` always resolves `context` to `None`, exactly like the other five.


### PR DESCRIPTION
## What this does

Agents can be declared in `.armadai/agents.yaml` instead of being written as Markdown files: metadata inherited from a shared `defaults` block, system prompt composed from named prompt fragments with `{{var}}` substitution, producing an `Agent` in memory with **no intermediate `.md` written to disk**.

```yaml
defaults:
  provider: claude
  model: latest:pro
  temperature: 0.3

agents:
  - name: core-specialist
    description: Core domain and orchestration engine
    scope: [src/core/**, src/parser/**]
    prompt:
      - specialist-base
      - { armadai-architecture: { module: core } }
```

The 77 existing `.md` agents keep working unchanged. **YAML is an additional input, never a replacement**, and a test asserts a declared agent and its hand-written `.md` twin produce byte-identical projections across all five link targets.

Wired into `link`, `list`, `run`, `inspect`, `validate` and `models update`.

## What it does NOT buy — measured, not assumed

- **No token saving.** A composed prompt is the same prompt; the model sees identical bytes.
- **No reduced context saturation.** Same reason.
- **No guaranteed improvement in agent quality.** Composition removes duplication in the *source*, not in what the model reads.

The gain is one place to change a shared instruction instead of N, and a fleet whose shape is inspectable. If you adopt this expecting a lighter context, you will be disappointed — better here than at runtime.

## Design decisions worth knowing

- **Composition fails hard.** A missing fragment or an unsubstituted `{{var}}` is an error naming both the agent and the fragment. An agent shipped with amputated instructions does not complain — it fills the gaps itself and hallucinates. Same reason a missing `description` refuses rather than substituting an empty string (a step can supply one as an escape hatch).
- **Lists are replaced, never merged.** `tags: [own]` means exactly that; `tags: []` means empty, not inherited. Less expressive, but a specialist that declares a `scope` has exactly that scope.
- **A name that is both declared and a library `.md` is refused, with no precedence either way.** A silent "local wins" would recreate the duplicated truth this format removes: you would edit a `.md`, see no effect, and have nothing to tell you why. The check covers all three library directories, **including `~/.config/armadai/agents/`** — worth knowing if you have a large personal library.
- **Only the colliding declaration is dropped, but `link` then refuses to write.** A command that writes config must not ship a smaller fleet than the one declared. `list`, being read-only, warns and continues.
- **Deprecated models are fixed in `agents.yaml` too**, per occurrence, by textual rewrite so comments and key order survive. Two forms are deliberately unsupported and **fail loudly rather than half-fixing**: a quoted `"model":` key, and any case where the structured detection and the textual rewrite disagree. The tool refuses rather than guesses.

## Limits and follow-ups

Not wired, and documented as such: `run --pipe`, the TUI, the Web API, and `armadai shell`. Two follow-ups worth filing:

- **TUI and Web API fail by silent substitution, not omission.** Measured: `armadai list` shows the declared agents while `/api/agents` returns the same-named agent from the global library — two surfaces, two different fleets.
- **`armadai shell` cannot see declared agents at all** (needs a capability change, not a message fix).

There is no `.md` → YAML converter; migration is manual by design.

## Verification

- `cargo fmt --all -- --check` clean
- clippy clean with `-D warnings` in all 4 CI modes (`tui`; `tui,providers-api`; `tui,web,storage`; `tui,storage,e2e-fake`)
- both test modes pass, 0 failures; gaveldrop 13 cases / 13 passed / score 83/83
- reachability confirmed on a real throwaway project: a declarations-only fleet appears in `link --dry-run`, `list`, `inspect`, and runs end to end

Spec: `docs/superpowers/specs/2026-08-20-declarative-agents-design.md` · Plan: `docs/superpowers/plans/2026-08-20-declarative-agents.md` · Docs: `docs/wiki/declarative-agents.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
