### PR TITLE
test(providers): widen the post-EOF bounds so they stop flaking under load

### DIFF
--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -1086,7 +1086,13 @@ mod tests {
     #[tokio::test]
     async fn stream_post_eof_wait_is_bounded_not_unbounded() {
         use tokio_stream::StreamExt;
-        let outcome = tokio::time::timeout(Duration::from_secs(10), async {
+        // Both bounds sit well below the child's 30s sleep, which is what an
+        // unbounded post-EOF wait would run toward — so either bound tripping
+        // still proves the defect. They are generous because the timings are
+        // measured against a real subprocess spawn under a loaded parallel
+        // `cargo test`: at 10s/5s this test failed roughly 1 run in 12 on the
+        // full suite while passing 6/6 in isolation (#270 review, #348).
+        let outcome = tokio::time::timeout(Duration::from_secs(25), async {
             with_env_lock(async {
                 let start = std::time::Instant::now();
                 let provider = CliProvider::new("sh".to_string(), vec!["-c".to_string()], 1);
@@ -1105,13 +1111,15 @@ mod tests {
         .await;
 
         let (items, elapsed) =
-            outcome.expect("must not hang past 10s if the post-EOF wait becomes unbounded");
+            outcome.expect("must not hang past 25s if the post-EOF wait becomes unbounded");
         assert!(
             items.iter().any(|i| i.as_ref().is_ok_and(|s| s == "hi")),
             "expected the line written before EOF to still arrive: {items:?}"
         );
+        // The inner bound catches a *partial* regression — a wait that grew but
+        // did not become infinite — which the outer timeout alone would miss.
         assert!(
-            elapsed < Duration::from_secs(5),
+            elapsed < Duration::from_secs(15),
             "must not block toward the child's 30s post-EOF sleep: {elapsed:?}"
         );
     }


### PR DESCRIPTION
## Problème

`stream_post_eof_wait_is_bounded_not_unbounded`, ajouté par #270 (PR #360), est **flaky sous parallélisme**. Il asserte que l'attente post-EOF se termine en moins de 5 s, dans un `timeout` externe de 10 s. Les deux bornes sont mesurées contre un vrai `spawn` de sous-processus : sous `cargo test` complet, le spawn seul peut consommer la marge.

Mesuré sur master (`810233a`) :
- **6/6 vert en isolation**
- **échec ~1 run sur 12** sur la suite complète, dans deux modes de features différents (`tui,storage,e2e-fake,web` et `tui,providers-api`)

Il allait donc faire échouer la CI au hasard sur toutes les PR suivantes.

## Correctif

Borne externe 10 s → **25 s**, borne interne 5 s → **15 s**. Les deux restent largement sous les **30 s** de `sleep` de l'enfant, qui est ce vers quoi une attente non bornée courrait — le test garde donc sa sensibilité.

## Vérification

La détection est préservée, mesurée et non déduite. Mutation du `timeout(timeout, child.wait())` borné vers un `child.wait()` non borné, soit exactement le défaut que #270 a corrigé :

```
test cli::tests::stream_post_eof_wait_is_bounded_not_unbounded ... FAILED
must not hang past 25s if the post-EOF wait becomes unbounded: Elapsed(())
finished in 25.01s
```

Puis, code restauré : **5 passes consécutives vertes** sous charge complète (contre 8/9 avant correctif).

Gate local complet : fmt + **5 modes clippy** + **4 modes de test**, tout vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)