### PR TITLE
ci: run the web module's tests, which no job ever executed

### DIFF
--- a/.claude/agents/qa-specialist.md
+++ b/.claude/agents/qa-specialist.md
@@ -20,7 +20,7 @@ Your scope covers:
 - Use `tempfile::tempdir()` for filesystem tests — never write to real config dirs
 - Mock providers with `ScriptedProvider` or `NoopProvider` — never call real APIs in tests
 - Verify clippy passes in **all 3 CI modes** before declaring done: `--features tui`, `--features tui,providers-api`, `--features tui,web,storage`
-- Tests run in 2 modes: `--features tui` and `--features tui,storage,e2e-fake` (the latter covers storage-gated code and the gaveldrop e2e suite)
+- Tests run in 3 modes: `--features tui`, `--features tui,storage,e2e-fake,web` (covers storage-gated code, the gaveldrop e2e suite, and — since #350 — the `web/` module's own tests, previously never executed by any test job), and `--features tui,providers-api`
 - Check `cargo fmt` compliance
 - When reviewing, prioritize: correctness > safety > performance > style
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,19 +93,28 @@ jobs:
       #
       # tui: baseline (bin + all members; armadai-providers without `api`).
       - run: cargo test --no-default-features --features tui
-      # tui,storage,e2e-fake: adds the bin's SQLite-gated code (SqliteLog wiring, the
-      # storage-backed CLI paths) — the armadai-storage crate's own tests
-      # already run under bare `tui`. `e2e-fake` additionally builds the
-      # `fake-claude` bin and the `gaveldrop` test target (crates/armadai/
+      # tui,storage,e2e-fake,web: adds the bin's SQLite-gated code (SqliteLog
+      # wiring, the storage-backed CLI paths) — the armadai-storage crate's
+      # own tests already run under bare `tui`. `e2e-fake` additionally builds
+      # the `fake-claude` bin and the `gaveldrop` test target (crates/armadai/
       # tests/gaveldrop.rs), which runs the 10-case e2e suite through the
       # external `gaveldrop` YAML test engine (a git dependency, pinned by
       # `tag` — see crates/armadai/Cargo.toml) and writes an HTML report to
-      # target/gaveldrop-report/ for the next step to upload. Kept off the
-      # `tui`-only mode above to keep that mode minimal.
-      - run: cargo test --no-default-features --features tui,storage,e2e-fake
+      # target/gaveldrop-report/ for the next step to upload. `web` extends
+      # this mode (rather than adding a fourth job) to mirror clippy's
+      # `tui,web,storage` combo above: before this, no test job ever enabled
+      # `web`, so every `#[cfg(test)]` in src/web/{mod,api}.rs — including the
+      # ones gated on `feature = "storage"` — was compiled and linted by
+      # clippy but never actually run (#350). Kept off the `tui`-only mode
+      # above to keep that mode minimal.
+      - run: cargo test --no-default-features --features tui,storage,e2e-fake,web
       # tui,providers-api: exercises the bin's providers-api-gated code
-      # (linker/cli/tui/web) AND armadai-providers WITH `api` (HTTP providers +
-      # online model_registry) — both untested by the two modes above.
+      # (linker/cli/tui) AND armadai-providers WITH `api` (HTTP providers +
+      # online model_registry) — both untested by the two modes above. `web`
+      # is NOT enabled here, so none of `web`'s own providers-api-gated code
+      # (e.g. `refresh_models`) is exercised by this mode either — it has no
+      # test of its own today, see #350's report for the full feature/test
+      # coverage matrix.
       - run: cargo test --no-default-features --features tui,providers-api
       - name: Upload gaveldrop report
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ CI runs clippy in **3 feature modes** to catch lints that only trip under one co
 - `--no-default-features --features tui,providers-api`
 - `--no-default-features --features tui,web,storage`
 
-Tests run in 3 modes: `--no-default-features --features tui`, `--no-default-features --features tui,storage,e2e-fake` (this one also covers the SQLite storage paths and the gaveldrop e2e suite, run via the `--test gaveldrop` target), and `--no-default-features --features tui,providers-api`. Build (`--release`) uses `--no-default-features --features tui,storage`.
+Tests run in 3 modes: `--no-default-features --features tui`, `--no-default-features --features tui,storage,e2e-fake,web` (this one also covers the SQLite storage paths, the gaveldrop e2e suite run via the `--test gaveldrop` target, and — since #350 — the `web/` module's own tests, previously compiled/linted by clippy's `tui,web,storage` combo but never executed by any test job), and `--no-default-features --features tui,providers-api`. Build (`--release`) uses `--no-default-features --features tui,storage`.
 
 ## Feature Flags
 


### PR DESCRIPTION
Ferme #350.

## Le défaut

Aucun job de test n'activait la feature `web`, donc **aucun test du module `web/` n'était jamais exécuté**. Les trois modes étaient `tui`, `tui,storage,e2e-fake` et `tui,providers-api`.

Le code web *était* compilé et linté — le mode clippy `tui,web,storage` existe — mais ses tests, gardés par `#[cfg(feature = "web")]`, ne tournaient nulle part.

Conséquence : une PR cassant un test web affichait une CI **verte**. C'est le pire mode de défaillance pour un garde-fou — il ne manque pas d'attraper le défaut, il affirme qu'il n'y en a pas. Et `web/` n'est pas marginal : c'est l'API JSON que consomme le frontend Svelte.

## Le correctif

Le mode existant devient `tui,storage,e2e-fake,web`, plutôt qu'un quatrième job. Ça reflète la combinaison `tui,web,storage` déjà utilisée côté clippy, donc les deux matrices restent symétriques et la CI ne gagne pas une dimension.

## Ce que ça révèle

**Sept tests web s'exécutent maintenant, dont cinq préexistants** — les gestionnaires de la SPA et les endpoints de trace d'orchestration. Tous passent : rien n'était silencieusement cassé, le garde-fou était simplement absent. C'est le profil typique d'un défaut qui ne se signale jamais de lui-même, un test qui ne tourne pas étant indistinguable d'un test qui réussit.

## Vérifié, pas supposé

Ajouter un flag à un fichier YAML ne prouve rien — d'autant moins sur une issue dont le sujet *est* un garde-fou qui affirmait l'absence de défauts qu'il ne pouvait pas voir.

**Preuve que le job attrape désormais une casse** : en inversant l'assertion de `unknown_asset_is_404` (`NOT_FOUND` → `OK`), la commande échoue — `test result: FAILED. 6 passed; 1 failed`. Restauré ensuite, arbre vérifié propre.

## Matrice de couverture

| feature | tests sous `cfg` | job qui les exécute |
|---|---|---|
| `tui` | 10 fichiers | les 3 |
| `storage` | 8 fichiers | 2 (`tui,storage,e2e-fake,web`) |
| `providers-api` | 5 fichiers | 3 (`tui,providers-api`) |
| `web` | 1 fichier | 2 — **corrigé ici** |
| `e2e-fake` | 0 fichier | 2 (harnais, pas de test propre) |

Toute feature portant des tests les voit désormais exécutés.

**Lacune restante, énoncée dans le commentaire du workflow** : `web` n'est pas activé sous `providers-api`, donc `web/api.rs:587` (`refresh_models`) reste hors couverture. Il n'a de toute façon aucun test aujourd'hui — la lacune est réelle mais rien n'est perdu.

## Documentation

`CLAUDE.md` et `.claude/agents/qa-specialist.md` sont mis à jour. Ce dernier portait une **erreur préexistante** : il annonçait deux modes de test là où il y en a trois.

fmt · clippy `-D warnings` sur les 4 modes · les trois modes de test verts · gaveldrop 13/83-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
