### PR TITLE
build(deps): bump gaveldrop from v0.1.12 to v0.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,8 +953,8 @@ dependencies = [
 
 [[package]]
 name = "gaveldrop"
-version = "0.1.12"
-source = "git+https://github.com/Dr0drigues/gaveldrop.git?tag=v0.1.12#4962ae0fa4aa8ec863cb66b29c8bf9e839bbf2b3"
+version = "0.1.16"
+source = "git+https://github.com/Dr0drigues/gaveldrop.git?tag=v0.1.16#0032413b5a40ede5ea534bc05d59bc52b4798950"
 dependencies = [
  "anstream",
  "anstyle",
@@ -971,16 +971,16 @@ dependencies = [
 
 [[package]]
 name = "gaveldrop-conformance"
-version = "0.1.12"
-source = "git+https://github.com/Dr0drigues/gaveldrop.git?tag=v0.1.12#4962ae0fa4aa8ec863cb66b29c8bf9e839bbf2b3"
+version = "0.1.16"
+source = "git+https://github.com/Dr0drigues/gaveldrop.git?tag=v0.1.16#0032413b5a40ede5ea534bc05d59bc52b4798950"
 dependencies = [
  "gaveldrop",
 ]
 
 [[package]]
 name = "gaveldrop-fake"
-version = "0.1.12"
-source = "git+https://github.com/Dr0drigues/gaveldrop.git?tag=v0.1.12#4962ae0fa4aa8ec863cb66b29c8bf9e839bbf2b3"
+version = "0.1.16"
+source = "git+https://github.com/Dr0drigues/gaveldrop.git?tag=v0.1.16#0032413b5a40ede5ea534bc05d59bc52b4798950"
 dependencies = [
  "schemars",
  "serde",

--- a/crates/armadai-fake/Cargo.toml
+++ b/crates/armadai-fake/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 engine = ["dep:gaveldrop-fake"]
 
 [dependencies]
-gaveldrop-fake = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.12", optional = true }
+gaveldrop-fake = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.16", optional = true }
 serde = { workspace = true }
 serde_yaml_ng = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/armadai/Cargo.toml
+++ b/crates/armadai/Cargo.toml
@@ -97,7 +97,7 @@ anstream = "1.0.0"
 armadai-core = { path = "../armadai-core", features = ["test-support"] }
 armadai-fake = { path = "../armadai-fake", features = ["engine"] }
 assert_cmd = "2.2.2"
-gaveldrop = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.12" }
-gaveldrop-fake = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.12" }
-gaveldrop-conformance = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.12" }
+gaveldrop = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.16" }
+gaveldrop-fake = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.16" }
+gaveldrop-conformance = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.16" }
 tempfile = { workspace = true }


### PR DESCRIPTION
Passe le moteur de test externe gaveldrop de `v0.1.12` à **`v0.1.16`**, la dernière release réelle.

## Pourquoi pas les PR Dependabot #326, #327, #328

Elles proposent une montée « vers v1 » qui n'existe pas comme release. Le dépôt gaveldrop porte un tag **`v1` non-semver** à côté de ses tags réels, donc Dependabot trie `v1 > v0.1.16` et propose une version fantôme.

Et chacune de ses PR bumpe **une seule** des trois crates en laissant les sœurs en `v0.1.12` — deux versions incompatibles du même moteur dans le workspace, d'où leur échec sur Clippy et Test. Ce n'était pas une rupture d'API v1, mais un mélange de versions provoqué par le tri des tags.

Ces trois PR sont donc à fermer, pas à merger.

## Ce que fait celle-ci

Les **quatre** déclarations passent à `v0.1.16` dans le même commit — les trois crates sont un seul moteur, les déplacer séparément est précisément l'erreur ci-dessus :

- `crates/armadai/Cargo.toml` — `gaveldrop`, `gaveldrop-fake`, `gaveldrop-conformance`
- `crates/armadai-fake/Cargo.toml` — `gaveldrop-fake` (optionnel, derrière la feature `engine`)

## Vérification

- **Aucune correction au compilateur nécessaire** : `v0.1.13`→`v0.1.16` n'introduit aucune rupture d'API sur ce que nous utilisons. Build et clippy propres du premier coup.
- **Suite e2e inchangée** : `13 cases · 13 passed · 0 failed · 0 tolerated · score 83/83`, vérifiée avec `--features e2e-fake` seul et dans le run complet `tui,storage,e2e-fake`.
- **La release reste sans gaveldrop** — l'invariant que le gating `e2e-fake`/`engine` existe pour tenir :
  `cargo tree -e normal,build -i gaveldrop --no-default-features --features tui,storage` → `warning: nothing to print`
- **Diff minimal** : les 4 lignes de tag, plus un `Cargo.lock` qui ne touche que les trois paquets `gaveldrop*` — aucune dérive transitive.

fmt propre · clippy `-D warnings` sur les 4 modes · les deux modes de test verts

## Suite

La cause racine est en amont : le tag `v1` sur le dépôt gaveldrop fera reproposer cette fausse montée à chaque cycle hebdomadaire. Le supprimer ou le renommer là-bas règle le problème définitivement, sans avoir à ajouter un `ignore` défensif ici qui masquerait aussi les vrais bumps `0.1.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
