### PR TITLE
fix(providers): retry 429/503/529 with a capped Retry-After and jittered backoff

### DIFF
--- a/crates/armadai-providers/src/api/anthropic.rs
+++ b/crates/armadai-providers/src/api/anthropic.rs
@@ -5,6 +5,8 @@ use tokio_stream::StreamExt;
 
 use armadai_core::provider::*;
 
+use super::retry::{RetryPolicy, send_with_retry};
+
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
@@ -117,14 +119,14 @@ impl Provider for AnthropicProvider {
             stream: None,
         };
 
-        let response = self
-            .client
-            .post(format!("{}/messages", self.base_url))
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", ANTHROPIC_VERSION)
-            .json(&body)
-            .send()
-            .await?;
+        let response = send_with_retry(&RetryPolicy::default(), || {
+            self.client
+                .post(format!("{}/messages", self.base_url))
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .json(&body)
+        })
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -179,14 +181,14 @@ impl Provider for AnthropicProvider {
             stream: Some(true),
         };
 
-        let response = self
-            .client
-            .post(format!("{}/messages", self.base_url))
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", ANTHROPIC_VERSION)
-            .json(&body)
-            .send()
-            .await?;
+        let response = send_with_retry(&RetryPolicy::default(), || {
+            self.client
+                .post(format!("{}/messages", self.base_url))
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .json(&body)
+        })
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/armadai-providers/src/api/google.rs
+++ b/crates/armadai-providers/src/api/google.rs
@@ -5,6 +5,8 @@ use tokio_stream::StreamExt;
 
 use armadai_core::provider::*;
 
+use super::retry::{RetryPolicy, send_with_retry};
+
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 pub struct GoogleProvider {
@@ -125,7 +127,10 @@ impl Provider for GoogleProvider {
             self.base_url, request.model, self.api_key
         );
 
-        let response = self.client.post(&url).json(&body).send().await?;
+        let response = send_with_retry(&RetryPolicy::default(), || {
+            self.client.post(&url).json(&body)
+        })
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -179,7 +184,10 @@ impl Provider for GoogleProvider {
             self.base_url, request.model, self.api_key
         );
 
-        let response = self.client.post(&url).json(&body).send().await?;
+        let response = send_with_retry(&RetryPolicy::default(), || {
+            self.client.post(&url).json(&body)
+        })
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/crates/armadai-providers/src/api/mod.rs
+++ b/crates/armadai-providers/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod anthropic;
 pub mod google;
 pub mod openai;
+pub(crate) mod retry;

--- a/crates/armadai-providers/src/api/retry.rs
+++ b/crates/armadai-providers/src/api/retry.rs
@@ -6,26 +6,46 @@
 //! is the reactive half — what to do when the SERVER comes back with a
 //! rate-limit or overload response.
 //!
-//! Both providers speak plain HTTP and hit exactly the same two failure
-//! modes (429 rate-limited, 529 overloaded), read the same `Retry-After`
-//! header, and need the same retryable/terminal distinction (a 400 or 401
-//! is never worth retrying — doing so only delays a clear error). This is
-//! implemented ONCE here and used by both `api::anthropic` and `api::google`
-//! rather than grown independently in each — two copies of one policy is
-//! the defect class this repo has fixed repeatedly (see the issue write-up).
-//! `openai.rs`/`proxy.rs` are still `todo!()` stubs and make no HTTP calls
-//! yet, so they have nothing to wire up here.
+//! Both providers speak plain HTTP and hit overlapping — not identical —
+//! failure modes under overload, all of which need the same retryable/
+//! terminal distinction (a 400 or 401 is never worth retrying — doing so
+//! only delays a clear error):
+//!
+//! - **429** (rate limited): both Anthropic (`rate_limit_error`) and
+//!   Google/Gemini (`RESOURCE_EXHAUSTED`) emit this.
+//! - **529**: Anthropic's `overloaded_error`. Not part of Gemini's
+//!   documented error taxonomy, but harmless to keep in the shared set —
+//!   Google will simply never produce it.
+//! - **503**: Gemini's overload signal (`UNAVAILABLE`). Also RFC 7231's
+//!   generic "Service Unavailable", which per spec MAY carry `Retry-After`
+//!   and is meant to be transient — so treating it as retryable is the
+//!   conventional reading, not a stretch. Anthropic doesn't document it,
+//!   but the same "harmless if unused" reasoning applies.
+//!
+//! One shared, provider-agnostic set — `is_retryable` below — covers both
+//! rather than dispatching per provider, and is implemented ONCE here and
+//! used by both `api::anthropic` and `api::google` rather than grown
+//! independently in each — two copies of one policy is the defect class
+//! this repo has fixed repeatedly (see the issue write-up). `openai.rs`/
+//! `proxy.rs` are still `todo!()` stubs and make no HTTP calls yet, so they
+//! have nothing to wire up here.
 //!
 //! Bounded by ATTEMPT COUNT, not elapsed time and not a caller-supplied
 //! deadline: neither provider threads `agent.metadata.timeout` (that only
 //! feeds `CliProvider`) or any `reqwest::Client` timeout into its request
 //! path today, so there is no existing deadline for this loop to interact
-//! with. A `Retry-After` value from the server is honored verbatim and
-//! uncapped — capping it would defeat the point of trusting the server's
-//! own knowledge of its quota window — so the wall-clock cost of a single
-//! wait is not bounded, only the number of waits is (`RetryPolicy::max_retries`).
-//! If a caller-side deadline for API providers is added later, it composes
-//! for free: wrap the whole `complete()`/`stream()` call in
+//! with. A `Retry-After` value from the server is honored close to
+//! verbatim — capping it too aggressively would defeat the point of
+//! trusting the server's own knowledge of its quota window — but it IS
+//! capped, at the dedicated, more generous `RetryPolicy::max_retry_after`
+//! (default 60s, well above the guessed-backoff cap): an unbounded,
+//! server-controlled sleep inside a client is a defect regardless of
+//! whether the server is well-behaved — a misconfigured proxy or a buggy
+//! upstream sending `Retry-After: 86400` must not park the caller for a
+//! day. Only the HTTP delta-seconds form of the header is parsed (see
+//! `parse_retry_after`); the header is only ever a hint, and every wait is
+//! still bounded overall by `max_retries`, so a caller-side deadline added
+//! later composes for free: wrap the whole `complete()`/`stream()` call in
 //! `tokio::time::timeout(..)` from the outside; nothing in this loop needs
 //! to change.
 
@@ -44,9 +64,16 @@ pub(crate) struct RetryPolicy {
     /// Base for the exponential backoff used when the server sends no
     /// `Retry-After` (`base * 2^(attempt-1)`, before jitter).
     pub base_delay: Duration,
-    /// Ceiling for a GUESSED backoff wait. Never applied to a server-declared
-    /// `Retry-After` (see module docs).
+    /// Ceiling for a GUESSED backoff wait (no `Retry-After` present).
     pub max_backoff: Duration,
+    /// Ceiling for a server-declared `Retry-After`. Deliberately separate
+    /// from, and more generous than, `max_backoff`: the server told us
+    /// something real about its own quota window, which deserves more
+    /// trust than our own guess — but not unlimited trust. 60s is long
+    /// enough to respect a real rate-limit window while still bounding the
+    /// worst case from a misconfigured proxy or a buggy/malicious upstream
+    /// (e.g. `Retry-After: 86400`) to something sane.
+    pub max_retry_after: Duration,
 }
 
 impl Default for RetryPolicy {
@@ -55,6 +82,7 @@ impl Default for RetryPolicy {
             max_retries: 3,
             base_delay: Duration::from_millis(500),
             max_backoff: Duration::from_secs(30),
+            max_retry_after: Duration::from_secs(60),
         }
     }
 }
@@ -66,18 +94,23 @@ pub(crate) enum RetryDecision {
     GiveUp,
 }
 
-/// Whether an HTTP status is worth retrying: 429 (rate limited) and 529
-/// (Anthropic's "overloaded"). Everything else — including other 4xx/5xx —
-/// is terminal. A 400 or 401 will never succeed on replay; retrying it only
-/// turns a clear, fast error into a slow one.
+/// Whether an HTTP status is worth retrying: 429 (rate limited, both
+/// providers), 529 (Anthropic's "overloaded"), and 503 (Gemini's overload
+/// signal, and RFC 7231's generic transient "Service Unavailable"). See the
+/// module docs for which provider actually emits which. Everything else —
+/// including other 4xx/5xx — is terminal. A 400 or 401 will never succeed
+/// on replay; retrying it only turns a clear, fast error into a slow one.
 pub(crate) fn is_retryable(status: StatusCode) -> bool {
-    matches!(status.as_u16(), 429 | 529)
+    matches!(status.as_u16(), 429 | 503 | 529)
 }
 
 /// Parse a `Retry-After` value as a plain count of seconds — the only form
-/// Anthropic/Google actually send. The HTTP-date form (`Retry-After: <date>`)
-/// is not produced by either provider today, so a value that doesn't parse
-/// as an unsigned integer is treated as absent rather than guessed at.
+/// Anthropic/Google actually send. The HTTP-date form (`Retry-After: <date>`,
+/// e.g. `Wed, 21 Oct 2026 07:28:00 GMT`) is legal per RFC 7231 but is not
+/// produced by either provider today and is not parsed here — a value that
+/// doesn't parse as an unsigned integer is treated as absent (falling back
+/// to computed backoff) rather than guessed at. `send_with_retry` logs when
+/// this happens so the fallback isn't silent.
 pub(crate) fn parse_retry_after(value: &str) -> Option<Duration> {
     value.trim().parse::<u64>().ok().map(Duration::from_secs)
 }
@@ -97,7 +130,7 @@ pub(crate) fn decide(
         return RetryDecision::GiveUp;
     }
     match retry_after {
-        Some(delay) => RetryDecision::Retry(delay),
+        Some(delay) => RetryDecision::Retry(delay.min(policy.max_retry_after)),
         None => RetryDecision::Retry(backoff_with_jitter(policy, attempt)),
     }
 }
@@ -132,8 +165,9 @@ fn full_jitter(cap: Duration) -> Duration {
     cap.mul_f64(frac)
 }
 
-/// Send a request, retrying on 429/529 per `policy` and honoring
-/// `Retry-After` when the server sends one. `build` is called once per
+/// Send a request, retrying on 429/503/529 per `policy` and honoring
+/// `Retry-After` (capped, see module docs) when the server sends one.
+/// `build` is called once per
 /// attempt (never `Fn`-cached) since a `RequestBuilder` is consumed by
 /// `send()` and can't be replayed.
 ///
@@ -157,11 +191,24 @@ where
             return Ok(response);
         }
 
-        let retry_after = response
+        let retry_after_raw = response
             .headers()
             .get(RETRY_AFTER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(parse_retry_after);
+            .and_then(|v| v.to_str().ok());
+        let retry_after = retry_after_raw.and_then(parse_retry_after);
+
+        if let Some(raw) = retry_after_raw
+            && retry_after.is_none()
+        {
+            // Legal (HTTP-date) but unsupported form — see parse_retry_after.
+            // Not silent: falling back to computed backoff without saying so
+            // would hide that we ignored a hint the server actually gave us.
+            tracing::debug!(
+                raw_value = raw,
+                "Retry-After header present but not in the supported delta-seconds form \
+                 (HTTP-date is not parsed) — falling back to computed backoff",
+            );
+        }
 
         match decide(policy, status, retry_after, attempt) {
             RetryDecision::GiveUp => return Ok(response),
@@ -200,17 +247,28 @@ mod tests {
     }
 
     #[test]
-    fn is_retryable_is_exactly_429_and_529() {
-        // Mutation this catches: the retryable set drifting — e.g. someone
-        // "helpfully" adding a generic 5xx, or dropping 529 because it's
-        // Anthropic-specific and easy to forget when generalizing.
-        for code in [429, 529] {
+    fn parse_retry_after_does_not_parse_the_http_date_form() {
+        // Documents a known, deliberate limitation (see module docs):
+        // Retry-After's HTTP-date form is legal per RFC 7231 but not
+        // parsed. Mutation this catches: silently starting to accept it
+        // (which would need re-auditing the "falls back to backoff, with a
+        // log line" behavior this test and `send_with_retry` both assume).
+        assert_eq!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT"), None);
+    }
+
+    #[test]
+    fn is_retryable_is_exactly_429_503_and_529() {
+        // Mutation this catches: the retryable set drifting — e.g. dropping
+        // 503 (Gemini's actual overload status) or 529 (Anthropic's,
+        // easy to forget when generalizing) because they're
+        // provider-specific, or "helpfully" widening to a generic 5xx.
+        for code in [429, 503, 529] {
             assert!(
                 is_retryable(StatusCode::from_u16(code).unwrap()),
                 "{code} should be retryable"
             );
         }
-        for code in [400, 401, 403, 404, 500, 502, 503] {
+        for code in [400, 401, 403, 404, 500, 502, 504] {
             assert!(
                 !is_retryable(StatusCode::from_u16(code).unwrap()),
                 "{code} must NOT be retryable"
@@ -219,14 +277,17 @@ mod tests {
     }
 
     #[test]
-    fn retry_after_header_is_honored_verbatim_over_backoff() {
+    fn retry_after_header_is_honored_up_to_the_cap() {
         // Mutation this catches: computing a backoff delay even when the
-        // server gave an explicit `Retry-After`, or scaling/capping that
-        // value instead of using it as-is.
+        // server gave an explicit `Retry-After`, or scaling that value
+        // instead of using it as-is (for a value comfortably under the
+        // cap, "as-is" and "capped" are indistinguishable — that's the
+        // point of this test; the next one pins the cap itself).
         let policy = RetryPolicy {
             max_retries: 3,
             base_delay: Duration::from_millis(1),
             max_backoff: Duration::from_millis(1),
+            max_retry_after: Duration::from_secs(60),
         };
         let decision = decide(
             &policy,
@@ -235,6 +296,28 @@ mod tests {
             1,
         );
         assert_eq!(decision, RetryDecision::Retry(Duration::from_secs(7)));
+    }
+
+    #[test]
+    fn retry_after_header_above_the_cap_is_clamped() {
+        // The defect this closes: a buggy server or an injecting proxy
+        // sending `Retry-After: 86400` must not park the caller for a day.
+        // Mutation this catches: dropping the `.min(max_retry_after)` (or
+        // applying it to the wrong branch, e.g. the guessed backoff
+        // instead of the header).
+        let policy = RetryPolicy {
+            max_retries: 3,
+            base_delay: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+            max_retry_after: Duration::from_secs(60),
+        };
+        let decision = decide(
+            &policy,
+            StatusCode::TOO_MANY_REQUESTS,
+            Some(Duration::from_secs(86_400)),
+            1,
+        );
+        assert_eq!(decision, RetryDecision::Retry(Duration::from_secs(60)));
     }
 
     #[test]
@@ -247,6 +330,7 @@ mod tests {
             max_retries: 5,
             base_delay: Duration::from_millis(100),
             max_backoff: Duration::from_millis(100),
+            ..RetryPolicy::default()
         };
         let mut seen = std::collections::HashSet::new();
         for _ in 0..30 {
@@ -290,6 +374,7 @@ mod tests {
             max_retries: 2,
             base_delay: Duration::from_millis(1),
             max_backoff: Duration::from_millis(1),
+            ..RetryPolicy::default()
         };
         assert!(matches!(
             decide(&policy, StatusCode::TOO_MANY_REQUESTS, None, 2),
@@ -374,6 +459,7 @@ mod tests {
             max_retries: 2,
             base_delay: Duration::from_millis(20),
             max_backoff: Duration::from_millis(20),
+            ..RetryPolicy::default()
         }
     }
 
@@ -401,6 +487,75 @@ mod tests {
             "should have waited ~1s per Retry-After, took {:?}",
             start.elapsed()
         );
+        assert_eq!(server.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_clamps_a_pathological_retry_after_header() {
+        // The over-the-wire proof of the cap fix: a server (or an
+        // injecting proxy) sending a huge Retry-After must not park the
+        // caller anywhere near that long. Mutation this catches: the cap
+        // not actually being wired into the real `send_with_retry` path
+        // (e.g. only added to `decide` in isolation, or applied to the
+        // wrong Duration) — this test uses a policy whose cap is tiny and
+        // whose base_delay/max_backoff are LARGER, so honoring the
+        // (huge) header uncapped OR falling back to the backoff cap would
+        // both blow the timing assertion; only clamping to
+        // `max_retry_after` fits inside it. Without the cap this doesn't
+        // just fail the assertion — it actually sleeps for 999999s
+        // (confirmed by hand: the test hung until killed), so the call is
+        // wrapped in a `tokio::time::timeout` the same way as the
+        // give-up-after-budget test, turning "no cap" into a fast failure.
+        let policy = RetryPolicy {
+            max_retries: 2,
+            base_delay: Duration::from_millis(200),
+            max_backoff: Duration::from_millis(200),
+            max_retry_after: Duration::from_millis(20),
+        };
+        let server = ScriptedServer::start(vec![
+            (429, vec![("Retry-After", "999999".to_string())], ""),
+            (200, vec![], "ok"),
+        ]);
+        let client = reqwest::Client::new();
+        let url = server.url();
+        let start = std::time::Instant::now();
+        let response = tokio::time::timeout(
+            Duration::from_secs(5),
+            send_with_retry(&policy, || client.get(&url)),
+        )
+        .await
+        .expect("send_with_retry did not clamp the Retry-After header")
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            start.elapsed() < Duration::from_millis(150),
+            "a Retry-After of 999999s must be clamped to the 20ms cap, took {:?}",
+            start.elapsed()
+        );
+        assert_eq!(server.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_falls_back_to_backoff_on_an_http_date_header() {
+        // Wiring proof for the HTTP-date limitation: a legal but unparsed
+        // `Retry-After` form must not crash or hang the request — it
+        // should behave exactly like "no header", i.e. computed backoff.
+        // Mutation this catches: `send_with_retry` panicking or stalling
+        // on a header it can't parse instead of falling through cleanly.
+        let server = ScriptedServer::start(vec![
+            (
+                429,
+                vec![("Retry-After", "Wed, 21 Oct 2026 07:28:00 GMT".to_string())],
+                "",
+            ),
+            (200, vec![], "ok"),
+        ]);
+        let client = reqwest::Client::new();
+        let url = server.url();
+        let response = send_with_retry(&tiny_policy(), || client.get(&url))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(server.request_count(), 2);
     }
 
@@ -452,6 +607,7 @@ mod tests {
             max_retries: 2,
             base_delay: Duration::from_millis(5),
             max_backoff: Duration::from_millis(5),
+            ..RetryPolicy::default()
         };
         let server = ScriptedServer::start(vec![(429, vec![], "still overloaded")]);
         let client = reqwest::Client::new();

--- a/crates/armadai-providers/src/api/retry.rs
+++ b/crates/armadai-providers/src/api/retry.rs
@@ -1,0 +1,470 @@
+//! Shared HTTP retry/backoff for the API providers (anthropic, google).
+//!
+//! Lot 1 (`rate_limiter.rs`, one directory up) is a pure token-bucket
+//! throttler: it smooths OUTGOING calls, proactively, before they hit the
+//! wire. It contains no retry, no backoff, no 429/529 handling. This module
+//! is the reactive half — what to do when the SERVER comes back with a
+//! rate-limit or overload response.
+//!
+//! Both providers speak plain HTTP and hit exactly the same two failure
+//! modes (429 rate-limited, 529 overloaded), read the same `Retry-After`
+//! header, and need the same retryable/terminal distinction (a 400 or 401
+//! is never worth retrying — doing so only delays a clear error). This is
+//! implemented ONCE here and used by both `api::anthropic` and `api::google`
+//! rather than grown independently in each — two copies of one policy is
+//! the defect class this repo has fixed repeatedly (see the issue write-up).
+//! `openai.rs`/`proxy.rs` are still `todo!()` stubs and make no HTTP calls
+//! yet, so they have nothing to wire up here.
+//!
+//! Bounded by ATTEMPT COUNT, not elapsed time and not a caller-supplied
+//! deadline: neither provider threads `agent.metadata.timeout` (that only
+//! feeds `CliProvider`) or any `reqwest::Client` timeout into its request
+//! path today, so there is no existing deadline for this loop to interact
+//! with. A `Retry-After` value from the server is honored verbatim and
+//! uncapped — capping it would defeat the point of trusting the server's
+//! own knowledge of its quota window — so the wall-clock cost of a single
+//! wait is not bounded, only the number of waits is (`RetryPolicy::max_retries`).
+//! If a caller-side deadline for API providers is added later, it composes
+//! for free: wrap the whole `complete()`/`stream()` call in
+//! `tokio::time::timeout(..)` from the outside; nothing in this loop needs
+//! to change.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use reqwest::{RequestBuilder, Response, StatusCode, header::RETRY_AFTER};
+
+/// Bounds and pacing for the retry loop. `Default` gives the production
+/// values; tests build a `RetryPolicy` with tiny delays so the suite stays
+/// fast and deterministic (never sleeping seconds for no reason).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetryPolicy {
+    /// Retries allowed AFTER the first attempt. 3 -> up to 4 total tries.
+    pub max_retries: u32,
+    /// Base for the exponential backoff used when the server sends no
+    /// `Retry-After` (`base * 2^(attempt-1)`, before jitter).
+    pub base_delay: Duration,
+    /// Ceiling for a GUESSED backoff wait. Never applied to a server-declared
+    /// `Retry-After` (see module docs).
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay: Duration::from_millis(500),
+            max_backoff: Duration::from_secs(30),
+        }
+    }
+}
+
+/// One retry-or-give-up decision, and — when retrying — how long to wait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetryDecision {
+    Retry(Duration),
+    GiveUp,
+}
+
+/// Whether an HTTP status is worth retrying: 429 (rate limited) and 529
+/// (Anthropic's "overloaded"). Everything else — including other 4xx/5xx —
+/// is terminal. A 400 or 401 will never succeed on replay; retrying it only
+/// turns a clear, fast error into a slow one.
+pub(crate) fn is_retryable(status: StatusCode) -> bool {
+    matches!(status.as_u16(), 429 | 529)
+}
+
+/// Parse a `Retry-After` value as a plain count of seconds — the only form
+/// Anthropic/Google actually send. The HTTP-date form (`Retry-After: <date>`)
+/// is not produced by either provider today, so a value that doesn't parse
+/// as an unsigned integer is treated as absent rather than guessed at.
+pub(crate) fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+/// Decide whether the response to attempt number `attempt` (1-based: 1 is
+/// the first try) should be retried, and after how long.
+pub(crate) fn decide(
+    policy: &RetryPolicy,
+    status: StatusCode,
+    retry_after: Option<Duration>,
+    attempt: u32,
+) -> RetryDecision {
+    if !is_retryable(status) {
+        return RetryDecision::GiveUp;
+    }
+    if attempt > policy.max_retries {
+        return RetryDecision::GiveUp;
+    }
+    match retry_after {
+        Some(delay) => RetryDecision::Retry(delay),
+        None => RetryDecision::Retry(backoff_with_jitter(policy, attempt)),
+    }
+}
+
+fn backoff_with_jitter(policy: &RetryPolicy, attempt: u32) -> Duration {
+    let exp = attempt.saturating_sub(1).min(16);
+    let cap = policy
+        .base_delay
+        .saturating_mul(1u32 << exp)
+        .min(policy.max_backoff);
+    full_jitter(cap)
+}
+
+/// Uniform-in-`[0, cap]` "full jitter" (AWS's term for the classic
+/// decorrelated-backoff trick), so concurrent callers backing off from the
+/// same overload don't retry in lockstep. Hand-rolled xorshift64* seeded
+/// from the wall clock and a process-wide counter — no `rand` dependency
+/// needed for what is, deliberately, a dozen lines; this doesn't need to be
+/// cryptographically strong, only unpredictable enough to decorrelate.
+fn full_jitter(cap: Duration) -> Duration {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let mut x = nanos ^ n.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xD1B5_4A32_D192_ED03;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    let frac = (x >> 11) as f64 / (1u64 << 53) as f64; // uniform in [0, 1)
+    cap.mul_f64(frac)
+}
+
+/// Send a request, retrying on 429/529 per `policy` and honoring
+/// `Retry-After` when the server sends one. `build` is called once per
+/// attempt (never `Fn`-cached) since a `RequestBuilder` is consumed by
+/// `send()` and can't be replayed.
+///
+/// Returns the FIRST response that is either successful or not worth
+/// retrying (terminal status, or the retry budget is exhausted) — success
+/// or failure, callers keep their existing status-check / error-body
+/// logic completely unchanged; this function only decides whether to try
+/// again, never how to interpret the final response.
+pub(crate) async fn send_with_retry<F>(
+    policy: &RetryPolicy,
+    mut build: F,
+) -> reqwest::Result<Response>
+where
+    F: FnMut() -> RequestBuilder,
+{
+    let mut attempt: u32 = 1;
+    loop {
+        let response = build().send().await?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response);
+        }
+
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_retry_after);
+
+        match decide(policy, status, retry_after, attempt) {
+            RetryDecision::GiveUp => return Ok(response),
+            RetryDecision::Retry(delay) => {
+                tracing::warn!(
+                    %status,
+                    attempt,
+                    max_retries = policy.max_retries,
+                    delay_ms = delay.as_millis() as u64,
+                    "provider HTTP error is retryable, backing off before retry",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- pure decision logic: no networking, no sleeping ---
+
+    #[test]
+    fn parse_retry_after_reads_plain_seconds_and_rejects_garbage() {
+        // Mutation this catches: the parser accepting non-integer input
+        // (e.g. switching to `f64` parsing, or not trimming whitespace).
+        assert_eq!(parse_retry_after("7"), Some(Duration::from_secs(7)));
+        assert_eq!(parse_retry_after("  3  "), Some(Duration::from_secs(3)));
+        assert_eq!(parse_retry_after("0"), Some(Duration::from_secs(0)));
+        assert_eq!(parse_retry_after("abc"), None);
+        assert_eq!(parse_retry_after(""), None);
+        assert_eq!(parse_retry_after("-1"), None);
+        assert_eq!(parse_retry_after("1.5"), None);
+    }
+
+    #[test]
+    fn is_retryable_is_exactly_429_and_529() {
+        // Mutation this catches: the retryable set drifting — e.g. someone
+        // "helpfully" adding a generic 5xx, or dropping 529 because it's
+        // Anthropic-specific and easy to forget when generalizing.
+        for code in [429, 529] {
+            assert!(
+                is_retryable(StatusCode::from_u16(code).unwrap()),
+                "{code} should be retryable"
+            );
+        }
+        for code in [400, 401, 403, 404, 500, 502, 503] {
+            assert!(
+                !is_retryable(StatusCode::from_u16(code).unwrap()),
+                "{code} must NOT be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_after_header_is_honored_verbatim_over_backoff() {
+        // Mutation this catches: computing a backoff delay even when the
+        // server gave an explicit `Retry-After`, or scaling/capping that
+        // value instead of using it as-is.
+        let policy = RetryPolicy {
+            max_retries: 3,
+            base_delay: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+        };
+        let decision = decide(
+            &policy,
+            StatusCode::TOO_MANY_REQUESTS,
+            Some(Duration::from_secs(7)),
+            1,
+        );
+        assert_eq!(decision, RetryDecision::Retry(Duration::from_secs(7)));
+    }
+
+    #[test]
+    fn no_header_backs_off_within_cap_and_jitters() {
+        // Mutation this catches: backoff ignoring `max_backoff` (unbounded
+        // growth), and backoff being deterministic (no jitter at all —
+        // e.g. always returning the cap), which would make concurrent
+        // retries lock-step.
+        let policy = RetryPolicy {
+            max_retries: 5,
+            base_delay: Duration::from_millis(100),
+            max_backoff: Duration::from_millis(100),
+        };
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..30 {
+            let RetryDecision::Retry(d) = decide(&policy, StatusCode::TOO_MANY_REQUESTS, None, 1)
+            else {
+                panic!("expected a retry decision");
+            };
+            assert!(
+                d <= Duration::from_millis(100),
+                "backoff exceeded the cap: {d:?}"
+            );
+            seen.insert(d);
+        }
+        assert!(
+            seen.len() > 1,
+            "30 samples produced no variation — jitter looks disabled"
+        );
+    }
+
+    #[test]
+    fn terminal_status_never_retries_regardless_of_attempt_or_header() {
+        // Mutation this catches: the retryable check being skipped or
+        // inverted, so a 400 with a (nonsensical but present) Retry-After
+        // header would still be retried.
+        let policy = RetryPolicy::default();
+        let decision = decide(
+            &policy,
+            StatusCode::BAD_REQUEST,
+            Some(Duration::from_secs(1)),
+            1,
+        );
+        assert_eq!(decision, RetryDecision::GiveUp);
+    }
+
+    #[test]
+    fn retry_budget_boundary_last_allowed_attempt_retries_next_gives_up() {
+        // Mutation this catches: an off-by-one in the exhaustion check
+        // (`>=` vs `>`), which either retries one time too many or gives up
+        // one time too early. Pins the exact boundary.
+        let policy = RetryPolicy {
+            max_retries: 2,
+            base_delay: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+        };
+        assert!(matches!(
+            decide(&policy, StatusCode::TOO_MANY_REQUESTS, None, 2),
+            RetryDecision::Retry(_)
+        ));
+        assert_eq!(
+            decide(&policy, StatusCode::TOO_MANY_REQUESTS, None, 3),
+            RetryDecision::GiveUp
+        );
+    }
+
+    // --- end-to-end over real (local-only) HTTP: proves the wiring, not
+    // just the decision table ---
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Minimal scripted HTTP/1.1 server so `send_with_retry` is exercised
+    /// against REAL wire traffic (real status line, real headers) without
+    /// calling any external API. Each accepted connection gets exactly one
+    /// scripted `(status, headers, body)`, served then closed
+    /// (`Connection: close`, so reqwest never reuses a stale connection
+    /// across scripts). Requests past the end of the script repeat the last
+    /// entry — tests that don't know the exact attempt count (the
+    /// give-up-after-budget case) rely on that.
+    /// (status code, extra headers, body) for one scripted response.
+    type ScriptedResponse = (u16, Vec<(&'static str, String)>, &'static str);
+
+    struct ScriptedServer {
+        addr: std::net::SocketAddr,
+        requests: Arc<AtomicUsize>,
+    }
+
+    impl ScriptedServer {
+        fn start(responses: Vec<ScriptedResponse>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test server");
+            let addr = listener.local_addr().expect("local addr");
+            let requests = Arc::new(AtomicUsize::new(0));
+            let requests_clone = requests.clone();
+            std::thread::spawn(move || {
+                for stream in listener.incoming() {
+                    let Ok(mut stream) = stream else { break };
+                    let idx = requests_clone.fetch_add(1, Ordering::SeqCst);
+                    let (code, headers, body) = responses
+                        .get(idx)
+                        .or_else(|| responses.last())
+                        .cloned()
+                        .expect("script must have at least one response");
+
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                    let mut buf = [0u8; 4096];
+                    let _ = stream.read(&mut buf); // drain the request, ignore its content
+
+                    let mut resp = format!(
+                        "HTTP/1.1 {code} X\r\nConnection: close\r\nContent-Length: {}\r\n",
+                        body.len()
+                    );
+                    for (k, v) in &headers {
+                        resp.push_str(&format!("{k}: {v}\r\n"));
+                    }
+                    resp.push_str("\r\n");
+                    resp.push_str(body);
+                    let _ = stream.write_all(resp.as_bytes());
+                }
+            });
+            Self { addr, requests }
+        }
+
+        fn url(&self) -> String {
+            format!("http://{}", self.addr)
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.load(Ordering::SeqCst)
+        }
+    }
+
+    fn tiny_policy() -> RetryPolicy {
+        RetryPolicy {
+            max_retries: 2,
+            base_delay: Duration::from_millis(20),
+            max_backoff: Duration::from_millis(20),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_honors_real_retry_after_header() {
+        // Mutation this catches: the header extraction never being wired
+        // into `send_with_retry` (wrong header name/case, or the
+        // `.headers().get(...)` call being dropped) — if honoring the
+        // header were broken, this would fall through to the tiny 20ms
+        // backoff instead of the header's declared 1s, and the timing
+        // assertion below would fail.
+        let server = ScriptedServer::start(vec![
+            (429, vec![("Retry-After", "1".to_string())], ""),
+            (200, vec![], "ok"),
+        ]);
+        let client = reqwest::Client::new();
+        let url = server.url();
+        let start = std::time::Instant::now();
+        let response = send_with_retry(&tiny_policy(), || client.get(&url))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            start.elapsed() >= Duration::from_millis(900),
+            "should have waited ~1s per Retry-After, took {:?}",
+            start.elapsed()
+        );
+        assert_eq!(server.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_backs_off_and_succeeds_without_header() {
+        // Mutation this catches: treating "no Retry-After header" as "don't
+        // retry" (an easy slip once the header-based path exists) — if so,
+        // the server would see only 1 request and the final status would
+        // still be 429, not 200.
+        let server = ScriptedServer::start(vec![(429, vec![], ""), (200, vec![], "ok")]);
+        let client = reqwest::Client::new();
+        let url = server.url();
+        let response = send_with_retry(&tiny_policy(), || client.get(&url))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(server.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_never_retries_a_400_over_the_wire() {
+        // Mutation this catches: retrying on any non-2xx instead of just
+        // 429/529 — would show up here as more than one request and a slow
+        // return instead of an immediate one.
+        let server = ScriptedServer::start(vec![(400, vec![], "bad request")]);
+        let client = reqwest::Client::new();
+        let url = server.url();
+        let start = std::time::Instant::now();
+        let response = send_with_retry(&tiny_policy(), || client.get(&url))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(server.request_count(), 1);
+        assert!(start.elapsed() < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn send_with_retry_gives_up_after_budget_and_stops_the_server_traffic() {
+        // The one that matters most: a server that NEVER recovers must not
+        // be retried forever. Mutation this catches: a missing/broken
+        // exhaustion check turning this into an infinite loop, or a count
+        // that drifts from the configured budget. An infinite loop would
+        // otherwise just hang this test (and the CI job) instead of failing
+        // it — confirmed by removing the exhaustion check by hand: the test
+        // hung until killed rather than reporting a failure — so the call
+        // is wrapped in a generous `tokio::time::timeout` that turns "loops
+        // forever" into an explicit, fast assertion failure.
+        let policy = RetryPolicy {
+            max_retries: 2,
+            base_delay: Duration::from_millis(5),
+            max_backoff: Duration::from_millis(5),
+        };
+        let server = ScriptedServer::start(vec![(429, vec![], "still overloaded")]);
+        let client = reqwest::Client::new();
+        let url = server.url();
+        let response = tokio::time::timeout(
+            Duration::from_secs(5),
+            send_with_retry(&policy, || client.get(&url)),
+        )
+        .await
+        .expect("send_with_retry did not give up — it looped past the retry budget")
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        // 1 initial attempt + 2 retries = 3, never more.
+        assert_eq!(server.request_count(), 3);
+    }
+}


### PR DESCRIPTION
Ferme #272 (rate-limiting Lot 2).

## Le point de départ, et ce que le Lot 1 n'était pas

`api/anthropic.rs` et `api/google.rs` faisaient un `bail!` sur **tout** statut non-2xx, sans lire les en-têtes — donc `Retry-After` n'était jamais consulté.

Et le Lot 1 (#269) pouvait laisser croire le contraire : son `rate_limiter.rs` est un **token-bucket de throttling pur**, qui lisse les appels sortants. Aucun retry, aucun backoff, aucun traitement de 429/529.

## Un helper partagé, pas deux copies

`api::retry::send_with_retry`, utilisé par les **deux** providers. Les deux subissent les mêmes pannes avec le même en-tête ; deux copies de cette politique seraient la classe de défaut que ce dépôt a corrigée quatre fois cette semaine.

Il ne pouvait pas vivre dans le décorateur `RateLimitedProvider` du Lot 1 : celui-ci n'a plus accès au statut ni aux en-têtes HTTP bruts une fois convertis en `anyhow::Error`.

## Les statuts, fondés sur ce que les API émettent

**429, 503, 529** — et cette liste est le cœur du correctif :

| provider | émet |
|---|---|
| Anthropic | 429 (`rate_limit_error`), 529 (`overloaded_error`) |
| Google/Gemini | 429 (`RESOURCE_EXHAUSTED`), **503** (`UNAVAILABLE`) — jamais 529 |

La première version ne retryait que 429 et 529. Or **529 est spécifique à Anthropic** : le helper traitait donc les deux providers à égalité dans sa structure, mais pas dans ses effets — `google.rs` recevait un chemin de retry qui ne se déclenchait presque jamais sur la panne pour laquelle il existe. 504 est explicitement rangé parmi les non-retryables.

## Deux plafonds, et pourquoi ils sont distincts

- `max_retry_after` = **60 s** — ce que le serveur nous annonce
- `max_backoff` = **30 s** — ce que nous devinons

Un `Retry-After` était d'abord honoré **verbatim, sans plafond** : un serveur bogué, ou un proxy injectant l'en-tête, répondant `Retry-After: 86400` garait le client vingt-quatre heures. Un sommeil non borné piloté par le serveur, à l'intérieur d'un client, est indéfendable.

La séparation est justifiée par un écart de confiance : une valeur annoncée par le serveur dit quelque chose de réel sur son quota, ce qui mérite plus qu'une supposition — mais pas une confiance illimitée.

Frontières sondées en revue : 60 s passe, 61 s se plafonne, `0` traverse comme `0` (et non comme « absent »), une valeur malformée est rejetée au parsing et bascule sur le backoff, lui-même borné séparément.

**Pire cas chiffré** : 4 tentatives, 3 sommeils, chemin en-tête dominant → **180 s** avant qu'un endpoint durablement en 503 rende son erreur finale. C'est ce qu'un utilisateur attend, donc autant que ce soit connu.

## La forme date de `Retry-After`

HTTP autorise aussi une date (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`). Elle n'est **pas** parsée — ajouter une dépendance de parsing de date pour ce cas ne le valait pas — mais elle n'est plus **silencieuse** : `tracing::debug!` avec la valeur brute, et un commentaire nommant la limite. C'est le silence qui en faisait un piège.

## Vérification

10 tests, **aucun appel réseau réel** : 6 tables de décision pures, 4 contre un `TcpListener` local. Chaque test nomme la mutation qu'il attrape, et chacune a été appliquée puis restaurée à la main.

Une finesse qui vaut d'être dite : le test du budget épuisé enveloppe un `tokio::time::timeout` de 5 s, car sans lui la mutation **bloque** le test au lieu de le faire échouer. Un test bloqué n'échoue pas, il fait attendre.

Deux mutations revérifiées indépendamment en revue : retirer le plafond fait échouer les tests de clamp ; retirer 503 fait échouer la liste des statuts.

**Aucune dépendance ajoutée** — jitter xorshift64* maison (~12 lignes), serveur de test en `std::net::TcpListener`.

fmt · clippy `-D warnings` sur les 5 modes · les 4 modes de test verts · gaveldrop 13 cas / 83-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
