### PR TITLE
fix(cli): unlink ne supprime plus que ce dont le contenu correspond

### DIFF
--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -1,7 +1,45 @@
 use std::path::{Path, PathBuf};
 
+use crate::linker::model_resolution::{self, TargetKind};
 use crate::linker::{self, LinkAgent};
 use armadai_core::project;
+
+/// A file `unlink` might remove, together with what removing it safely
+/// requires.
+///
+/// `unlink` keeps no manifest of what `link` actually wrote (issue #338) —
+/// it only knows how to recompute what `link` *would* write today. So for
+/// anything the linker itself produces (agent/coordinator instruction
+/// files, skill copies, prompt copies), the only safe rule is: **delete a
+/// file only if its on-disk content is byte-for-byte identical to what
+/// would be generated right now.** A hand-written file at a would-be
+/// generated path never matches and is always kept; a file the linker
+/// really did write and that hasn't been touched since always matches and
+/// is reclaimed.
+///
+/// Accepted limitation, stated here and echoed in the CLI output: a file
+/// that genuinely was generated and then *edited* no longer matches either,
+/// so it is kept too — it becomes a visible orphan instead of a silent
+/// deletion. An orphan can be spotted and removed by hand; content deleted
+/// by mistake cannot be un-deleted. The write manifest (the other half of
+/// #338) will make this exact and remove the limitation.
+///
+/// `AlwaysDelete` covers the single opt-in case that isn't linker output at
+/// all: the project config file removed via `--with-config`. There is
+/// nothing generated to diff it against — the flag is the user's own
+/// confirmation, so no content guard applies.
+enum Candidate {
+    Generated { path: PathBuf, expected: Vec<u8> },
+    AlwaysDelete { path: PathBuf },
+}
+
+impl Candidate {
+    fn path(&self) -> &Path {
+        match self {
+            Candidate::Generated { path, .. } | Candidate::AlwaysDelete { path } => path,
+        }
+    }
+}
 
 pub async fn execute(
     target: Option<crate::linker::LinkTarget>,
@@ -48,6 +86,16 @@ pub async fn execute(
         anyhow::bail!("No agents could be resolved. Check your project config.");
     }
 
+    // 2b. Resolve deprecated model aliases — `link` does this before
+    // generating, so the content guard below must reproduce it too, or
+    // every agent still using a since-renamed model would never match.
+    for agent in &mut link_agents {
+        armadai_core::model_aliases::resolve_model_deprecations(
+            &mut agent.model,
+            &mut agent.model_fallback,
+        );
+    }
+
     // 3. Filter by --agents if provided
     if let Some(ref filter) = agents_filter {
         let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
@@ -60,7 +108,7 @@ pub async fn execute(
     // 3b. Extract coordinator if configured (CLI flag takes priority over config)
     let coordinator_name =
         coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
-    let coordinator = coordinator_name.and_then(|name| {
+    let mut coordinator = coordinator_name.and_then(|name| {
         let idx = link_agents
             .iter()
             .position(|a| a.name.eq_ignore_ascii_case(&name))?;
@@ -78,6 +126,51 @@ pub async fn execute(
             )
         })?;
 
+    // 4b. Model resolution — mirror what `link` computes for this target,
+    // so the regenerated content used by the guard below matches what
+    // `link` actually wrote. For `LlmEditor` targets (claude, gemini,
+    // codex) this is a pure function of the current config, exactly like
+    // `link`'s own step 4b, so it reproduces byte-for-byte. For
+    // `Orchestrator` targets (copilot, opencode), `link` may additionally
+    // honour an explicit `--model` flag or an interactive prompt at link
+    // time — `unlink` takes neither, so it can only reproduce the
+    // no-flag/non-interactive default (`latest:*` resolution per agent). A
+    // link that used an explicit model there produces content `unlink`
+    // cannot recompute; the guard then correctly keeps those files instead
+    // of guessing, same as any other hand-edited file.
+    let target_kind = model_resolution::classify_target(&target_name);
+    match target_kind {
+        TargetKind::LlmEditor { provider } => {
+            #[cfg(feature = "providers-api")]
+            {
+                model_resolution::remap_models_for_llm_editor(&mut link_agents, provider).await;
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_llm_editor(
+                        std::slice::from_mut(coord),
+                        provider,
+                    )
+                    .await;
+                }
+            }
+            #[cfg(not(feature = "providers-api"))]
+            {
+                model_resolution::remap_models_for_llm_editor(&mut link_agents, provider);
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_llm_editor(
+                        std::slice::from_mut(coord),
+                        provider,
+                    );
+                }
+            }
+        }
+        TargetKind::Orchestrator => {
+            model_resolution::resolve_latest_placeholders(&mut link_agents);
+            if let Some(ref mut coord) = coordinator {
+                model_resolution::resolve_latest_placeholders(std::slice::from_mut(coord));
+            }
+        }
+    }
+
     // 5. Create linker
     let linker = linker::create_linker(&target_name)?;
 
@@ -92,8 +185,14 @@ pub async fn execute(
                 .map(PathBuf::from)
         })
         .unwrap_or_else(|| PathBuf::from(linker.default_output_dir()));
+    // The target's own root directory (`.claude/`, `.github/`, ...) —
+    // `remove_empty_ancestors` must never delete this, however empty it
+    // ends up (issue #338 case 1's second half).
+    let target_root = root.join(&output_dir);
 
-    // 7. Generate file list (we only need paths, not content)
+    // 7. Regenerate the expected file list — same content `link` would
+    // write today — so deletions can be gated on a content match instead
+    // of trusting paths alone.
     let sources = &config.sources;
     let files = linker.generate(&link_agents, coordinator.as_ref(), sources);
 
@@ -103,43 +202,68 @@ pub async fn execute(
         return Ok(());
     }
 
-    // 8. Resolve output paths relative to project root
-    let mut targets: Vec<PathBuf> = files
+    // 8. Resolve output paths relative to project root, keeping the
+    // generated content alongside each path for the guard below.
+    let mut candidates: Vec<Candidate> = files
         .into_iter()
         .map(|f| {
             let default_dir = PathBuf::from(linker.default_output_dir());
-            let relative = f.path.strip_prefix(&default_dir).unwrap_or(&f.path);
-            root.join(&output_dir).join(relative)
+            let relative = f
+                .path
+                .strip_prefix(&default_dir)
+                .unwrap_or(&f.path)
+                .to_path_buf();
+            Candidate::Generated {
+                path: root.join(&output_dir).join(relative),
+                expected: f.content.into_bytes(),
+            }
         })
         .collect();
 
-    // 8b. Include skill files in targets
+    // 8b. Include skill files — but only the ones the skill's *source*
+    // directory still names. `link` copies exactly those paths into
+    // `<output_dir>/skills/<name>/`; anything else found there afterwards
+    // (issue #338 case 3 — the worst measured outcome) was placed by the
+    // user and has no source-side counterpart, so it is never even
+    // considered, let alone swept recursively.
     let (skill_dirs, _) = project::resolve_all_skills(&config, &root);
     for skill_dir in &skill_dirs {
         let skill_name = skill_dir
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
-        let dest = root.join(&output_dir).join("skills").join(skill_name);
-        if dest.exists() {
-            collect_files_recursive(&dest, &mut targets);
+        let dest_dir = root.join(&output_dir).join("skills").join(skill_name);
+        if !dest_dir.exists() {
+            continue;
+        }
+        for (relative, expected) in collect_source_files(skill_dir) {
+            candidates.push(Candidate::Generated {
+                path: dest_dir.join(&relative),
+                expected,
+            });
         }
     }
 
-    // 8c. Include prompt files in targets
+    // 8c. Include prompt files, gated the same way: the expected content is
+    // whatever the source prompt file currently holds.
     let (prompt_paths, _) = project::resolve_all_prompts(&config, &root);
     for prompt_path in &prompt_paths {
         let filename = prompt_path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown.md");
-        let dest = root.join(&output_dir).join("prompts").join(filename);
-        if dest.exists() {
-            targets.push(dest);
+        if let Ok(expected) = std::fs::read(prompt_path) {
+            candidates.push(Candidate::Generated {
+                path: root.join(&output_dir).join("prompts").join(filename),
+                expected,
+            });
         }
     }
 
-    // 9. Optionally include the project config file itself
+    // 9. Optionally include the project config file itself. This is the
+    // user's own config, not something the linker generates, so there is
+    // nothing to diff it against — `--with-config` is opt-in and is itself
+    // the confirmation.
     if with_config {
         // Detect which config file is active
         let dotarmadai_config = root.join(".armadai").join("config.yaml");
@@ -147,11 +271,13 @@ pub async fn execute(
         let legacy_yml = root.join("armadai.yml");
 
         if dotarmadai_config.exists() {
-            targets.push(dotarmadai_config);
+            candidates.push(Candidate::AlwaysDelete {
+                path: dotarmadai_config,
+            });
         } else if legacy_yaml.exists() {
-            targets.push(legacy_yaml);
+            candidates.push(Candidate::AlwaysDelete { path: legacy_yaml });
         } else if legacy_yml.exists() {
-            targets.push(legacy_yml);
+            candidates.push(Candidate::AlwaysDelete { path: legacy_yml });
         }
     }
 
@@ -160,47 +286,114 @@ pub async fn execute(
         let h = crate::cli::style::header();
         let a = crate::cli::style::accent();
         let m = crate::cli::style::muted();
+        let w = crate::cli::style::warn();
         anstream::println!(
             "{h}Dry run{h:#} — files that would be removed for {a}'{}'{a:#}:\n",
             target_name
         );
-        let mut existing = 0;
-        for path in &targets {
-            if path.exists() {
-                anstream::println!("{m}  {}{m:#}", path.display());
-                existing += 1;
-            } else {
+        let mut would_remove = 0;
+        let mut would_keep = 0;
+        let mut absent = 0;
+        for candidate in &candidates {
+            let path = candidate.path();
+            if !path.exists() {
                 anstream::println!("{m}  {} (already absent){m:#}", path.display());
+                absent += 1;
+                continue;
+            }
+            match candidate {
+                Candidate::AlwaysDelete { .. } => {
+                    anstream::println!("{m}  {}{m:#}", path.display());
+                    would_remove += 1;
+                }
+                Candidate::Generated { expected, .. } => {
+                    if content_matches(path, expected) {
+                        anstream::println!("{m}  {}{m:#}", path.display());
+                        would_remove += 1;
+                    } else {
+                        anstream::println!(
+                            "{w}  {} (would keep — content differs from what \
+                             link would generate){w:#}",
+                            path.display()
+                        );
+                        would_keep += 1;
+                    }
+                }
             }
         }
         anstream::println!(
-            "\n{m}  {} existing, {} already absent.{m:#}",
-            existing,
-            targets.len() - existing
+            "\n{m}  {} would be removed, {} would be kept (content differs), \
+             {} already absent.{m:#}",
+            would_remove,
+            would_keep,
+            absent
         );
+        if would_keep > 0 {
+            anstream::println!(
+                "{m}  Kept files look hand-written or edited since linking; unlink never \
+                 touches them. Remove them by hand if you no longer want them.{m:#}"
+            );
+        }
         return Ok(());
     }
 
-    // 11. Delete existing files
+    // 11. Delete existing files whose content still matches what the linker
+    // would generate today.
     let mut deleted = 0;
+    let mut kept = 0;
     let mut absent = 0;
+    let mut deleted_generated: Vec<PathBuf> = Vec::new();
+    let mut deleted_config: Vec<PathBuf> = Vec::new();
 
-    for path in &targets {
-        if path.exists() {
-            std::fs::remove_file(path)?;
-            let m = crate::cli::style::muted();
-            anstream::println!("{m}  deleted {}{m:#}", path.display());
-            deleted += 1;
-        } else {
+    for candidate in &candidates {
+        let path = candidate.path();
+        if !path.exists() {
             absent += 1;
+            continue;
+        }
+
+        match candidate {
+            Candidate::AlwaysDelete { .. } => {
+                std::fs::remove_file(path)?;
+                let m = crate::cli::style::muted();
+                anstream::println!("{m}  deleted {}{m:#}", path.display());
+                deleted += 1;
+                deleted_config.push(path.to_path_buf());
+            }
+            Candidate::Generated { expected, .. } => {
+                if content_matches(path, expected) {
+                    std::fs::remove_file(path)?;
+                    let m = crate::cli::style::muted();
+                    anstream::println!("{m}  deleted {}{m:#}", path.display());
+                    deleted += 1;
+                    deleted_generated.push(path.to_path_buf());
+                } else {
+                    let w = crate::cli::style::warn();
+                    anstream::println!(
+                        "{w}  kept {} (content differs from what link would generate — \
+                         looks hand-written or edited){w:#}",
+                        path.display()
+                    );
+                    kept += 1;
+                }
+            }
         }
     }
 
-    // 12. Clean up empty ancestor directories
-    let stop_at = &root;
-    for path in &targets {
+    // 12. Clean up empty ancestor directories left behind — bounded so the
+    // cascade can never remove the target's own root directory (issue
+    // #338 case 1's second half). Linker-generated paths are bounded by
+    // `target_root` (e.g. `.claude/`); the project config file (if
+    // removed) is bounded by the project root instead, since it lives
+    // outside the target's tree entirely.
+    for path in &deleted_generated {
         if let Some(parent) = path.parent() {
-            remove_empty_ancestors(parent, stop_at);
+            remove_empty_ancestors(parent, &target_root);
+        }
+    }
+    for path in &deleted_config {
+        if let Some(parent) = path.parent() {
+            remove_empty_ancestors(parent, &root);
         }
     }
 
@@ -208,32 +401,75 @@ pub async fn execute(
     let a = crate::cli::style::accent();
     let m = crate::cli::style::muted();
     anstream::println!(
-        "\n{o}Unlinked{o:#} {a}'{}'{a:#}: {m}{} deleted, {} already absent.{m:#}",
+        "\n{o}Unlinked{o:#} {a}'{}'{a:#}: {m}{} deleted, {} kept (content differs), \
+         {} already absent.{m:#}",
         target_name,
         deleted,
+        kept,
         absent
     );
+    if kept > 0 {
+        anstream::println!(
+            "{m}  Kept files look hand-written or edited since linking; unlink never touches \
+             them. Remove them by hand if you no longer want them.{m:#}"
+        );
+    }
 
     Ok(())
 }
 
-/// Recursively collect all file paths under a directory.
-fn collect_files_recursive(dir: &Path, targets: &mut Vec<PathBuf>) {
-    let entries = match std::fs::read_dir(dir) {
+/// Whether `path`'s on-disk bytes are identical to `expected`. Exact byte
+/// comparison on purpose — no whitespace or line-ending normalisation. A
+/// read failure (permissions, race with an external delete, ...) is treated
+/// as "does not match": erring toward keeping a file is the whole point of
+/// this guard.
+fn content_matches(path: &Path, expected: &[u8]) -> bool {
+    std::fs::read(path)
+        .map(|actual| actual == expected)
+        .unwrap_or(false)
+}
+
+/// Collect every file under a skill's *source* directory, keyed by its path
+/// relative to that directory, together with its raw bytes. This mirrors
+/// exactly what `link` copies into `<output_dir>/skills/<name>/` (see
+/// `cli::link::collect_dir_files`), so the relative paths returned here —
+/// and only those — are eligible for `unlink` to reclaim. A file in the
+/// destination whose relative path isn't in this list was placed there by
+/// the user after linking and must never be touched.
+fn collect_source_files(dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut files = Vec::new();
+    collect_source_files_recursive(dir, dir, &mut files);
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
+}
+
+fn collect_source_files_recursive(
+    base: &Path,
+    current: &Path,
+    files: &mut Vec<(PathBuf, Vec<u8>)>,
+) {
+    let entries = match std::fs::read_dir(current) {
         Ok(e) => e,
         Err(_) => return,
     };
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            collect_files_recursive(&path, targets);
-        } else if path.is_file() {
-            targets.push(path);
+            collect_source_files_recursive(base, &path, files);
+        } else if path.is_file()
+            && let Ok(content) = std::fs::read(&path)
+        {
+            let relative = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
+            files.push((relative, content));
         }
     }
 }
 
-/// Walk up from `path` removing empty directories, stopping at `stop_at` (exclusive).
+/// Walk up from `path` removing empty directories, stopping at `stop_at`
+/// (exclusive: `stop_at` itself is never removed, no matter how empty it
+/// is). Callers pass the boundary that must survive — the target's root
+/// directory for linker-generated paths, the project root for the config
+/// file — so this function has no target-specific knowledge of its own.
 fn remove_empty_ancestors(path: &Path, stop_at: &Path) {
     let mut current = path.to_path_buf();
     while current.starts_with(stop_at) && current != stop_at {

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -319,10 +319,7 @@ pub async fn execute(
                         would_remove += 1;
                     } else {
                         anstream::println!(
-                            "{w}  {} (would keep — content differs from what link \
-                             would generate now; possibly edited since linking, or \
-                             linked with different options such as --model or an \
-                             interactive prompt answer){w:#}",
+                            "{w}  {} (would keep — content differs){w:#}",
                             path.display()
                         );
                         would_keep += 1;
@@ -380,12 +377,7 @@ pub async fn execute(
                     deleted_generated.push(path.to_path_buf());
                 } else {
                     let w = crate::cli::style::warn();
-                    anstream::println!(
-                        "{w}  kept {} (content differs from what link would generate \
-                         now; possibly edited since linking, or linked with different \
-                         options such as --model or an interactive prompt answer){w:#}",
-                        path.display()
-                    );
+                    anstream::println!("{w}  kept {} (content differs){w:#}", path.display());
                     kept += 1;
                 }
             }

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -17,12 +17,17 @@ use armadai_core::project;
 /// really did write and that hasn't been touched since always matches and
 /// is reclaimed.
 ///
-/// Accepted limitation, stated here and echoed in the CLI output: a file
-/// that genuinely was generated and then *edited* no longer matches either,
-/// so it is kept too — it becomes a visible orphan instead of a silent
-/// deletion. An orphan can be spotted and removed by hand; content deleted
-/// by mistake cannot be un-deleted. The write manifest (the other half of
-/// #338) will make this exact and remove the limitation.
+/// Accepted limitation, stated here and echoed in the CLI output: content
+/// can differ from what `link` would generate right now for two reasons
+/// `unlink` has no way to distinguish — the file was edited since linking,
+/// or it was linked with different options (an explicit `--model`, or an
+/// interactive prompt answer). Either way the file is kept, becoming a
+/// visible orphan instead of a silent deletion. An orphan can be spotted
+/// and removed by hand; content deleted by mistake cannot be un-deleted.
+/// On `opencode` (an `Orchestrator` target below) in particular, `--model`
+/// or an interactive answer at link time makes the generated file
+/// permanently un-reclaimable by `unlink` until the write manifest (the
+/// other half of #338) lands and makes detection exact.
 ///
 /// `AlwaysDelete` covers the single opt-in case that isn't linker output at
 /// all: the project config file removed via `--with-config`. There is
@@ -136,8 +141,10 @@ pub async fn execute(
     // time — `unlink` takes neither, so it can only reproduce the
     // no-flag/non-interactive default (`latest:*` resolution per agent). A
     // link that used an explicit model there produces content `unlink`
-    // cannot recompute; the guard then correctly keeps those files instead
-    // of guessing, same as any other hand-edited file.
+    // cannot recompute; the guard then correctly keeps those files rather
+    // than guessing why they differ. On `opencode` specifically, this makes
+    // a `--model`-linked (or interactively-answered) file permanently
+    // un-reclaimable by `unlink` until the write manifest lands.
     let target_kind = model_resolution::classify_target(&target_name);
     match target_kind {
         TargetKind::LlmEditor { provider } => {
@@ -312,8 +319,10 @@ pub async fn execute(
                         would_remove += 1;
                     } else {
                         anstream::println!(
-                            "{w}  {} (would keep — content differs from what \
-                             link would generate){w:#}",
+                            "{w}  {} (would keep — content differs from what link \
+                             would generate now; possibly edited since linking, or \
+                             linked with different options such as --model or an \
+                             interactive prompt answer){w:#}",
                             path.display()
                         );
                         would_keep += 1;
@@ -330,8 +339,10 @@ pub async fn execute(
         );
         if would_keep > 0 {
             anstream::println!(
-                "{m}  Kept files look hand-written or edited since linking; unlink never \
-                 touches them. Remove them by hand if you no longer want them.{m:#}"
+                "{m}  Kept files differ from what link would generate now — possibly \
+                 edited since linking, or linked with different options (e.g. \
+                 --model, or an interactive prompt answer); unlink cannot tell \
+                 which. Remove them by hand if you no longer want them.{m:#}"
             );
         }
         return Ok(());
@@ -370,8 +381,9 @@ pub async fn execute(
                 } else {
                     let w = crate::cli::style::warn();
                     anstream::println!(
-                        "{w}  kept {} (content differs from what link would generate — \
-                         looks hand-written or edited){w:#}",
+                        "{w}  kept {} (content differs from what link would generate \
+                         now; possibly edited since linking, or linked with different \
+                         options such as --model or an interactive prompt answer){w:#}",
                         path.display()
                     );
                     kept += 1;
@@ -410,8 +422,10 @@ pub async fn execute(
     );
     if kept > 0 {
         anstream::println!(
-            "{m}  Kept files look hand-written or edited since linking; unlink never touches \
-             them. Remove them by hand if you no longer want them.{m:#}"
+            "{m}  Kept files differ from what link would generate now — possibly edited \
+             since linking, or linked with different options (e.g. --model, or an \
+             interactive prompt answer); unlink cannot tell which. Remove them by hand \
+             if you no longer want them.{m:#}"
         );
     }
 
@@ -430,12 +444,16 @@ fn content_matches(path: &Path, expected: &[u8]) -> bool {
 }
 
 /// Collect every file under a skill's *source* directory, keyed by its path
-/// relative to that directory, together with its raw bytes. This mirrors
+/// relative to that directory, together with its bytes. This mirrors
 /// exactly what `link` copies into `<output_dir>/skills/<name>/` (see
-/// `cli::link::collect_dir_files`), so the relative paths returned here —
-/// and only those — are eligible for `unlink` to reclaim. A file in the
-/// destination whose relative path isn't in this list was placed there by
-/// the user after linking and must never be touched.
+/// `cli::link::collect_dir_files`) — including its valid-UTF-8-only gate: a
+/// binary asset (e.g. `logo.png`) that `link` silently skips must be
+/// skipped here too, or it would surface as a destination candidate that
+/// was never actually written, inflating the "already absent" count with a
+/// path that was never a real deletion candidate. The relative paths
+/// returned here — and only those — are eligible for `unlink` to reclaim. A
+/// file in the destination whose relative path isn't in this list was
+/// placed there by the user after linking and must never be touched.
 fn collect_source_files(dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
     let mut files = Vec::new();
     collect_source_files_recursive(dir, dir, &mut files);
@@ -457,10 +475,10 @@ fn collect_source_files_recursive(
         if path.is_dir() {
             collect_source_files_recursive(base, &path, files);
         } else if path.is_file()
-            && let Ok(content) = std::fs::read(&path)
+            && let Ok(content) = std::fs::read_to_string(&path)
         {
             let relative = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
-            files.push((relative, content));
+            files.push((relative, content.into_bytes()));
         }
     }
 }

--- a/crates/armadai/tests/unlink_content_guard.rs
+++ b/crates/armadai/tests/unlink_content_guard.rs
@@ -294,4 +294,77 @@ mod tests {
              even when it ends up empty"
         );
     }
+
+    /// A project using `.armadai/config.yaml` (the current format) with a
+    /// declared agent, a prompt fragment it composes from, and the
+    /// declarations file itself — three siblings under `.armadai/` besides
+    /// the config file, none of which `--with-config` should ever touch.
+    fn project_declared_with_extra_dotarmadai_files() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai/prompts")).unwrap();
+        std::fs::write(
+            root.join(".armadai/config.yaml"),
+            "link:\n  target: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  - name: solo\n    prompt: [base]\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".armadai/prompts/base.md"), "You are {{name}}.\n").unwrap();
+        dir
+    }
+
+    /// F5: `--with-config` is the one deletion path left intentionally
+    /// unguarded — there is nothing generated to diff the project's own
+    /// config file against, so the flag itself is the confirmation. That
+    /// makes it the one place a careless edit (e.g. widening `with_config`
+    /// into removing the whole `.armadai/` directory, or all three
+    /// candidate config paths instead of only the active one) would cause
+    /// real damage with no content guard to catch it. Pin the exact blast
+    /// radius: the active config file, and nothing else under `.armadai/`.
+    #[test]
+    fn unlink_with_config_removes_exactly_the_active_config_file() {
+        let dir = project_declared_with_extra_dotarmadai_files();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let config_file = root.join(".armadai/config.yaml");
+        let agents_decl = root.join(".armadai/agents.yaml");
+        let prompt_fragment = root.join(".armadai/prompts/base.md");
+        assert!(config_file.is_file(), "sanity: config file must exist");
+        assert!(agents_decl.is_file(), "sanity: declarations must exist");
+        assert!(
+            prompt_fragment.is_file(),
+            "sanity: prompt fragment must exist"
+        );
+
+        let (unlink_ok, _, unlink_stderr) = run_armadai(
+            &root,
+            &config,
+            &["unlink", "--target", "claude", "--with-config"],
+        );
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+
+        assert!(
+            !config_file.exists(),
+            "--with-config must remove the active project config file"
+        );
+        assert!(
+            agents_decl.exists(),
+            "--with-config must not remove sibling .armadai/ files — its blast \
+             radius must stay pinned to exactly the config file, since nothing \
+             guards it"
+        );
+        assert!(
+            prompt_fragment.exists(),
+            "--with-config must not remove sibling .armadai/ files"
+        );
+    }
 }

--- a/crates/armadai/tests/unlink_content_guard.rs
+++ b/crates/armadai/tests/unlink_content_guard.rs
@@ -1,0 +1,297 @@
+//! Black-box regressions for issue #338's mitigation half: `unlink` deleted
+//! files `link` never wrote — including user content unrelated to armadai.
+//! Spawns the real binary (like `link_list_gate.rs`) since the guard lives
+//! end to end in `cli::unlink::execute`.
+//!
+//! Each test below reproduces one of the four cases confirmed by the
+//! project's spike (see issue #338 body + its approved-design comment) and
+//! is written to FAIL against the pre-fix `unlink` (unconditional
+//! `remove_file` on every path `linker.generate()` still names today, plus
+//! an unbounded `remove_empty_ancestors` sweep). After the content-match
+//! guard + source-scoped skill sweep + bounded cascade land, all three pass.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+
+    /// Isolated `ARMADAI_CONFIG_DIR` per project — see `link_list_gate.rs`
+    /// for why this matters (a real global agent library on this machine
+    /// would otherwise leak into the shadowing check and the project
+    /// registry write would hit the developer's real `~/.config/armadai/`).
+    fn isolated_config(dir: &std::path::Path) -> std::path::PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(&config).unwrap();
+        config
+    }
+
+    fn run_armadai(
+        root: &std::path::Path,
+        config: &std::path::Path,
+        args: &[&str],
+    ) -> (bool, String, String) {
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(root)
+            .env("ARMADAI_CONFIG_DIR", config)
+            .args(args);
+        let output = cmd.output().unwrap();
+        (
+            output.status.success(),
+            String::from_utf8_lossy(&output.stdout).into_owned(),
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        )
+    }
+
+    /// A project with a coordinator ("coord") plus one regular member
+    /// ("member"), targeting `claude` — the shape needed to make `link`
+    /// generate `.claude/CLAUDE.md` (only emitted when a coordinator is
+    /// configured, per `linker::claude::generate_claude_md`) alongside a
+    /// plain per-agent file (`.claude/agents/member.md`).
+    fn project_with_coordinator() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let agents = root.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: coord\n  - name: member\nlink:\n  target: claude\n  coordinator: coord\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("coord.md"),
+            "# coord\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou coordinate.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("member.md"),
+            "# member\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work.\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// Case 1 (issue #338): a hand-written `.claude/CLAUDE.md` predates
+    /// `link` (which skips it, having no `--force`) and must survive
+    /// `unlink` untouched — while the file `link` actually wrote
+    /// (`.claude/agents/member.md`) must still be reclaimed. Both
+    /// assertions live in one test on purpose: a fix that simply stops
+    /// deleting everything would pass the first half and fail the second;
+    /// today's code fails the first half by deleting real user content.
+    #[test]
+    fn unlink_keeps_a_hand_written_file_but_removes_what_it_generated() {
+        let dir = project_with_coordinator();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        // Pre-existing, hand-written — NOT what `generate_claude_md` would
+        // produce for this roster.
+        let claude_md_dir = root.join(".claude");
+        std::fs::create_dir_all(&claude_md_dir).unwrap();
+        let hand_written = "# My own notes\n\nDo not touch this file, it is mine.\n";
+        std::fs::write(claude_md_dir.join("CLAUDE.md"), hand_written).unwrap();
+
+        let (link_ok, link_stdout, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(
+            link_ok,
+            "link must succeed even though CLAUDE.md pre-exists: stdout={link_stdout} stderr={link_stderr}"
+        );
+        assert!(
+            link_stderr.contains("CLAUDE.md"),
+            "link must have skipped (not overwritten) the pre-existing file: {link_stderr}"
+        );
+        // Sanity: link left the hand-written content untouched.
+        assert_eq!(
+            std::fs::read_to_string(claude_md_dir.join("CLAUDE.md")).unwrap(),
+            hand_written
+        );
+        let member_file = root.join(".claude/agents/member.md");
+        assert!(
+            member_file.is_file(),
+            "link must have generated the member's file: {}",
+            member_file.display()
+        );
+
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            unlink_ok,
+            "unlink must succeed: stdout={unlink_stdout} stderr={unlink_stderr}"
+        );
+
+        // The core assertion: the hand-written file survives, byte for byte.
+        let claude_md_path = claude_md_dir.join("CLAUDE.md");
+        assert!(
+            claude_md_path.exists(),
+            "a hand-written CLAUDE.md must never be deleted by unlink"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&claude_md_path).unwrap(),
+            hand_written,
+            "the surviving file's content must be exactly what the user wrote"
+        );
+        // The user must be told why it was kept.
+        assert!(
+            unlink_stdout.contains("CLAUDE.md") || unlink_stderr.contains("CLAUDE.md"),
+            "unlink must report the kept file to the user: stdout={unlink_stdout} stderr={unlink_stderr}"
+        );
+
+        // The control: a genuinely generated, untouched file is still
+        // reclaimed — proves the guard doesn't degrade into "keep
+        // everything".
+        assert!(
+            !member_file.exists(),
+            "a generated, unmodified file must still be deleted by unlink"
+        );
+    }
+
+    /// A project declaring one skill (`.armadai/skills/notes/`) alongside a
+    /// single file-backed agent, targeting `claude`.
+    fn project_with_a_skill() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let agents = root.join("agents");
+        let skill_dir = root.join(".armadai/skills/notes");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: solo\nskills:\n  - name: notes\nlink:\n  target: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("solo.md"),
+            "# solo\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work alone.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: notes\ndescription: take notes\n---\n\nTake notes.\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// Case 3 (issue #338), the worst measured outcome: a file the user
+    /// drops into a linked skill's destination directory after `link` ran
+    /// — with no relation to armadai whatsoever — must survive `unlink`.
+    /// The skill's own copied file must still be reclaimed (control, same
+    /// reasoning as the CLAUDE.md test above).
+    #[test]
+    fn unlink_keeps_user_files_inside_a_linked_skill_directory() {
+        let dir = project_with_a_skill();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, link_stdout, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(
+            link_ok,
+            "link must succeed: stdout={link_stdout} stderr={link_stderr}"
+        );
+
+        let skill_dest = root.join(".claude/skills/notes");
+        let copied_skill_md = skill_dest.join("SKILL.md");
+        assert!(
+            copied_skill_md.is_file(),
+            "link must have copied the skill: {}",
+            copied_skill_md.display()
+        );
+
+        // The user drops an unrelated file into the linked skill directory
+        // AFTER linking — e.g. their own scratch notes sitting right next
+        // to the copied SKILL.md.
+        let user_file = skill_dest.join("my-own-scratchpad.txt");
+        let user_content = "totally unrelated to armadai\n";
+        std::fs::write(&user_file, user_content).unwrap();
+
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            unlink_ok,
+            "unlink must succeed: stdout={unlink_stdout} stderr={unlink_stderr}"
+        );
+
+        assert!(
+            user_file.exists(),
+            "a user file with no source-side counterpart must survive unlink"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&user_file).unwrap(),
+            user_content,
+            "the surviving file's content must be untouched"
+        );
+
+        // Control: the skill file `link` actually copied, unmodified since,
+        // must still be reclaimed.
+        assert!(
+            !copied_skill_md.exists(),
+            "the skill file link copied verbatim must still be deleted by unlink"
+        );
+    }
+
+    /// A minimal project: one file-backed agent, no coordinator, targeting
+    /// `claude` — `link` writes exactly one file, `.claude/agents/solo.md`.
+    fn project_minimal() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let agents = root.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: solo\nlink:\n  target: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("solo.md"),
+            "# solo\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work alone.\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// Case 1's second half (issue #338): once every generated file under
+    /// `.claude/` is legitimately reclaimed, the now-empty ancestor
+    /// directories get cleaned up — but the cascade must stop at the
+    /// target's own root directory. `.claude/` itself must never be
+    /// removed, even though nothing armadai-related is left inside it.
+    #[test]
+    fn unlink_never_removes_the_target_root_directory() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let claude_dir = root.join(".claude");
+        assert!(
+            claude_dir.is_dir(),
+            "link must have created .claude/: {}",
+            claude_dir.display()
+        );
+        let agent_file = claude_dir.join("agents/solo.md");
+        assert!(
+            agent_file.is_file(),
+            "link must have written the agent file"
+        );
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+
+        assert!(
+            !agent_file.exists(),
+            "the generated agent file must be reclaimed"
+        );
+        assert!(
+            !claude_dir.join("agents").exists(),
+            "the now-empty agents/ subdirectory must be cleaned up"
+        );
+        assert!(
+            claude_dir.is_dir(),
+            "the target root directory .claude/ must never be removed by unlink, \
+             even when it ends up empty"
+        );
+    }
+}


### PR DESCRIPTION
Ferme la moitié « mitigation » de #338. La moitié « manifeste » reste ouverte — voir plus bas.

## Le problème

`armadai unlink` supprimait des fichiers qu'`armadai link` n'a jamais écrits, y compris du contenu utilisateur sans rapport avec ArmadAI. Les quatre cas ont été **confirmés par exécution** du binaire réel sur des dépôts jetables, pas déduits du code.

L'asymétrie était la cause : `link` refuse de toucher un fichier existant (`link.rs:295`), puis `unlink` le supprime sans condition (`unlink.rs:187`) après avoir rejoué `generate()` contre la config courante. Aucun manifeste ne relie les deux.

Le pire cas mesuré : des fichiers déposés à la main dans `.claude/skills/<nom>/`, étrangers à ArmadAI, supprimés en silence — puis le répertoire lui-même.

## Le correctif

`unlink` régénérait déjà le contenu attendu et n'en utilisait que les chemins. Il s'en sert maintenant :

**Un fichier n'est supprimé que si son contenu sur disque est identique, octet pour octet, à ce que le linker vient de générer.**

Trois changements dans `cli/unlink.rs` :

1. **Garde par contenu avant chaque suppression.** Un fichier écrit ou édité à la main est conservé et annoncé. Comparaison stricte — aucune normalisation d'espaces ni de fins de ligne : une différence est une différence, et pencher vers « on garde » est tout l'objet du correctif. Un fichier illisible est conservé, jamais supprimé sur une comparaison échouée.
2. **Fin du balayage récursif des skills.** Au lieu de ramasser tout `.claude/skills/<nom>/`, seuls les fichiers présents dans le répertoire **source** de la skill sont candidats. Un fichier en destination mais absent de la source appartient à l'utilisateur.
3. **Cascade bornée.** `remove_empty_ancestors` ne supprime plus le répertoire racine de la cible.

## La limite assumée

Un fichier réellement généré **puis édité** n'est plus supprimé : il devient un orphelin. Compromis délibéré — un orphelin se voit et s'enlève à la main, une donnée perdue ne se récupère pas. Le manifeste rendra la détection exacte et fera disparaître cette limite.

Cas particulier documenté : sur la cible `opencode`, `link` estampille `model:` en honorant `--model` ou l'invite interactive. `unlink` ne peut que rejouer la résolution, donc le fichier est conservé. **Tout usage interactif rencontre ce cas** — c'est pourquoi le message ne prétend pas connaître la cause.

## Sortie utilisateur

```
  deleted <projet>/.claude/agents/member.md
  kept <projet>/.claude/CLAUDE.md (content differs)

Unlinked 'claude': 1 deleted, 1 kept (content differs), 0 already absent.
Kept files differ from what link would generate now — possibly edited since
linking, or linked with different options (e.g. --model, or an interactive
prompt answer); unlink cannot tell which. Remove them by hand if you no
longer want them.
```

L'explication complète apparaît **une fois**, dans le résumé ; la ligne par fichier reste laconique, le chemin étant la seule chose que l'œil cherche sur vingt lignes.

## Vérification

Les quatre cas du spike sont devenus des tests de régression, tous **confirmés rouges sur `74d0d86`** avant le correctif. Une revue indépendante a inventorié les trois sites de suppression du fichier et vérifié que le seul pouvant toucher le répertoire cible passe par la garde ; elle a rejoué les mutations elle-même plutôt que de croire le rapport, et vérifié les deux moitiés du changement sur les skills — ce qui doit être supprimé l'est toujours.

fmt propre · clippy `-D warnings` sur les 4 modes · les deux modes de test verts · gaveldrop 13/13 (83/83)

## Ce qui reste

- **#338 (manifeste)** : produire l'inverse au moment d'écrire. C'est aussi le substrat de la réconciliation incrémentale de #253.
- **#341** : `unlink` apparie le coordinateur par nom seul là où `link` accepte nom ou slug — orphelin silencieux, préexistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
