### PR TITLE
ci: compile the web + providers-api intersection, the product's default feature set

### DIFF
--- a/.claude/agents/qa-specialist.md
+++ b/.claude/agents/qa-specialist.md
@@ -10,7 +10,7 @@ Your scope covers:
 - **Tests**: unit tests (inline `#[cfg(test)]`) and integration, always via `tempfile::tempdir()`
 - **E2E suite**: `crates/armadai/tests/gaveldrop.rs` (the `--test gaveldrop` binary, behind the `e2e-fake` feature) — an `Armadai` adapter for the external [`gaveldrop`](https://github.com/Dr0drigues/gaveldrop) YAML test engine (a git dependency pinned by **`tag`** in `crates/armadai/Cargo.toml` **and** `crates/armadai-fake/Cargo.toml` — both must carry the **same** tag). Runs the **10 cases** in `crates/armadai/tests/cases/*.yaml` through `gaveldrop::runner::run_all_with`, config in `gaveldrop.yaml`, against the deterministic `fake-claude` engine (`crates/armadai-fake`, built on `gaveldrop-fake`). Writes an HTML report to `target/gaveldrop-report/` uploaded by CI as the `gaveldrop-report` artifact. The old hand-rolled `tests/e2e/` harness is **gone** — do not reference it
 - **CI pipeline**: `.github/workflows/` and the 6 checks (fmt, clippy, test, build, conventional commits, audit)
-- **Code quality**: clippy in **3 feature modes**, `cargo fmt`, dead-code hygiene
+- **Code quality**: clippy in **5 feature modes**, `cargo fmt`, dead-code hygiene
 - **Test infrastructure**: mock providers (ScriptedProvider/NoopProvider), fixtures, coverage gaps
 
 ## Instructions
@@ -19,8 +19,8 @@ Your scope covers:
 - For feature-gated code, test with the appropriate feature enabled
 - Use `tempfile::tempdir()` for filesystem tests — never write to real config dirs
 - Mock providers with `ScriptedProvider` or `NoopProvider` — never call real APIs in tests
-- Verify clippy passes in **all 3 CI modes** before declaring done: `--features tui`, `--features tui,providers-api`, `--features tui,web,storage`
-- Tests run in 3 modes: `--features tui`, `--features tui,storage,e2e-fake,web` (covers storage-gated code, the gaveldrop e2e suite, and — since #350 — the `web/` module's own tests, previously never executed by any test job), and `--features tui,providers-api`
+- Verify clippy passes in **all 5 CI modes** before declaring done: `--features tui`, `--features tui,providers-api`, `--features tui,web,storage`, `--features tui,web,storage,providers-api` (the default feature set — since #355, the only mode where `web` and `providers-api` are both enabled, e.g. `web/api.rs`'s `refresh_models`), `--features tui,storage,e2e-fake` (compiles the gaveldrop e2e test surface)
+- Tests run in 4 modes: `--features tui`; `--features tui,storage,e2e-fake,web` (covers storage-gated code, the gaveldrop e2e suite, and — since #350 — the `web/` module's own tests, previously never executed by any test job); `--features tui,providers-api`; and `--features tui,web,storage,providers-api` (the default feature set — since #355, this is what exercises `web` and `providers-api` together)
 - Check `cargo fmt` compliance
 - When reviewing, prioritize: correctness > safety > performance > style
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,22 @@ jobs:
       # We run every feature combination the code is gated for so a lint that
       # only trips under one combo is caught in CI, not just locally. The
       # feature flags belong to the bin and propagate to the member crates,
-      # so these three combos also cover armadai-providers in BOTH states:
-      # `tui` builds it without `api` (the `#[cfg(not(feature = "api"))]`
+      # so these combos also cover armadai-providers in BOTH states: `tui`
+      # builds it without `api` (the `#[cfg(not(feature = "api"))]`
       # fallbacks), `tui,providers-api` builds it with `api` (HTTP providers +
       # online model_registry). See CLAUDE.md and the OH1 event-sourcing spec §9.
       - run: cargo clippy --all-targets --no-default-features --features tui -- -D warnings
       - run: cargo clippy --all-targets --no-default-features --features tui,providers-api -- -D warnings
       - run: cargo clippy --all-targets --no-default-features --features tui,web,storage -- -D warnings
+      # tui,web,storage,providers-api: `web` and `providers-api` never appear
+      # together in any mode above (#355), so the `#[cfg(feature =
+      # "providers-api")]` arms inside src/web/ (e.g. `refresh_models` in
+      # web/api.rs) were never compiled by CI at all — only their
+      # `#[cfg(not(...))]` fallback was. This mode is also, deliberately,
+      # exactly the crate's default feature set (`default = ["tui", "web",
+      # "storage", "providers-api"]` in Cargo.toml): before this line, no job
+      # compiled what a user gets from a bare `cargo build`/`cargo install`.
+      - run: cargo clippy --all-targets --no-default-features --features tui,web,storage,providers-api -- -D warnings
       # tui,storage,e2e-fake: the only mode that compiles the e2e test surface
       # (crates/armadai/tests/gaveldrop.rs, the fake-claude bin, and
       # armadai-fake's `engine` feature) — everything else above skips it, so
@@ -88,7 +97,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
       # The repo root is a VIRTUAL workspace, so each `cargo test` below runs
       # the WHOLE workspace (bin + core/providers/storage/secrets); the bin's
-      # feature flags propagate to the member crates. The three modes together
+      # feature flags propagate to the member crates. The modes together
       # exercise every crate in every gated state — no explicit `-p` steps needed.
       #
       # tui: baseline (bin + all members; armadai-providers without `api`).
@@ -111,11 +120,16 @@ jobs:
       # tui,providers-api: exercises the bin's providers-api-gated code
       # (linker/cli/tui) AND armadai-providers WITH `api` (HTTP providers +
       # online model_registry) — both untested by the two modes above. `web`
-      # is NOT enabled here, so none of `web`'s own providers-api-gated code
-      # (e.g. `refresh_models`) is exercised by this mode either — it has no
-      # test of its own today, see #350's report for the full feature/test
-      # coverage matrix.
+      # is NOT enabled here; its own providers-api-gated code (e.g.
+      # `refresh_models`) is covered by the dedicated mode below instead.
       - run: cargo test --no-default-features --features tui,providers-api
+      # tui,web,storage,providers-api: mirrors clippy's mode of the same name
+      # (#355) — `web` and `providers-api` are otherwise never enabled
+      # together, so `web/api.rs`'s `#[cfg(feature = "providers-api")]` arm
+      # (`refresh_models`'s real body) was compiled by no job and run by
+      # none. This is also exactly the crate's default feature set, so it
+      # doubles as the "does the default build even compile" check.
+      - run: cargo test --no-default-features --features tui,web,storage,providers-api
       - name: Upload gaveldrop report
         if: always()
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,14 @@ cargo test --no-default-features --features tui,providers-api test_name
 RUST_LOG=debug cargo run -- list
 ```
 
-CI runs clippy in **3 feature modes** to catch lints that only trip under one combo (see `.github/workflows/ci.yml`):
+CI runs clippy in **5 feature modes** to catch lints that only trip under one combo (see `.github/workflows/ci.yml`):
 - `--no-default-features --features tui`
 - `--no-default-features --features tui,providers-api`
 - `--no-default-features --features tui,web,storage`
+- `--no-default-features --features tui,web,storage,providers-api` — the crate's default feature set, and (since #355) the only mode where `web` and `providers-api` are both enabled, e.g. `web/api.rs`'s `refresh_models`
+- `--no-default-features --features tui,storage,e2e-fake` — the only mode that compiles the gaveldrop e2e test surface
 
-Tests run in 3 modes: `--no-default-features --features tui`, `--no-default-features --features tui,storage,e2e-fake,web` (this one also covers the SQLite storage paths, the gaveldrop e2e suite run via the `--test gaveldrop` target, and — since #350 — the `web/` module's own tests, previously compiled/linted by clippy's `tui,web,storage` combo but never executed by any test job), and `--no-default-features --features tui,providers-api`. Build (`--release`) uses `--no-default-features --features tui,storage`.
+Tests run in 4 modes: `--no-default-features --features tui`; `--no-default-features --features tui,storage,e2e-fake,web` (this one also covers the SQLite storage paths, the gaveldrop e2e suite run via the `--test gaveldrop` target, and — since #350 — the `web/` module's own tests, previously compiled/linted by clippy's `tui,web,storage` combo but never executed by any test job); `--no-default-features --features tui,providers-api`; and `--no-default-features --features tui,web,storage,providers-api` (the default feature set — since #355, this is what exercises `web` and `providers-api` together, previously untested by any job). Build (`--release`) uses `--no-default-features --features tui,storage`.
 
 ## Feature Flags
 


### PR DESCRIPTION
Ferme #355.

## Le défaut

Aucun job de CI — ni clippy, ni test — n'activait `web` et `providers-api` ensemble. Le code sous l'intersection n'était donc **jamais compilé**.

Concrètement : `crates/armadai/src/web/api.rs:587`, le bras `#[cfg(feature = "providers-api")]` portant le vrai `refresh_models`, n'était vu par aucun job. Ce que la CI compilait pour cet endpoint était **exclusivement** le bras `not(providers-api)`, celui qui renvoie « Model sync requires providers-api feature ».

Et le point qui donne sa gravité au défaut : les features **par défaut** du projet sont `tui`, `web`, `storage`, `providers-api`. **La combinaison que la CI ne compilait jamais était celle que les utilisateurs obtiennent par défaut.**

Un test manquant laisse un comportement non vérifié ; une compilation manquante laisse le code libre de ne plus compiler. Un changement de signature dans `armadai_providers::model_registry::fetch` aurait cassé ce gestionnaire sans que rien ne le signale.

## Le choix : ajouter un mode, pas fusionner

Nouveau mode `tui,web,storage,providers-api` — exactement le jeu de features par défaut — ajouté **des deux côtés**, clippy et test.

Fusionner `tui,providers-api` et `tui,web,storage` aurait fermé le trou plus économiquement, mais en perdant quelque chose : chacun correspond à une configuration de build réelle et autonome (le premier est la commande du cycle de développement documentée dans `CLAUDE.md`), et chacun attrape les `cfg` mal cadrés propres à une feature **sans** l'autre. Un mode large ne peut pas distinguer « correctement gardé par une feature » de « incorrectement gardé par les deux ».

## Vérifié dans les deux sens

C'est la seule preuve qui vaut pour un garde-fou : montrer qu'il attrape, **et** que l'ancien n'attrapait pas.

En cassant le corps réel de `refresh_models` :

| commande | résultat |
|---|---|
| `clippy tui,providers-api` | passe |
| `clippy tui,web,storage` | passe |
| `test tui,storage,e2e-fake,web` | passe |
| `test tui,providers-api` | passe |
| **`clippy tui,web,storage,providers-api`** | **échoue** — E0425 |
| **`test tui,web,storage,providers-api`** | **échoue** — E0425 |

Restauré ensuite, les deux nouvelles commandes passent proprement. Le nouveau mode de test exécute **1373 tests, 0 échec**, et ne construit pas la cible gaveldrop — `e2e-fake` en est correctement absent.

## Inventaire de l'intersection

Un seul élément, confirmé par deux greps indépendants : `refresh_models`. Aucun code gardé par `web` dans les modules providers, aucun `all()`/`any()` combinant les deux ailleurs dans le workspace.

## Matrice résultante

```
clippy : tui │ tui,providers-api │ tui,web,storage │ tui,web,storage,providers-api │ tui,storage,e2e-fake
test   : tui │ tui,storage,e2e-fake,web │ tui,providers-api │ tui,web,storage,providers-api
```

Cinq modes clippy contre quatre en test : l'écart est exactement l'asymétrie **préexistante** (`tui,storage,e2e-fake` côté clippy seul), pas une dérive nouvelle. #354 avait aligné les intentions des deux matrices, et cette PR le préserve.

`CLAUDE.md` et `.claude/agents/qa-specialist.md` sont mis à jour — tous deux documentent la liste des modes et venaient d'être corrigés par #354.

## Relevé au passage, non corrigé

Le commentaire de `ci.yml` et `qa-specialist.md` mentionnent encore « 10 cas » pour la suite gaveldrop, qui en compte **13**. Préexistant, non introduit ici.

fmt · clippy `-D warnings` sur les 5 modes · les 4 modes de test verts · gaveldrop 13/83-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
