### PR TITLE
fix(ui): make the TUI and Web API see declared agents

### DIFF
--- a/crates/armadai/src/tui/app.rs
+++ b/crates/armadai/src/tui/app.rs
@@ -406,22 +406,41 @@ impl App {
     }
 
     pub fn load_agents(&mut self) {
+        use armadai_core::agent_source;
         use armadai_core::config::is_force_global;
         use armadai_core::project;
 
-        // Project-aware agent loading
+        // Project-aware agent loading. `project_declares_agents` (rather
+        // than a bare `!config.agents.is_empty()` check) so a project that
+        // relies purely on `.armadai/agents.yaml` — no `agents:` list at
+        // all — still takes this branch instead of falling through to the
+        // global library below, and `load_all_agents` (rather than
+        // `project::resolve_all_agents`, which only ever resolves file
+        // paths and silently drops every declared agent) so a declared
+        // agent is actually loaded instead of leaving a same-named global
+        // agent to be shown in its place.
         if !is_force_global()
             && let Some((root, config)) = project::find_project_config()
-            && !config.agents.is_empty()
+            && agent_source::project_declares_agents(&root, &config)
         {
-            let (paths, _) = project::resolve_all_agents(&config, &root);
-            let mut agents = Vec::new();
-            for path in &paths {
-                if let Ok(agent) = armadai_core::parser::parse_agent_file(path) {
-                    agents.push(agent);
-                }
-            }
+            let fragments = agent_source::project_fragments(&root);
+            let (agents, warnings) = agent_source::load_all_agents(&config, &root, &fragments);
             self.agents = agents;
+            // Read-only view: never refuse over a load warning, just
+            // surface it instead of letting it vanish unnoticed (the
+            // silent-substitution defect this wiring fixes lived
+            // unnoticed for exactly that reason).
+            self.status_msg = warnings.first().map(|w| {
+                if warnings.len() > 1 {
+                    format!(
+                        "{} agent load warning(s) — first: {}",
+                        warnings.len(),
+                        w.message()
+                    )
+                } else {
+                    format!("agent load warning: {}", w.message())
+                }
+            });
             return;
         }
 
@@ -918,5 +937,163 @@ mod esc_armed_tests {
     fn esc_armed_starts_disarmed() {
         let app = App::new();
         assert!(!app.esc_armed);
+    }
+}
+
+#[cfg(test)]
+mod load_agents_declarative_tests {
+    use super::*;
+    use armadai_core::config::ENV_MUTEX;
+
+    /// Points `ARMADAI_CONFIG_DIR` at a fresh, empty temp dir and the
+    /// process's cwd at `project_root` for its lifetime, restoring both on
+    /// drop (even on panic via a plain `Drop` impl, not a try/finally).
+    /// `App::load_agents` resolves its project via the cwd-based
+    /// `project::find_project_config()` and its global fallback via the
+    /// env-var-based `user_agents_dir()` -- both process-global state, so
+    /// this is serialised on `ENV_MUTEX` (shared with the rest of the
+    /// workspace's env-mutating tests) to avoid racing a concurrently
+    /// running test that reads either one unguarded.
+    struct ProjectDirGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        orig_cwd: std::path::PathBuf,
+        orig_config_dir: Option<String>,
+        config_tmp: tempfile::TempDir,
+    }
+
+    impl ProjectDirGuard {
+        fn enter(project_root: &std::path::Path) -> Self {
+            let lock = ENV_MUTEX.lock().unwrap();
+            let orig_cwd = std::env::current_dir().unwrap();
+            let orig_config_dir = std::env::var("ARMADAI_CONFIG_DIR").ok();
+            let config_tmp = tempfile::tempdir().unwrap();
+            // SAFETY: serialised via ENV_MUTEX above.
+            unsafe {
+                std::env::set_var("ARMADAI_CONFIG_DIR", config_tmp.path());
+            }
+            std::env::set_current_dir(project_root).unwrap();
+            Self {
+                _lock: lock,
+                orig_cwd,
+                orig_config_dir,
+                config_tmp,
+            }
+        }
+
+        /// The isolated global agent library, for a test that wants to
+        /// plant a same-named `.md` there to check it isn't shadowing a
+        /// declared agent.
+        fn global_agents_dir(&self) -> std::path::PathBuf {
+            self.config_tmp.path().join("agents")
+        }
+    }
+
+    impl Drop for ProjectDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.orig_cwd);
+            // SAFETY: restoring original env state, still under the guard
+            // held by `self._lock` until this `Drop` returns.
+            unsafe {
+                match &self.orig_config_dir {
+                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
+                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
+                }
+            }
+        }
+    }
+
+    /// A declarations-only project: no `agents:` list at all (the layout
+    /// this format exists to enable), two declared agents -- one plain, one
+    /// named to collide with a global homonym a test can plant separately.
+    fn declared_only_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai/prompts")).unwrap();
+        std::fs::write(root.join("armadai.yaml"), "link:\n  target: claude\n").unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: healthy-declared\n    prompt: [base]\n  \
+             - name: shared-name\n    prompt: [base]\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".armadai/prompts/base.md"), "You are {{name}}.\n").unwrap();
+        dir
+    }
+
+    /// Catches a regression of the gate alone (`!config.agents.is_empty()`
+    /// instead of `agent_source::project_declares_agents`) as well as the
+    /// body alone (`project::resolve_all_agents` instead of
+    /// `agent_source::load_all_agents`): either mutation, on this fixture,
+    /// leaves `app.agents` without these two names.
+    #[test]
+    fn declared_agents_appear_for_a_declarations_only_project() {
+        let dir = declared_only_project();
+        let root = dir.path().join("project");
+        let _guard = ProjectDirGuard::enter(&root);
+
+        let mut app = App::new();
+        app.load_agents();
+
+        let mut names: Vec<&str> = app.agents.iter().map(|a| a.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["healthy-declared", "shared-name"],
+            "a project relying purely on .armadai/agents.yaml (no `agents:` list) must still \
+             have its declared agents loaded by the TUI, not fall through to the global library"
+        );
+    }
+
+    /// The actual defect (#339 level 1): reverting the fix makes this
+    /// declarations-only project's empty `config.agents` fall through
+    /// entirely to the global library fallback, which then returns the
+    /// homonym's own content under the declared agent's name -- worse than
+    /// omission, a silent substitution.
+    #[test]
+    fn a_declared_agent_is_not_shadowed_by_a_same_named_global_agent() {
+        let dir = declared_only_project();
+        let root = dir.path().join("project");
+        let guard = ProjectDirGuard::enter(&root);
+
+        let global_agents = guard.global_agents_dir();
+        std::fs::create_dir_all(&global_agents).unwrap();
+        std::fs::write(
+            global_agents.join("shared-name.md"),
+            "# shared-name\n\n## Metadata\n- provider: global-marker-provider\n\n\
+             ## System Prompt\n\nGlobal homonym.\n",
+        )
+        .unwrap();
+
+        let mut app = App::new();
+        app.load_agents();
+
+        assert!(
+            !app.agents
+                .iter()
+                .any(|a| a.metadata.provider == "global-marker-provider"),
+            "the project's declared 'shared-name' must never resolve to the global \
+             library's same-named agent's content: {:?}",
+            app.agents
+                .iter()
+                .map(|a| (&a.name, &a.metadata.provider))
+                .collect::<Vec<_>>()
+        );
+        // The colliding declaration is refused outright (no precedence
+        // between the two sides), but the unrelated declared agent must
+        // still load -- proving the assertion above isn't a vacuous pass
+        // from a totally broken load.
+        assert!(
+            app.agents.iter().any(|a| a.name == "healthy-declared"),
+            "an unrelated declared agent must still load despite the collision: {:?}",
+            app.agents.iter().map(|a| &a.name).collect::<Vec<_>>()
+        );
+        assert!(
+            app.status_msg
+                .as_deref()
+                .is_some_and(|m| m.contains("shared-name")),
+            "the collision must be surfaced to the user, not silently dropped: {:?}",
+            app.status_msg
+        );
     }
 }

--- a/crates/armadai/src/web/api.rs
+++ b/crates/armadai/src/web/api.rs
@@ -188,20 +188,32 @@ pub struct ErrorResponse {
 }
 
 fn load_agents() -> Vec<Agent> {
+    use armadai_core::agent_source;
     use armadai_core::config::is_force_global;
     use armadai_core::project;
 
-    // If in a project context (and not forced global), resolve from project config
+    // If in a project context (and not forced global), resolve from project
+    // config — file-backed and declared agents alike.
+    // `project_declares_agents` (rather than a bare `!config.agents.is_empty()`
+    // check) so a project that relies purely on `.armadai/agents.yaml` — no
+    // `agents:` list at all — still takes this branch instead of falling
+    // through to the global library below, and `load_all_agents` (rather
+    // than `project::resolve_all_agents`, which only ever resolves file
+    // paths and silently drops every declared agent) so a declared agent is
+    // actually returned instead of leaving a same-named global agent to be
+    // served in its place.
     if !is_force_global()
         && let Some((root, config)) = project::find_project_config()
-        && !config.agents.is_empty()
+        && agent_source::project_declares_agents(&root, &config)
     {
-        let (paths, _) = project::resolve_all_agents(&config, &root);
-        let mut agents = Vec::new();
-        for path in &paths {
-            if let Ok(agent) = armadai_core::parser::parse_agent_file(path) {
-                agents.push(agent);
-            }
+        let fragments = agent_source::project_fragments(&root);
+        let (agents, warnings) = agent_source::load_all_agents(&config, &root, &fragments);
+        // Read-only endpoint: never refuse over a load warning. The JSON
+        // shape stays a bare agent list (unchanged API contract), so a
+        // dropped/shadowed declared agent is surfaced via the server log
+        // instead of vanishing unnoticed.
+        for w in &warnings {
+            tracing::warn!("agent load warning: {}", w.message());
         }
         return agents;
     }
@@ -1186,6 +1198,156 @@ mod tests {
         assert!(
             !traces.iter().any(|t| t["id"] == "c-1"),
             "nested child must not appear in the list"
+        );
+    }
+}
+
+#[cfg(test)]
+mod load_agents_declarative_tests {
+    use super::*;
+    use armadai_core::config::ENV_MUTEX;
+
+    /// Points `ARMADAI_CONFIG_DIR` at a fresh, empty temp dir and the
+    /// process's cwd at `project_root` for its lifetime, restoring both on
+    /// drop (even on panic via a plain `Drop` impl, not a try/finally). The
+    /// handler under test resolves its project via the cwd-based
+    /// `project::find_project_config()` and its global fallback via the
+    /// env-var-based `user_agents_dir()` -- both process-global state, so
+    /// this is serialised on `ENV_MUTEX` (shared with the rest of the
+    /// workspace's env-mutating tests) to avoid racing a concurrently
+    /// running test that reads either one unguarded.
+    struct ProjectDirGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        orig_cwd: std::path::PathBuf,
+        orig_config_dir: Option<String>,
+        config_tmp: tempfile::TempDir,
+    }
+
+    impl ProjectDirGuard {
+        fn enter(project_root: &std::path::Path) -> Self {
+            let lock = ENV_MUTEX.lock().unwrap();
+            let orig_cwd = std::env::current_dir().unwrap();
+            let orig_config_dir = std::env::var("ARMADAI_CONFIG_DIR").ok();
+            let config_tmp = tempfile::tempdir().unwrap();
+            // SAFETY: serialised via ENV_MUTEX above.
+            unsafe {
+                std::env::set_var("ARMADAI_CONFIG_DIR", config_tmp.path());
+            }
+            std::env::set_current_dir(project_root).unwrap();
+            Self {
+                _lock: lock,
+                orig_cwd,
+                orig_config_dir,
+                config_tmp,
+            }
+        }
+
+        /// The isolated global agent library, for a test that wants to
+        /// plant a same-named `.md` there to check it isn't shadowing a
+        /// declared agent.
+        fn global_agents_dir(&self) -> std::path::PathBuf {
+            self.config_tmp.path().join("agents")
+        }
+    }
+
+    impl Drop for ProjectDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.orig_cwd);
+            // SAFETY: restoring original env state, still under the guard
+            // held by `self._lock` until this `Drop` returns.
+            unsafe {
+                match &self.orig_config_dir {
+                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
+                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
+                }
+            }
+        }
+    }
+
+    /// A declarations-only project: no `agents:` list at all (the layout
+    /// this format exists to enable), two declared agents -- one plain, one
+    /// named to collide with a global homonym a test can plant separately.
+    fn declared_only_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".armadai/prompts")).unwrap();
+        std::fs::write(root.join("armadai.yaml"), "link:\n  target: claude\n").unwrap();
+        std::fs::write(
+            root.join(".armadai/agents.yaml"),
+            "defaults:\n  provider: claude\nagents:\n  \
+             - name: healthy-declared\n    prompt: [base]\n  \
+             - name: shared-name\n    prompt: [base]\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".armadai/prompts/base.md"), "You are {{name}}.\n").unwrap();
+        dir
+    }
+
+    /// Catches a regression of the gate alone (`!config.agents.is_empty()`
+    /// instead of `agent_source::project_declares_agents`) as well as the
+    /// body alone (`project::resolve_all_agents` instead of
+    /// `agent_source::load_all_agents`): either mutation, on this fixture,
+    /// leaves the response without these two names.
+    #[test]
+    fn declared_agents_appear_for_a_declarations_only_project() {
+        let dir = declared_only_project();
+        let root = dir.path().join("project");
+        let _guard = ProjectDirGuard::enter(&root);
+
+        let mut names: Vec<String> = load_agents().into_iter().map(|a| a.name).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["healthy-declared", "shared-name"],
+            "a project relying purely on .armadai/agents.yaml (no `agents:` list) must still \
+             have its declared agents returned by /api/agents, not fall through to the global \
+             library"
+        );
+    }
+
+    /// The actual defect (#339 level 1): reverting the fix makes this
+    /// declarations-only project's empty `config.agents` fall through
+    /// entirely to the global library fallback, which then returns the
+    /// homonym's own content under the declared agent's name -- worse than
+    /// omission, a silent substitution (measured: `armadai list` shows the
+    /// project's declared agents while `/api/agents` returns the
+    /// global-library agent of the same name instead).
+    #[test]
+    fn a_declared_agent_is_not_shadowed_by_a_same_named_global_agent() {
+        let dir = declared_only_project();
+        let root = dir.path().join("project");
+        let guard = ProjectDirGuard::enter(&root);
+
+        let global_agents = guard.global_agents_dir();
+        std::fs::create_dir_all(&global_agents).unwrap();
+        std::fs::write(
+            global_agents.join("shared-name.md"),
+            "# shared-name\n\n## Metadata\n- provider: global-marker-provider\n\n\
+             ## System Prompt\n\nGlobal homonym.\n",
+        )
+        .unwrap();
+
+        let agents = load_agents();
+
+        assert!(
+            !agents
+                .iter()
+                .any(|a| a.metadata.provider == "global-marker-provider"),
+            "the project's declared 'shared-name' must never resolve to the global \
+             library's same-named agent's content: {:?}",
+            agents
+                .iter()
+                .map(|a| (&a.name, &a.metadata.provider))
+                .collect::<Vec<_>>()
+        );
+        // The colliding declaration is refused outright (no precedence
+        // between the two sides), but the unrelated declared agent must
+        // still load -- proving the assertion above isn't a vacuous pass
+        // from a totally broken load.
+        assert!(
+            agents.iter().any(|a| a.name == "healthy-declared"),
+            "an unrelated declared agent must still load despite the collision: {:?}",
+            agents.iter().map(|a| &a.name).collect::<Vec<_>>()
         );
     }
 }

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -194,13 +194,20 @@ file-backed ones — except where noted:
 | `armadai models check` / `armadai models update` | Yes — including the deprecated-model rewrite described above |
 | `armadai unlink` | Yes |
 | `armadai validate` | Yes — a declared agent named as an `orchestration.coordinator`/`teams[].lead`/`teams[].agents` entry resolves, even when never relisted in `armadai.yaml`'s `agents:` |
-| TUI dashboard | **No** |
-| Web API | **No** |
+| TUI dashboard | Yes |
+| Web API | Yes |
 | `armadai shell` | **No** |
 
-Do not assume any of the three remaining "No" rows will discover a declared agent by some other
-path — they were simply not touched by this chantier, and hitting one of them is the way to find
-out the hard way if this table goes unread.
+Do not assume the remaining "No" row will discover a declared agent by some other path — it was
+simply not touched by this chantier, and hitting it is the way to find out the hard way if this
+table goes unread.
+
+The TUI dashboard and Web API used to be worse than an omission: both resolved a project's agents
+via `project::resolve_all_agents`, which only ever returns file paths, so a declared agent (which
+has no file) was silently dropped — and if a same-named agent happened to exist in the global
+library (`~/.config/armadai/agents/`), *that* agent was shown in its place, with no warning. Both
+now go through the same `agent_source::load_all_agents` every other wired surface uses, so a
+declared agent is loaded on its own terms rather than shadowed by an unrelated global homonym.
 
 ## Parity with the `.md` format — and its limits
 


### PR DESCRIPTION
Ferme le **niveau 1** de #339. Le niveau 2 (`armadai shell`, `run --pipe`) reste ouvert, volontairement — voir plus bas.

## Le défaut était pire que l'issue ne le disait

`tui/app.rs:415` et `web/api.rs:197` résolvaient les agents en **chemins** via `resolve_all_agents`, donc un agent déclaré dans `.armadai/agents.yaml` (#337) leur était invisible.

Mesuré sur un projet jetable (`ARMADAI_CONFIG_DIR` isolé, 2 agents déclarés sains + 1 en collision avec un homonyme global) :

| | `armadai list` | `/api/agents` |
|---|---|---|
| **avant** | `agent-alpha, agent-beta` | `[{"name":"shared-agent","provider":"openai"}]` |
| **après** | `agent-alpha, agent-beta` | identique |

L'issue annonçait « l'homonyme global est affiché ». En réalité l'API renvoyait **uniquement** l'homonyme, les agents du projet étant **entièrement absents**, sans aucun avertissement. Pas une flotte partiellement fausse : une flotte entièrement fausse.

C'est ce qui justifiait de traiter ce niveau d'abord : une liste incomplète est un désagrément, une liste fausse est un piège.

## Le correctif

Les deux surfaces passent par `agent_source::load_all_agents`, déjà utilisé par `link`, `list`, `run`, `inspect` et `validate`. Rien de nouveau n'est inventé.

Les deux sites jetaient les erreurs de chargement (`let (paths, _) = …`) — ce qui est précisément ce qui a permis à ce défaut de vivre inaperçu. Elles sont désormais visibles, chacune par le canal de sa surface : la barre de statut existante pour la TUI (même convention que le message « N skipped » préexistant), `tracing::warn!` pour le Web.

**Un consommateur HTTP n'a aucun moyen d'apprendre qu'une collision a eu lieu.** C'est délibéré : c'est la seule option compatible avec la contrainte de ne pas changer la forme du JSON, vérifiée inchangée (`AgentSummary`/`AgentDetail` sans une ligne de diff).

## Vérification

Les 4 tests créent chacun **un homonyme dans la bibliothèque globale**, puisque le défaut réel est la *substitution* : un test montrant simplement que les agents déclarés apparaissent passerait même avec le bug présent, faute d'homonyme pour se faire piéger.

L'isolation a été tracée jusqu'au bout par la revue — `ProjectDirGuard` isole `ARMADAI_CONFIG_DIR` et le cwd sous un mutex, et `config_dir()` honore bien la variable. Aucun test ne lit le vrai `~/.config/armadai/`. Ce point n'est pas théorique : une suite de ce dépôt avait déjà passé pour la mauvaise raison, en entrant en collision avec un fichier réel de la config du développeur.

Spot-check de mutation par la revue, sur un clone jetable : en revenant à l'ancien corps de `tui/app.rs`, les deux tests TUI échouent et reproduisent exactement la substitution historique.

**TUI, pour la validation visuelle** : aucun changement de disposition, d'onglet ni de widget. Même tableau de bord Agents, mêmes colonnes. Deux différences : la liste est correcte sur un projet en déclarations seules, et une collision de noms affiche une ligne dans la barre de statut là où c'était silencieux.

fmt · clippy `-D warnings` sur les 4 modes (dont `tui,web,storage` recompilé et vérifié) · tests verts : `tui` 627, `tui,storage,e2e-fake` 652, gaveldrop 13/83-83

## ⚠️ Ce que la CI de cette PR ne prouve pas

Relevé pendant la revue et filé en **#350** : **aucun job de test de la CI n'active `web`**. Les trois modes sont `tui`, `tui,storage,e2e-fake` et `tui,providers-api`. Les deux tests d'API ajoutés ici sont donc compilés et lintés par la CI, mais **jamais exécutés** par elle. La revue les a fait tourner en local (4/4). Le problème est préexistant et vaut pour tous les tests de `web/api.rs`.

## Reste ouvert

**#339 niveau 2** — `armadai shell` (changement de capacité requis, et son fichier porte #347) et `run --pipe` (changement de signature). Traités ensemble plus tard, pas ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
