### PR TITLE
test(core): pin that the model_fallbacks alias does not weaken deny_unknown_fields

### DIFF
--- a/crates/armadai-core/src/agent_decl.rs
+++ b/crates/armadai-core/src/agent_decl.rs
@@ -360,6 +360,31 @@ agents:
         );
     }
 
+    /// The alias above must accept exactly the two spellings the `.md`
+    /// parser accepts (`model_fallback`, `model_fallbacks`) and nothing
+    /// else. A near-miss typo that merely drops a letter is not one of
+    /// those two spellings and must still trip `deny_unknown_fields`,
+    /// naming itself in the error — this catches both an accidental
+    /// removal of `deny_unknown_fields` on `AgentDefaults`/`AgentDecl` (the
+    /// typo would then silently vanish instead of erroring) and a typo in
+    /// the alias string itself (e.g. `alias = "model_falback"`, which would
+    /// make this exact near-miss match).
+    #[test]
+    fn a_near_miss_typo_of_model_fallback_is_still_rejected_and_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("agents.yaml");
+        std::fs::write(
+            &p,
+            "defaults:\n  model_falback: [latest:fast]\n\nagents:\n  - name: x\n",
+        )
+        .unwrap();
+        let err = load(&p).unwrap_err().to_string();
+        assert!(
+            err.contains("model_falback"),
+            "the alias must not swallow a near-miss typo: {err}"
+        );
+    }
+
     #[test]
     fn a_plain_prompt_step_is_a_bare_fragment_name() {
         let d = parsed();


### PR DESCRIPTION
Ajoute le test de garde qui manquait autour de l'alias `model_fallbacks`.

## Contexte : l'issue #340 était déjà corrigée

J'ai ouvert #340 en m'appuyant sur une liste de findings différés, sans vérifier le code. L'alias `#[serde(alias = "model_fallbacks")]` sur `AgentDecl` et `AgentDefaults`, ainsi que le test qui charge une déclaration écrite au pluriel, **étaient déjà sur master** — arrivés dans la vague de correction finale de #337 (`74d0d86`). #340 est donc fermée comme déjà résolue.

## Ce qui manquait réellement

Un alias peut ouvrir un trou : si `deny_unknown_fields` cesse de mordre autour de lui, une faute de frappe proche passe en silence — et c'est exactement ce que `deny_unknown_fields` existe pour empêcher dans une déclaration de flotte.

Ce PR ajoute `a_near_miss_typo_of_model_fallback_is_still_rejected_and_named` : il écrit `model_falback` (une lettre en moins) sous `defaults` et vérifie que `load()` échoue **en nommant cette clé précise**.

## Le test est capable d'échouer

Vérifié par mutation, en direct : en orthographiant l'alias `"model_falback"` au lieu de `"model_fallbacks"`, ce test échoue — la faute proche se met à parser silencieusement — **et** le test du pluriel échoue aussi, puisque la vraie orthographe plurielle n'est plus acceptée. Les deux redeviennent verts après restauration.

## Vérification annexe

Contrôle demandé au passage : `model_fallback` est bien **la seule** clé du parser Markdown à accepter deux orthographes. La liste complète du parser est `provider, model, command, args, temperature, max_tokens, timeout, tags, stacks, scope, model_fallback/model_fallbacks, cost_limit, rate_limit, context_window, mode, orchestration`. Le format déclaratif en expose un sous-ensemble — `cost_limit`, `rate_limit`, `context_window`, `mode`, `orchestration`, `triggers`, `ring_config` ne sont pas déclarables — mais c'est un écart de périmètre documenté, pas une seconde orthographe. Aucune autre asymétrie du même type à rattraper.

fmt propre · clippy `-D warnings` sur les 4 modes · les deux modes de test verts (gaveldrop inclus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
