### PR TITLE
fix(providers): bound CLI inactivity with an absolute ceiling, not total call duration

### DIFF
--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -52,7 +52,16 @@ pub struct AgentMetadata {
     pub temperature: f32,
     /// Max output tokens
     pub max_tokens: Option<u32>,
-    /// Execution timeout in seconds
+    /// CLI provider timeout in seconds.
+    ///
+    /// Since #270, this bounds *inactivity* — the longest gap between two
+    /// consecutive lines of subprocess output — not the call's total
+    /// duration: a `CliProvider` call that keeps producing output survives
+    /// past this many seconds; one that goes fully silent for this long is
+    /// killed (see `armadai_providers::cli::CliProvider::complete`). Only
+    /// applies to CLI-backed providers (`provider: cli`, or a unified name
+    /// like `claude`/`gemini` resolving to its CLI); API providers ignore
+    /// this field.
     pub timeout: Option<u64>,
     /// Tags for filtering
     #[serde(default)]

--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -103,23 +103,76 @@ impl Provider for CliProvider {
         // the agent's explicit args). Then parse stdout opportunistically:
         // `parse_json_stdout` extracts content + cost/tokens from JSONL events
         // when present, and falls back to raw stdout (zeroed metrics) otherwise.
-        let mut cmd = self.build_command(&input);
+        let mut child = self.build_command(&input).spawn()?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture stderr"))?;
+
+        // Drain stderr concurrently. Reading stdout to EOF *before* `wait()`ing
+        // (below) is required to avoid the classic pipe-deadlock (a chatty
+        // child blocks on a full stdout pipe while we're not reading it), and
+        // draining stderr on its own task means a chatty stderr can't cause
+        // the same deadlock while we wait on stdout lines.
+        let stderr_task = tokio::spawn(async move {
+            let mut buf = String::new();
+            let mut lines = tokio::io::AsyncBufReadExt::lines(tokio::io::BufReader::new(stderr));
+            while let Ok(Some(line)) = lines.next_line().await {
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+            buf
+        });
+
+        let mut lines = tokio::io::AsyncBufReadExt::lines(tokio::io::BufReader::new(stdout));
         let timeout = std::time::Duration::from_secs(self.timeout_secs);
 
-        let output = match tokio::time::timeout(timeout, cmd.output()).await {
-            Ok(result) => result?,
-            Err(_) => {
-                anyhow::bail!("CLI command timed out after {}s", self.timeout_secs);
+        // Inactivity timeout (#270): rearmed on every line read from stdout,
+        // rather than a single deadline covering the whole call. Any line —
+        // a delegation (`tool_use`) event, a token delta, an init/result
+        // event, even a line that fails to parse as JSON — counts as
+        // activity: it proves the subprocess is still producing observable
+        // output, which is the only signal available here that it isn't
+        // hung (this works uniformly for JSON-streaming CLIs and plain-text
+        // ones like `aider`, without coupling to `json_runner`'s
+        // per-provider event parsing). A subprocess that goes fully silent
+        // for `timeout_secs` is killed; one that keeps streaming survives
+        // indefinitely past what used to be a hard wall-clock ceiling.
+        let mut raw = String::new();
+        loop {
+            match tokio::time::timeout(timeout, lines.next_line()).await {
+                Ok(Ok(Some(line))) => {
+                    raw.push_str(&line);
+                    raw.push('\n');
+                }
+                Ok(Ok(None)) => break, // stdout closed: subprocess done writing
+                Ok(Err(e)) => {
+                    let _ = child.kill().await;
+                    return Err(e.into());
+                }
+                Err(_) => {
+                    let _ = child.kill().await;
+                    anyhow::bail!(
+                        "CLI command timed out after {}s of inactivity (no output)",
+                        self.timeout_secs
+                    );
+                }
             }
-        };
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("CLI command failed ({}): {stderr}", output.status);
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        Ok(self.parse_json_stdout(&stdout))
+        let status = child.wait().await?;
+        let stderr_buf = stderr_task.await.unwrap_or_default();
+
+        if !status.success() {
+            anyhow::bail!("CLI command failed ({status}): {stderr_buf}");
+        }
+
+        Ok(self.parse_json_stdout(&raw))
     }
 
     async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
@@ -138,23 +191,45 @@ impl Provider for CliProvider {
         tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stdout);
             let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
-
             let timeout = std::time::Duration::from_secs(timeout_secs);
-            let result = tokio::time::timeout(timeout, async {
-                while let Ok(Some(line)) = lines.next_line().await {
-                    if tx.send(Ok(line)).await.is_err() {
+
+            // Inactivity timeout (#270), mirroring `complete()`: the timeout
+            // is rearmed on every line, not held once around the whole loop
+            // — otherwise a steadily-streaming child would still be cut off
+            // once the loop's cumulative duration passed `timeout_secs`,
+            // even though it never went silent.
+            loop {
+                match tokio::time::timeout(timeout, lines.next_line()).await {
+                    Ok(Ok(Some(line))) => {
+                        if tx.send(Ok(line)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Ok(None)) => break, // stdout closed: child done writing
+                    Ok(Err(e)) => {
+                        let _ = tx
+                            .send(Err(anyhow::anyhow!("Failed to read CLI output: {e}")))
+                            .await;
                         break;
                     }
-                }
-            })
-            .await;
-
-            if result.is_err() {
-                if let Err(e) = tx.send(Err(anyhow::anyhow!("CLI command timed out"))).await {
-                    tracing::debug!("Failed to send timeout error (receiver dropped): {:?}", e);
-                }
-                if let Err(e) = child.kill().await {
-                    tracing::debug!("Failed to kill timed-out CLI command: {:?}", e);
+                    Err(_) => {
+                        if let Err(e) = tx
+                            .send(Err(anyhow::anyhow!(
+                                "CLI command timed out after {timeout_secs}s of inactivity (no output)"
+                            )))
+                            .await
+                        {
+                            tracing::debug!(
+                                "Failed to send timeout error (receiver dropped): {:?}",
+                                e
+                            );
+                        }
+                        if let Err(e) = child.kill().await {
+                            tracing::debug!("Failed to kill timed-out CLI command: {:?}", e);
+                        }
+                        let _ = child.wait().await;
+                        return;
+                    }
                 }
             }
 
@@ -321,6 +396,85 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("timed out"), "Error was: {err}");
+    }
+
+    // ── Inactivity timeout, rearmed per line (#270) ──
+    //
+    // The pre-fix implementation wrapped ONE `tokio::time::timeout` around
+    // the entire subprocess call, so the ceiling measured total call
+    // duration. That kills a hierarchical run mid-progress: each delegated
+    // `claude -p` turn is itself long-running and agentic, and a
+    // multi-delegation coordinator run legitimately exceeds any fixed
+    // wall-clock ceiling while still making steady progress. The two tests
+    // below pin the replacement contract: the ceiling must measure the gap
+    // between successive lines of subprocess output, not the call's total
+    // duration.
+
+    /// A subprocess whose individual gaps between lines never exceed the
+    /// ceiling must survive even once its TOTAL runtime exceeds it.
+    ///
+    /// Mutation this catches: reverting to a single `tokio::time::timeout`
+    /// around the whole read loop (the pre-fix shape) instead of one
+    /// rearmed on every line — that shape kills this exact case, since the
+    /// process's total runtime (~1.2s over 3 ticks of 0.4s) exceeds the 1s
+    /// ceiling even though no single gap does. It also catches a mutation
+    /// that reads the whole stdout in one shot before checking the
+    /// deadline (e.g. reverting to `cmd.output()`), which would observe no
+    /// intermediate activity at all and time out the same way.
+    #[tokio::test]
+    async fn steady_stream_survives_past_the_old_static_ceiling() {
+        let result = with_env_lock(async {
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
+            provider
+                .complete(echo_request(
+                    "for i in 1 2 3; do echo tick; sleep 0.4; done",
+                ))
+                .await
+        })
+        .await;
+
+        let response = result.expect("a steadily-ticking subprocess must not time out");
+        assert_eq!(
+            response.content.matches("tick").count(),
+            3,
+            "expected all 3 ticks to have been read before the process exited, got: {}",
+            response.content
+        );
+    }
+
+    /// A subprocess producing NOTHING on stdout must be killed once
+    /// `timeout_secs` of silence elapses — it must die near that ceiling,
+    /// not run toward its much longer natural completion (or hang forever
+    /// if the mechanism is broken).
+    ///
+    /// Mutation this catches: disabling/removing the inactivity check, or
+    /// rearming it on something other than actual stdout activity (e.g. an
+    /// unconditional tick) — either would let this call run well past the
+    /// 1s ceiling instead of erroring within a couple of seconds of it, so
+    /// the elapsed-time bound below would fail.
+    #[tokio::test]
+    async fn silent_subprocess_dies_near_the_inactivity_ceiling_not_later() {
+        let start = std::time::Instant::now();
+        let result = with_env_lock(async {
+            let provider = CliProvider::new("sleep".to_string(), vec![], 1);
+            provider.complete(echo_request("60")).await
+        })
+        .await;
+        let elapsed = start.elapsed();
+
+        let err = result
+            .expect_err("a silent subprocess must time out")
+            .to_string();
+        assert!(err.contains("timed out"), "error was: {err}");
+        // Generous bound (well under the 60s sleep, generous over the 1s
+        // ceiling) to absorb scheduling jitter when the full suite runs many
+        // real subprocess-spawning tests in parallel — the point is only to
+        // rule out "ran to natural completion" or "hung forever", not to
+        // pin exact timing.
+        assert!(
+            elapsed < std::time::Duration::from_secs(20),
+            "should die near the 1s inactivity ceiling, not run toward the 60s sleep: {elapsed:?}"
+        );
     }
 
     // ── JSON-mode stdout parsing (Part C: real cost/tokens from `claude`) ──

--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -1,7 +1,49 @@
 use async_trait::async_trait;
+use std::time::{Duration, Instant};
 use tokio::process::Command;
 
 use armadai_core::provider::*;
+
+/// Absolute backstop on top of the per-line inactivity timeout (#270 review
+/// F4): inactivity is the right thing to bound (see `CliProvider::complete`),
+/// but it cannot be the *only* bound — a subprocess that keeps producing
+/// some output forever (a heartbeat that never converges) would otherwise
+/// never be killed. This must never trip on any legitimate call, including
+/// a single `claude -p` invocation that itself drives many native
+/// Task-tool delegations in one process (a whole hierarchical session can
+/// be ONE `CliProvider::complete()` call) — so it is deliberately large: 2
+/// hours comfortably exceeds every turn duration observed on this project
+/// (single agentic turns ~500-600s) with room for several chained turns.
+/// It is a safety net, not a tuned control: if genuinely multi-hour
+/// sessions become routine, this should become its own configurable field
+/// instead of a larger constant.
+const ABSOLUTE_CEILING_SECS: u64 = 2 * 60 * 60;
+
+/// Decide how long the next single read may wait, given how long the call
+/// has run so far (`elapsed`), the per-line inactivity ceiling
+/// (`inactivity_timeout`), and the absolute backstop (`absolute_ceiling`).
+///
+/// Returns `None` once `absolute_ceiling` itself has already been reached
+/// (the caller must stop, regardless of activity). Otherwise returns the
+/// duration the next read may wait, and whether THIS step is bounded by
+/// the absolute ceiling rather than by genuine inactivity — the caller
+/// uses that flag to report an accurate reason if the step times out.
+///
+/// Pure and sync so the scheduling math is unit-testable without any real
+/// waiting (mirrors this codebase's existing `orchestrated_agent_timeout_secs`
+/// pattern of keeping timeout arithmetic in a plain, fast-testable fn).
+fn next_step_timeout(
+    elapsed: Duration,
+    inactivity_timeout: Duration,
+    absolute_ceiling: Duration,
+) -> Option<(Duration, bool)> {
+    if elapsed >= absolute_ceiling {
+        return None;
+    }
+    let remaining_to_ceiling = absolute_ceiling - elapsed;
+    let ceiling_bound = remaining_to_ceiling < inactivity_timeout;
+    Some((inactivity_timeout.min(remaining_to_ceiling), ceiling_bound))
+}
 
 /// Generic CLI provider that spawns any configured command.
 pub struct CliProvider {
@@ -118,19 +160,28 @@ impl Provider for CliProvider {
         // (below) is required to avoid the classic pipe-deadlock (a chatty
         // child blocks on a full stdout pipe while we're not reading it), and
         // draining stderr on its own task means a chatty stderr can't cause
-        // the same deadlock while we wait on stdout lines.
+        // the same deadlock while we wait on stdout lines. Byte-oriented
+        // (`read_until`, not `.lines()`): a single non-UTF-8 byte on stderr
+        // must not abort the drain, it must lossily substitute like the rest
+        // of this method (#270 review F2).
         let stderr_task = tokio::spawn(async move {
-            let mut buf = String::new();
-            let mut lines = tokio::io::AsyncBufReadExt::lines(tokio::io::BufReader::new(stderr));
-            while let Ok(Some(line)) = lines.next_line().await {
-                buf.push_str(&line);
-                buf.push('\n');
+            let mut reader = tokio::io::BufReader::new(stderr);
+            let mut out = Vec::new();
+            let mut chunk = Vec::new();
+            loop {
+                chunk.clear();
+                match tokio::io::AsyncBufReadExt::read_until(&mut reader, b'\n', &mut chunk).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => out.extend_from_slice(&chunk),
+                }
             }
-            buf
+            String::from_utf8_lossy(&out).into_owned()
         });
 
-        let mut lines = tokio::io::AsyncBufReadExt::lines(tokio::io::BufReader::new(stdout));
-        let timeout = std::time::Duration::from_secs(self.timeout_secs);
+        let mut reader = tokio::io::BufReader::new(stdout);
+        let timeout = Duration::from_secs(self.timeout_secs);
+        let absolute_ceiling = Duration::from_secs(ABSOLUTE_CEILING_SECS);
+        let start = Instant::now();
 
         // Inactivity timeout (#270): rearmed on every line read from stdout,
         // rather than a single deadline covering the whole call. Any line —
@@ -142,21 +193,49 @@ impl Provider for CliProvider {
         // ones like `aider`, without coupling to `json_runner`'s
         // per-provider event parsing). A subprocess that goes fully silent
         // for `timeout_secs` is killed; one that keeps streaming survives
-        // indefinitely past what used to be a hard wall-clock ceiling.
+        // past what used to be a hard wall-clock ceiling, up to the
+        // `ABSOLUTE_CEILING_SECS` backstop.
+        //
+        // Reads are byte-oriented (`read_until`, not `.lines()`), so a
+        // single non-UTF-8 byte lossily substitutes (matching the pre-#270
+        // `String::from_utf8_lossy(&output.stdout)` behavior) instead of
+        // aborting the whole call — `provider: cli` is documented for
+        // arbitrary scripts, and a stray byte from one must not be fatal.
         let mut raw = String::new();
+        let mut line_buf: Vec<u8> = Vec::new();
         loop {
-            match tokio::time::timeout(timeout, lines.next_line()).await {
-                Ok(Ok(Some(line))) => {
-                    raw.push_str(&line);
-                    raw.push('\n');
-                }
-                Ok(Ok(None)) => break, // stdout closed: subprocess done writing
+            let Some((step_timeout, ceiling_bound)) =
+                next_step_timeout(start.elapsed(), timeout, absolute_ceiling)
+            else {
+                let _ = child.start_kill();
+                stderr_task.abort();
+                anyhow::bail!(
+                    "CLI command exceeded the absolute {}s ceiling despite ongoing activity",
+                    absolute_ceiling.as_secs()
+                );
+            };
+
+            line_buf.clear();
+            let read = tokio::io::AsyncBufReadExt::read_until(&mut reader, b'\n', &mut line_buf);
+            match tokio::time::timeout(step_timeout, read).await {
+                Ok(Ok(0)) => break, // stdout closed: subprocess done writing
+                Ok(Ok(_)) => raw.push_str(&String::from_utf8_lossy(&line_buf)),
                 Ok(Err(e)) => {
-                    let _ = child.kill().await;
+                    let _ = child.start_kill();
+                    stderr_task.abort();
                     return Err(e.into());
                 }
+                Err(_) if ceiling_bound => {
+                    let _ = child.start_kill();
+                    stderr_task.abort();
+                    anyhow::bail!(
+                        "CLI command exceeded the absolute {}s ceiling despite ongoing activity",
+                        absolute_ceiling.as_secs()
+                    );
+                }
                 Err(_) => {
-                    let _ = child.kill().await;
+                    let _ = child.start_kill();
+                    stderr_task.abort();
                     anyhow::bail!(
                         "CLI command timed out after {}s of inactivity (no output)",
                         self.timeout_secs
@@ -165,13 +244,49 @@ impl Provider for CliProvider {
             }
         }
 
-        let status = child.wait().await?;
-        let stderr_buf = stderr_task.await.unwrap_or_default();
+        // Bound the post-EOF awaits too (#270 review F1): a process — or an
+        // orphaned descendant that inherited a pipe fd (e.g. an MCP server
+        // `claude -p` spawned) — that doesn't exit/close promptly once
+        // stdout is fully read must not hang the whole call. `child` is
+        // dropped on every return path below; `kill_on_drop` (set in
+        // `build_command`) then SIGKILLs it and tokio's own orphan queue
+        // reaps it in the background, so no explicit wait-for-exit is
+        // needed here to avoid leaking a zombie.
+        let status = match tokio::time::timeout(timeout, child.wait()).await {
+            Ok(result) => result?,
+            Err(_) => {
+                // stdout already reached a clean EOF, so `raw` holds a
+                // complete response (the common real case: `claude -p`
+                // itself finished and flushed its `result` event; a
+                // spawned MCP server subprocess is what's still holding a
+                // pipe open). Prefer that known-good content over hanging
+                // or discarding it — we cannot learn anything more here
+                // without blocking indefinitely on a descendant we don't
+                // control (a surviving grandchild is a separate, pre-
+                // existing concern, not this call's to solve). Abort the
+                // stderr drain too rather than leaving it detached forever
+                // reading a pipe that may never EOF.
+                stderr_task.abort();
+                return Ok(self.parse_json_stdout(&raw));
+            }
+        };
 
         if !status.success() {
+            let stderr_buf = tokio::time::timeout(timeout, stderr_task)
+                .await
+                .ok()
+                .and_then(Result::ok)
+                .unwrap_or_default();
             anyhow::bail!("CLI command failed ({status}): {stderr_buf}");
         }
 
+        // Successful exit: `stderr_buf` was never needed. Abort the drain
+        // task explicitly rather than leaving it detached — the child
+        // already exited, so in the common case this is a no-op (the task
+        // already finished on its own when the child's stderr fd closed),
+        // but it still frees the task+fd promptly if some descendant is
+        // holding the pipe open.
+        stderr_task.abort();
         Ok(self.parse_json_stdout(&raw))
     }
 
@@ -189,23 +304,56 @@ impl Provider for CliProvider {
         let (tx, rx) = tokio::sync::mpsc::channel(64);
 
         tokio::spawn(async move {
-            let reader = tokio::io::BufReader::new(stdout);
-            let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
-            let timeout = std::time::Duration::from_secs(timeout_secs);
+            let mut reader = tokio::io::BufReader::new(stdout);
+            let timeout = Duration::from_secs(timeout_secs);
+            let absolute_ceiling = Duration::from_secs(ABSOLUTE_CEILING_SECS);
+            let start = Instant::now();
+            let mut line_buf: Vec<u8> = Vec::new();
 
-            // Inactivity timeout (#270), mirroring `complete()`: the timeout
-            // is rearmed on every line, not held once around the whole loop
-            // — otherwise a steadily-streaming child would still be cut off
-            // once the loop's cumulative duration passed `timeout_secs`,
-            // even though it never went silent.
+            // Mirrors `complete()`: inactivity timeout rearmed on every
+            // line (byte-oriented `read_until`, lossy on non-UTF-8, not
+            // `.lines()` — #270 review F1/F2/F4), bounded overall by
+            // `ABSOLUTE_CEILING_SECS` so a child that never goes silent
+            // still ends eventually. `child` is dropped on every path out
+            // of this task; `kill_on_drop` (set in `build_command`) then
+            // handles the kill+reap, so no unbounded `child.wait()` is
+            // needed here to avoid a zombie.
             loop {
-                match tokio::time::timeout(timeout, lines.next_line()).await {
-                    Ok(Ok(Some(line))) => {
+                let Some((step_timeout, ceiling_bound)) =
+                    next_step_timeout(start.elapsed(), timeout, absolute_ceiling)
+                else {
+                    let _ = child.start_kill();
+                    let _ = tx
+                        .send(Err(anyhow::anyhow!(
+                            "CLI command exceeded the absolute {}s ceiling despite ongoing activity",
+                            absolute_ceiling.as_secs()
+                        )))
+                        .await;
+                    return;
+                };
+
+                line_buf.clear();
+                let read =
+                    tokio::io::AsyncBufReadExt::read_until(&mut reader, b'\n', &mut line_buf);
+                match tokio::time::timeout(step_timeout, read).await {
+                    Ok(Ok(0)) => break, // stdout closed: child done writing
+                    Ok(Ok(_)) => {
+                        // `read_until` keeps the delimiter; strip it (and a
+                        // preceding `\r`) so a line matches what `.lines()`
+                        // used to yield — callers expect terminator-free
+                        // lines (e.g. `cli_stream_echo`, `json_runner`'s
+                        // per-line JSONL parsing).
+                        if line_buf.last() == Some(&b'\n') {
+                            line_buf.pop();
+                            if line_buf.last() == Some(&b'\r') {
+                                line_buf.pop();
+                            }
+                        }
+                        let line = String::from_utf8_lossy(&line_buf).into_owned();
                         if tx.send(Ok(line)).await.is_err() {
                             break;
                         }
                     }
-                    Ok(Ok(None)) => break, // stdout closed: child done writing
                     Ok(Err(e)) => {
                         let _ = tx
                             .send(Err(anyhow::anyhow!("Failed to read CLI output: {e}")))
@@ -213,27 +361,27 @@ impl Provider for CliProvider {
                         break;
                     }
                     Err(_) => {
-                        if let Err(e) = tx
-                            .send(Err(anyhow::anyhow!(
+                        let _ = child.start_kill();
+                        let message = if ceiling_bound {
+                            format!(
+                                "CLI command exceeded the absolute {}s ceiling despite ongoing activity",
+                                absolute_ceiling.as_secs()
+                            )
+                        } else {
+                            format!(
                                 "CLI command timed out after {timeout_secs}s of inactivity (no output)"
-                            )))
-                            .await
-                        {
+                            )
+                        };
+                        if let Err(e) = tx.send(Err(anyhow::anyhow!(message))).await {
                             tracing::debug!(
                                 "Failed to send timeout error (receiver dropped): {:?}",
                                 e
                             );
                         }
-                        if let Err(e) = child.kill().await {
-                            tracing::debug!("Failed to kill timed-out CLI command: {:?}", e);
-                        }
-                        let _ = child.wait().await;
                         return;
                     }
                 }
             }
-
-            let _ = child.wait().await;
         });
 
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
@@ -416,29 +564,47 @@ mod tests {
     /// Mutation this catches: reverting to a single `tokio::time::timeout`
     /// around the whole read loop (the pre-fix shape) instead of one
     /// rearmed on every line — that shape kills this exact case, since the
-    /// process's total runtime (~1.2s over 3 ticks of 0.4s) exceeds the 1s
+    /// process's total runtime (~2.4s over 6 ticks of 0.4s) exceeds the 2s
     /// ceiling even though no single gap does. It also catches a mutation
     /// that reads the whole stdout in one shot before checking the
     /// deadline (e.g. reverting to `cmd.output()`), which would observe no
     /// intermediate activity at all and time out the same way.
+    ///
+    /// The elapsed-time assertion is load-bearing, not decorative: without
+    /// it, degenerating the script to `sleep 0` would still pass in ~10ms
+    /// while proving nothing about surviving PAST the old ceiling — the
+    /// exact premise in this test's name (#270 review F6). Margins are
+    /// deliberately generous (2s ceiling, 0.4s ticks): a 5x per-gap margin
+    /// tolerates scheduling jitter when the full suite runs many real
+    /// subprocess-spawning tests in parallel, without needing the test
+    /// itself to run much longer.
     #[tokio::test]
     async fn steady_stream_survives_past_the_old_static_ceiling() {
+        let old_static_ceiling = std::time::Duration::from_secs(2);
+        let start = std::time::Instant::now();
         let result = with_env_lock(async {
-            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 2);
             provider
                 .complete(echo_request(
-                    "for i in 1 2 3; do echo tick; sleep 0.4; done",
+                    "for i in 1 2 3 4 5 6; do echo tick; sleep 0.4; done",
                 ))
                 .await
         })
         .await;
+        let elapsed = start.elapsed();
 
         let response = result.expect("a steadily-ticking subprocess must not time out");
         assert_eq!(
             response.content.matches("tick").count(),
-            3,
-            "expected all 3 ticks to have been read before the process exited, got: {}",
+            6,
+            "expected all 6 ticks to have been read before the process exited, got: {}",
             response.content
+        );
+        assert!(
+            elapsed > old_static_ceiling,
+            "test must actually run longer than the old 2s ceiling to prove the premise \
+             (a degenerate sleep-0 script would pass this test without exercising the \
+             reset-on-activity behavior at all): elapsed {elapsed:?}"
         );
     }
 
@@ -451,7 +617,12 @@ mod tests {
     /// rearming it on something other than actual stdout activity (e.g. an
     /// unconditional tick) — either would let this call run well past the
     /// 1s ceiling instead of erroring within a couple of seconds of it, so
-    /// the elapsed-time bound below would fail.
+    /// the UPPER elapsed-time bound below would fail. The LOWER bound
+    /// catches the opposite mutation — e.g. a stray unit conversion turning
+    /// the configured 1s into 1ms (`Duration::from_millis(self.timeout_secs)`
+    /// instead of `from_secs`) — which the upper bound alone does not:
+    /// dying near-instantly still satisfies "died before 20s" (#270 review
+    /// F6).
     #[tokio::test]
     async fn silent_subprocess_dies_near_the_inactivity_ceiling_not_later() {
         let start = std::time::Instant::now();
@@ -466,14 +637,184 @@ mod tests {
             .expect_err("a silent subprocess must time out")
             .to_string();
         assert!(err.contains("timed out"), "error was: {err}");
-        // Generous bound (well under the 60s sleep, generous over the 1s
-        // ceiling) to absorb scheduling jitter when the full suite runs many
-        // real subprocess-spawning tests in parallel — the point is only to
-        // rule out "ran to natural completion" or "hung forever", not to
-        // pin exact timing.
+        // Lower bound: must have actually waited close to the configured 1s
+        // ceiling, not fired near-instantly (catches a unit-conversion-style
+        // mutation that shrinks the effective ceiling by orders of
+        // magnitude). Upper bound: generous (well under the 60s sleep) to
+        // absorb scheduling jitter when the full suite runs many real
+        // subprocess-spawning tests in parallel — the point there is only to
+        // rule out "ran to natural completion" or "hung forever", not to pin
+        // exact timing.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(500),
+            "should wait close to the configured 1s ceiling before dying, not fire near-instantly: {elapsed:?}"
+        );
         assert!(
             elapsed < std::time::Duration::from_secs(20),
             "should die near the 1s inactivity ceiling, not run toward the 60s sleep: {elapsed:?}"
+        );
+    }
+
+    // ── Post-EOF phase must be bounded too (#270 review F1) ──
+    //
+    // The read loop above only covers reading stdout up to EOF. Two MORE
+    // awaits follow it: `child.wait()` (for the exit status) and, on
+    // failure, joining the stderr-drain task. Both were originally
+    // unbounded, so a subprocess (or an orphaned descendant holding an
+    // inherited pipe fd — e.g. an MCP server `claude -p` spawns) that
+    // reaches stdout EOF but doesn't exit/close promptly would hang
+    // `complete()` forever, reproducing #274's symptom even though the read
+    // loop itself timed out correctly. Both tests below are direct
+    // reconstructions of the review's own repro shapes.
+
+    /// The direct child keeps running (sleeping) itself after redirecting
+    /// its OWN stdout away — stdout hits EOF almost immediately, but the
+    /// process doesn't exit for a long time afterward.
+    ///
+    /// Mutation this catches: reverting `child.wait()` after the read loop
+    /// to an unbounded `.await` (no `tokio::time::timeout` around it) —
+    /// this call would then block for the full 30s sleep instead of
+    /// returning within roughly the 1s inactivity ceiling.
+    #[tokio::test]
+    async fn complete_does_not_hang_when_stdout_closes_but_the_child_keeps_running() {
+        let start = std::time::Instant::now();
+        let result = with_env_lock(async {
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
+            provider
+                .complete(echo_request("echo hi; exec 1>/dev/null; sleep 30"))
+                .await
+        })
+        .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "must not block toward the child's 30s post-EOF sleep: {elapsed:?}"
+        );
+        // Either outcome (a successful response built from the already-read
+        // "hi", or a bounded timeout error) is acceptable — what matters is
+        // that the call returns promptly. It must not hang.
+        match result {
+            Ok(response) => assert!(response.content.contains("hi")),
+            Err(e) => {
+                assert!(e.to_string().contains("timed out") || e.to_string().contains("ceiling"))
+            }
+        }
+    }
+
+    /// The direct child exits almost immediately after printing "hi", but
+    /// backgrounds a detached grandchild that inherits the (unredirected)
+    /// stderr pipe fd and keeps it open — so `stderr` never sees EOF, even
+    /// though the process we spawned is long gone.
+    ///
+    /// Mutation this catches: reverting the success path to unconditionally
+    /// join `stderr_task` (or joining it without a `tokio::time::timeout`)
+    /// before returning — this call would then block for the full 30s the
+    /// grandchild lives, instead of returning as soon as `child.wait()`
+    /// resolves (near-instantly, since the direct child exits fast).
+    #[tokio::test]
+    async fn complete_does_not_hang_on_an_orphaned_descendant_holding_stderr_open() {
+        let start = std::time::Instant::now();
+        let result = with_env_lock(async {
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
+            provider
+                .complete(echo_request("(sleep 30 >/dev/null 0</dev/null &); echo hi"))
+                .await
+        })
+        .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "must not block on the orphaned grandchild's 30s lifetime: {elapsed:?}"
+        );
+        let response = result.expect("the direct child exits successfully");
+        assert!(response.content.contains("hi"));
+    }
+
+    // ── Lossy UTF-8 on stdout must not be fatal (#270 review F2) ──
+
+    /// `provider: cli` is documented for arbitrary scripts; a single
+    /// non-UTF-8 byte from one must lossily substitute (matching the
+    /// pre-#270 `String::from_utf8_lossy(&output.stdout)` behavior), not
+    /// abort the whole call.
+    ///
+    /// Mutation this catches: reverting the byte-oriented `read_until`
+    /// reader back to `.lines()` (which requires valid UTF-8 and errors
+    /// out on a bad byte) — this call would then fail instead of returning
+    /// a response containing the lossy replacement character.
+    #[tokio::test]
+    async fn non_utf8_byte_on_stdout_is_lossily_substituted_not_fatal() {
+        let result = with_env_lock(async {
+            // printf writes a lone continuation byte (0x80), invalid on its
+            // own in UTF-8, between two valid words.
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 10);
+            provider
+                .complete(echo_request(r"printf 'hello \200world\n'"))
+                .await
+        })
+        .await;
+
+        let response = result.expect("a stray non-UTF-8 byte must not fail the call");
+        assert!(
+            response.content.contains("hello") && response.content.contains("world"),
+            "expected the surrounding valid text to survive: {:?}",
+            response.content
+        );
+        assert!(
+            response.content.contains('\u{FFFD}'),
+            "expected the invalid byte to lossily substitute as U+FFFD: {:?}",
+            response.content
+        );
+    }
+
+    // ── Absolute ceiling scheduling math is pure/sync (#270 review F4) ──
+    //
+    // `next_step_timeout` is unit-tested directly, without any real
+    // waiting, so the ceiling-vs-inactivity arithmetic is verified fast and
+    // deterministically rather than only implicitly via a multi-hour test.
+
+    #[test]
+    fn next_step_timeout_uses_inactivity_timeout_when_far_from_the_ceiling() {
+        let (step, ceiling_bound) = next_step_timeout(
+            Duration::from_secs(0),
+            Duration::from_secs(300),
+            Duration::from_secs(7200),
+        )
+        .expect("well under the ceiling");
+        assert_eq!(step, Duration::from_secs(300));
+        assert!(!ceiling_bound);
+    }
+
+    #[test]
+    fn next_step_timeout_shrinks_the_step_as_the_ceiling_approaches() {
+        let (step, ceiling_bound) = next_step_timeout(
+            Duration::from_secs(7100),
+            Duration::from_secs(300),
+            Duration::from_secs(7200),
+        )
+        .expect("still under the ceiling, by 100s");
+        assert_eq!(step, Duration::from_secs(100));
+        assert!(ceiling_bound);
+    }
+
+    #[test]
+    fn next_step_timeout_is_none_once_the_ceiling_is_reached() {
+        assert!(
+            next_step_timeout(
+                Duration::from_secs(7200),
+                Duration::from_secs(300),
+                Duration::from_secs(7200),
+            )
+            .is_none()
+        );
+        assert!(
+            next_step_timeout(
+                Duration::from_secs(7300),
+                Duration::from_secs(300),
+                Duration::from_secs(7200),
+            )
+            .is_none()
         );
     }
 

--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -17,7 +17,25 @@ use armadai_core::provider::*;
 /// It is a safety net, not a tuned control: if genuinely multi-hour
 /// sessions become routine, this should become its own configurable field
 /// instead of a larger constant.
-const ABSOLUTE_CEILING_SECS: u64 = 2 * 60 * 60;
+///
+/// `pub` so `armadai/src/cli/run.rs` can assert against it at compile time
+/// (see the `const _: () = assert!(...)` below and its sibling in
+/// `run.rs`) — nothing enforced the relationship between the three
+/// timeout constants spread across two crates (this one,
+/// `factory::DEFAULT_TIMEOUT_SECS`, `run.rs::ORCHESTRATED_DEFAULT_TIMEOUT_SECS`)
+/// otherwise: if an inactivity default ever grew past this ceiling, every
+/// timeout in the product would be misreported as "absolute ceiling".
+pub const ABSOLUTE_CEILING_SECS: u64 = 2 * 60 * 60;
+
+// This ceiling must stay strictly above the non-orchestrated inactivity
+// default, or every direct-run timeout would misreport as "absolute
+// ceiling" instead of "inactivity" (see `next_step_timeout`'s
+// `ceiling_bound` flag). The orchestrated default (600s, in a different
+// crate) is asserted against separately in `armadai/src/cli/run.rs`.
+const _: () = assert!(
+    ABSOLUTE_CEILING_SECS > crate::factory::DEFAULT_TIMEOUT_SECS,
+    "ABSOLUTE_CEILING_SECS must stay above factory::DEFAULT_TIMEOUT_SECS"
+);
 
 /// Decide how long the next single read may wait, given how long the call
 /// has run so far (`elapsed`), the per-line inactivity ceiling
@@ -50,6 +68,15 @@ pub struct CliProvider {
     pub command: String,
     pub args: Vec<String>,
     pub timeout_secs: u64,
+    /// Absolute backstop, in seconds. Always `ABSOLUTE_CEILING_SECS` in
+    /// production (`new()` sets it; there is no public way to change it) —
+    /// this only exists as a field, instead of `complete`/`stream` reading
+    /// the module constant directly, so a test can shrink it via
+    /// `with_absolute_ceiling_secs` and prove the ceiling is genuinely
+    /// consulted end-to-end (not just correct in isolation as pure math —
+    /// see `next_step_timeout`'s own unit tests, and the review that found
+    /// deleting the ceiling check from both loops left the suite green).
+    absolute_ceiling_secs: u64,
 }
 
 impl CliProvider {
@@ -58,7 +85,17 @@ impl CliProvider {
             command,
             args,
             timeout_secs,
+            absolute_ceiling_secs: ABSOLUTE_CEILING_SECS,
         }
+    }
+
+    /// Test-only: override the absolute ceiling so a test can observe it
+    /// actually firing without waiting 2 real hours. Not exposed outside
+    /// `#[cfg(test)]` — production code always uses `ABSOLUTE_CEILING_SECS`.
+    #[cfg(test)]
+    fn with_absolute_ceiling_secs(mut self, secs: u64) -> Self {
+        self.absolute_ceiling_secs = secs;
+        self
     }
 
     /// Compose the input string sent to the CLI command from the request's
@@ -164,7 +201,7 @@ impl Provider for CliProvider {
         // (`read_until`, not `.lines()`): a single non-UTF-8 byte on stderr
         // must not abort the drain, it must lossily substitute like the rest
         // of this method (#270 review F2).
-        let stderr_task = tokio::spawn(async move {
+        let mut stderr_task = tokio::spawn(async move {
             let mut reader = tokio::io::BufReader::new(stderr);
             let mut out = Vec::new();
             let mut chunk = Vec::new();
@@ -180,7 +217,7 @@ impl Provider for CliProvider {
 
         let mut reader = tokio::io::BufReader::new(stdout);
         let timeout = Duration::from_secs(self.timeout_secs);
-        let absolute_ceiling = Duration::from_secs(ABSOLUTE_CEILING_SECS);
+        let absolute_ceiling = Duration::from_secs(self.absolute_ceiling_secs);
         let start = Instant::now();
 
         // Inactivity timeout (#270): rearmed on every line read from stdout,
@@ -201,6 +238,24 @@ impl Provider for CliProvider {
         // `String::from_utf8_lossy(&output.stdout)` behavior) instead of
         // aborting the whole call — `provider: cli` is documented for
         // arbitrary scripts, and a stray byte from one must not be fatal.
+        //
+        // Design choice (#270 review round 2, item 4): every timeout below
+        // in THIS loop discards `raw` and errors, even though some lines
+        // may already have been collected — unlike the post-EOF
+        // `child.wait()` timeout further down, which returns `raw` as a
+        // success. The axis that decides it is not "was this a timeout",
+        // it's "did the subprocess ever tell us it was done": stdout
+        // reaching EOF is the subprocess's own unambiguous completion
+        // signal, so returning `raw` there is trusting the subprocess, not
+        // guessing. A timeout firing HERE means we gave up before EOF —
+        // `raw` is provably an interrupted, unfinished response (most
+        // often missing the terminal `result` event `parse_json_stdout`
+        // looks for). Returning that as `Ok` would make the timeout
+        // decorative in a new way: instead of visibly failing, it would
+        // quietly hand the caller truncated content indistinguishable from
+        // a real answer. Erroring here — while still killing the process
+        // and freeing resources exactly like a successful path — is what
+        // keeps a hang or a runaway heartbeat visible to the caller.
         let mut raw = String::new();
         let mut line_buf: Vec<u8> = Vec::new();
         loop {
@@ -272,11 +327,21 @@ impl Provider for CliProvider {
         };
 
         if !status.success() {
-            let stderr_buf = tokio::time::timeout(timeout, stderr_task)
-                .await
-                .ok()
-                .and_then(Result::ok)
-                .unwrap_or_default();
+            // Poll `&mut stderr_task` (not `stderr_task` by value): moving
+            // the `JoinHandle` into `tokio::time::timeout` would, on
+            // timeout, just DROP it — which detaches the task rather than
+            // aborting it (a `JoinHandle`'s `Drop` does not cancel the
+            // task), leaking it and its stderr fd if a descendant is still
+            // holding the pipe open. Keeping our own handle lets us call
+            // `.abort()` explicitly on that path.
+            let stderr_buf = match tokio::time::timeout(timeout, &mut stderr_task).await {
+                Ok(Ok(buf)) => buf,
+                Ok(Err(_)) => String::new(), // drain task panicked/was cancelled
+                Err(_) => {
+                    stderr_task.abort();
+                    String::new()
+                }
+            };
             anyhow::bail!("CLI command failed ({status}): {stderr_buf}");
         }
 
@@ -301,12 +366,13 @@ impl Provider for CliProvider {
             .ok_or_else(|| anyhow::anyhow!("Failed to capture stdout"))?;
 
         let timeout_secs = self.timeout_secs;
+        let absolute_ceiling_secs = self.absolute_ceiling_secs;
         let (tx, rx) = tokio::sync::mpsc::channel(64);
 
         tokio::spawn(async move {
             let mut reader = tokio::io::BufReader::new(stdout);
             let timeout = Duration::from_secs(timeout_secs);
-            let absolute_ceiling = Duration::from_secs(ABSOLUTE_CEILING_SECS);
+            let absolute_ceiling = Duration::from_secs(absolute_ceiling_secs);
             let start = Instant::now();
             let mut line_buf: Vec<u8> = Vec::new();
 
@@ -351,14 +417,21 @@ impl Provider for CliProvider {
                         }
                         let line = String::from_utf8_lossy(&line_buf).into_owned();
                         if tx.send(Ok(line)).await.is_err() {
-                            break;
+                            // Receiver dropped: nobody is listening any
+                            // more (e.g. the caller aborted). Return
+                            // immediately rather than run the post-EOF
+                            // wait below — `child` drops here and
+                            // `kill_on_drop` handles cleanup (#274).
+                            return;
                         }
                     }
                     Ok(Err(e)) => {
+                        // Already reported via `tx`; nothing more useful to
+                        // learn from also waiting for an exit status here.
                         let _ = tx
                             .send(Err(anyhow::anyhow!("Failed to read CLI output: {e}")))
                             .await;
-                        break;
+                        return;
                     }
                     Err(_) => {
                         let _ = child.start_kill();
@@ -380,6 +453,40 @@ impl Provider for CliProvider {
                         }
                         return;
                     }
+                }
+            }
+
+            // Reached only via the normal-EOF `break` above. Bound the
+            // post-EOF wait like `complete()` does (review round 2, item
+            // 2): closing stdout does not mean the child has exited, and
+            // `kill_on_drop` SIGKILLs it the instant `child` drops — doing
+            // that immediately here would kill a child that closed stdout
+            // but is still doing legitimate post-EOF work (a clean exit,
+            // flushing a log), where the pre-#270 code let it finish via
+            // an unbounded `child.wait()`. This also closes item 3: with
+            // no exit-status check at all, a non-zero exit after
+            // successful output was silently reported as a clean stream
+            // end — no error item was ever sent.
+            match tokio::time::timeout(timeout, child.wait()).await {
+                Ok(Ok(status)) if !status.success() => {
+                    let _ = tx
+                        .send(Err(anyhow::anyhow!("CLI command failed ({status})")))
+                        .await;
+                }
+                Ok(Ok(_)) => {} // clean exit: every line was already forwarded
+                Ok(Err(e)) => {
+                    let _ = tx
+                        .send(Err(anyhow::anyhow!("Failed to wait for CLI command: {e}")))
+                        .await;
+                }
+                Err(_) => {
+                    // Child closed stdout but did not exit within one more
+                    // inactivity window (e.g. an orphaned descendant is
+                    // still holding a pipe open, per `complete()`'s F1
+                    // fix). We already forwarded every line; `child` drops
+                    // here and `kill_on_drop` reaps it in the background
+                    // rather than this task hanging on a descendant it
+                    // doesn't control.
                 }
             }
         });
@@ -564,29 +671,30 @@ mod tests {
     /// Mutation this catches: reverting to a single `tokio::time::timeout`
     /// around the whole read loop (the pre-fix shape) instead of one
     /// rearmed on every line — that shape kills this exact case, since the
-    /// process's total runtime (~2.4s over 6 ticks of 0.4s) exceeds the 2s
-    /// ceiling even though no single gap does. It also catches a mutation
-    /// that reads the whole stdout in one shot before checking the
-    /// deadline (e.g. reverting to `cmd.output()`), which would observe no
-    /// intermediate activity at all and time out the same way.
+    /// process's total runtime (~1.25s over 5 ticks of 0.25s) exceeds the
+    /// 1s ceiling even though no single gap does. It also catches a
+    /// mutation that reads the whole stdout in one shot before checking
+    /// the deadline (e.g. reverting to `cmd.output()`), which would
+    /// observe no intermediate activity at all and time out the same way.
     ///
     /// The elapsed-time assertion is load-bearing, not decorative: without
     /// it, degenerating the script to `sleep 0` would still pass in ~10ms
     /// while proving nothing about surviving PAST the old ceiling — the
-    /// exact premise in this test's name (#270 review F6). Margins are
-    /// deliberately generous (2s ceiling, 0.4s ticks): a 5x per-gap margin
-    /// tolerates scheduling jitter when the full suite runs many real
-    /// subprocess-spawning tests in parallel, without needing the test
-    /// itself to run much longer.
+    /// exact premise in this test's name (#270 review F6). A 4x per-gap
+    /// margin (1s ceiling / 0.25s ticks) tolerates scheduling jitter when
+    /// the full suite runs many real subprocess-spawning tests in
+    /// parallel, kept modest (not wider) so this test doesn't add to the
+    /// affected binary's runtime (#270 review round 2: "prefer
+    /// patched-down constants over real sleeps").
     #[tokio::test]
     async fn steady_stream_survives_past_the_old_static_ceiling() {
-        let old_static_ceiling = std::time::Duration::from_secs(2);
+        let old_static_ceiling = std::time::Duration::from_secs(1);
         let start = std::time::Instant::now();
         let result = with_env_lock(async {
-            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 2);
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
             provider
                 .complete(echo_request(
-                    "for i in 1 2 3 4 5 6; do echo tick; sleep 0.4; done",
+                    "for i in 1 2 3 4 5; do echo tick; sleep 0.25; done",
                 ))
                 .await
         })
@@ -596,13 +704,13 @@ mod tests {
         let response = result.expect("a steadily-ticking subprocess must not time out");
         assert_eq!(
             response.content.matches("tick").count(),
-            6,
-            "expected all 6 ticks to have been read before the process exited, got: {}",
+            5,
+            "expected all 5 ticks to have been read before the process exited, got: {}",
             response.content
         );
         assert!(
             elapsed > old_static_ceiling,
-            "test must actually run longer than the old 2s ceiling to prove the premise \
+            "test must actually run longer than the old 1s ceiling to prove the premise \
              (a degenerate sleep-0 script would pass this test without exercising the \
              reset-on-activity behavior at all): elapsed {elapsed:?}"
         );
@@ -815,6 +923,146 @@ mod tests {
                 Duration::from_secs(7200),
             )
             .is_none()
+        );
+    }
+
+    // ── The ceiling must be genuinely CONSULTED, not just correct in
+    // isolation (#270 review round 2, item 1) ──
+    //
+    // `next_step_timeout`'s own tests above prove the scheduling math is
+    // right. They prove nothing about whether `complete()`/`stream()`
+    // actually call it and act on the result — a review deleted the
+    // ceiling check from BOTH loops and the suite stayed green (20/20);
+    // only an incidental `unused variable: start` warning betrayed it.
+    // `with_absolute_ceiling_secs` (test-only) patches the ceiling down so
+    // this can observe it actually firing without waiting 2 real hours —
+    // mirroring how the reviewer proved the mechanism works (patched to
+    // 3s, watched a heartbeat-forever process die at 3.004s).
+
+    /// Mutation this catches: replacing the `next_step_timeout(...)` call
+    /// with an unconditional `Some((timeout, false))` (i.e. ignoring the
+    /// ceiling entirely, ceiling check optimized away/deleted) — the
+    /// heartbeat-forever script would then run forever, caught here by the
+    /// outer 6s test-level timeout instead of dying at the expected ~1s.
+    /// That outer timeout exists so a real regression fails this ONE test
+    /// cleanly instead of hanging the whole suite. Ceiling patched down to
+    /// 1s (not the reviewer's own 3s) to keep this fast — "prefer
+    /// patched-down constants over real sleeps" cuts both ways: patch it
+    /// down as far as it can go and still be unambiguous.
+    #[tokio::test]
+    async fn absolute_ceiling_is_actually_consulted_by_complete() {
+        // Margins are asymmetric on purpose: contention from the rest of the
+        // suite running real subprocesses in parallel can only ever DELAY
+        // this (never fire it early), so the lower bound stays tight while
+        // the upper bound (and the outer hang-guard) stay generous. A first
+        // version with `< 4s` / outer `6s` was observed to fail under full
+        // `cargo test` load; isolated it reliably lands just above 1s.
+        let outcome = tokio::time::timeout(Duration::from_secs(20), async {
+            let start = std::time::Instant::now();
+            let result = with_env_lock(async {
+                let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 30)
+                    .with_absolute_ceiling_secs(1);
+                provider
+                    .complete(echo_request("while true; do echo tick; sleep 0.1; done"))
+                    .await
+            })
+            .await;
+            (result, start.elapsed())
+        })
+        .await;
+
+        let (result, elapsed) =
+            outcome.expect("must not hang past 20s if the ceiling wiring regresses");
+        let err = result
+            .expect_err("a heartbeat-forever process must still die at the absolute ceiling")
+            .to_string();
+        assert!(err.contains("ceiling"), "error was: {err}");
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "must not fire meaningfully before the patched 1s ceiling: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(15),
+            "must fire at the patched 1s ceiling, not the 30s inactivity one: {elapsed:?}"
+        );
+    }
+
+    // ── `stream()`'s post-EOF phase (#270 review round 2, items 2 & 3) ──
+    //
+    // Closing stdout does not mean the child has exited. `stream()` used
+    // to drop `child` (SIGKILLing it via `kill_on_drop`) the instant EOF
+    // was seen, with no exit-status check at all — a non-zero exit after
+    // successful output was silently reported as a clean stream end.
+
+    /// Mutation this catches: reverting to no post-EOF exit-status check
+    /// at all (the pre-fix shape) — the stream would end with only the
+    /// `Ok("hi")` item and no error, silently reporting success for a
+    /// command that actually failed.
+    #[tokio::test]
+    async fn stream_reports_a_non_zero_exit_after_successful_output() {
+        use tokio_stream::StreamExt;
+        let items = with_env_lock(async {
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 10);
+            let mut stream = provider
+                .stream(echo_request("echo hi; exit 42"))
+                .await
+                .unwrap();
+            let mut items = Vec::new();
+            while let Some(item) = stream.next().await {
+                items.push(item);
+            }
+            items
+        })
+        .await;
+
+        assert_eq!(
+            items.len(),
+            2,
+            "expected the line then a failure item: {items:?}"
+        );
+        assert_eq!(items[0].as_ref().unwrap(), "hi");
+        let err = items[1].as_ref().unwrap_err().to_string();
+        assert!(
+            err.contains("exit status: 42"),
+            "expected the exit code to surface, error was: {err}"
+        );
+    }
+
+    /// The child keeps running (past stdout EOF) just long enough to reach
+    /// its OWN distinct exit code (7, chosen to be unmistakable) — an
+    /// instant SIGKILL at EOF would never let it get there.
+    ///
+    /// Mutation this catches: dropping `child` right after the read loop
+    /// instead of bounding a `child.wait()` first — the process would be
+    /// SIGKILLed mid-sleep, before reaching `exit 7`, so this specific
+    /// exit code would never surface.
+    #[tokio::test]
+    async fn stream_gives_the_child_time_to_finish_after_stdout_eof() {
+        use tokio_stream::StreamExt;
+        let items = with_env_lock(async {
+            let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 10);
+            let mut stream = provider
+                .stream(echo_request("echo hi; exec 1>/dev/null; sleep 0.3; exit 7"))
+                .await
+                .unwrap();
+            let mut items = Vec::new();
+            while let Some(item) = stream.next().await {
+                items.push(item);
+            }
+            items
+        })
+        .await;
+
+        let last = items.last().expect("expected at least the failure item");
+        let err = last
+            .as_ref()
+            .expect_err("expected an error for a non-zero exit")
+            .to_string();
+        assert!(
+            err.contains("exit status: 7"),
+            "expected the child's own post-EOF exit code (7) to survive to \
+             the status check — an early kill would prevent it from ever \
+             being reached: {err}"
         );
     }
 

--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -689,17 +689,25 @@ mod tests {
     #[tokio::test]
     async fn steady_stream_survives_past_the_old_static_ceiling() {
         let old_static_ceiling = std::time::Duration::from_secs(1);
-        let start = std::time::Instant::now();
-        let result = with_env_lock(async {
+        // `start` MUST be taken inside `with_env_lock`, after the global
+        // `ENV_MUTEX` is actually held — not before. `with_env_lock` blocks
+        // on that mutex, shared by every test in this module that spawns a
+        // real subprocess; under a loaded parallel `cargo test`, queueing
+        // for it can itself take seconds. Timing from outside the lock
+        // measures queue-wait + real work, not the mechanism under test —
+        // which is exactly why this assertion could pass on a no-sleep
+        // script under load despite proving nothing (#270 review round 3).
+        let (result, elapsed) = with_env_lock(async {
+            let start = std::time::Instant::now();
             let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
-            provider
+            let result = provider
                 .complete(echo_request(
                     "for i in 1 2 3 4 5; do echo tick; sleep 0.25; done",
                 ))
-                .await
+                .await;
+            (result, start.elapsed())
         })
         .await;
-        let elapsed = start.elapsed();
 
         let response = result.expect("a steadily-ticking subprocess must not time out");
         assert_eq!(
@@ -729,17 +737,21 @@ mod tests {
     /// catches the opposite mutation — e.g. a stray unit conversion turning
     /// the configured 1s into 1ms (`Duration::from_millis(self.timeout_secs)`
     /// instead of `from_secs`) — which the upper bound alone does not:
-    /// dying near-instantly still satisfies "died before 20s" (#270 review
+    /// dying near-instantly still satisfies "died before Ns" (#270 review
     /// F6).
     #[tokio::test]
     async fn silent_subprocess_dies_near_the_inactivity_ceiling_not_later() {
-        let start = std::time::Instant::now();
-        let result = with_env_lock(async {
+        // `start` inside `with_env_lock`, not outside — see the identical
+        // note on `steady_stream_survives_past_the_old_static_ceiling`
+        // (#270 review round 3: queue-wait for the shared `ENV_MUTEX` must
+        // not be counted as part of the measured duration).
+        let (result, elapsed) = with_env_lock(async {
+            let start = std::time::Instant::now();
             let provider = CliProvider::new("sleep".to_string(), vec![], 1);
-            provider.complete(echo_request("60")).await
+            let result = provider.complete(echo_request("60")).await;
+            (result, start.elapsed())
         })
         .await;
-        let elapsed = start.elapsed();
 
         let err = result
             .expect_err("a silent subprocess must time out")
@@ -748,17 +760,16 @@ mod tests {
         // Lower bound: must have actually waited close to the configured 1s
         // ceiling, not fired near-instantly (catches a unit-conversion-style
         // mutation that shrinks the effective ceiling by orders of
-        // magnitude). Upper bound: generous (well under the 60s sleep) to
-        // absorb scheduling jitter when the full suite runs many real
-        // subprocess-spawning tests in parallel — the point there is only to
-        // rule out "ran to natural completion" or "hung forever", not to pin
-        // exact timing.
+        // magnitude). Upper bound: tight now that `start` is measured
+        // inside the lock (well under the 60s sleep, but no longer needs
+        // to absorb queue-wait time from other tests contending for
+        // `ENV_MUTEX`).
         assert!(
             elapsed >= std::time::Duration::from_millis(500),
             "should wait close to the configured 1s ceiling before dying, not fire near-instantly: {elapsed:?}"
         );
         assert!(
-            elapsed < std::time::Duration::from_secs(20),
+            elapsed < std::time::Duration::from_secs(5),
             "should die near the 1s inactivity ceiling, not run toward the 60s sleep: {elapsed:?}"
         );
     }
@@ -785,15 +796,21 @@ mod tests {
     /// returning within roughly the 1s inactivity ceiling.
     #[tokio::test]
     async fn complete_does_not_hang_when_stdout_closes_but_the_child_keeps_running() {
-        let start = std::time::Instant::now();
-        let result = with_env_lock(async {
+        // `start` inside `with_env_lock`, not outside (#270 review round 3
+        // / round 4): the shared `ENV_MUTEX` is contended by every
+        // subprocess-spawning test in this module, and queue-wait for it
+        // must not be counted toward "did this call hang". The margin here
+        // is coarse (correct ~1s vs a hang toward 30s) so the bound itself
+        // doesn't need retuning — only the measurement point did.
+        let (result, elapsed) = with_env_lock(async {
+            let start = std::time::Instant::now();
             let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
-            provider
+            let result = provider
                 .complete(echo_request("echo hi; exec 1>/dev/null; sleep 30"))
-                .await
+                .await;
+            (result, start.elapsed())
         })
         .await;
-        let elapsed = start.elapsed();
 
         assert!(
             elapsed < std::time::Duration::from_secs(10),
@@ -822,15 +839,17 @@ mod tests {
     /// resolves (near-instantly, since the direct child exits fast).
     #[tokio::test]
     async fn complete_does_not_hang_on_an_orphaned_descendant_holding_stderr_open() {
-        let start = std::time::Instant::now();
-        let result = with_env_lock(async {
+        // `start` inside `with_env_lock` — see the identical note on
+        // `complete_does_not_hang_when_stdout_closes_but_the_child_keeps_running`.
+        let (result, elapsed) = with_env_lock(async {
+            let start = std::time::Instant::now();
             let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
-            provider
+            let result = provider
                 .complete(echo_request("(sleep 30 >/dev/null 0</dev/null &); echo hi"))
-                .await
+                .await;
+            (result, start.elapsed())
         })
         .await;
-        let elapsed = start.elapsed();
 
         assert!(
             elapsed < std::time::Duration::from_secs(10),
@@ -941,49 +960,159 @@ mod tests {
 
     /// Mutation this catches: replacing the `next_step_timeout(...)` call
     /// with an unconditional `Some((timeout, false))` (i.e. ignoring the
-    /// ceiling entirely, ceiling check optimized away/deleted) — the
-    /// heartbeat-forever script would then run forever, caught here by the
-    /// outer 6s test-level timeout instead of dying at the expected ~1s.
-    /// That outer timeout exists so a real regression fails this ONE test
-    /// cleanly instead of hanging the whole suite. Ceiling patched down to
-    /// 1s (not the reviewer's own 3s) to keep this fast — "prefer
-    /// patched-down constants over real sleeps" cuts both ways: patch it
-    /// down as far as it can go and still be unambiguous.
+    /// ceiling entirely, ceiling check optimized away/deleted). The script
+    /// never goes silent (a tick every 0.1s, far under the 30s inactivity
+    /// timeout), so with the ceiling bypassed this call has nothing left
+    /// to make it return at all — it hangs, caught by the generous outer
+    /// test-level timeout instead of the whole suite.
+    ///
+    /// Asserts on the OUTCOME, not the clock (#270 review round 4): a
+    /// prior version asserted `elapsed` fell in a tight window around the
+    /// patched 1s ceiling (even after fixing round 3's separate `start`-
+    /// outside-the-lock measurement bug). That is sensitive to a magnitude
+    /// mutation (e.g. a 10x ceiling inflation) but still flaky under real
+    /// load — subprocess spawn plus scheduling can push the observed time
+    /// past a tight bound even when the mechanism is correct — and this
+    /// sentinel is the ONLY guard on the ceiling's wiring, so a flaky one
+    /// is worse than none: it gets silenced, then deleted, and the wiring
+    /// goes back to being unguarded with a green suite. Measured: 1
+    /// failure in 12 full-suite runs with the tight bound. The categorical
+    /// check below — the error is specifically the absolute-ceiling one,
+    /// not an inactivity timeout — reads no clock at all, so it is immune
+    /// to scheduling load, while staying fully sensitive to the mutation
+    /// this test exists to catch (deleting/bypassing the ceiling check
+    /// either hangs, or would have to relabel the error as an inactivity
+    /// timeout instead — the negative assertion below rejects that).
+    /// Traded away, deliberately: sensitivity to the ceiling firing at the
+    /// WRONG time (a 10x inflation still produces a "ceiling" error, just
+    /// late) — closing that gap without a wall-clock assertion would
+    /// reintroduce the exact flakiness this redesign removes; the pure
+    /// `next_step_timeout` unit tests above remain the authority on the
+    /// scheduling math itself.
     #[tokio::test]
     async fn absolute_ceiling_is_actually_consulted_by_complete() {
-        // Margins are asymmetric on purpose: contention from the rest of the
-        // suite running real subprocesses in parallel can only ever DELAY
-        // this (never fire it early), so the lower bound stays tight while
-        // the upper bound (and the outer hang-guard) stay generous. A first
-        // version with `< 4s` / outer `6s` was observed to fail under full
-        // `cargo test` load; isolated it reliably lands just above 1s.
-        let outcome = tokio::time::timeout(Duration::from_secs(20), async {
-            let start = std::time::Instant::now();
-            let result = with_env_lock(async {
+        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
+            with_env_lock(async {
                 let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 30)
                     .with_absolute_ceiling_secs(1);
                 provider
                     .complete(echo_request("while true; do echo tick; sleep 0.1; done"))
                     .await
             })
-            .await;
-            (result, start.elapsed())
+            .await
         })
         .await;
 
-        let (result, elapsed) =
-            outcome.expect("must not hang past 20s if the ceiling wiring regresses");
+        // The 15s outer bound is generous on purpose: its job is only to
+        // fail a genuine hang, not to measure the mechanism.
+        let result = outcome.expect("must not hang past 15s if the ceiling wiring regresses");
         let err = result
             .expect_err("a heartbeat-forever process must still die at the absolute ceiling")
             .to_string();
-        assert!(err.contains("ceiling"), "error was: {err}");
         assert!(
-            elapsed >= Duration::from_millis(900),
-            "must not fire meaningfully before the patched 1s ceiling: {elapsed:?}"
+            err.contains("ceiling"),
+            "expected the absolute-ceiling error specifically: {err}"
         );
         assert!(
-            elapsed < Duration::from_secs(15),
-            "must fire at the patched 1s ceiling, not the 30s inactivity one: {elapsed:?}"
+            !err.contains("inactivity"),
+            "the error must not be an inactivity timeout — this script never goes \
+             silent, so an inactivity error here means the ceiling check was \
+             bypassed and the (far longer) inactivity timeout fired instead: {err}"
+        );
+    }
+
+    /// Same sentinel, for `stream()`: its ceiling is threaded through
+    /// separately (`absolute_ceiling_secs` captured into the spawned task
+    /// before `complete()`'s logic ever runs), so pinning `complete()`
+    /// alone proves nothing about `stream()` — confirmed by hand:
+    /// multiplying `stream()`'s `absolute_ceiling` by 1000 left the whole
+    /// suite green (#270 review round 3, item 1). See the sibling test
+    /// above for why this asserts on the error kind, not elapsed time.
+    #[tokio::test]
+    async fn absolute_ceiling_is_actually_consulted_by_stream() {
+        use tokio_stream::StreamExt;
+        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
+            with_env_lock(async {
+                let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 30)
+                    .with_absolute_ceiling_secs(1);
+                let mut stream = provider
+                    .stream(echo_request("while true; do echo tick; sleep 0.1; done"))
+                    .await
+                    .unwrap();
+                let mut items = Vec::new();
+                while let Some(item) = stream.next().await {
+                    items.push(item);
+                }
+                items
+            })
+            .await
+        })
+        .await;
+
+        let items = outcome.expect("must not hang past 15s if the ceiling wiring regresses");
+        let err = items
+            .last()
+            .expect("expected at least the ceiling error item")
+            .as_ref()
+            .expect_err("a heartbeat-forever process must still die at the absolute ceiling")
+            .to_string();
+        assert!(
+            err.contains("ceiling"),
+            "expected the absolute-ceiling error specifically: {err}"
+        );
+        assert!(
+            !err.contains("inactivity"),
+            "the error must not be an inactivity timeout — this script never goes \
+             silent, so an inactivity error here means the ceiling check was \
+             bypassed and the (far longer) inactivity timeout fired instead: {err}"
+        );
+    }
+
+    /// `stream()`'s post-EOF `child.wait()` must itself be BOUNDED, not
+    /// just correct about exit status once it returns — a script that
+    /// closes stdout but keeps running for far longer than the inactivity
+    /// timeout must not hang the spawned task forever (#270 review round
+    /// 3, item 1: `stream_gives_the_child_time_to_finish_after_stdout_eof`
+    /// and `stream_reports_a_non_zero_exit_after_successful_output` both
+    /// use a SHORT post-EOF delay, so neither would notice if the
+    /// `tokio::time::timeout` wrapping `child.wait()` were deleted and the
+    /// wait became unbounded — this is the dedicated sentinel for that).
+    ///
+    /// Mutation this catches: removing the `tokio::time::timeout(...)`
+    /// around `child.wait()` in `stream()`'s post-loop code (unbounded
+    /// wait) — this would hang past the 30s the script actually sleeps,
+    /// caught here by the outer 10s test-level guard instead of hanging
+    /// the whole suite.
+    #[tokio::test]
+    async fn stream_post_eof_wait_is_bounded_not_unbounded() {
+        use tokio_stream::StreamExt;
+        let outcome = tokio::time::timeout(Duration::from_secs(10), async {
+            with_env_lock(async {
+                let start = std::time::Instant::now();
+                let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
+                let mut stream = provider
+                    .stream(echo_request("echo hi; exec 1>/dev/null; sleep 30"))
+                    .await
+                    .unwrap();
+                let mut items = Vec::new();
+                while let Some(item) = stream.next().await {
+                    items.push(item);
+                }
+                (items, start.elapsed())
+            })
+            .await
+        })
+        .await;
+
+        let (items, elapsed) =
+            outcome.expect("must not hang past 10s if the post-EOF wait becomes unbounded");
+        assert!(
+            items.iter().any(|i| i.as_ref().is_ok_and(|s| s == "hi")),
+            "expected the line written before EOF to still arrive: {items:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must not block toward the child's 30s post-EOF sleep: {elapsed:?}"
         );
     }
 

--- a/crates/armadai-providers/src/factory.rs
+++ b/crates/armadai-providers/src/factory.rs
@@ -79,10 +79,32 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
 /// between consecutive lines of subprocess output), not the call's total
 /// duration — see `cli::CliProvider::complete`.
 ///
+/// Honest caveat: that change buys real headroom for an orchestrated,
+/// multi-delegation run (each delegation's output resets the clock), but
+/// it buys a `direct` single-agent run comparatively little. A `direct`
+/// run is exactly one subprocess call with nothing inside it to reset the
+/// clock on its own output, so the largest inactivity gap it can have is
+/// approximately its *total* duration anyway — meaning 300s here still
+/// behaves close to the old wall-clock ceiling for that path. Measured
+/// machine-side turn durations on this project put a single agentic turn
+/// at roughly 500s+ (the same order of magnitude `ORCHESTRATED_DEFAULT_
+/// TIMEOUT_SECS`'s doc cites), i.e. *above* this 300s default — a long
+/// single-turn `direct` run can still hit this ceiling. Not changed here
+/// (raising it is a separate, deliberate call, not a side effect of this
+/// fix); recorded so the number isn't read as more protective than it is.
+///
 /// Previously duplicated as a bare `300` literal at both call sites below
 /// (`create_unified_provider` and `create_cli_provider`); collapsed to one
 /// named constant so the two can't independently drift.
-const DEFAULT_TIMEOUT_SECS: u64 = 300;
+///
+/// `pub` (not `pub(crate)`): `armadai/src/cli/run.rs` needs to reference
+/// this exact value too (its own `ORCHESTRATED_DEFAULT_TIMEOUT_SECS` doc
+/// comment, and its `direct`-vs-orchestrated test assertions) — the point
+/// of naming this constant was to have ONE place a future change lands, so
+/// a private constant that forces callers to restate "300s" in prose or
+/// literals would just move the duplication one layer up instead of
+/// closing it.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 300;
 
 fn find_tool(name: &str) -> Option<&'static ToolDef> {
     KNOWN_TOOLS

--- a/crates/armadai-providers/src/factory.rs
+++ b/crates/armadai-providers/src/factory.rs
@@ -61,6 +61,29 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
     ),
 ];
 
+/// Default `CliProvider` timeout (seconds) when neither the agent's own
+/// frontmatter `timeout` nor an orchestration-level override sets one.
+///
+/// This value only applies to a `direct` (non-orchestrated) single-agent
+/// run: `armadai/src/cli/run.rs`'s `apply_orchestrated_timeout` always sets
+/// `agent.metadata.timeout` before `create_provider` runs for blackboard/
+/// ring/hierarchical agents, using its own `ORCHESTRATED_DEFAULT_TIMEOUT_SECS`
+/// (600s) — so this constant is never reached on the orchestrated path.
+/// The two are intentionally different, not merely duplicated: a `direct`
+/// run is one CLI call, whereas an orchestrated run's coordinator turn is
+/// itself agentic (delegating, waiting on sub-agents) and legitimately
+/// takes longer, see #270. They are named and documented on both sides so a
+/// future change to one doesn't silently drift from the other.
+///
+/// Since #270, `CliProvider::timeout_secs` bounds *inactivity* (the gap
+/// between consecutive lines of subprocess output), not the call's total
+/// duration — see `cli::CliProvider::complete`.
+///
+/// Previously duplicated as a bare `300` literal at both call sites below
+/// (`create_unified_provider` and `create_cli_provider`); collapsed to one
+/// named constant so the two can't independently drift.
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
 fn find_tool(name: &str) -> Option<&'static ToolDef> {
     KNOWN_TOOLS
         .iter()
@@ -191,7 +214,7 @@ fn create_unified_provider(
         } else {
             tool.cli_args.iter().map(|s| (*s).to_string()).collect()
         };
-        let timeout = agent.metadata.timeout.unwrap_or(300);
+        let timeout = agent.metadata.timeout.unwrap_or(DEFAULT_TIMEOUT_SECS);
         tracing::info!("Provider '{name}': using CLI ({command}) — tool detected on system");
         Ok(Box::new(super::cli::CliProvider::new(
             command.to_string(),
@@ -214,7 +237,7 @@ fn create_cli_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
         .clone()
         .ok_or_else(|| anyhow::anyhow!("CLI provider requires 'command' in Metadata"))?;
     let args = agent.metadata.args.clone().unwrap_or_default();
-    let timeout = agent.metadata.timeout.unwrap_or(300);
+    let timeout = agent.metadata.timeout.unwrap_or(DEFAULT_TIMEOUT_SECS);
     Ok(Box::new(super::cli::CliProvider::new(
         command, args, timeout,
     )))

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -2411,8 +2411,8 @@ async fn dispatch_hierarchical_es(
 /// agent's own frontmatter `timeout` nor the project's
 /// `defaults.orchestration.agent_timeout_secs` sets one.
 ///
-/// Higher than the non-orchestrated single-agent default (300s, see
-/// `providers::factory::DEFAULT_TIMEOUT_SECS`) because an orchestrated
+/// Higher than the non-orchestrated single-agent default
+/// (`providers::factory::DEFAULT_TIMEOUT_SECS`) because an orchestrated
 /// coordinator's `claude -p` turn is itself agentic (delegating, waiting on
 /// sub-agents, synthesizing) — 242k-499k tokens/turn were observed on real
 /// hierarchical runs (#270).
@@ -2427,6 +2427,21 @@ async fn dispatch_hierarchical_es(
 /// output at all before its next line.
 const ORCHESTRATED_DEFAULT_TIMEOUT_SECS: u64 = 600;
 
+// Three timeout constants govern this feature across two crates
+// (`providers::factory::DEFAULT_TIMEOUT_SECS`, this file's
+// `ORCHESTRATED_DEFAULT_TIMEOUT_SECS`, and `providers::cli::
+// ABSOLUTE_CEILING_SECS`) and nothing enforced their relationship — if an
+// inactivity default ever grew past the absolute ceiling, every timeout in
+// the product would be misreported as "absolute ceiling" instead of
+// "inactivity" (`cli::next_step_timeout`'s `ceiling_bound` flag would be
+// wrong for every call). This constant's sibling assertion, against
+// `factory::DEFAULT_TIMEOUT_SECS`, lives in `armadai-providers::cli` where
+// both those constants are in scope; this one covers the cross-crate half.
+const _: () = assert!(
+    armadai_providers::cli::ABSOLUTE_CEILING_SECS > ORCHESTRATED_DEFAULT_TIMEOUT_SECS,
+    "ABSOLUTE_CEILING_SECS must stay above ORCHESTRATED_DEFAULT_TIMEOUT_SECS"
+);
+
 /// Resolve the effective CLI provider timeout (seconds) for an agent
 /// participating in an orchestrated run.
 ///
@@ -2437,7 +2452,7 @@ const ORCHESTRATED_DEFAULT_TIMEOUT_SECS: u64 = 600;
 ///
 /// This is the ONE place that actually reaches the provider timeout for
 /// orchestrated runs: `create_provider` only reads `agent.metadata.timeout`
-/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s), so this must run before
+/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`), so this must run before
 /// `create_provider` is called on each agent in `run_orchestrated`'s
 /// loading loop — the BlackboardConfig/
 /// RingConfig `agent_timeout_secs` field (populated by
@@ -2465,10 +2480,10 @@ fn orchestrated_agent_timeout_secs(
 /// loop in `run_orchestrated` AND the `--resume` reconstruction loop in
 /// `resume_run` — MUST call this before `create_provider`, since
 /// `create_provider` only reads `agent.metadata.timeout`
-/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s) once and never re-reads it
+/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`) once and never re-reads it
 /// afterward. Extracted to a single fn so both paths share the exact same
 /// precedence and cannot drift (a resumed
-/// orchestrated run re-hitting the 300s default was the gap this closes —
+/// orchestrated run re-hitting that default was the gap this closes —
 /// see `.superpowers/sdd/orch-e2e-report.md`).
 fn apply_orchestrated_timeout(agent: &mut Agent, config_override: Option<u64>) {
     agent.metadata.timeout = Some(orchestrated_agent_timeout_secs(
@@ -2485,8 +2500,9 @@ fn apply_orchestrated_timeout(agent: &mut Agent, config_override: Option<u64>) {
 /// touch `agent.metadata.timeout`: `resume_run` reconstructs the roster for
 /// BOTH `direct` and orchestrated resumes through the same loop, so calling
 /// the override unconditionally there once regressed a resumed `direct` run
-/// onto the 600s+ orchestrated timeout instead of the correct 300s default
-/// (see `.superpowers/sdd/orch-e2e-report.md`). `execute_resume`'s own
+/// onto the 600s+ orchestrated timeout instead of the correct
+/// `DEFAULT_TIMEOUT_SECS` default (see `.superpowers/sdd/orch-e2e-report.md`).
+/// `execute_resume`'s own
 /// `use_tui` decision uses the identical `!= "direct"` marker (the Workroom
 /// TUI never applies to `direct` runs either) — sharing this fn keeps both
 /// checks from drifting apart.

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -2409,12 +2409,19 @@ async fn dispatch_hierarchical_es(
 /// `defaults.orchestration.agent_timeout_secs` sets one.
 ///
 /// Higher than the non-orchestrated single-agent default (300s, see
-/// `providers::factory::create_provider`) because an orchestrated
+/// `providers::factory::DEFAULT_TIMEOUT_SECS`) because an orchestrated
 /// coordinator's `claude -p` turn is itself agentic (delegating, waiting on
-/// sub-agents, synthesizing) and can legitimately run past 300s — 242k-499k
-/// tokens/turn were observed on real hierarchical runs (#270). This is a
-/// stopgap pending the per-delegation-reset timeout design (#270); it does
-/// NOT change the non-orchestrated default.
+/// sub-agents, synthesizing) — 242k-499k tokens/turn were observed on real
+/// hierarchical runs (#270).
+///
+/// Since #270, `CliProvider::timeout_secs` bounds *inactivity* between
+/// lines of subprocess output, not the call's total duration (see
+/// `providers::cli::CliProvider::complete`) — so this value no longer needs
+/// to cover an entire multi-delegation run in one wall-clock budget, only
+/// the longest silent gap within it. It stays higher than the non-
+/// orchestrated default because a coordinator can legitimately think for a
+/// long stretch (e.g. synthesizing a final answer) with no observable
+/// output at all before its next line.
 const ORCHESTRATED_DEFAULT_TIMEOUT_SECS: u64 = 600;
 
 /// Resolve the effective CLI provider timeout (seconds) for an agent
@@ -2427,7 +2434,7 @@ const ORCHESTRATED_DEFAULT_TIMEOUT_SECS: u64 = 600;
 ///
 /// This is the ONE place that actually reaches the provider timeout for
 /// orchestrated runs: `create_provider` only reads `agent.metadata.timeout`
-/// (`.unwrap_or(300)`), so this must run before `create_provider` is called
+/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s), so this must run before `create_provider` is called
 /// on each agent in `run_orchestrated`'s loading loop — the BlackboardConfig/
 /// RingConfig `agent_timeout_secs` field (populated by
 /// `apply_blackboard_overrides`/`apply_ring_overrides`) is never read by the
@@ -2453,8 +2460,8 @@ fn orchestrated_agent_timeout_secs(
 /// Both roster-loading loops that feed an orchestrated run — the fresh-run
 /// loop in `run_orchestrated` AND the `--resume` reconstruction loop in
 /// `resume_run` — MUST call this before `create_provider`, since
-/// `create_provider` only reads `agent.metadata.timeout` (`.unwrap_or(300)`)
-/// once and never re-reads it afterward. Extracted to a single fn so both
+/// `create_provider` only reads `agent.metadata.timeout`
+/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s) once and never re-reads it afterward. Extracted to a single fn so both
 /// paths share the exact same precedence and cannot drift (a resumed
 /// orchestrated run re-hitting the 300s default was the gap this closes —
 /// see `.superpowers/sdd/orch-e2e-report.md`).

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -11,6 +11,8 @@ use armadai_core::orchestration::es::log::{EventLog, InMemoryLog};
 use armadai_core::orchestration::es::state::ExecutionState;
 use armadai_core::project::{self, AgentRef, ProjectConfig, ProjectDefaults};
 use armadai_core::provider::{ChatMessage, CompletionRequest};
+#[cfg(test)]
+use armadai_providers::factory::DEFAULT_TIMEOUT_SECS;
 use armadai_providers::factory::create_provider;
 
 const GUIDED_MODE_INSTRUCTION: &str = "\
@@ -444,7 +446,8 @@ async fn resume_run(
     // Fix B (#270) covered fresh orchestrated runs via `run_orchestrated`'s
     // loading loop but not resume; without this, a resumed orchestrated run
     // rebuilds its providers with the plain `create_provider(&agent)` default
-    // (300s) and re-hits the exact timeout this fix exists to prevent. Source
+    // (`DEFAULT_TIMEOUT_SECS`) and re-hits the exact timeout this fix exists to
+    // prevent. Source
     // the config override the same way `run_orchestrated` does, from the
     // resolved project's `defaults.orchestration`.
     //
@@ -456,7 +459,7 @@ async fn resume_run(
     // `is_orchestrated_pattern` gate on the `apply_orchestrated_timeout` call
     // (a prior regression applied it unconditionally here, giving resumed
     // `direct` runs the 600s+ orchestrated timeout instead of the correct
-    // 300s default — see `.superpowers/sdd/orch-e2e-report.md`).
+    // `DEFAULT_TIMEOUT_SECS` default — see `.superpowers/sdd/orch-e2e-report.md`).
     let timeout_overrides = match &resolution {
         AgentResolution::Project { config, .. } => {
             config.defaults.orchestration.clone().unwrap_or_default()
@@ -478,7 +481,7 @@ async fn resume_run(
         );
         // Gate: only orchestrated patterns get the orchestrated timeout
         // override — a resumed `direct` run must keep `create_provider`'s
-        // own 300s default untouched.
+        // own `DEFAULT_TIMEOUT_SECS` default untouched.
         if is_orchestrated_pattern(&pattern) {
             apply_orchestrated_timeout(&mut agent, timeout_overrides.agent_timeout_secs);
         }
@@ -2434,8 +2437,9 @@ const ORCHESTRATED_DEFAULT_TIMEOUT_SECS: u64 = 600;
 ///
 /// This is the ONE place that actually reaches the provider timeout for
 /// orchestrated runs: `create_provider` only reads `agent.metadata.timeout`
-/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s), so this must run before `create_provider` is called
-/// on each agent in `run_orchestrated`'s loading loop — the BlackboardConfig/
+/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s), so this must run before
+/// `create_provider` is called on each agent in `run_orchestrated`'s
+/// loading loop — the BlackboardConfig/
 /// RingConfig `agent_timeout_secs` field (populated by
 /// `apply_blackboard_overrides`/`apply_ring_overrides`) is never read by the
 /// event-sourced engine (`es::blackboard`/`es::ring` call
@@ -2461,8 +2465,9 @@ fn orchestrated_agent_timeout_secs(
 /// loop in `run_orchestrated` AND the `--resume` reconstruction loop in
 /// `resume_run` — MUST call this before `create_provider`, since
 /// `create_provider` only reads `agent.metadata.timeout`
-/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s) once and never re-reads it afterward. Extracted to a single fn so both
-/// paths share the exact same precedence and cannot drift (a resumed
+/// (`.unwrap_or(DEFAULT_TIMEOUT_SECS)`, 300s) once and never re-reads it
+/// afterward. Extracted to a single fn so both paths share the exact same
+/// precedence and cannot drift (a resumed
 /// orchestrated run re-hitting the 300s default was the gap this closes —
 /// see `.superpowers/sdd/orch-e2e-report.md`).
 fn apply_orchestrated_timeout(agent: &mut Agent, config_override: Option<u64>) {
@@ -2707,13 +2712,16 @@ mod tests {
     }
 
     /// With neither frontmatter nor config override, the orchestrated default
-    /// must be 600s, NOT the non-orchestrated single-agent default (300s) —
-    /// an orchestrated coordinator's agentic turn can legitimately exceed
-    /// 300s.
+    /// must be 600s, NOT the non-orchestrated single-agent default
+    /// (`DEFAULT_TIMEOUT_SECS`) — an orchestrated coordinator's agentic turn
+    /// can legitimately exceed that default.
     #[test]
     fn orchestrated_timeout_defaults_to_600_not_300() {
         assert_eq!(orchestrated_agent_timeout_secs(None, None), 600);
-        assert_ne!(orchestrated_agent_timeout_secs(None, None), 300);
+        assert_ne!(
+            orchestrated_agent_timeout_secs(None, None),
+            DEFAULT_TIMEOUT_SECS
+        );
     }
 
     // --- resume-path coverage gap: `apply_orchestrated_timeout` is the SAME
@@ -2784,15 +2792,15 @@ mod tests {
     /// Mirrors `orchestrated_timeout_defaults_to_600_not_300`: with neither
     /// frontmatter nor config override, a resumed orchestrated run must land
     /// on the 600s orchestrated default, NOT silently fall back to
-    /// `create_provider`'s bare 300s default — that regression (a resumed
-    /// orchestrated run re-hitting the 300s wall) is exactly the gap this
-    /// fix closes.
+    /// `create_provider`'s bare `DEFAULT_TIMEOUT_SECS` default — that
+    /// regression (a resumed orchestrated run re-hitting that wall) is
+    /// exactly the gap this fix closes.
     #[test]
     fn apply_orchestrated_timeout_defaults_to_600_not_300() {
         let mut agent = agent_with_timeout(None);
         apply_orchestrated_timeout(&mut agent, None);
         assert_eq!(agent.metadata.timeout, Some(600));
-        assert_ne!(agent.metadata.timeout, Some(300));
+        assert_ne!(agent.metadata.timeout, Some(DEFAULT_TIMEOUT_SECS));
     }
 
     // --- Re-review regression: `resume_run` must NOT apply the orchestrated

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -64,7 +64,7 @@ Key-value pairs configuring the agent's technical behavior.
 | `args` | list | No | — | CLI arguments: `["-p", "--model", "sonnet"]` |
 | `temperature` | float | No | `0.7` | Sampling temperature (0.0 - 2.0) |
 | `max_tokens` | int | No | — | Maximum output tokens |
-| `timeout` | int | No | — | Execution timeout in seconds |
+| `timeout` | int | No | — | CLI-provider inactivity timeout in seconds (300s default for a non-orchestrated agent, 600s for one in an orchestrated run) — bounds the gap between two lines of subprocess output, not the call's total duration; a CLI call that keeps producing output survives past it, one that goes silent for this long is killed. Ignored by API providers. |
 | `tags` | list | No | `[]` | Tags for filtering: `[dev, review]` |
 | `stacks` | list | No | `[]` | Tech stacks: `[rust, typescript]` |
 | `cost_limit` | float | No | — | Max cost per execution in USD |

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -34,6 +34,14 @@ You can override the CLI args:
 - timeout: 600
 ```
 
+> **`timeout` bounds inactivity, not total duration.** When the CLI tool is
+> used (as opposed to the API fallback), `timeout` is the longest gap
+> allowed between two lines of subprocess output — it resets every time the
+> CLI produces something, including a native sub-agent delegation. A call
+> that keeps streaming output can run well past `timeout` seconds in total;
+> one that goes fully silent for that long is killed. See [CLI
+> Provider](#cli-provider) below for the full explanation.
+
 ## Model Selection
 
 When using `armadai new -i` (interactive wizard), the model selection step fetches available models from the [models.dev](https://models.dev) registry with enriched metadata (context window size, input/output cost per MTok). Results are cached locally for 24 hours. If the registry is unreachable, the wizard falls back to the static model list in `providers.yaml`.
@@ -108,6 +116,19 @@ Execute any command-line tool as an agent. The input is passed as the last argum
 - args: ["-p", "--model", "sonnet", "--output-format", "json"]
 - timeout: 300
 ```
+
+`timeout` here is an **inactivity** timeout, not a total-duration one: it is
+the longest gap allowed between two consecutive lines the command writes to
+stdout, and it is rearmed on every line — a delegation event, a token
+delta, or (for a CLI with no structured output) just the next chunk of
+text. A command that keeps producing output can run well past `timeout`
+seconds in total. A command that goes fully silent for `timeout` seconds
+(a hung process, a deadlocked script) is killed — that failure mode is
+exactly what `timeout` still protects against, so a script wrapped by
+`provider: cli` should still print *something* periodically if it expects
+to run long. There is also a generous absolute backstop (2 hours) so a
+process that never goes silent — but never finishes either — still ends
+eventually.
 
 ### Examples
 


### PR DESCRIPTION
Ferme #270.

## Le problème

`providers/cli.rs` bornait l'**appel entier** par un unique `tokio::time::timeout`. Or chaque tour de spécialiste `claude -p` sur ce projet est une session agentique complète d'environ 500 s : un run hiérarchique qui progressait régulièrement se faisait tuer par le plafond global.

Le palliatif précédent avait porté le plafond orchestré à 600 s — ce qui achetait la marge d'**une** délégation et laissait le défaut. C'est pourquoi l'issue est restée ouverte.

## Le correctif

Le timeout mesure désormais l'**inactivité** — l'écart entre deux sorties — et non la durée totale. Un sous-processus qui produit régulièrement survit quelle que soit sa durée ; un sous-processus qui devient muet meurt toujours, sinon le timeout serait décoratif.

**Un plafond absolu de 2 h** vient par-dessus : l'inactivité seule ne peut pas être la seule borne, sinon un processus qui bat éternellement devient impossible à tuer. Deux assertions `const` inter-crates garantissent que le plafond reste supérieur à l'inactivité — vérifiées comme échouant **à la compilation** quand on les viole.

Et le `300` dupliqué aux deux sites de la factory devient un unique `DEFAULT_TIMEOUT_SECS` public, référencé par son nom. Deux plafonds qui doivent s'accorder, maintenus séparément, c'est la classe de défaut que ce dépôt a corrigée quatre fois cette semaine.

## Trois défauts trouvés en revue, dont une régression du correctif lui-même

**La réécriture avait fait passer `complete()` d'un `await` borné à quatre, en n'en bornant qu'un.** Après la fin du flux, `child.wait()` et `stderr_task` étaient sans limite. Mesuré en A/B contre le corps pré-correctif dans le même binaire : un processus produisant **zéro sortie** bloquait 12 s là où l'ancien code échouait à 1 s. Le déclencheur réaliste : `claude -p` lance des serveurs MCP qui héritent de stderr — `claude` sort proprement, le résultat est déjà collecté, et `complete()` ne revenait jamais. Le symptôme de #274.

**Un octet non-UTF-8 sur stdout devenait fatal**, sur le chemin même que la doc recommande pour les scripts arbitraires. Restauré en lecture tolérante — `raw` est de nouveau byte-identique à master.

**`stream()` avait perdu sa grâce post-EOF**, tuant l'enfant au SIGKILL là où `complete()` lui laissait le temps de sortir. Et un exit non-zéro y était silencieusement avalé — `exit 42` rendait `Ok`.

Vérifié : sur le chemin d'expiration, **l'enfant est bien tué**, mesuré, sans zombie. Les descendants survivent, exactement comme sur master.

## Une asymétrie gardée, et rendue délibérée

Le chemin plafond `bail!` et jette la sortie collectée ; le chemin post-EOF la retourne. J'inclinais à la retourner dans les deux cas ; la revue a tranché autrement, avec un argument meilleur : un timeout de boucle produit un préfixe JSONL **sans événement `result` terminal**, donc le rendre en `Ok` livrerait à un orchestrateur une sortie de coordinateur tronquée **indiscernable d'une vraie réponse**. L'EOF, lui, est le signal de complétion du sous-processus : y faire confiance est légitime. Documenté au site de la boucle.

## La sémantique de `metadata.timeout` a changé

Elle signifiait la durée **totale** et signifie l'**inactivité**. Mis à jour dans `agent.rs`, `docs/wiki/agent-format.md` et les exemples de `docs/wiki/providers.md` — quatre endroits disaient encore « Execution timeout in seconds ».

## Les garde-fous sont eux-mêmes gardés

C'est ce qui a demandé le plus de rounds, et le sujet de l'issue le justifie.

Le plafond de 2 h **fonctionnait** mais son câblage était supprimable des deux boucles sans qu'un test ne bronche — seul un `unused variable` le trahissait. Les deux boucles ont maintenant leur sentinelle.

Et ces sentinelles ont dû être repensées : mesurer un temps mural serré les rendait **instables (1 échec sur 12)**, tandis qu'élargir la borne détruisait leur sensibilité — une inflation ×10 du plafond passait. Elles assertent désormais sur la **nature de l'erreur** (plafond absolu, et non inactivité), signal catégoriel à la fois pleinement sensible et insensible à la charge, avec une borne externe généreuse dont le seul rôle est de faire échouer un blocage. **25 exécutions consécutives sans échec** côté implémenteur, 12 de plus côté contrôle.

Un test m'avait trompé deux fois — `steady_stream_survives_past_the_old_static_ceiling` passait avec un script sans aucun `sleep`. Cause : `Instant::now()` pris **hors** du verrou global, donc le temps mesuré incluait l'attente du mutex. Un voisin rapportait 22,94 s pour un processus mort à 1 s. Corrigé en déplaçant la mesure dans le verrou — pas en élargissant la tolérance — et vérifié par mutation : il échoue maintenant à `elapsed 515 ms`.

fmt · clippy `-D warnings` sur les 5 modes · les 4 modes de test verts · gaveldrop 13 cas / 83-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
