### PR TITLE
fix(cli): align unlink's dry-run with its real pass and name the real cause

### DIFF
--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -470,9 +470,8 @@ fn unlink_from_manifest(
     );
     if kept > 0 {
         anstream::println!(
-            "{m}  Kept files are either hand-written (link recorded them as skipped), have \
-             content that no longer matches what link wrote, or could not be verified. \
-             Remove them by hand if you no longer want them.{m:#}"
+            "{m}  Kept files were left in place for the reason given on each line above: \
+             {KEPT_FILE_REASONS}. Remove them by hand if you no longer want them.{m:#}"
         );
     }
     if untrusted > 0 {
@@ -507,18 +506,39 @@ fn unlink_from_manifest(
     Ok(())
 }
 
+/// Why the manifest path can leave a file in place — one list, shared by
+/// the real pass and its `--dry-run` preview so the two cannot drift into
+/// two different accounts of the same set.
+///
+/// Open-ended on purpose (issue #348, third round): the closed list of
+/// three it replaces omitted the broken-symlink outcome the very same
+/// code path prints, so a user reading the footer could not find their
+/// own case in it. The fallback's footer had already been opened for
+/// exactly this reason.
+const KEPT_FILE_REASONS: &str = "hand-written (link recorded them as skipped), content \
+     that no longer matches what link wrote, a file that could not be verified, or a \
+     broken symlink whose content cannot be compared at all";
+
 /// Human-readable explanation for one [`linker::manifest::TrustFailure`]
 /// cause — shared by the real pass and its `--dry-run` preview so the two
 /// never phrase the same cause two different ways.
+///
+/// Neither wording dates the fault (issue #348, third round): the earlier
+/// `FilesystemDiverged` text said the filesystem "has changed since link
+/// ran", which is a claim the code cannot make. All it compares is the
+/// recorded text against the filesystem *as it is now* — it keeps no
+/// snapshot of how the filesystem looked at link time, so it can name
+/// which side puts the path where it is, never when that became true. The
+/// symlink may well have been there before `link` ever ran.
 fn trust_failure_reason(cause: linker::manifest::TrustFailure) -> &'static str {
     match cause {
         linker::manifest::TrustFailure::ManifestEscapesRoot => {
             "the manifest may be corrupt or forged"
         }
         linker::manifest::TrustFailure::FilesystemDiverged => {
-            "the manifest itself looks intact, but something on the filesystem has \
-             changed since link ran (e.g. a new symlink) — inspect the target \
-             directory before retrying"
+            "the manifest's own text does not put it there — something on the \
+             filesystem does, most likely a symlink along the path; inspect the \
+             target directory before retrying"
         }
     }
 }
@@ -530,14 +550,19 @@ fn trust_failure_reason(cause: linker::manifest::TrustFailure) -> &'static str {
 /// different ways.
 ///
 /// The verb has to move with the cause (issue #348): a manifest that
-/// literally records `.claude` *names* the root, while a manifest that
-/// correctly records `.claude/agents` and finds it symlinked to `.claude`
-/// afterwards *now resolves to* it — saying "names" for the second blames
-/// the manifest for text it never contained.
+/// literally records `.claude` — under any spelling of it — *names* the
+/// root, while a manifest that correctly records `.claude/agents` and
+/// finds a symlink collapsing it onto `.claude` *resolves onto* it.
+/// Saying "names" for the second blames the manifest for text it never
+/// contained; saying "resolves onto" for the first sends the user to
+/// inspect a filesystem where nothing is wrong.
+///
+/// "resolves onto", not "now resolves onto": the adverb dated a change
+/// this code cannot observe — see [`trust_failure_reason`].
 fn target_root_relation(cause: linker::manifest::TrustFailure) -> &'static str {
     match cause {
         linker::manifest::TrustFailure::ManifestEscapesRoot => "names",
-        linker::manifest::TrustFailure::FilesystemDiverged => "now resolves to",
+        linker::manifest::TrustFailure::FilesystemDiverged => "resolves onto",
     }
 }
 
@@ -561,10 +586,17 @@ fn target_root_relation(cause: linker::manifest::TrustFailure) -> &'static str {
 /// still on disk and *empty at that moment*, which is only true after the
 /// files inside it have been deleted — files this preview, by definition,
 /// has not deleted. So the count below is what its wording says,
-/// "recorded for cleanup", not "would be removed": a directory the user
+/// "eligible for cleanup", not "would be removed": a directory the user
 /// deleted by hand still counts here and the real pass then quietly
 /// touches nothing. Overstating that as an identical filesystem check is
 /// what this doc used to do.
+///
+/// "eligible", not "recorded" (issue #348, third round): the counter is
+/// the number of directories that passed
+/// [`linker::manifest::decide_created_dir`], which is neither how many
+/// the manifest records nor how many would actually be removed — a
+/// manifest recording one directory that the guard refuses used to print
+/// "0 directories recorded for cleanup", denying a record it holds.
 fn print_manifest_dry_run(
     root: &Path,
     target_name: &str,
@@ -594,7 +626,13 @@ fn print_manifest_dry_run(
             linker::manifest::diagnose_trust_failure(root, target_root, &entry.path)
         {
             let reason = trust_failure_reason(cause);
-            anstream::println!(
+            // On **stderr**, like the refusal the real pass prints for the
+            // same item (issue #348, third round): the preview must be
+            // readable the same way the run it previews is. As a
+            // `println!` a caller journalling `2>errors.log` got the
+            // reasons from a real pass and nothing at all from its
+            // preview, while one parsing stdout got the opposite.
+            anstream::eprintln!(
                 "{e}  {} (would refuse — outside the trusted root; {reason}){e:#}",
                 entry.path.display()
             );
@@ -675,7 +713,7 @@ fn print_manifest_dry_run(
             linker::manifest::CreatedDirDecision::IsTargetRoot(cause) => {
                 let relation = target_root_relation(cause);
                 let reason = trust_failure_reason(cause);
-                anstream::println!(
+                anstream::eprintln!(
                     "{e}  {} (would refuse — {relation} the target's own root; \
                      {reason}){e:#}",
                     dir.display()
@@ -684,14 +722,14 @@ fn print_manifest_dry_run(
             }
             linker::manifest::CreatedDirDecision::Untrusted(cause) => {
                 let reason = trust_failure_reason(cause);
-                anstream::println!(
+                anstream::eprintln!(
                     "{e}  {} (would refuse — outside the trusted root; {reason}){e:#}",
                     dir.display()
                 );
                 untrusted += 1;
             }
             linker::manifest::CreatedDirDecision::Implausible => {
-                anstream::println!(
+                anstream::eprintln!(
                     "{e}  {} (would refuse — matches no file link recorded creating; \
                      the manifest may be corrupt or forged){e:#}",
                     dir.display()
@@ -703,7 +741,7 @@ fn print_manifest_dry_run(
 
     anstream::println!(
         "\n{m}  {} would be removed, {} would be kept, {} already absent \
-         ({} director{} recorded for cleanup).{m:#}",
+         ({} director{} eligible for cleanup).{m:#}",
         would_remove,
         would_keep,
         absent,
@@ -712,15 +750,20 @@ fn print_manifest_dry_run(
     );
     if would_keep > 0 {
         anstream::println!(
-            "{m}  Kept files are either hand-written (recorded as skipped by link), have \
-             content that no longer matches what link wrote, or could not be verified. \
-             Remove them by hand if you no longer want them.{m:#}"
+            "{m}  Files listed as kept would be left in place for the reason given on \
+             each line above: {KEPT_FILE_REASONS}. Remove them by hand if you no longer \
+             want them.{m:#}"
         );
     }
     if untrusted > 0 {
-        anstream::println!(
-            "{e}  {} manifest item(s) would be refused — see the reason(s) given for \
-             each one above.{e:#}",
+        // Same sentence the real pass prints, on the same stream, with the
+        // one word that has to differ (issue #348, third round: the two
+        // summaries had drifted into two formulations of the same fact,
+        // which is what extracting `trust_failure_reason` and
+        // `target_root_relation` was supposed to stop).
+        anstream::eprintln!(
+            "{e}  {} manifest item(s) would be refused and left untouched; each \
+             refusal above names the item and why.{e:#}",
             untrusted
         );
         // Mirrors the real pass's own exit behaviour (design review R5):

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -290,9 +290,10 @@ fn unlink_from_manifest(
             target_name,
             &target_root,
             &relevant,
+            &entries,
             &created_dirs,
             config_candidate.as_deref(),
-        );
+        )?;
         return Ok(());
     }
 
@@ -302,11 +303,14 @@ fn unlink_from_manifest(
     let mut untrusted = 0;
 
     for entry in &relevant {
-        if !linker::manifest::is_trusted(root, &target_root, &entry.path) {
+        if let Some(cause) =
+            linker::manifest::diagnose_trust_failure(root, &target_root, &entry.path)
+        {
             let e = crate::cli::style::err();
+            let reason = trust_failure_reason(cause);
             anstream::eprintln!(
                 "{e}  refused: manifest entry '{}' for target '{}' resolves outside its \
-                 trusted root — ignoring it; the manifest may be corrupt or forged{e:#}",
+                 trusted root — ignoring it; {reason}{e:#}",
                 entry.path.display(),
                 target_name
             );
@@ -324,7 +328,22 @@ fn unlink_from_manifest(
         // whose literal `a` component doesn't exist (R4).
         let path = linker::manifest::resolve_real(root, &entry.path);
         if !path.exists() {
-            absent += 1;
+            if path.is_symlink() {
+                // Present on disk, but its target is gone — not "already
+                // absent" (issue #348, 3rd bullet), and its content can
+                // never be verified against a digest either, so the same
+                // conservative "kept" outcome other unverifiable entries
+                // get applies here too — just with an accurate reason.
+                let w = crate::cli::style::warn();
+                anstream::println!(
+                    "{w}  kept {} (broken symlink — its target is missing, so its \
+                     content can't be verified){w:#}",
+                    path.display()
+                );
+                kept += 1;
+            } else {
+                absent += 1;
+            }
             continue;
         }
         match entry.outcome {
@@ -386,39 +405,57 @@ fn unlink_from_manifest(
 
     // Remove exactly the directories `link` itself created for this
     // target (design fix 1b) — deepest first, so a child never blocks its
-    // own parent's removal, and each still checked against the trust root
-    // so a corrupted `created_dirs` list can't be used to remove something
-    // outside the target's own tree either.
+    // own parent's removal. Every dir's fate is decided by the single
+    // `decide_created_dir` function `--dry-run`'s preview also calls
+    // (issue #348, 1st bullet: the two must never silently diverge on
+    // this decision again — a real regression this chantier shipped
+    // once).
     let mut created_dirs = created_dirs;
     created_dirs.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
-    // The target's own root, resolved once — never a removal candidate
-    // itself, no matter what `created_dirs` claims (design review R3).
-    // R1's root confirmation only constrains which root a manifest can
-    // *declare*; it says nothing about a `created_dirs` entry naming
-    // that root right back, which trivially satisfies `is_trusted`
-    // (a path is always contained within itself). This is the one
-    // invariant that does not depend on trusting the manifest at all.
-    let resolved_target_root = linker::manifest::resolve_real(root, &target_root);
     for dir in &created_dirs {
-        let dir_path = linker::manifest::resolve_real(root, dir);
-        let refused = dir_path == resolved_target_root
-            || !linker::manifest::is_trusted(root, &target_root, dir);
-        if refused {
-            let e = crate::cli::style::err();
-            anstream::eprintln!(
-                "{e}  refused: recorded directory '{}' for target '{}' resolves outside its \
-                 trusted root, or names the root itself — ignoring it{e:#}",
-                dir.display(),
-                target_name
-            );
-            untrusted += 1;
-            continue;
-        }
-        let is_empty = std::fs::read_dir(&dir_path)
-            .map(|mut d| d.next().is_none())
-            .unwrap_or(false);
-        if dir_path.is_dir() && is_empty {
-            let _ = std::fs::remove_dir(&dir_path);
+        match linker::manifest::decide_created_dir(root, &target_root, dir, &entries) {
+            linker::manifest::CreatedDirDecision::Eligible => {
+                let dir_path = linker::manifest::resolve_real(root, dir);
+                let is_empty = std::fs::read_dir(&dir_path)
+                    .map(|mut d| d.next().is_none())
+                    .unwrap_or(false);
+                if dir_path.is_dir() && is_empty {
+                    let _ = std::fs::remove_dir(&dir_path);
+                }
+            }
+            linker::manifest::CreatedDirDecision::IsTargetRoot => {
+                let e = crate::cli::style::err();
+                anstream::eprintln!(
+                    "{e}  refused: recorded directory '{}' for target '{}' names the \
+                     target's own root — ignoring it; the manifest may be corrupt or \
+                     forged{e:#}",
+                    dir.display(),
+                    target_name
+                );
+                untrusted += 1;
+            }
+            linker::manifest::CreatedDirDecision::Untrusted(cause) => {
+                let e = crate::cli::style::err();
+                let reason = trust_failure_reason(cause);
+                anstream::eprintln!(
+                    "{e}  refused: recorded directory '{}' for target '{}' resolves \
+                     outside its trusted root — ignoring it; {reason}{e:#}",
+                    dir.display(),
+                    target_name
+                );
+                untrusted += 1;
+            }
+            linker::manifest::CreatedDirDecision::Implausible => {
+                let e = crate::cli::style::err();
+                anstream::eprintln!(
+                    "{e}  refused: recorded directory '{}' for target '{}' does not \
+                     correspond to any file link recorded creating — ignoring it; the \
+                     manifest may be corrupt or forged{e:#}",
+                    dir.display(),
+                    target_name
+                );
+                untrusted += 1;
+            }
         }
     }
 
@@ -441,9 +478,14 @@ fn unlink_from_manifest(
     }
     if untrusted > 0 {
         let e = crate::cli::style::err();
+        // Deliberately not a single blanket cause here (issue #348, 2nd
+        // bullet): the warning(s) printed above already said, per item,
+        // whether it was the manifest's own text or the filesystem that
+        // was at fault — this summary must not paper back over that
+        // distinction with one claim that doesn't hold for both.
         anstream::println!(
-            "{e}  {} manifest entry(ies) were refused for resolving outside the trusted \
-             root — see the warning(s) above; the manifest may be corrupt or forged.{e:#}",
+            "{e}  {} manifest item(s) were refused — see the reason(s) given for each \
+             one above.{e:#}",
             untrusted
         );
         // A refusal is a failure to complete the requested work, not a
@@ -451,8 +493,8 @@ fn unlink_from_manifest(
         // (design review R5), even though every trustworthy entry above
         // was still handled.
         anyhow::bail!(
-            "{} manifest entry(ies) for target '{}' were refused for resolving outside \
-             the trusted root; the request did not fully complete",
+            "{} manifest item(s) for target '{}' were refused; the request did not \
+             fully complete",
             untrusted,
             target_name
         );
@@ -461,17 +503,42 @@ fn unlink_from_manifest(
     Ok(())
 }
 
+/// Human-readable explanation for one [`linker::manifest::TrustFailure`]
+/// cause — shared by the real pass and its `--dry-run` preview so the two
+/// never phrase the same cause two different ways.
+fn trust_failure_reason(cause: linker::manifest::TrustFailure) -> &'static str {
+    match cause {
+        linker::manifest::TrustFailure::ManifestEscapesRoot => {
+            "the manifest may be corrupt or forged"
+        }
+        linker::manifest::TrustFailure::FilesystemDiverged => {
+            "the manifest itself looks intact, but something on the filesystem has \
+             changed since link ran (e.g. a new symlink) — inspect the target \
+             directory before retrying"
+        }
+    }
+}
+
 /// `--dry-run` rendering for the manifest path — mirrors the fallback's own
 /// dry-run output shape so the two paths read the same way to a user who
 /// doesn't know (and shouldn't need to know) which one is active.
+///
+/// Applies exactly the same guards the real pass does — `created_dirs`
+/// included (issue #348, 1st bullet: this was the actual defect, not just
+/// the wording — the pre-fix dry run counted a directory "recorded for
+/// cleanup" that the real pass would have refused, and exited 0 where the
+/// real pass exits 1). Anything this preview would refuse makes it return
+/// an error too, so scripted callers see the same signal a real run would
+/// give — a preview that can't fail is not a preview.
 fn print_manifest_dry_run(
     root: &Path,
     target_name: &str,
     target_root: &Path,
     entries: &[&linker::manifest::ManifestEntry],
+    all_entries: &[linker::manifest::ManifestEntry],
     created_dirs: &[PathBuf],
     config_candidate: Option<&Path>,
-) {
+) -> anyhow::Result<()> {
     let h = crate::cli::style::header();
     let a = crate::cli::style::accent();
     let m = crate::cli::style::muted();
@@ -488,9 +555,12 @@ fn print_manifest_dry_run(
     let mut untrusted = 0;
 
     for entry in entries {
-        if !linker::manifest::is_trusted(root, target_root, &entry.path) {
+        if let Some(cause) =
+            linker::manifest::diagnose_trust_failure(root, target_root, &entry.path)
+        {
+            let reason = trust_failure_reason(cause);
             anstream::println!(
-                "{e}  {} (would refuse — outside the trusted root){e:#}",
+                "{e}  {} (would refuse — outside the trusted root; {reason}){e:#}",
                 entry.path.display()
             );
             untrusted += 1;
@@ -498,8 +568,16 @@ fn print_manifest_dry_run(
         }
         let path = linker::manifest::resolve_real(root, &entry.path);
         if !path.exists() {
-            anstream::println!("{m}  {} (already absent){m:#}", path.display());
-            absent += 1;
+            if path.is_symlink() {
+                anstream::println!(
+                    "{w}  {} (would keep — broken symlink, cannot verify content){w:#}",
+                    path.display()
+                );
+                would_keep += 1;
+            } else {
+                anstream::println!("{m}  {} (already absent){m:#}", path.display());
+                absent += 1;
+            }
             continue;
         }
         match entry.outcome {
@@ -549,10 +627,42 @@ fn print_manifest_dry_run(
         }
     }
 
-    let would_clean_dirs = created_dirs
-        .iter()
-        .filter(|d| linker::manifest::is_trusted(root, target_root, d))
-        .count();
+    // Same decision the real pass makes for each recorded directory (issue
+    // #348, 1st bullet) — a refusal here counts into `untrusted` exactly
+    // like an entry's does, so the preview's exit code matches what a real
+    // run would do.
+    let mut would_clean_dirs = 0;
+    for dir in created_dirs {
+        match linker::manifest::decide_created_dir(root, target_root, dir, all_entries) {
+            linker::manifest::CreatedDirDecision::Eligible => {
+                would_clean_dirs += 1;
+            }
+            linker::manifest::CreatedDirDecision::IsTargetRoot => {
+                anstream::println!(
+                    "{e}  {} (would refuse — names the target's own root; the \
+                     manifest may be corrupt or forged){e:#}",
+                    dir.display()
+                );
+                untrusted += 1;
+            }
+            linker::manifest::CreatedDirDecision::Untrusted(cause) => {
+                let reason = trust_failure_reason(cause);
+                anstream::println!(
+                    "{e}  {} (would refuse — outside the trusted root; {reason}){e:#}",
+                    dir.display()
+                );
+                untrusted += 1;
+            }
+            linker::manifest::CreatedDirDecision::Implausible => {
+                anstream::println!(
+                    "{e}  {} (would refuse — matches no file link recorded creating; \
+                     the manifest may be corrupt or forged){e:#}",
+                    dir.display()
+                );
+                untrusted += 1;
+            }
+        }
+    }
 
     anstream::println!(
         "\n{m}  {} would be removed, {} would be kept, {} already absent \
@@ -572,11 +682,23 @@ fn print_manifest_dry_run(
     }
     if untrusted > 0 {
         anstream::println!(
-            "{e}  {} manifest entry(ies) would be refused for resolving outside the \
-             trusted root; the manifest may be corrupt or forged.{e:#}",
+            "{e}  {} manifest item(s) would be refused — see the reason(s) given for \
+             each one above.{e:#}",
             untrusted
         );
+        // Mirrors the real pass's own exit behaviour (design review R5):
+        // a refusal is a failure to complete, not a partial success, so
+        // the preview must fail too — otherwise it is not actually
+        // showing what the real run would do (issue #348, 1st bullet).
+        anyhow::bail!(
+            "{} manifest item(s) for target '{}' would be refused; a real run would \
+             not fully complete",
+            untrusted,
+            target_name
+        );
     }
+
+    Ok(())
 }
 
 /// The #342 fallback: recompute what `link` would write for the *current*

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -410,12 +410,10 @@ fn unlink_from_manifest(
     // (issue #348, 1st bullet: the two must never silently diverge on
     // this decision again — a real regression this chantier shipped
     // once).
-    let mut created_dirs = created_dirs;
-    created_dirs.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
-    for dir in &created_dirs {
-        match linker::manifest::decide_created_dir(root, &target_root, dir, &entries) {
+    for dir in linker::manifest::deepest_first(&created_dirs) {
+        match linker::manifest::decide_created_dir(root, &target_root, &dir, &entries) {
             linker::manifest::CreatedDirDecision::Eligible => {
-                let dir_path = linker::manifest::resolve_real(root, dir);
+                let dir_path = linker::manifest::resolve_real(root, &dir);
                 let is_empty = std::fs::read_dir(&dir_path)
                     .map(|mut d| d.next().is_none())
                     .unwrap_or(false);
@@ -423,12 +421,13 @@ fn unlink_from_manifest(
                     let _ = std::fs::remove_dir(&dir_path);
                 }
             }
-            linker::manifest::CreatedDirDecision::IsTargetRoot => {
+            linker::manifest::CreatedDirDecision::IsTargetRoot(cause) => {
                 let e = crate::cli::style::err();
+                let relation = target_root_relation(cause);
+                let reason = trust_failure_reason(cause);
                 anstream::eprintln!(
-                    "{e}  refused: recorded directory '{}' for target '{}' names the \
-                     target's own root — ignoring it; the manifest may be corrupt or \
-                     forged{e:#}",
+                    "{e}  refused: recorded directory '{}' for target '{}' {relation} the \
+                     target's own root — ignoring it; {reason}{e:#}",
                     dir.display(),
                     target_name
                 );
@@ -479,13 +478,18 @@ fn unlink_from_manifest(
     if untrusted > 0 {
         let e = crate::cli::style::err();
         // Deliberately not a single blanket cause here (issue #348, 2nd
-        // bullet): the warning(s) printed above already said, per item,
+        // bullet): the refusal(s) printed above already said, per item,
         // whether it was the manifest's own text or the filesystem that
         // was at fault — this summary must not paper back over that
         // distinction with one claim that doesn't hold for both.
-        anstream::println!(
-            "{e}  {} manifest item(s) were refused — see the reason(s) given for each \
-             one above.{e:#}",
+        //
+        // On **stderr**, like the per-item refusals it points at: as a
+        // `println!` it told a `2>/dev/null` caller to consult reasons
+        // that stream had just discarded. A pointer must live on the same
+        // stream as what it points to.
+        anstream::eprintln!(
+            "{e}  {} manifest item(s) were refused and left untouched; each refusal \
+             above names the item and why.{e:#}",
             untrusted
         );
         // A refusal is a failure to complete the requested work, not a
@@ -519,17 +523,48 @@ fn trust_failure_reason(cause: linker::manifest::TrustFailure) -> &'static str {
     }
 }
 
+/// How a recorded `created_dirs` entry relates to the target's own root,
+/// for the two causes [`linker::manifest::CreatedDirDecision::IsTargetRoot`]
+/// can have — shared by the real pass and its `--dry-run` preview, like
+/// [`trust_failure_reason`], so the two never phrase the same cause two
+/// different ways.
+///
+/// The verb has to move with the cause (issue #348): a manifest that
+/// literally records `.claude` *names* the root, while a manifest that
+/// correctly records `.claude/agents` and finds it symlinked to `.claude`
+/// afterwards *now resolves to* it — saying "names" for the second blames
+/// the manifest for text it never contained.
+fn target_root_relation(cause: linker::manifest::TrustFailure) -> &'static str {
+    match cause {
+        linker::manifest::TrustFailure::ManifestEscapesRoot => "names",
+        linker::manifest::TrustFailure::FilesystemDiverged => "now resolves to",
+    }
+}
+
 /// `--dry-run` rendering for the manifest path — mirrors the fallback's own
 /// dry-run output shape so the two paths read the same way to a user who
 /// doesn't know (and shouldn't need to know) which one is active.
 ///
-/// Applies exactly the same guards the real pass does — `created_dirs`
+/// Applies the same *decisions* the real pass does — `created_dirs`
 /// included (issue #348, 1st bullet: this was the actual defect, not just
 /// the wording — the pre-fix dry run counted a directory "recorded for
 /// cleanup" that the real pass would have refused, and exited 0 where the
-/// real pass exits 1). Anything this preview would refuse makes it return
-/// an error too, so scripted callers see the same signal a real run would
-/// give — a preview that can't fail is not a preview.
+/// real pass exits 1). Every refusal comes from the same
+/// [`linker::manifest::decide_created_dir`] call, in the same
+/// deepest-first order ([`linker::manifest::deepest_first`]), and anything
+/// this preview would refuse makes it return an error too, so scripted
+/// callers see the same signal a real run would give — a preview that
+/// can't fail is not a preview.
+///
+/// One thing it deliberately does **not** mirror, because it cannot: the
+/// real pass removes an eligible directory only if that directory is
+/// still on disk and *empty at that moment*, which is only true after the
+/// files inside it have been deleted — files this preview, by definition,
+/// has not deleted. So the count below is what its wording says,
+/// "recorded for cleanup", not "would be removed": a directory the user
+/// deleted by hand still counts here and the real pass then quietly
+/// touches nothing. Overstating that as an identical filesystem check is
+/// what this doc used to do.
 fn print_manifest_dry_run(
     root: &Path,
     target_name: &str,
@@ -632,15 +667,17 @@ fn print_manifest_dry_run(
     // like an entry's does, so the preview's exit code matches what a real
     // run would do.
     let mut would_clean_dirs = 0;
-    for dir in created_dirs {
-        match linker::manifest::decide_created_dir(root, target_root, dir, all_entries) {
+    for dir in linker::manifest::deepest_first(created_dirs) {
+        match linker::manifest::decide_created_dir(root, target_root, &dir, all_entries) {
             linker::manifest::CreatedDirDecision::Eligible => {
                 would_clean_dirs += 1;
             }
-            linker::manifest::CreatedDirDecision::IsTargetRoot => {
+            linker::manifest::CreatedDirDecision::IsTargetRoot(cause) => {
+                let relation = target_root_relation(cause);
+                let reason = trust_failure_reason(cause);
                 anstream::println!(
-                    "{e}  {} (would refuse — names the target's own root; the \
-                     manifest may be corrupt or forged){e:#}",
+                    "{e}  {} (would refuse — {relation} the target's own root; \
+                     {reason}){e:#}",
                     dir.display()
                 );
                 untrusted += 1;
@@ -921,8 +958,16 @@ async fn unlink_via_fallback(
         for candidate in &candidates {
             let path = candidate.path();
             if !path.exists() {
-                anstream::println!("{m}  {} (already absent){m:#}", path.display());
-                absent += 1;
+                if path.is_symlink() {
+                    anstream::println!(
+                        "{w}  {} (would keep — broken symlink, cannot verify content){w:#}",
+                        path.display()
+                    );
+                    would_keep += 1;
+                } else {
+                    anstream::println!("{m}  {} (already absent){m:#}", path.display());
+                    absent += 1;
+                }
                 continue;
             }
             match candidate {
@@ -945,18 +990,19 @@ async fn unlink_via_fallback(
             }
         }
         anstream::println!(
-            "\n{m}  {} would be removed, {} would be kept (content differs), \
-             {} already absent.{m:#}",
+            "\n{m}  {} would be removed, {} would be kept, {} already absent.{m:#}",
             would_remove,
             would_keep,
             absent
         );
         if would_keep > 0 {
             anstream::println!(
-                "{m}  Kept files differ from what link would generate now — possibly \
-                 edited since linking, or linked with different options (e.g. \
-                 --model, or an interactive prompt answer); unlink cannot tell \
-                 which. Remove them by hand if you no longer want them.{m:#}"
+                "{m}  Kept files were left in place for the reason given on each line \
+                 above: content that differs from what link would generate now \
+                 (possibly edited since linking, or linked with different options — \
+                 e.g. --model, or an interactive prompt answer; unlink cannot tell \
+                 which), or a broken symlink whose content cannot be compared at all. \
+                 Remove them by hand if you no longer want them.{m:#}"
             );
         }
         return Ok(());
@@ -973,7 +1019,25 @@ async fn unlink_via_fallback(
     for candidate in &candidates {
         let path = candidate.path();
         if !path.exists() {
-            absent += 1;
+            if path.is_symlink() {
+                // Present on disk, its target gone. The manifest path
+                // stopped calling this "already absent" for issue #348's
+                // 3rd bullet; the same reasoning holds here word for word
+                // — a dangling link is not an absence, and its content
+                // can never match what `link` would generate, so the
+                // guard's own conservative "kept" outcome is the right
+                // one. The fallback is the *degraded* mode, where odd
+                // trees are more likely, not less.
+                let w = crate::cli::style::warn();
+                anstream::println!(
+                    "{w}  kept {} (broken symlink — its target is missing, so its \
+                     content can't be compared){w:#}",
+                    path.display()
+                );
+                kept += 1;
+            } else {
+                absent += 1;
+            }
             continue;
         }
 
@@ -1022,8 +1086,8 @@ async fn unlink_via_fallback(
     let a = crate::cli::style::accent();
     let m = crate::cli::style::muted();
     anstream::println!(
-        "\n{o}Unlinked{o:#} {a}'{}'{a:#}: {m}{} deleted, {} kept (content differs), \
-         {} already absent.{m:#}",
+        "\n{o}Unlinked{o:#} {a}'{}'{a:#}: {m}{} deleted, {} kept, {} already \
+         absent.{m:#}",
         target_name,
         deleted,
         kept,
@@ -1031,10 +1095,12 @@ async fn unlink_via_fallback(
     );
     if kept > 0 {
         anstream::println!(
-            "{m}  Kept files differ from what link would generate now — possibly edited \
-             since linking, or linked with different options (e.g. --model, or an \
-             interactive prompt answer); unlink cannot tell which. Remove them by hand \
-             if you no longer want them.{m:#}"
+            "{m}  Kept files were left in place for the reason given on each line \
+             above: content that differs from what link would generate now \
+             (possibly edited since linking, or linked with different options — \
+             e.g. --model, or an interactive prompt answer; unlink cannot tell \
+             which), or a broken symlink whose content cannot be compared at all. \
+             Remove them by hand if you no longer want them.{m:#}"
         );
     }
 

--- a/crates/armadai/src/linker/manifest.rs
+++ b/crates/armadai/src/linker/manifest.rs
@@ -343,6 +343,119 @@ pub fn root_confirmed(project_root: &Path, computed_root: &Path, declared_root: 
     resolve_real(project_root, computed_root) == resolve_real(project_root, declared_root)
 }
 
+/// Why a candidate path failed [`is_trusted`] — distinguishes a manifest
+/// whose own text already escapes the trust root (forged, hand-corrupted,
+/// or otherwise wrong) from one whose text is fine but the *filesystem*
+/// changed since `link` ran (a symlink now redirects an otherwise
+/// legitimate path outside the root). Issue #348: these two causes were
+/// collapsed into a single "the manifest may be corrupt or forged"
+/// message, which is simply false for the second case — the manifest is
+/// exactly what `link` wrote, and the disk moved under it. The two causes
+/// call for different next steps from the user (fix or regenerate the
+/// manifest, versus investigate what changed on disk), so callers must
+/// keep them distinct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustFailure {
+    /// The path escapes the trusted root even under pure lexical
+    /// resolution (no filesystem access) — the manifest text itself names
+    /// a path outside its own root.
+    ManifestEscapesRoot,
+    /// The path stays within the trusted root under lexical resolution,
+    /// but resolving it against the real filesystem (following symlinks)
+    /// puts it outside — something on disk changed since `link` ran.
+    FilesystemDiverged,
+}
+
+/// Diagnose why `candidate` fails [`is_trusted`] under `target_root` — or
+/// `None` if it doesn't. See [`TrustFailure`] for what the two possible
+/// causes mean and why callers must not collapse them into one message.
+pub fn diagnose_trust_failure(
+    project_root: &Path,
+    target_root: &Path,
+    candidate: &Path,
+) -> Option<TrustFailure> {
+    if is_trusted(project_root, target_root, candidate) {
+        return None;
+    }
+    let lexical_root = resolve(project_root, target_root);
+    let lexical_candidate = resolve(project_root, candidate);
+    if lexical_candidate.starts_with(&lexical_root) {
+        Some(TrustFailure::FilesystemDiverged)
+    } else {
+        Some(TrustFailure::ManifestEscapesRoot)
+    }
+}
+
+/// Whether `dir` (a recorded `created_dirs` entry) is a plausible ancestor
+/// of at least one `Created` entry — i.e. a directory `link` could
+/// plausibly have created while writing one of its own files.
+///
+/// This is the second half of the `created_dirs` trust boundary (residue
+/// of design review R3, issue #348's 4th bullet): [`is_trusted`] alone
+/// only bounds *where* a recorded directory may resolve — inside the
+/// target's own root — not *whether* it corresponds to anything `link`
+/// actually wrote. A forged or hand-corrupted `created_dirs` entry naming
+/// a pre-existing, currently-empty directory the user made by hand (e.g.
+/// `.claude/notes/`) passes [`is_trusted`] trivially as long as it sits
+/// under the target root, and would otherwise be removed on nothing more
+/// than "empty and trusted". Requiring it to be an ancestor of at least
+/// one `Created` entry ties the removal back to real generated content —
+/// [`create_dir_all_recording`] is only ever called immediately before
+/// writing a file that becomes a `Created` entry (see [`write_files`]), so
+/// every legitimate `created_dirs` entry satisfies this by construction.
+/// A `Skipped` entry never causes a directory to be created, so it never
+/// counts here either.
+pub fn created_dir_is_plausible(dir: &Path, entries: &[ManifestEntry]) -> bool {
+    entries
+        .iter()
+        .any(|e| e.outcome == Outcome::Created && e.path.starts_with(dir))
+}
+
+/// A recorded `created_dirs` entry's fate — decided once by
+/// [`decide_created_dir`] and shared by both `unlink`'s real pass and its
+/// `--dry-run` preview, so the two can never silently diverge on this
+/// decision again (issue #348's 1st bullet: they once did — the dry run
+/// announced a directory safe to clean up that the real pass would have
+/// refused).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreatedDirDecision {
+    /// Safe to remove, once actually confirmed empty on disk.
+    Eligible,
+    /// Refused: names the target's own root — `link` never records that
+    /// (design review R3), so a manifest claiming otherwise is simply
+    /// wrong.
+    IsTargetRoot,
+    /// Refused: fails the trust boundary — see [`TrustFailure`] for why.
+    Untrusted(TrustFailure),
+    /// Refused: doesn't correspond to any file `link` actually recorded
+    /// creating — see [`created_dir_is_plausible`].
+    Implausible,
+}
+
+/// Decide `dir`'s fate against `target_root`'s trust boundary and
+/// `entries`' recorded `Created` paths. Pure and side-effect free — the
+/// caller does the actual filesystem check (still empty? still a
+/// directory?) only for the [`CreatedDirDecision::Eligible`] case.
+pub fn decide_created_dir(
+    project_root: &Path,
+    target_root: &Path,
+    dir: &Path,
+    entries: &[ManifestEntry],
+) -> CreatedDirDecision {
+    let resolved_target_root = resolve_real(project_root, target_root);
+    let dir_path = resolve_real(project_root, dir);
+    if dir_path == resolved_target_root {
+        return CreatedDirDecision::IsTargetRoot;
+    }
+    if let Some(cause) = diagnose_trust_failure(project_root, target_root, dir) {
+        return CreatedDirDecision::Untrusted(cause);
+    }
+    if !created_dir_is_plausible(dir, entries) {
+        return CreatedDirDecision::Implausible;
+    }
+    CreatedDirDecision::Eligible
+}
+
 /// Result of looking up one target's manifest data.
 pub enum Lookup {
     /// A usable — possibly empty — target manifest.
@@ -497,6 +610,24 @@ pub fn write_files(
     files: Vec<(PathBuf, String, ProducedBy)>,
     force: bool,
 ) -> std::io::Result<Vec<FileOutcome>> {
+    // The previous manifest write for this exact target, keyed by path —
+    // used only to recognise a file that is still exactly what `link`
+    // itself wrote last time, even when the freshly generated content has
+    // since changed (issue #348, coordination note 2): without this, such
+    // a file gets downgraded to `Skipped`/no digest below purely because
+    // the *upstream* agent source changed, not because anyone touched the
+    // file — mislabelling `link`'s own untouched output as hand-written,
+    // permanently (nothing short of a `--force` relink ever corrects it).
+    let previous_digests: BTreeMap<PathBuf, String> = match lookup_target(root, target_name) {
+        Lookup::Found(t) => t
+            .entries
+            .into_iter()
+            .filter(|e| e.outcome == Outcome::Created)
+            .filter_map(|e| e.digest.map(|d| (e.path, d)))
+            .collect(),
+        Lookup::Fallback => BTreeMap::new(),
+    };
+
     let mut outcomes = Vec::with_capacity(files.len());
     let mut manifest_entries: Vec<ManifestEntry> = Vec::with_capacity(files.len());
     let mut created_dirs: Vec<PathBuf> = Vec::new();
@@ -520,6 +651,25 @@ pub fn write_files(
                     digest: Some(digest_of(content.as_bytes())),
                 });
                 outcomes.push(FileOutcome::UpToDate(path));
+                continue;
+            }
+
+            // The freshly generated content differs from what's on disk —
+            // but if the on-disk bytes are still exactly what `link`
+            // itself wrote last time (per the previous manifest), this is
+            // still `link`'s own file, just stale relative to an upstream
+            // change, not a stranger's to leave mislabelled forever.
+            let still_own_output = previous_digests
+                .get(&relative_path)
+                .is_some_and(|old_digest| check_digest(old_digest, &path) == DigestCheck::Matches);
+            if still_own_output {
+                manifest_entries.push(ManifestEntry {
+                    path: relative_path.clone(),
+                    produced_by,
+                    outcome: Outcome::Created,
+                    digest: previous_digests.get(&relative_path).cloned(),
+                });
+                outcomes.push(FileOutcome::SkippedExisting(path));
                 continue;
             }
 
@@ -1039,5 +1189,315 @@ mod tests {
             Lookup::Found(found) => assert_eq!(found.entries[0].outcome, Outcome::Created),
             Lookup::Fallback => panic!("write_files must leave a usable manifest behind"),
         }
+    }
+
+    /// Issue #348, coordination note 2: a re-`link` that leaves a file
+    /// untouched (no `--force`, because the *newly generated* content
+    /// differs from what's on disk) must not mislabel that file `Skipped`
+    /// in the manifest when the on-disk bytes are still exactly what
+    /// `link` itself wrote last time — only the upstream source changed,
+    /// not the file.
+    ///
+    /// Mutation this catches: if the previous-digest check were removed
+    /// (or always returned `false`), the second write's entry would come
+    /// back `Skipped`/`None` instead of `Created` with the digest of
+    /// what's actually on disk — this test's outcome/digest assertions
+    /// would fail.
+    #[test]
+    fn write_files_relink_of_untouched_own_output_stays_created_even_when_content_changed_upstream()
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let target_root = root.join(".claude");
+        let path = target_root.join("agents/solo.md");
+
+        // First link: writes "v1".
+        write_files(
+            root,
+            "claude",
+            Path::new(".claude"),
+            &target_root,
+            vec![(path.clone(), "v1".to_string(), ProducedBy::agent("solo"))],
+            false,
+        )
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v1");
+
+        // Second link: the agent's source changed upstream, so the
+        // *newly generated* content is "v2" — but the file on disk is
+        // still exactly "v1", untouched by anyone since the first link
+        // wrote it.
+        let outcomes = write_files(
+            root,
+            "claude",
+            Path::new(".claude"),
+            &target_root,
+            vec![(path.clone(), "v2".to_string(), ProducedBy::agent("solo"))],
+            false,
+        )
+        .unwrap();
+
+        // Conservative file-system behaviour is unchanged: without
+        // --force, the file itself is never overwritten.
+        assert_eq!(outcomes, vec![FileOutcome::SkippedExisting(path.clone())]);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v1");
+
+        match lookup_target(root, "claude") {
+            Lookup::Found(found) => {
+                assert_eq!(
+                    found.entries[0].outcome,
+                    Outcome::Created,
+                    "a file that is still exactly what link wrote last time must stay \
+                     attributed to link, not be downgraded to hand-written just \
+                     because the upstream source has since changed"
+                );
+                assert_eq!(
+                    found.entries[0].digest,
+                    Some(digest_of(b"v1")),
+                    "the recorded digest must match what's actually on disk, so a \
+                     later unlink can still reclaim this file"
+                );
+            }
+            Lookup::Fallback => panic!("write_files must leave a usable manifest behind"),
+        }
+    }
+
+    // ── resolve_real (issue #348: no direct unit tests before this) ───
+
+    /// The defining property `resolve_real` exists for: it follows a
+    /// symlink for the part of the path that actually exists on disk,
+    /// where a purely lexical join would just stop at the symlink's own
+    /// (lexically valid) path.
+    ///
+    /// Mutation this catches: if `resolve_real` were replaced by the
+    /// pure-lexical `resolve` fallback unconditionally (dropping the
+    /// `canonicalize` call entirely), the equality assertion against the
+    /// real, canonicalised target would fail — the result would instead
+    /// equal the un-followed `root.join("link-name/child.md")`.
+    #[test]
+    #[cfg(unix)]
+    fn resolve_real_follows_a_symlinked_existing_path_to_its_real_location() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let real_target = root.join("real-target");
+        std::fs::create_dir_all(&real_target).unwrap();
+        let link_name = root.join("link-name");
+        std::os::unix::fs::symlink(&real_target, &link_name).unwrap();
+
+        let resolved = resolve_real(root, Path::new("link-name/child.md"));
+        let expected = std::fs::canonicalize(&real_target)
+            .unwrap()
+            .join("child.md");
+        assert_eq!(
+            resolved, expected,
+            "resolve_real must follow the symlink to where it actually points"
+        );
+        assert_ne!(
+            resolved,
+            root.join("link-name/child.md"),
+            "a purely lexical join (never following the symlink) must not be what \
+             this function returns — that is exactly the boundary bypass R2 fixed"
+        );
+    }
+
+    /// The other half of `resolve_real`'s contract: for a tail that
+    /// doesn't exist yet, it canonicalises the longest existing prefix and
+    /// re-appends the missing suffix lexically, rather than failing or
+    /// falling back to a fully lexical resolution.
+    ///
+    /// Mutation this catches: if the suffix re-append loop dropped a
+    /// component, or canonicalised the wrong prefix, this test's equality
+    /// assertion against the manually constructed expected path would
+    /// fail.
+    #[test]
+    fn resolve_real_canonicalizes_the_existing_prefix_and_appends_the_missing_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let existing = root.join("existing");
+        std::fs::create_dir_all(&existing).unwrap();
+
+        let resolved = resolve_real(root, Path::new("existing/missing/deep/file.md"));
+        let expected = std::fs::canonicalize(&existing)
+            .unwrap()
+            .join("missing")
+            .join("deep")
+            .join("file.md");
+        assert_eq!(resolved, expected);
+    }
+
+    /// Issue #338's R4, pinned with its own test for the first time (issue
+    /// #348): `a/../b` must resolve to `<root>/b` even when `a` itself
+    /// doesn't exist as a real directory to canonicalise through. The OS
+    /// cannot traverse into a nonexistent `a` to cancel the following
+    /// `..`, so the *whole* literal path fails to resolve via
+    /// canonicalisation even though it logically names `<root>/b` — this
+    /// is exactly the false-absence trap `resolve_real`'s fallback to pure
+    /// lexical resolution (when canonicalising the found prefix itself
+    /// fails) exists to avoid.
+    ///
+    /// Mutation this catches: if the `Err(_) => resolve(project_root,
+    /// field)` fallback in `resolve_real` were removed (propagating the
+    /// canonicalize error, or returning the unresolved intermediate path
+    /// instead), this test's equality assertion would fail.
+    #[test]
+    fn resolve_real_normalizes_a_parent_escape_through_a_missing_intermediate() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // Deliberately do NOT create `root/a` — it must never need to
+        // exist for this to resolve correctly.
+        let resolved = resolve_real(root, Path::new("a/../b"));
+        assert_eq!(resolved, root.join("b"));
+    }
+
+    // ── root_confirmed (issue #348: no direct unit tests before this) ─
+
+    #[test]
+    fn root_confirmed_true_for_textually_identical_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        assert!(root_confirmed(
+            root,
+            Path::new(".claude"),
+            Path::new(".claude")
+        ));
+    }
+
+    /// The property that actually justifies `resolve_real` over a plain
+    /// `PathBuf` equality check: two textually different roots that
+    /// resolve to the same real directory must still be confirmed as the
+    /// same root.
+    ///
+    /// Mutation this catches: if `root_confirmed` compared the two paths
+    /// with plain equality (or `resolve` instead of `resolve_real`)
+    /// instead of resolving both through the filesystem first, this
+    /// test's `assert!` would fail.
+    #[test]
+    #[cfg(unix)]
+    fn root_confirmed_true_when_the_declared_root_is_reached_through_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let real_dir = root.join("real-claude");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let link_dir = root.join(".claude");
+        std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+        assert!(
+            root_confirmed(root, Path::new(".claude"), Path::new("real-claude")),
+            "two textually different roots that resolve to the same real directory \
+             must be confirmed as the same root"
+        );
+    }
+
+    /// Mutation this catches: if `root_confirmed` were hardcoded to `true`
+    /// (or its equality inverted), this test would fail to catch two
+    /// genuinely different directories being confirmed as the same root.
+    #[test]
+    fn root_confirmed_false_for_genuinely_different_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".claude")).unwrap();
+        std::fs::create_dir_all(root.join(".codex")).unwrap();
+        assert!(!root_confirmed(
+            root,
+            Path::new(".claude"),
+            Path::new(".codex")
+        ));
+    }
+
+    // ── diagnose_trust_failure (issue #348, 2nd bullet) ────────────────
+
+    /// A path that escapes the trusted root even under pure lexical
+    /// resolution — no filesystem access needed to see it — is the
+    /// manifest's own text being wrong.
+    #[test]
+    fn diagnose_trust_failure_reports_manifest_escapes_root_for_a_textual_escape() {
+        let project_root = PathBuf::from("/project");
+        assert_eq!(
+            diagnose_trust_failure(
+                &project_root,
+                Path::new(".claude"),
+                Path::new(".claude/../../outside/victim.txt"),
+            ),
+            Some(TrustFailure::ManifestEscapesRoot)
+        );
+    }
+
+    /// A path that stays inside the trusted root textually, but resolves
+    /// outside once an intermediate symlink (added after `link` ran) is
+    /// followed, must be reported as a filesystem change — not blamed on
+    /// the manifest, which never named anything outside its root at all.
+    ///
+    /// Mutation this catches: if `diagnose_trust_failure` always returned
+    /// `ManifestEscapesRoot` for any `is_trusted` failure (the pre-#348
+    /// behaviour, collapsed into one cause), this test's equality
+    /// assertion would fail.
+    #[test]
+    #[cfg(unix)]
+    fn diagnose_trust_failure_reports_filesystem_diverged_when_only_a_symlink_moved() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let target_root = root.join(".claude");
+        std::fs::create_dir_all(target_root.join("agents")).unwrap();
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        // Text-wise, `.claude/agents/keys.md` stays fully inside `.claude`
+        // — no `..`, no absolute escape. Only the *filesystem* changes:
+        // `.claude/agents` becomes a symlink to somewhere outside the
+        // project.
+        std::fs::remove_dir_all(target_root.join("agents")).unwrap();
+        std::os::unix::fs::symlink(&outside, target_root.join("agents")).unwrap();
+
+        let cause = diagnose_trust_failure(
+            root,
+            Path::new(".claude"),
+            Path::new(".claude/agents/keys.md"),
+        );
+        assert_eq!(
+            cause,
+            Some(TrustFailure::FilesystemDiverged),
+            "a legitimate path whose intermediate directory was symlinked away \
+             since link ran must not be reported as if the manifest's own text \
+             were at fault"
+        );
+    }
+
+    // ── created_dir_is_plausible (issue #348, 4th bullet / R3 residue) ─
+
+    #[test]
+    fn created_dir_is_plausible_true_for_an_ancestor_of_a_created_entry() {
+        let entries = vec![entry(".claude/agents/solo.md", "solo", b"x")];
+        assert!(created_dir_is_plausible(
+            Path::new(".claude/agents"),
+            &entries
+        ));
+    }
+
+    /// The exact residue issue #348 names: a directory with no matching
+    /// `Created` entry at all — e.g. a pre-existing, empty user directory
+    /// a forged manifest merely claims to have created — must not be
+    /// considered plausible.
+    #[test]
+    fn created_dir_is_plausible_false_for_a_directory_with_no_matching_entry() {
+        let entries = vec![entry(".claude/agents/solo.md", "solo", b"x")];
+        assert!(!created_dir_is_plausible(
+            Path::new(".claude/my-own-empty-dir"),
+            &entries
+        ));
+    }
+
+    /// A `Skipped` entry never caused `create_dir_all` to run (`link`
+    /// only creates directories immediately before an actual write), so a
+    /// directory must not be considered plausible on the strength of a
+    /// `Skipped` entry living under it alone.
+    #[test]
+    fn created_dir_is_plausible_false_when_the_only_matching_entry_is_skipped() {
+        let entries = vec![ManifestEntry {
+            path: PathBuf::from(".claude/notes.md"),
+            produced_by: ProducedBy::agent("solo"),
+            outcome: Outcome::Skipped,
+            digest: None,
+        }];
+        assert!(!created_dir_is_plausible(Path::new(".claude"), &entries));
     }
 }

--- a/crates/armadai/src/linker/manifest.rs
+++ b/crates/armadai/src/linker/manifest.rs
@@ -245,6 +245,52 @@ fn resolve(project_root: &Path, field: &Path) -> PathBuf {
     lexically_normalize(&joined)
 }
 
+/// Resolve `field` like [`resolve`] — lexically, following no symlink
+/// *within* the project — but with exactly one filesystem fact folded in:
+/// the **spelling of the project root itself**. `/tmp` is a symlink to
+/// `/private/tmp` on macOS, and a home directory or an automount can be
+/// reached through one on Linux, so the very same directory has two
+/// absolute spellings. A manifest is not at fault for which of them it
+/// happens to hold.
+///
+/// This is the resolution [`fault_side`]'s question actually needs — "does
+/// the recorded *text* already put this path where it must not be?" — and
+/// plain [`resolve`] was not it (issue #348, third round, measured): a
+/// `created_dirs` entry naming the target root through `/tmp/…` names it
+/// just as literally as `.claude` does, yet compared lexically against a
+/// root spelled `/private/tmp/…` it read as a path the *filesystem* had
+/// moved, so `unlink` sent the user to inspect a directory where nothing
+/// had happened — the exact false accusation issue #348 exists to remove.
+///
+/// Canonicalising both sides outright would not do: it is what
+/// [`resolve_real`] already does, and by construction it makes the two
+/// paths equal in *both* cases, collapsing the distinction back into one
+/// answer. Only the prefix that is the project root under another
+/// spelling is resolved here; every component below it stays textual, so
+/// a symlink *inside* the project — the case where the disk really is
+/// what moved the path — still resolves differently and stays the
+/// filesystem's fault.
+fn resolve_lexical(project_root: &Path, field: &Path) -> PathBuf {
+    let lexical = resolve(project_root, field);
+    let Ok(canonical_project) = std::fs::canonicalize(project_root) else {
+        return lexical;
+    };
+    if lexical.starts_with(&canonical_project) {
+        return lexical;
+    }
+    let mut prefix = PathBuf::new();
+    let mut components = lexical.components();
+    while let Some(component) = components.next() {
+        prefix.push(component);
+        if std::fs::canonicalize(&prefix).is_ok_and(|c| c == canonical_project) {
+            let mut rerooted = canonical_project;
+            rerooted.extend(components);
+            return rerooted;
+        }
+    }
+    lexical
+}
+
 /// Resolve `field` into its real, symlink-free location as far as the
 /// filesystem allows *right now*: canonicalise the longest existing
 /// prefix, then re-append whatever suffix doesn't exist yet, lexically —
@@ -347,14 +393,15 @@ pub fn root_confirmed(project_root: &Path, computed_root: &Path, declared_root: 
 /// manifest's own text, or the filesystem it is being resolved against.
 /// Issue #348: these two causes were collapsed into a single "the manifest
 /// may be corrupt or forged" message, which is simply false for the second
-/// case — the manifest is exactly what `link` wrote, and the disk moved
-/// under it. The two call for different next steps from the user (fix or
-/// regenerate the manifest, versus investigate what changed on disk), so
-/// callers must keep them distinct.
+/// case — the manifest is exactly what `link` wrote, and the filesystem
+/// is what puts the path elsewhere. The two call for different next steps
+/// from the user (fix or regenerate the manifest, versus inspect the
+/// filesystem), so callers must keep them distinct.
 ///
 /// Used for both refusal kinds a recorded path can hit, because the
-/// question — "is the text wrong, or did the disk move?" — is the same one
-/// either way and must be answered the same way:
+/// question — "is the text wrong, or is the filesystem what puts it
+/// there?" — is the same one either way and must be answered the same
+/// way:
 ///
 /// - failing [`is_trusted`] (the path lands outside the trusted root), via
 ///   [`diagnose_trust_failure`];
@@ -365,20 +412,35 @@ pub fn root_confirmed(project_root: &Path, computed_root: &Path, declared_root: 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrustFailure {
     /// The manifest's own text is what puts the path where it must not be:
-    /// even under pure lexical resolution (no filesystem access) it
-    /// escapes the trusted root, or names that root itself.
+    /// even under lexical resolution ([`resolve_lexical`] — no symlink
+    /// inside the project followed) it escapes the trusted root, or names
+    /// that root itself.
     ManifestEscapesRoot,
     /// Under lexical resolution the path is exactly where it should be;
     /// only resolving it against the real filesystem (following symlinks)
     /// puts it outside the root, or onto the root itself — something on
-    /// disk changed since `link` ran.
+    /// disk, not the recorded text, is what brings it there.
+    ///
+    /// Deliberately says nothing about *when* that something appeared:
+    /// this code compares "lexical" against "real", never "before `link`"
+    /// against "after `link`", and it has no record of the filesystem as
+    /// it was at link time to compare against. A message claiming the
+    /// disk "changed since `link` ran" asserts more than the value can
+    /// carry (issue #348, third round).
     FilesystemDiverged,
 }
 
 /// Which side is at fault, given whether the recorded path's own text is
-/// already enough to condemn it: if pure lexical resolution alone lands it
-/// where it must not be, the manifest is wrong; if only resolving against
-/// the real filesystem does, the disk moved under an intact manifest.
+/// already enough to condemn it: if lexical resolution alone
+/// ([`resolve_lexical`]) lands it where it must not be, the manifest is
+/// wrong; if only resolving against the real filesystem does, the
+/// manifest is intact and the filesystem is what puts it there.
+///
+/// The caller passes the lexical verdict computed with [`resolve_lexical`]
+/// — never plain [`resolve`]. The distinction this function draws is
+/// "text versus filesystem", and a path spelled through a non-canonical
+/// but perfectly ordinary prefix (`/tmp` for `/private/tmp`) is still the
+/// text naming a place, not the filesystem moving it.
 ///
 /// One function so the two refusal kinds ([`diagnose_trust_failure`] and
 /// [`CreatedDirDecision::IsTargetRoot`]) cannot answer it differently —
@@ -403,8 +465,8 @@ pub fn diagnose_trust_failure(
     if is_trusted(project_root, target_root, candidate) {
         return None;
     }
-    let lexical_root = resolve(project_root, target_root);
-    let lexical_candidate = resolve(project_root, candidate);
+    let lexical_root = resolve_lexical(project_root, target_root);
+    let lexical_candidate = resolve_lexical(project_root, candidate);
     Some(fault_side(!lexical_candidate.starts_with(&lexical_root)))
 }
 
@@ -446,8 +508,8 @@ pub enum CreatedDirDecision {
     /// Refused: resolves onto the target's own root — `link` never
     /// records that (design review R3). Carries which side put it there
     /// (issue #348): the manifest's text names the root outright, or the
-    /// disk has since merged a legitimately recorded subdirectory into it
-    /// (a symlink appeared). The second is reachable with the manifest
+    /// filesystem merges a legitimately recorded subdirectory into it (a
+    /// symlink along the path). The second is reachable with the manifest
     /// completely untouched, so this must never be reported as "corrupt
     /// or forged" unconditionally.
     IsTargetRoot(TrustFailure),
@@ -489,9 +551,12 @@ pub fn decide_created_dir(
         // for the same reason (issue #348): if the recorded text already
         // names the root, the manifest is wrong; if only the resolved
         // paths coincide, the manifest is intact and the filesystem
-        // merged the two.
+        // merged the two. The lexical half goes through
+        // `resolve_lexical`, not `resolve`, so a root named by a
+        // non-canonical absolute path (`/tmp/…` for `/private/tmp/…`) is
+        // still recognised as *named* rather than blamed on the disk.
         return CreatedDirDecision::IsTargetRoot(fault_side(
-            resolve(project_root, dir) == resolve(project_root, target_root),
+            resolve_lexical(project_root, dir) == resolve_lexical(project_root, target_root),
         ));
     }
     if let Some(cause) = diagnose_trust_failure(project_root, target_root, dir) {
@@ -1503,9 +1568,8 @@ mod tests {
         assert_eq!(
             cause,
             Some(TrustFailure::FilesystemDiverged),
-            "a legitimate path whose intermediate directory was symlinked away \
-             since link ran must not be reported as if the manifest's own text \
-             were at fault"
+            "a legitimate path whose intermediate directory is symlinked away must \
+             not be reported as if the manifest's own text were at fault"
         );
     }
 
@@ -1593,6 +1657,42 @@ mod tests {
         assert_eq!(
             decide_created_dir(root, &target_root, Path::new(".claude/agents"), &entries),
             CreatedDirDecision::IsTargetRoot(TrustFailure::FilesystemDiverged)
+        );
+    }
+
+    /// The third-round regression: a manifest that names the target's own
+    /// root through a **non-canonical absolute path** is still the
+    /// manifest naming the root, and must be diagnosed as such. Nothing
+    /// on the filesystem moved — an ancestor simply has two spellings, as
+    /// `/tmp` and `/private/tmp` do on macOS, or a symlinked home or
+    /// automount does on Linux.
+    ///
+    /// Mutation this catches: compare the two sides with `resolve`
+    /// instead of `resolve_lexical` (the code shipped in the previous fix
+    /// wave) and this answers `FilesystemDiverged` — sending the user to
+    /// inspect a directory where there is nothing to find, which is the
+    /// exact false accusation issue #348 exists to remove. Its two
+    /// siblings above fail on the opposite hardcodings, so no single
+    /// pinned value satisfies all three.
+    #[test]
+    #[cfg(unix)]
+    fn decide_created_dir_blames_the_manifest_when_it_names_the_root_non_canonically() {
+        let dir = tempfile::tempdir().unwrap();
+        // The project lives under `real/`, and `alias/` is another
+        // spelling of `real/` — a symlink *above* the project root, so
+        // nothing inside the project is symlinked at all.
+        let project = dir.path().join("real/project");
+        std::fs::create_dir_all(project.join(".claude/agents")).unwrap();
+        std::os::unix::fs::symlink("real", dir.path().join("alias")).unwrap();
+
+        let target_root = project.join(".claude");
+        let named_through_the_alias = dir.path().join("alias/project/.claude");
+        let entries = vec![entry(".claude/agents/solo.md", "solo", b"body")];
+
+        assert_eq!(
+            decide_created_dir(&project, &target_root, &named_through_the_alias, &entries),
+            CreatedDirDecision::IsTargetRoot(TrustFailure::ManifestEscapesRoot),
+            "the recorded text names the root; no filesystem change is involved"
         );
     }
 

--- a/crates/armadai/src/linker/manifest.rs
+++ b/crates/armadai/src/linker/manifest.rs
@@ -343,27 +343,53 @@ pub fn root_confirmed(project_root: &Path, computed_root: &Path, declared_root: 
     resolve_real(project_root, computed_root) == resolve_real(project_root, declared_root)
 }
 
-/// Why a candidate path failed [`is_trusted`] — distinguishes a manifest
-/// whose own text already escapes the trust root (forged, hand-corrupted,
-/// or otherwise wrong) from one whose text is fine but the *filesystem*
-/// changed since `link` ran (a symlink now redirects an otherwise
-/// legitimate path outside the root). Issue #348: these two causes were
-/// collapsed into a single "the manifest may be corrupt or forged"
-/// message, which is simply false for the second case — the manifest is
-/// exactly what `link` wrote, and the disk moved under it. The two causes
-/// call for different next steps from the user (fix or regenerate the
-/// manifest, versus investigate what changed on disk), so callers must
-/// keep them distinct.
+/// **Which side is at fault** when a manifest-recorded path is refused: the
+/// manifest's own text, or the filesystem it is being resolved against.
+/// Issue #348: these two causes were collapsed into a single "the manifest
+/// may be corrupt or forged" message, which is simply false for the second
+/// case — the manifest is exactly what `link` wrote, and the disk moved
+/// under it. The two call for different next steps from the user (fix or
+/// regenerate the manifest, versus investigate what changed on disk), so
+/// callers must keep them distinct.
+///
+/// Used for both refusal kinds a recorded path can hit, because the
+/// question — "is the text wrong, or did the disk move?" — is the same one
+/// either way and must be answered the same way:
+///
+/// - failing [`is_trusted`] (the path lands outside the trusted root), via
+///   [`diagnose_trust_failure`];
+/// - resolving *onto* the target's own root, via [`decide_created_dir`]'s
+///   [`CreatedDirDecision::IsTargetRoot`] — reachable by a pure filesystem
+///   mutation with the manifest untouched (replace `.claude/agents` with a
+///   symlink to `.claude`), so it must not hardcode either cause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrustFailure {
-    /// The path escapes the trusted root even under pure lexical
-    /// resolution (no filesystem access) — the manifest text itself names
-    /// a path outside its own root.
+    /// The manifest's own text is what puts the path where it must not be:
+    /// even under pure lexical resolution (no filesystem access) it
+    /// escapes the trusted root, or names that root itself.
     ManifestEscapesRoot,
-    /// The path stays within the trusted root under lexical resolution,
-    /// but resolving it against the real filesystem (following symlinks)
-    /// puts it outside — something on disk changed since `link` ran.
+    /// Under lexical resolution the path is exactly where it should be;
+    /// only resolving it against the real filesystem (following symlinks)
+    /// puts it outside the root, or onto the root itself — something on
+    /// disk changed since `link` ran.
     FilesystemDiverged,
+}
+
+/// Which side is at fault, given whether the recorded path's own text is
+/// already enough to condemn it: if pure lexical resolution alone lands it
+/// where it must not be, the manifest is wrong; if only resolving against
+/// the real filesystem does, the disk moved under an intact manifest.
+///
+/// One function so the two refusal kinds ([`diagnose_trust_failure`] and
+/// [`CreatedDirDecision::IsTargetRoot`]) cannot answer it differently —
+/// which is exactly the bug issue #348 found in the second one, where the
+/// cause was hardcoded to "corrupt or forged".
+fn fault_side(text_alone_condemns: bool) -> TrustFailure {
+    if text_alone_condemns {
+        TrustFailure::ManifestEscapesRoot
+    } else {
+        TrustFailure::FilesystemDiverged
+    }
 }
 
 /// Diagnose why `candidate` fails [`is_trusted`] under `target_root` — or
@@ -379,11 +405,7 @@ pub fn diagnose_trust_failure(
     }
     let lexical_root = resolve(project_root, target_root);
     let lexical_candidate = resolve(project_root, candidate);
-    if lexical_candidate.starts_with(&lexical_root) {
-        Some(TrustFailure::FilesystemDiverged)
-    } else {
-        Some(TrustFailure::ManifestEscapesRoot)
-    }
+    Some(fault_side(!lexical_candidate.starts_with(&lexical_root)))
 }
 
 /// Whether `dir` (a recorded `created_dirs` entry) is a plausible ancestor
@@ -421,15 +443,33 @@ pub fn created_dir_is_plausible(dir: &Path, entries: &[ManifestEntry]) -> bool {
 pub enum CreatedDirDecision {
     /// Safe to remove, once actually confirmed empty on disk.
     Eligible,
-    /// Refused: names the target's own root — `link` never records that
-    /// (design review R3), so a manifest claiming otherwise is simply
-    /// wrong.
-    IsTargetRoot,
+    /// Refused: resolves onto the target's own root — `link` never
+    /// records that (design review R3). Carries which side put it there
+    /// (issue #348): the manifest's text names the root outright, or the
+    /// disk has since merged a legitimately recorded subdirectory into it
+    /// (a symlink appeared). The second is reachable with the manifest
+    /// completely untouched, so this must never be reported as "corrupt
+    /// or forged" unconditionally.
+    IsTargetRoot(TrustFailure),
     /// Refused: fails the trust boundary — see [`TrustFailure`] for why.
     Untrusted(TrustFailure),
     /// Refused: doesn't correspond to any file `link` actually recorded
     /// creating — see [`created_dir_is_plausible`].
     Implausible,
+}
+
+/// The order `created_dirs` must be walked in: deepest first, so a child
+/// directory is always removed before the parent whose emptiness its own
+/// removal is what makes possible.
+///
+/// Extracted (issue #348) because `unlink`'s real pass sorted and its
+/// `--dry-run` preview did not, so the two listed the same recorded
+/// directories in different orders — a preview whose output doesn't match
+/// the run it previews. One function, called by both.
+pub fn deepest_first(dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut sorted = dirs.to_vec();
+    sorted.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
+    sorted
 }
 
 /// Decide `dir`'s fate against `target_root`'s trust boundary and
@@ -445,7 +485,14 @@ pub fn decide_created_dir(
     let resolved_target_root = resolve_real(project_root, target_root);
     let dir_path = resolve_real(project_root, dir);
     if dir_path == resolved_target_root {
-        return CreatedDirDecision::IsTargetRoot;
+        // Same lexical-versus-real split `diagnose_trust_failure` makes,
+        // for the same reason (issue #348): if the recorded text already
+        // names the root, the manifest is wrong; if only the resolved
+        // paths coincide, the manifest is intact and the filesystem
+        // merged the two.
+        return CreatedDirDecision::IsTargetRoot(fault_side(
+            resolve(project_root, dir) == resolve(project_root, target_root),
+        ));
     }
     if let Some(cause) = diagnose_trust_failure(project_root, target_root, dir) {
         return CreatedDirDecision::Untrusted(cause);
@@ -1499,5 +1546,140 @@ mod tests {
             digest: None,
         }];
         assert!(!created_dir_is_plausible(Path::new(".claude"), &entries));
+    }
+
+    // ── issue #348: the two causes IsTargetRoot can have ──────────────
+
+    /// A manifest that literally records the target's own root is the
+    /// manifest's own fault.
+    ///
+    /// Mutation this catches: hardcode `IsTargetRoot`'s cause to
+    /// `FilesystemDiverged` and this fails; its sibling below fails on the
+    /// opposite hardcoding, so neither value can be pinned by accident.
+    #[test]
+    fn decide_created_dir_blames_the_manifest_when_its_text_names_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let target_root = root.join(".claude");
+        std::fs::create_dir_all(target_root.join("agents")).unwrap();
+        let entries = vec![entry(".claude/agents/solo.md", "solo", b"body")];
+
+        assert_eq!(
+            decide_created_dir(root, &target_root, Path::new(".claude"), &entries),
+            CreatedDirDecision::IsTargetRoot(TrustFailure::ManifestEscapesRoot)
+        );
+    }
+
+    /// The same arm, reached with the manifest untouched: a recorded
+    /// subdirectory that a symlink has since collapsed onto the root. This
+    /// is a filesystem change, and `unlink` must not call it a forged
+    /// manifest.
+    ///
+    /// Mutation this catches: hardcode `IsTargetRoot`'s cause to
+    /// `ManifestEscapesRoot` — the value the code shipped with — and this
+    /// fails.
+    #[test]
+    #[cfg(unix)]
+    fn decide_created_dir_blames_the_filesystem_when_a_symlink_collapsed_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let target_root = root.join(".claude");
+        std::fs::create_dir_all(&target_root).unwrap();
+        // `.claude/agents -> .` resolves to `.claude` itself, while the
+        // recorded text `.claude/agents` names a subdirectory.
+        std::os::unix::fs::symlink(".", target_root.join("agents")).unwrap();
+        let entries = vec![entry(".claude/agents/solo.md", "solo", b"body")];
+
+        assert_eq!(
+            decide_created_dir(root, &target_root, Path::new(".claude/agents"), &entries),
+            CreatedDirDecision::IsTargetRoot(TrustFailure::FilesystemDiverged)
+        );
+    }
+
+    // ── issue #348: created_dirs removal order ────────────────────────
+
+    /// `created_dirs` must be walked deepest first, so removing a child is
+    /// what makes its parent empty enough to remove in the same pass.
+    /// `unlink`'s real pass sorted and its `--dry-run` preview did not, so
+    /// the two listed the same directories in different orders; both now
+    /// call this.
+    ///
+    /// Mutation this catches: drop the `Reverse` (or the sort entirely) and
+    /// the returned order no longer puts the deepest path first.
+    #[test]
+    fn deepest_first_orders_children_before_their_parents() {
+        let dirs = vec![
+            PathBuf::from(".claude"),
+            PathBuf::from(".claude/skills/writer/refs"),
+            PathBuf::from(".claude/agents"),
+            PathBuf::from(".claude/skills/writer"),
+        ];
+        assert_eq!(
+            deepest_first(&dirs),
+            vec![
+                PathBuf::from(".claude/skills/writer/refs"),
+                PathBuf::from(".claude/skills/writer"),
+                PathBuf::from(".claude/agents"),
+                PathBuf::from(".claude"),
+            ]
+        );
+    }
+
+    /// The counterpart of
+    /// `write_files_relink_of_untouched_own_output_stays_created_even_when_content_changed_upstream`:
+    /// the previous-digest reclaim added for coordination note 2 must stay
+    /// unable to claim a file `link` never wrote. A hand-written file is
+    /// recorded `skipped` with no digest, so no digest of it ever enters
+    /// the reclaim's map, and repeated `link` runs — with the generated
+    /// content changing every time — must leave that verdict alone.
+    ///
+    /// Mutation this catches: have the differing-content branch record
+    /// `Outcome::Created` with the digest of what is on disk instead of
+    /// `Outcome::Skipped`/`None`, i.e. let `link` claim whatever it finds
+    /// in its way. Every assertion in the loop below fails on the first
+    /// pass.
+    #[test]
+    fn write_files_never_claims_a_hand_written_file_however_often_link_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let target_root = root.join(".claude");
+        let path = target_root.join("agents/solo.md");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let hand_written = "mine, not link's";
+        std::fs::write(&path, hand_written).unwrap();
+
+        for pass in 1..=3 {
+            let generated = format!("generated revision {pass}");
+            let outcomes = write_files(
+                root,
+                "claude",
+                Path::new(".claude"),
+                &target_root,
+                vec![(path.clone(), generated, ProducedBy::agent("solo"))],
+                false,
+            )
+            .unwrap();
+            assert_eq!(outcomes, vec![FileOutcome::SkippedExisting(path.clone())]);
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                hand_written,
+                "pass {pass}: the file itself must be untouched"
+            );
+            match lookup_target(root, "claude") {
+                Lookup::Found(found) => {
+                    assert_eq!(
+                        found.entries[0].outcome,
+                        Outcome::Skipped,
+                        "pass {pass}: a file link never wrote stays hand-written"
+                    );
+                    assert_eq!(
+                        found.entries[0].digest, None,
+                        "pass {pass}: and carries no digest — a digest is exactly what \
+                         would authorise unlink to delete it"
+                    );
+                }
+                Lookup::Fallback => panic!("write_files must leave a usable manifest behind"),
+            }
+        }
     }
 }

--- a/crates/armadai/tests/link_manifest.rs
+++ b/crates/armadai/tests/link_manifest.rs
@@ -64,6 +64,65 @@ mod tests {
         std::fs::read_to_string(manifest_path(root)).expect("manifest must exist and be readable")
     }
 
+    /// The `outcome:` the manifest records for one entry, by path.
+    ///
+    /// `read_manifest(..).contains("outcome: skipped")` cannot say *which*
+    /// entry it found, so a test with more than one entry can pass on the
+    /// wrong one. Relies on `ManifestEntry`'s field order (path,
+    /// produced_by, outcome, digest), which is what serde serialises.
+    fn outcome_for(manifest: &str, entry_path: &str) -> String {
+        for chunk in manifest.split("- path: ").skip(1) {
+            let (first_line, rest) = chunk.split_once('\n').unwrap_or((chunk, ""));
+            if first_line.trim() != entry_path {
+                continue;
+            }
+            for line in rest.lines() {
+                if let Some(value) = line.trim().strip_prefix("outcome: ") {
+                    return value.trim().to_string();
+                }
+            }
+            panic!("entry {entry_path} carries no outcome in:\n{manifest}");
+        }
+        panic!("no manifest entry for {entry_path} in:\n{manifest}");
+    }
+
+    /// The `created_dirs` list the manifest records for its single target
+    /// (every test using this links exactly one target).
+    fn created_dirs_of(manifest: &str) -> Vec<String> {
+        let after = manifest
+            .split_once("created_dirs:")
+            .unwrap_or_else(|| panic!("manifest has no created_dirs:\n{manifest}"))
+            .1;
+        let (same_line, rest) = after.split_once('\n').unwrap_or((after, ""));
+        if same_line.trim() == "[]" {
+            return Vec::new();
+        }
+        let mut dirs = Vec::new();
+        for line in rest.lines() {
+            match line.trim().strip_prefix("- ") {
+                Some(value) => dirs.push(value.trim().to_string()),
+                None => break,
+            }
+        }
+        dirs
+    }
+
+    /// The paths the manifest records as entries, in order.
+    fn entry_paths_of(manifest: &str) -> Vec<String> {
+        manifest
+            .split("- path: ")
+            .skip(1)
+            .map(|chunk| {
+                chunk
+                    .split_once('\n')
+                    .map(|(first, _)| first)
+                    .unwrap_or(chunk)
+                    .trim()
+                    .to_string()
+            })
+            .collect()
+    }
+
     /// A project with a coordinator ("coord") and two members
     /// ("member-a", "member-b"), targeting `claude`.
     fn project_with_coordinator_and_two_members() -> tempfile::TempDir {
@@ -601,7 +660,7 @@ mod tests {
         .join("\n");
         std::fs::write(manifest_path(&root), forged_manifest).unwrap();
 
-        let (unlink_ok, _, unlink_stderr) =
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
             run_armadai(&root, &config, &["unlink", "--target", "claude"]);
         // Design review R5: refusing a forged entry is a failure to
         // complete the requested work, not a partial success — the
@@ -624,6 +683,29 @@ mod tests {
         assert!(
             unlink_stderr.contains("outside its trusted root"),
             "unlink must report the refused entry: stderr={unlink_stderr}"
+        );
+        // The *cause*, not only the refusal (issue #348): this manifest was
+        // hand-crafted, so the manifest is what must be blamed. Without
+        // this, mutating `diagnose_trust_failure` to always answer
+        // `FilesystemDiverged` left the whole suite green — the two
+        // messages the sibling fix split apart were interchangeable again.
+        assert!(
+            unlink_stderr.contains("corrupt or forged"),
+            "a hand-crafted manifest entry is the manifest's own fault and must be \
+             reported as such: stderr={unlink_stderr}"
+        );
+        // The refusal summary must sit on the same stream as the refusals
+        // it points at: as a `println!` it told a `2>/dev/null` caller to
+        // read reasons that stream had just discarded.
+        assert!(
+            unlink_stderr.contains("manifest item(s) were refused"),
+            "the refusal summary belongs on stderr, beside the per-item reasons: \
+             stderr={unlink_stderr}"
+        );
+        assert!(
+            !unlink_stdout.contains("manifest item(s) were refused"),
+            "and must not be left on stdout, pointing at reasons stdout never \
+             carried: stdout={unlink_stdout}"
         );
     }
 
@@ -914,6 +996,20 @@ mod tests {
             "the target's own root must never be removed, even when a manifest's \
              created_dirs names it directly"
         );
+        // The other half of the two-cause split: this manifest really does
+        // name the root in its own text, so this is the case that *is* the
+        // manifest's fault. Its sibling test
+        // (`a_symlink_merging_a_recorded_dir_into_the_target_root_blames_the_filesystem`)
+        // pins the opposite verdict for an intact manifest, and one of the
+        // two fails if the cause is hardcoded either way.
+        assert!(
+            unlink_stderr.contains("names the target's own root"),
+            "a manifest that literally records the root names it: stderr={unlink_stderr}"
+        );
+        assert!(
+            unlink_stderr.contains("corrupt or forged"),
+            "and that is the manifest's own fault: stderr={unlink_stderr}"
+        );
     }
 
     /// Design review R2 (critical in effect): lexical normalisation alone
@@ -1100,23 +1196,41 @@ mod tests {
     /// by hand in two separate design reviews, never pinned by an
     /// automated test until issue #348.
     ///
-    /// Mutation this catches: any future cleanup logic that walks up from
-    /// a deleted generated file and removes an ancestor merely because it
-    /// is empty *of generated files* — without the explicit "never the
-    /// target's own root" exclusion `unlink_from_manifest` applies to
-    /// `created_dirs` — would delete `.claude/settings.json`,
-    /// `.claude/commands/my-command.md`, or `.claude/` itself.
+    /// Mutation this catches: drop the `if current.exists() { break; }`
+    /// early-out from `linker::manifest::create_dir_all_recording`, so it
+    /// reports directories it merely *walked past* rather than only the
+    /// ones it created. `created_dirs` then names the user's own
+    /// pre-existing `.claude/agents/`, the manifest assertion below fails,
+    /// and — because a `created_dirs` entry is all `unlink` needs to
+    /// justify removing an empty directory — the directory-survival
+    /// assertion fails too.
+    ///
+    /// Its own earlier version could not fail, and this is why: the guards
+    /// it claimed to protect (`decide_created_dir`'s `IsTargetRoot`, and
+    /// `write_files`' refusal to record the root) are unreachable for a
+    /// `.claude/` that already existed, because
+    /// `create_dir_all_recording` never reports a directory it did not
+    /// create. Both guards could be deleted outright with that test still
+    /// green (measured). The load-bearing invariant here is one layer
+    /// earlier — `link` must not *record* a pre-existing user directory as
+    /// created — so that is what this now asserts, on the manifest `link`
+    /// wrote and on the directory that survives because of it.
     #[test]
     fn a_preexisting_user_claude_directory_survives_link_then_unlink_intact() {
         let dir = project_minimal();
         let root = dir.path().join("project");
         let config = isolated_config(dir.path());
 
-        // The user's own `.claude/` predates `link` entirely, with
-        // content that has nothing to do with anything the linker would
-        // generate — not even a colliding filename.
+        // The user's own `.claude/` predates `link` entirely: unrelated
+        // content, plus — and this is the part that makes the test
+        // load-bearing — an `agents/` directory they created themselves
+        // and left empty, which is exactly where `link` is about to write.
+        // `link` therefore creates *nothing*, and the manifest must say
+        // so; a `created_dirs` that claimed this directory would hand
+        // `unlink` a licence to remove it once solo.md is gone.
         let claude_dir = root.join(".claude");
         std::fs::create_dir_all(claude_dir.join("commands")).unwrap();
+        std::fs::create_dir_all(claude_dir.join("agents")).unwrap();
         std::fs::write(claude_dir.join("settings.json"), "{\"theme\":\"dark\"}\n").unwrap();
         std::fs::write(
             claude_dir.join("commands/my-command.md"),
@@ -1131,6 +1245,23 @@ mod tests {
         let solo_file = root.join(".claude/agents/solo.md");
         assert!(solo_file.is_file(), "link must have generated solo's file");
 
+        // The recorded effect, not just the final filesystem state: every
+        // directory this write needed already existed, so `link` created
+        // none and `created_dirs` must be empty.
+        let manifest = read_manifest(&root);
+        assert_eq!(
+            created_dirs_of(&manifest),
+            Vec::<String>::new(),
+            "link must record only directories it actually created — a pre-existing \
+             user directory it merely wrote into is not one of them: {manifest}"
+        );
+        assert_eq!(
+            entry_paths_of(&manifest),
+            vec![".claude/agents/solo.md".to_string()],
+            "only the file link generated may be recorded as an entry — nothing the \
+             user put in .claude/ themselves: {manifest}"
+        );
+
         let (unlink_ok, _, unlink_stderr) =
             run_armadai(&root, &config, &["unlink", "--target", "claude"]);
         assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
@@ -1138,6 +1269,11 @@ mod tests {
         assert!(
             !solo_file.exists(),
             "the genuinely generated file must still be reclaimed"
+        );
+        assert!(
+            claude_dir.join("agents").is_dir(),
+            "the user's own pre-existing (and now empty again) .claude/agents/ must \
+             survive — unlink may only remove directories link recorded creating"
         );
         assert!(
             claude_dir.is_dir(),
@@ -1313,6 +1449,26 @@ mod tests {
             "the symlink itself must be present on disk before unlink runs"
         );
 
+        // The preview has to say the same thing. Emptying
+        // `print_manifest_dry_run`'s own `is_symlink()` branch left the
+        // whole suite green — a surviving mutant on the very fix this
+        // chantier had just shipped.
+        let (dry_ok, dry_stdout, dry_stderr) = run_armadai(
+            &root,
+            &config,
+            &["unlink", "--target", "claude", "--dry-run"],
+        );
+        assert!(dry_ok, "the preview must succeed: stderr={dry_stderr}");
+        assert!(
+            dry_stdout.contains("0 would be removed, 1 would be kept, 0 already absent"),
+            "the preview must count the dangling link kept, exactly as the real pass \
+             does below: stdout={dry_stdout}"
+        );
+        assert!(
+            dry_stdout.contains("broken symlink"),
+            "and must say why: stdout={dry_stdout}"
+        );
+
         let (unlink_ok, unlink_stdout, unlink_stderr) =
             run_armadai(&root, &config, &["unlink", "--target", "claude"]);
         assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
@@ -1478,5 +1634,328 @@ mod tests {
              still be reclaimed by unlink, even though a later link's \
              regeneration would have produced different content"
         );
+    }
+    /// 2nd bullet, sibling branch: `decide_created_dir`'s `IsTargetRoot`
+    /// arm is reachable **by a pure filesystem mutation with the manifest
+    /// untouched** — replace a legitimately recorded `.claude/agents` with
+    /// a symlink to `.claude` and the recorded directory now resolves onto
+    /// the target's own root. The cause used to be hardcoded there ("the
+    /// manifest may be corrupt or forged"), so this scenario produced
+    /// exactly the false accusation the sibling fix removed from the
+    /// entry-level guard — in the very PR that removed it.
+    ///
+    /// Mutation this catches: replace `CreatedDirDecision::IsTargetRoot`'s
+    /// computed cause with a hardcoded
+    /// `TrustFailure::ManifestEscapesRoot` (or restore the hardcoded
+    /// message in either of `unlink`'s two `IsTargetRoot` arms) and both
+    /// the "corrupt or forged" assertions below fail — on the real pass
+    /// and on `--dry-run`, which is why both are exercised here.
+    #[test]
+    #[cfg(unix)]
+    fn a_symlink_merging_a_recorded_dir_into_the_target_root_blames_the_filesystem() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        // Precondition: the manifest legitimately records `.claude/agents`
+        // as a directory `link` created. Nothing below edits the manifest.
+        let manifest = read_manifest(&root);
+        assert_eq!(
+            created_dirs_of(&manifest),
+            vec![".claude/agents".to_string()],
+            "link must have recorded the directory it created: {manifest}"
+        );
+
+        // Only the filesystem moves: `.claude/agents` becomes a symlink to
+        // its own parent, so the recorded directory resolves onto the
+        // target root without the manifest naming the root at all.
+        let claude_agents = root.join(".claude/agents");
+        std::fs::remove_dir_all(&claude_agents).unwrap();
+        std::os::unix::fs::symlink(".", &claude_agents).unwrap();
+        assert_eq!(
+            std::fs::canonicalize(&claude_agents).unwrap(),
+            std::fs::canonicalize(root.join(".claude")).unwrap(),
+            "the symlink must really collapse the recorded directory onto the root"
+        );
+
+        let (dry_ok, dry_stdout, dry_stderr) = run_armadai(
+            &root,
+            &config,
+            &["unlink", "--target", "claude", "--dry-run"],
+        );
+        assert!(
+            !dry_ok,
+            "the preview must refuse too, exactly like the real pass: \
+             stdout={dry_stdout} stderr={dry_stderr}"
+        );
+        assert!(
+            dry_stdout.contains("now resolves to the target's own root"),
+            "the preview must say the directory *resolves onto* the root, not that it \
+             names it: stdout={dry_stdout}"
+        );
+        assert!(
+            !dry_stdout.contains("corrupt or forged"),
+            "the manifest is byte-for-byte what link wrote — the preview must not \
+             accuse it: stdout={dry_stdout}"
+        );
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            !unlink_ok,
+            "unlink must refuse and exit non-zero: stderr={unlink_stderr}"
+        );
+        assert!(
+            unlink_stderr.contains("now resolves to the target's own root"),
+            "the real pass must say the same thing its preview said: \
+             stderr={unlink_stderr}"
+        );
+        assert!(
+            unlink_stderr.contains("something on the filesystem has changed"),
+            "the user must be pointed at the disk, which is what actually moved: \
+             stderr={unlink_stderr}"
+        );
+        assert!(
+            !unlink_stderr.contains("corrupt or forged"),
+            "the manifest is byte-for-byte what link wrote — it must not be blamed \
+             for a filesystem change it had nothing to do with: stderr={unlink_stderr}"
+        );
+
+        // The symlink itself is left alone: refusing means touching nothing.
+        assert!(claude_agents.symlink_metadata().is_ok());
+    }
+
+    /// 4th bullet, the half `created_dir_is_plausible` does **not** cover:
+    /// that check asks whether a recorded directory is an ancestor of some
+    /// recorded `Created` entry — it never asks whether that entry itself
+    /// passed the trust boundary. A manifest can therefore make an
+    /// out-of-project directory "plausible" simply by forging an entry
+    /// under it, which is why `decide_created_dir` must keep its own trust
+    /// check rather than lean on plausibility.
+    ///
+    /// Mutation this catches: delete the `Untrusted` arm from
+    /// `decide_created_dir` (its `diagnose_trust_failure` early return).
+    /// The forged directory below then reads as plausible — the forged
+    /// entry `../victim-empty/ghost.md` sits under it — and is removed for
+    /// being merely empty, so the directory-survival assertion fails.
+    /// Measured: with that arm deleted and no test like this one, the full
+    /// suite stayed green.
+    #[test]
+    fn forged_created_dirs_outside_the_trusted_root_is_refused() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        let solo_digest = sha256_digest(&std::fs::read(&solo_file).unwrap());
+
+        // An empty directory outside the project entirely — a real one a
+        // user might own, which the forged manifest below claims `link`
+        // created and therefore may remove.
+        let victim_dir = dir.path().join("victim-empty");
+        std::fs::create_dir_all(&victim_dir).unwrap();
+
+        let forged_manifest = [
+            "version: 1",
+            "targets:",
+            "  claude:",
+            "    linked_at: \"2026-01-01T00:00:00Z\"",
+            "    root: .claude",
+            "    created_dirs:",
+            "      - ../victim-empty",
+            "    entries:",
+            "      - path: .claude/agents/solo.md",
+            "        produced_by: { kind: agent, name: solo }",
+            "        outcome: created",
+            &format!("        digest: \"{solo_digest}\""),
+            // Present only to make the forged directory pass
+            // `created_dir_is_plausible` — it is an ancestor of a recorded
+            // `created` entry. Nothing on disk answers to this path.
+            "      - path: ../victim-empty/ghost.md",
+            "        produced_by: { kind: agent, name: solo }",
+            "        outcome: created",
+            &format!("        digest: \"{solo_digest}\""),
+            "",
+        ]
+        .join("\n");
+        std::fs::write(manifest_path(&root), forged_manifest).unwrap();
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            !unlink_ok,
+            "unlink must exit non-zero for the refused items: stderr={unlink_stderr}"
+        );
+
+        assert!(
+            victim_dir.is_dir(),
+            "an empty directory outside the trusted root must survive, however \
+             plausible the manifest's own entries make it look"
+        );
+        assert!(
+            unlink_stderr.contains("recorded directory '../victim-empty'"),
+            "unlink must name the refused directory, not only the refused entry: \
+             stderr={unlink_stderr}"
+        );
+        // Control: the one legitimate entry is still reclaimed.
+        assert!(!solo_file.exists());
+    }
+
+    /// The #342 fallback is the *degraded* mode — no manifest, so odd
+    /// trees are likelier, not less — and it reported a dangling symlink
+    /// as "already absent" long after the manifest path stopped (issue
+    /// #348's 3rd bullet, whose text restricts it to neither path). The
+    /// link is present on disk and its content can never be compared with
+    /// what `link` would generate, so the guard's own conservative "kept"
+    /// outcome applies, with an accurate reason.
+    ///
+    /// Mutation this catches: remove the `path.is_symlink()` branch from
+    /// either of `unlink_via_fallback`'s two existence checks (the real
+    /// pass's or its `--dry-run` preview's) and the corresponding count
+    /// assertion below flips back to "already absent".
+    #[test]
+    #[cfg(unix)]
+    fn the_fallback_reports_a_broken_symlink_as_kept_not_absent() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        std::fs::remove_file(&solo_file).unwrap();
+        std::os::unix::fs::symlink(root.join("does-not-exist.md"), &solo_file).unwrap();
+
+        // Drop the manifest so `unlink` takes the #342 fallback — the
+        // path this test is about.
+        std::fs::remove_dir_all(root.join(".armadai")).unwrap();
+
+        let (dry_ok, dry_stdout, dry_stderr) = run_armadai(
+            &root,
+            &config,
+            &["unlink", "--target", "claude", "--dry-run"],
+        );
+        assert!(dry_ok, "the preview must succeed: stderr={dry_stderr}");
+        assert!(
+            dry_stderr.contains("No link manifest found"),
+            "this test is only meaningful on the fallback path: stderr={dry_stderr}"
+        );
+        assert!(
+            dry_stdout.contains("0 would be removed, 1 would be kept, 0 already absent"),
+            "a dangling link is present on disk — the preview must count it kept, \
+             not absent: stdout={dry_stdout}"
+        );
+        assert!(
+            dry_stdout.contains("broken symlink"),
+            "the preview must say why it would be kept: stdout={dry_stdout}"
+        );
+
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+        assert!(
+            unlink_stdout.contains("0 deleted, 1 kept, 0 already absent"),
+            "the real pass must count it exactly as its own preview did: \
+             stdout={unlink_stdout}"
+        );
+        assert!(
+            unlink_stdout.contains("broken symlink"),
+            "unlink must explain why the dangling link was kept: \
+             stdout={unlink_stdout}"
+        );
+        assert!(
+            solo_file.symlink_metadata().is_ok(),
+            "the dangling symlink must still be on disk, reported rather than \
+             miscounted as an unrelated absence"
+        );
+    }
+
+    /// The invariant the `previous_digests` reclaim in
+    /// `linker::manifest::write_files` must never move (issue #348,
+    /// coordination note 2): that reclaim exists so `link`'s *own*
+    /// untouched output keeps its `created` attribution when the upstream
+    /// source changes, and it must stay unable to claim a file `link`
+    /// never wrote. A hand-written file therefore stays `skipped` across
+    /// any number of `link` runs, however often the generated content
+    /// changes underneath it.
+    ///
+    /// Mutation this catches: make `write_files`' final differing-content
+    /// branch record `Outcome::Created` with the on-disk digest instead of
+    /// `Outcome::Skipped`/`None` — i.e. let `link` claim whatever it finds
+    /// in its way. Both the manifest assertions and the file-survival
+    /// assertion below fail. No test pinned this before; the reclaim was
+    /// added with only its own positive case covered.
+    #[test]
+    fn a_hand_written_file_stays_skipped_across_repeated_links() {
+        let dir = project_with_coordinator_and_two_members();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let claude_dir = root.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let hand_written = "# My own notes\n\nDo not touch this file, it is mine.\n";
+        std::fs::write(claude_dir.join("CLAUDE.md"), hand_written).unwrap();
+
+        for pass in 1..=3 {
+            // Change the coordinator's source between passes so the
+            // content `link` would generate for CLAUDE.md differs every
+            // time — the situation the reclaim is about, applied to a file
+            // that is not link's to reclaim.
+            std::fs::write(
+                root.join("agents/coord.md"),
+                format!(
+                    "# coord\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\n\
+                     You coordinate, revision {pass}.\n"
+                ),
+            )
+            .unwrap();
+
+            let (link_ok, _, link_stderr) =
+                run_armadai(&root, &config, &["link", "--target", "claude"]);
+            assert!(
+                link_ok,
+                "link pass {pass} must succeed: stderr={link_stderr}"
+            );
+
+            let manifest = read_manifest(&root);
+            assert_eq!(
+                outcome_for(&manifest, ".claude/CLAUDE.md"),
+                "skipped",
+                "pass {pass}: a file link never wrote must stay recorded as \
+                 hand-written, whatever the manifest already said: {manifest}"
+            );
+            assert!(
+                !manifest.contains(&sha256_digest(hand_written.as_bytes())),
+                "pass {pass}: link must not record a digest for content it did not \
+                 write — that digest is what would authorise deleting it: {manifest}"
+            );
+            assert_eq!(
+                std::fs::read_to_string(claude_dir.join("CLAUDE.md")).unwrap(),
+                hand_written,
+                "pass {pass}: the file itself must be untouched"
+            );
+        }
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+        assert_eq!(
+            std::fs::read_to_string(claude_dir.join("CLAUDE.md")).unwrap(),
+            hand_written,
+            "three links later, the hand-written file must still be there, untouched"
+        );
+        // Control: the generated files are still reclaimed.
+        assert!(!root.join(".claude/agents/member-a.md").exists());
+        assert!(!root.join(".claude/agents/member-b.md").exists());
     }
 }

--- a/crates/armadai/tests/link_manifest.rs
+++ b/crates/armadai/tests/link_manifest.rs
@@ -1088,4 +1088,395 @@ mod tests {
              document too"
         );
     }
+
+    /// The original worst case of issue #338, generalised beyond a single
+    /// colliding filename (`case1` above pins that narrower one: a
+    /// hand-written `.claude/CLAUDE.md` at a path `link` would also
+    /// write): a `.claude/` directory that predates `armadai link`
+    /// entirely — the user's own Claude Code config, with content that
+    /// has nothing to do with anything the linker would ever generate,
+    /// not even a colliding filename — must survive a `link` + `unlink`
+    /// round trip completely intact, directory and all. Verified correct
+    /// by hand in two separate design reviews, never pinned by an
+    /// automated test until issue #348.
+    ///
+    /// Mutation this catches: any future cleanup logic that walks up from
+    /// a deleted generated file and removes an ancestor merely because it
+    /// is empty *of generated files* — without the explicit "never the
+    /// target's own root" exclusion `unlink_from_manifest` applies to
+    /// `created_dirs` — would delete `.claude/settings.json`,
+    /// `.claude/commands/my-command.md`, or `.claude/` itself.
+    #[test]
+    fn a_preexisting_user_claude_directory_survives_link_then_unlink_intact() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        // The user's own `.claude/` predates `link` entirely, with
+        // content that has nothing to do with anything the linker would
+        // generate — not even a colliding filename.
+        let claude_dir = root.join(".claude");
+        std::fs::create_dir_all(claude_dir.join("commands")).unwrap();
+        std::fs::write(claude_dir.join("settings.json"), "{\"theme\":\"dark\"}\n").unwrap();
+        std::fs::write(
+            claude_dir.join("commands/my-command.md"),
+            "# My own command\n\nDo not touch.\n",
+        )
+        .unwrap();
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        assert!(solo_file.is_file(), "link must have generated solo's file");
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+
+        assert!(
+            !solo_file.exists(),
+            "the genuinely generated file must still be reclaimed"
+        );
+        assert!(
+            claude_dir.is_dir(),
+            "the user's own pre-existing .claude/ directory must never be removed"
+        );
+        assert!(
+            claude_dir.join("settings.json").is_file(),
+            "unrelated pre-existing content must survive untouched"
+        );
+        assert_eq!(
+            std::fs::read_to_string(claude_dir.join("settings.json")).unwrap(),
+            "{\"theme\":\"dark\"}\n"
+        );
+        assert!(
+            claude_dir.join("commands/my-command.md").is_file(),
+            "a pre-existing subdirectory with unrelated content must survive \
+             untouched"
+        );
+    }
+
+    // ── issue #348: residues of this chantier's manifest ───────────────
+
+    /// 1st bullet: `--dry-run` must apply the exact same `created_dirs`
+    /// guard as the real pass, refusal and exit code included — reuses
+    /// R3's forged-root scenario above
+    /// (`forged_created_dirs_naming_the_targets_own_root_is_refused`) but
+    /// through `--dry-run` instead of a real unlink. Before this fix, the
+    /// dry run's own `created_dirs` count used only `is_trusted` (which a
+    /// path always satisfies against itself), so it announced both
+    /// `.claude/agents` *and* `.claude` itself as "recorded for cleanup"
+    /// and exited 0 — while the real pass refuses `.claude` and exits 1.
+    ///
+    /// Mutation this catches: if `--dry-run`'s `created_dirs` handling
+    /// reverted to a plain "is_trusted" count with no `decide_created_dir`
+    /// guard, this test's exit-code assertion would fail, and the printed
+    /// count would go back to 2 instead of 1.
+    #[test]
+    fn dry_run_applies_the_same_created_dirs_guard_as_the_real_pass() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        let solo_digest = sha256_digest(&std::fs::read(&solo_file).unwrap());
+
+        let forged_manifest = [
+            "version: 1",
+            "targets:",
+            "  claude:",
+            "    linked_at: \"2026-01-01T00:00:00Z\"",
+            "    root: .claude",
+            "    created_dirs:",
+            "      - .claude/agents",
+            "      - .claude",
+            "    entries:",
+            "      - path: .claude/agents/solo.md",
+            "        produced_by: { kind: agent, name: solo }",
+            "        outcome: created",
+            &format!("        digest: \"{solo_digest}\""),
+            "",
+        ]
+        .join("\n");
+        std::fs::write(manifest_path(&root), forged_manifest).unwrap();
+
+        let (dry_run_ok, dry_run_stdout, dry_run_stderr) = run_armadai(
+            &root,
+            &config,
+            &["unlink", "--target", "claude", "--dry-run"],
+        );
+        assert!(
+            !dry_run_ok,
+            "--dry-run must refuse and exit non-zero, exactly like the real pass \
+             would: stdout={dry_run_stdout} stderr={dry_run_stderr}"
+        );
+        assert!(
+            dry_run_stdout.contains("(1 directory recorded for cleanup)"),
+            "only the legitimate .claude/agents entry is eligible — the forged \
+             .claude entry (naming the target's own root) must be excluded from the \
+             count, not just from the actual deletion: stdout={dry_run_stdout}"
+        );
+
+        // A dry run must never have any side effect either way.
+        assert!(solo_file.exists());
+        assert!(root.join(".claude").is_dir());
+    }
+
+    /// 2nd bullet: when a symlink appears **between** `link` and `unlink`
+    /// — not a forged manifest at all, the manifest is exactly what
+    /// `link` itself wrote — the refusal must say the filesystem changed,
+    /// not accuse the manifest of being "corrupt or forged". The two
+    /// causes call for two different next steps from the user.
+    ///
+    /// Mutation this catches: if the cause were collapsed back into a
+    /// single message (`diagnose_trust_failure` dropped in favour of a
+    /// plain `is_trusted` boolean), this test's stderr assertions would
+    /// fail — the message would go back to blaming the manifest for a
+    /// disk change it had nothing to do with.
+    #[test]
+    #[cfg(unix)]
+    fn a_symlink_appearing_after_link_is_blamed_on_the_filesystem_not_the_manifest() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        // The manifest at this point is exactly what `link` wrote —
+        // nothing hand-edited, nothing forged. Only the filesystem
+        // changes afterwards: `.claude/agents` is replaced with a symlink
+        // pointing outside the project, entirely independent of the
+        // manifest's own content.
+        let claude_agents = root.join(".claude/agents");
+        std::fs::remove_dir_all(&claude_agents).unwrap();
+        let outside_dir = dir.path().join("elsewhere");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::os::unix::fs::symlink(&outside_dir, &claude_agents).unwrap();
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            !unlink_ok,
+            "unlink must still refuse and exit non-zero: stderr={unlink_stderr}"
+        );
+
+        assert!(
+            unlink_stderr.contains("filesystem") || unlink_stderr.contains("symlink"),
+            "unlink must explain that the filesystem changed since link ran: \
+             stderr={unlink_stderr}"
+        );
+        assert!(
+            !unlink_stderr.contains("corrupt or forged"),
+            "the manifest is intact — it must not be blamed for a filesystem \
+             change it had nothing to do with: stderr={unlink_stderr}"
+        );
+    }
+
+    /// 3rd bullet: a manifest entry whose path is a *broken* symlink (the
+    /// link itself is present on disk, but its target is gone) must not
+    /// be reported "already absent" — it is present, just unverifiable,
+    /// and must be kept and reported as such.
+    ///
+    /// Mutation this catches: if the existence check reverted to a plain
+    /// `!path.exists()` (`true` for a broken symlink too, since it
+    /// follows the link to a target that's gone), this test's stdout
+    /// assertions would fail — the entry would be silently miscounted
+    /// absent instead of reported kept.
+    #[test]
+    #[cfg(unix)]
+    fn a_broken_symlink_at_an_entrys_path_is_kept_and_reported_not_absent() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        assert!(solo_file.is_file());
+
+        // Replace the linked file with a dangling symlink — present on
+        // disk, but its target doesn't exist.
+        std::fs::remove_file(&solo_file).unwrap();
+        std::os::unix::fs::symlink(root.join("does-not-exist.md"), &solo_file).unwrap();
+        assert!(
+            solo_file.symlink_metadata().is_ok(),
+            "the symlink itself must be present on disk before unlink runs"
+        );
+
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+
+        assert!(
+            solo_file.symlink_metadata().is_ok(),
+            "the dangling symlink must still be on disk — unlink must not silently \
+             miscount it as an unrelated absence"
+        );
+        assert!(
+            unlink_stdout.contains("0 deleted, 1 kept, 0 already absent"),
+            "a broken symlink is present on disk and must count as kept, not \
+             absent: stdout={unlink_stdout}"
+        );
+        assert!(
+            unlink_stdout.contains("broken symlink"),
+            "unlink must explain why the dangling link was kept: \
+             stdout={unlink_stdout}"
+        );
+    }
+
+    /// 4th bullet, residue of design review R3: the trust root alone
+    /// bounds *where* a `created_dirs` entry may resolve, not *whether*
+    /// it corresponds to anything `link` actually created. A forged entry
+    /// naming a pre-existing, currently-empty directory the user made by
+    /// hand — inside the target's own tree, so it passes the trust-root
+    /// check trivially — must still survive, because it was never
+    /// `link`'s to remove.
+    ///
+    /// Mutation this catches: if the plausibility check
+    /// (`created_dir_is_plausible`) were removed and only the trust-root
+    /// and "not the root itself" guards remained, this test's
+    /// directory-survival assertion would fail — the forged entry would
+    /// be silently removed for being merely empty and in-bounds.
+    #[test]
+    fn forged_created_dirs_naming_a_preexisting_empty_user_directory_is_refused() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        let solo_digest = sha256_digest(&std::fs::read(&solo_file).unwrap());
+
+        // A directory the user made by hand, unrelated to anything link
+        // wrote — link never created it, and no manifest entry lives
+        // under it.
+        let user_dir = root.join(".claude/my-own-empty-dir");
+        std::fs::create_dir_all(&user_dir).unwrap();
+
+        let forged_manifest = [
+            "version: 1",
+            "targets:",
+            "  claude:",
+            "    linked_at: \"2026-01-01T00:00:00Z\"",
+            "    root: .claude",
+            "    created_dirs:",
+            "      - .claude/agents",
+            "      - .claude/my-own-empty-dir",
+            "    entries:",
+            "      - path: .claude/agents/solo.md",
+            "        produced_by: { kind: agent, name: solo }",
+            "        outcome: created",
+            &format!("        digest: \"{solo_digest}\""),
+            "",
+        ]
+        .join("\n");
+        std::fs::write(manifest_path(&root), forged_manifest).unwrap();
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            !unlink_ok,
+            "unlink must exit non-zero for the implausible created_dirs entry: \
+             stderr={unlink_stderr}"
+        );
+
+        assert!(
+            !solo_file.exists(),
+            "the legitimate file entry must still be reclaimed"
+        );
+        assert!(
+            user_dir.is_dir(),
+            "a pre-existing, empty user directory falsely claimed by created_dirs \
+             must survive — it corresponds to no file link ever recorded creating"
+        );
+    }
+
+    /// Coordination note 2: a re-`link` that leaves an already-linked file
+    /// untouched (no `--force`, because the newly generated content
+    /// differs from what's on disk) must not downgrade that file to
+    /// "hand-written" in the manifest when the file itself is still
+    /// exactly what the *first* `link` wrote — only the upstream agent
+    /// source changed, not the file. Getting this wrong turns a
+    /// completely untouched, still-`link`-owned file into a permanent
+    /// residue `unlink` can never reclaim again short of a `--force`
+    /// relink the user has no reason to know they need.
+    ///
+    /// Mutation this catches: if the manifest kept mislabelling this file
+    /// `skipped`/no-digest on the second link (the pre-fix behaviour),
+    /// the final `unlink` here would report it "kept ... hand-written"
+    /// instead of deleting it, and the file-survival assertion would
+    /// fail.
+    #[test]
+    fn relink_of_an_untouched_file_after_an_upstream_source_change_stays_reclaimable() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link1_ok, _, link1_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link1_ok, "first link must succeed: stderr={link1_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        let first_content = std::fs::read_to_string(&solo_file).unwrap();
+
+        // The agent's own source changes upstream — the next link would
+        // generate different content — but nobody touches the linked
+        // file itself.
+        std::fs::write(
+            root.join("agents/solo.md"),
+            "# solo\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work \
+             alone, updated.\n",
+        )
+        .unwrap();
+
+        let (link2_ok, _, link2_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link2_ok, "second link must succeed: stderr={link2_stderr}");
+        assert!(
+            link2_stderr.contains("skip:"),
+            "without --force the file must not be overwritten: stderr={link2_stderr}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&solo_file).unwrap(),
+            first_content,
+            "the file itself must remain untouched without --force"
+        );
+
+        let manifest = read_manifest(&root);
+        assert!(
+            manifest.contains("outcome: created"),
+            "a file that is still exactly what the first link wrote must stay \
+             attributed to link, not be downgraded to skipped just because the \
+             upstream source changed: {manifest}"
+        );
+        assert!(
+            !manifest.contains("outcome: skipped"),
+            "with a single agent and no other entries, the manifest must not \
+             contain a skipped outcome at all: {manifest}"
+        );
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+
+        assert!(
+            !solo_file.exists(),
+            "a file that was never touched since the first link wrote it must \
+             still be reclaimed by unlink, even though a later link's \
+             regeneration would have produced different content"
+        );
+    }
 }

--- a/crates/armadai/tests/link_manifest.rs
+++ b/crates/armadai/tests/link_manifest.rs
@@ -1210,11 +1210,16 @@ mod tests {
     /// `write_files`' refusal to record the root) are unreachable for a
     /// `.claude/` that already existed, because
     /// `create_dir_all_recording` never reports a directory it did not
-    /// create. Both guards could be deleted outright with that test still
-    /// green (measured). The load-bearing invariant here is one layer
-    /// earlier — `link` must not *record* a pre-existing user directory as
-    /// created — so that is what this now asserts, on the manifest `link`
-    /// wrote and on the directory that survives because of it.
+    /// create. Deleting either guard left *this scenario* green
+    /// (measured) — not the suite, which has its own tests for both:
+    /// mutating `write_files`' `created != target_root` filter turns 19
+    /// tests red (measured with `--no-fail-fast`; without it cargo stops
+    /// at the first failing target and only 3 show). The point is only
+    /// that this scenario proved nothing about them. The load-bearing
+    /// invariant here is one layer earlier — `link` must not *record* a
+    /// pre-existing user directory as created — so that is what this now
+    /// asserts, on the manifest `link` wrote and on the directory that
+    /// survives because of it.
     #[test]
     fn a_preexisting_user_claude_directory_survives_link_then_unlink_intact() {
         let dir = project_minimal();
@@ -1303,8 +1308,16 @@ mod tests {
     /// through `--dry-run` instead of a real unlink. Before this fix, the
     /// dry run's own `created_dirs` count used only `is_trusted` (which a
     /// path always satisfies against itself), so it announced both
-    /// `.claude/agents` *and* `.claude` itself as "recorded for cleanup"
+    /// `.claude/agents` *and* `.claude` itself as eligible for cleanup
     /// and exited 0 — while the real pass refuses `.claude` and exits 1.
+    ///
+    /// Also pins **which stream** each half of the preview goes to (issue
+    /// #348, third round): the refusal on stderr beside the reasons a
+    /// real pass puts there, the counts on stdout. They had drifted —
+    /// every refusal in the preview was a `println!` while every refusal
+    /// in the real pass was an `eprintln!`, so a caller journalling
+    /// `2>errors.log` got the reasons from the run and nothing from its
+    /// preview.
     ///
     /// Mutation this catches: if `--dry-run`'s `created_dirs` handling
     /// reverted to a plain "is_trusted" count with no `decide_created_dir`
@@ -1353,10 +1366,26 @@ mod tests {
              would: stdout={dry_run_stdout} stderr={dry_run_stderr}"
         );
         assert!(
-            dry_run_stdout.contains("(1 directory recorded for cleanup)"),
+            dry_run_stdout.contains("(1 directory eligible for cleanup)"),
             "only the legitimate .claude/agents entry is eligible — the forged \
              .claude entry (naming the target's own root) must be excluded from the \
              count, not just from the actual deletion: stdout={dry_run_stdout}"
+        );
+        assert!(
+            dry_run_stderr.contains("would refuse")
+                && dry_run_stderr.contains("names the target's own root"),
+            "the preview's refusal belongs on stderr, where the real pass puts its \
+             own: stderr={dry_run_stderr}"
+        );
+        assert!(
+            !dry_run_stdout.contains("would refuse"),
+            "and must not also be on stdout, or a caller reading one stream sees a \
+             different run than a caller reading the other: stdout={dry_run_stdout}"
+        );
+        assert!(
+            dry_run_stderr.contains("manifest item(s) would be refused"),
+            "the refusal summary must sit beside the refusals it points at: \
+             stderr={dry_run_stderr}"
         );
 
         // A dry run must never have any side effect either way.
@@ -1405,9 +1434,15 @@ mod tests {
         );
 
         assert!(
-            unlink_stderr.contains("filesystem") || unlink_stderr.contains("symlink"),
-            "unlink must explain that the filesystem changed since link ran: \
-             stderr={unlink_stderr}"
+            unlink_stderr.contains("something on the filesystem does"),
+            "unlink must point at the filesystem, which is what takes the recorded \
+             path outside the root: stderr={unlink_stderr}"
+        );
+        assert!(
+            !unlink_stderr.contains("since link ran"),
+            "and must not date that — the symlink did appear after `link` here, but \
+             nothing in the manifest records the filesystem as it was then, so the \
+             claim would be right only by luck: stderr={unlink_stderr}"
         );
         assert!(
             !unlink_stderr.contains("corrupt or forged"),
@@ -1426,6 +1461,13 @@ mod tests {
     /// follows the link to a target that's gone), this test's stdout
     /// assertions would fail — the entry would be silently miscounted
     /// absent instead of reported kept.
+    ///
+    /// Also pins that the kept-files footer accounts for this outcome
+    /// (issue #348, third round): both footers on the manifest path
+    /// carried a closed list of three reasons that omitted the very
+    /// outcome this test produces, so a user reading the explanation could
+    /// not find their own case in it. Reverting either footer to that list
+    /// fails here.
     #[test]
     #[cfg(unix)]
     fn a_broken_symlink_at_an_entrys_path_is_kept_and_reported_not_absent() {
@@ -1468,6 +1510,11 @@ mod tests {
             dry_stdout.contains("broken symlink"),
             "and must say why: stdout={dry_stdout}"
         );
+        assert!(
+            dry_stdout.contains("or a broken symlink whose content cannot be compared"),
+            "and the footer explaining kept files must account for this outcome \
+             instead of listing three reasons that exclude it: stdout={dry_stdout}"
+        );
 
         let (unlink_ok, unlink_stdout, unlink_stderr) =
             run_armadai(&root, &config, &["unlink", "--target", "claude"]);
@@ -1486,6 +1533,11 @@ mod tests {
         assert!(
             unlink_stdout.contains("broken symlink"),
             "unlink must explain why the dangling link was kept: \
+             stdout={unlink_stdout}"
+        );
+        assert!(
+            unlink_stdout.contains("or a broken symlink whose content cannot be compared"),
+            "and the footer explaining kept files must account for this outcome too: \
              stdout={unlink_stdout}"
         );
     }
@@ -1693,14 +1745,19 @@ mod tests {
              stdout={dry_stdout} stderr={dry_stderr}"
         );
         assert!(
-            dry_stdout.contains("now resolves to the target's own root"),
+            dry_stderr.contains("resolves onto the target's own root"),
             "the preview must say the directory *resolves onto* the root, not that it \
-             names it: stdout={dry_stdout}"
+             names it — on stderr, like the real pass: stderr={dry_stderr}"
         );
         assert!(
-            !dry_stdout.contains("corrupt or forged"),
+            !dry_stdout.contains("would refuse"),
+            "the preview must not put the same refusal on stdout as well: \
+             stdout={dry_stdout}"
+        );
+        assert!(
+            !dry_stderr.contains("corrupt or forged"),
             "the manifest is byte-for-byte what link wrote — the preview must not \
-             accuse it: stdout={dry_stdout}"
+             accuse it: stderr={dry_stderr}"
         );
 
         let (unlink_ok, _, unlink_stderr) =
@@ -1710,13 +1767,24 @@ mod tests {
             "unlink must refuse and exit non-zero: stderr={unlink_stderr}"
         );
         assert!(
-            unlink_stderr.contains("now resolves to the target's own root"),
+            unlink_stderr.contains("resolves onto the target's own root"),
             "the real pass must say the same thing its preview said: \
              stderr={unlink_stderr}"
         );
         assert!(
-            unlink_stderr.contains("something on the filesystem has changed"),
-            "the user must be pointed at the disk, which is what actually moved: \
+            unlink_stderr.contains("something on the filesystem does"),
+            "the user must be pointed at the disk, which is what puts the recorded \
+             directory on the root: stderr={unlink_stderr}"
+        );
+        // The code compares recorded text against the filesystem as it is
+        // now; it holds no snapshot of link time, so it must not date the
+        // change (issue #348, third round). Here the symlink really did
+        // appear after `link` — the point is that `unlink` cannot know
+        // that, and a message asserting it would be right by luck.
+        assert!(
+            !unlink_stderr.contains("since link ran"),
+            "the refusal must not claim *when* the filesystem came to say this — \
+             nothing in the manifest records the filesystem as it was at link time: \
              stderr={unlink_stderr}"
         );
         assert!(
@@ -1957,5 +2025,301 @@ mod tests {
         // Control: the generated files are still reclaimed.
         assert!(!root.join(".claude/agents/member-a.md").exists());
         assert!(!root.join(".claude/agents/member-b.md").exists());
+    }
+
+    // ── issue #348, third round ────────────────────────────────────────
+
+    /// A project whose skill has a subdirectory — the ordinary case, no
+    /// forging, no symlink. `link` records the parent `.claude/skills`
+    /// while writing `SKILL.md` and only then records the deeper
+    /// `.claude/skills/notes/refs` while writing the file inside it, so
+    /// `created_dirs` holds a parent *before* one of its own descendants:
+    ///
+    /// ```yaml
+    /// created_dirs:
+    /// - .claude/agents
+    /// - .claude/skills/notes
+    /// - .claude/skills
+    /// - .claude/skills/notes/refs
+    /// ```
+    ///
+    /// Walked in that order, `.claude/skills/notes` and `.claude/skills`
+    /// are both still non-empty when they come up (the `refs/` below them
+    /// has not been removed yet) and survive as empty residues — the very
+    /// class of bug this branch is named after.
+    ///
+    /// Mutation this catches: drop the
+    /// `linker::manifest::deepest_first` call from `unlink`'s real pass
+    /// (`for dir in created_dirs` instead of `for dir in
+    /// deepest_first(&created_dirs)`). Measured before this test existed:
+    /// removing it from *both* call sites left the whole suite green,
+    /// `deepest_first` being pinned only in isolation by its own unit
+    /// test.
+    #[test]
+    fn a_skill_with_a_subdirectory_leaves_no_empty_directories_behind() {
+        let dir = project_with_a_nested_skill();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        // Precondition — the ordering that makes this test load-bearing:
+        // a parent recorded before a descendant of its own.
+        let recorded = created_dirs_of(&read_manifest(&root));
+        let parent = recorded
+            .iter()
+            .position(|d| d == ".claude/skills")
+            .expect("link must record .claude/skills");
+        let deeper = recorded
+            .iter()
+            .position(|d| d == ".claude/skills/notes/refs")
+            .expect("link must record .claude/skills/notes/refs");
+        assert!(
+            parent < deeper,
+            "this test only bites while link records a parent before a deeper \
+             descendant; if that ever changes, rebuild the fixture rather than \
+             deleting the test: {recorded:?}"
+        );
+
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+
+        for residue in [
+            ".claude/agents",
+            ".claude/skills",
+            ".claude/skills/notes",
+            ".claude/skills/notes/refs",
+        ] {
+            assert!(
+                !root.join(residue).exists(),
+                "'{residue}' must not survive as an empty directory: \
+                 stdout={unlink_stdout}"
+            );
+        }
+        // The target's own root is never recorded and never removed.
+        assert!(
+            root.join(".claude").is_dir(),
+            "the target root itself must stay: stdout={unlink_stdout}"
+        );
+
+        // The run summary belongs on stdout, where a caller redirecting
+        // stderr away still sees it (measured good in both the manifest
+        // and the fallback path — do not let a refusal-stream change take
+        // it along).
+        assert!(
+            unlink_stdout.contains("Unlinked 'claude'"),
+            "the summary belongs on stdout: stdout={unlink_stdout}"
+        );
+        assert!(
+            !unlink_stderr.contains("Unlinked 'claude'"),
+            "and only there: stderr={unlink_stderr}"
+        );
+    }
+
+    /// The `--dry-run` half of the ordering above. A preview prints
+    /// nothing at all for a directory it would clean up, so the only place
+    /// its walk order is observable is the refusals — which is also the
+    /// only thing that can pin
+    /// `linker::manifest::deepest_first`'s *second* call site.
+    ///
+    /// Two recorded directories at different depths, deliberately listed
+    /// shallowest-first, correspond to no recorded file, so both are
+    /// refused and both are printed. Deepest first means the deeper one is
+    /// named first, in the preview and in the real pass alike.
+    ///
+    /// Mutation this catches: drop the `deepest_first` call from
+    /// `print_manifest_dry_run` and the preview lists them in manifest
+    /// order — shallowest first — while the real pass still leads with the
+    /// deeper one. Dropping it from the real pass instead fails the second
+    /// half. Each call site is covered on its own.
+    #[test]
+    fn preview_and_real_pass_walk_recorded_directories_in_the_same_order() {
+        let dir = project_minimal();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        let solo_digest = sha256_digest(&std::fs::read(&solo_file).unwrap());
+
+        // Shallowest first, so manifest order and deepest-first order
+        // genuinely disagree.
+        let forged_manifest = [
+            "version: 1",
+            "targets:",
+            "  claude:",
+            "    linked_at: \"2026-01-01T00:00:00Z\"",
+            "    root: .claude",
+            "    created_dirs:",
+            "      - .claude/notes",
+            "      - .claude/notes/deep/deeper",
+            "    entries:",
+            "      - path: .claude/agents/solo.md",
+            "        produced_by: { kind: agent, name: solo }",
+            "        outcome: created",
+            &format!("        digest: \"{solo_digest}\""),
+            "",
+        ]
+        .join("\n");
+        std::fs::write(manifest_path(&root), forged_manifest).unwrap();
+
+        let (_, _, dry_stderr) = run_armadai(
+            &root,
+            &config,
+            &["unlink", "--target", "claude", "--dry-run"],
+        );
+        let dry_deep = dry_stderr
+            .find(".claude/notes/deep/deeper (would refuse")
+            .unwrap_or_else(|| panic!("preview must refuse the deeper dir: {dry_stderr}"));
+        let dry_shallow = dry_stderr
+            .find(".claude/notes (would refuse")
+            .unwrap_or_else(|| panic!("preview must refuse the shallow dir: {dry_stderr}"));
+        assert!(
+            dry_deep < dry_shallow,
+            "the preview must walk recorded directories deepest first, like the pass \
+             it previews: stderr={dry_stderr}"
+        );
+
+        let (_, _, unlink_stderr) = run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        let real_deep = unlink_stderr
+            .find("'.claude/notes/deep/deeper'")
+            .unwrap_or_else(|| panic!("real pass must refuse the deeper dir: {unlink_stderr}"));
+        let real_shallow = unlink_stderr
+            .find("'.claude/notes'")
+            .unwrap_or_else(|| panic!("real pass must refuse the shallow dir: {unlink_stderr}"));
+        assert!(
+            real_deep < real_shallow,
+            "the real pass must walk recorded directories deepest first: \
+             stderr={unlink_stderr}"
+        );
+    }
+
+    /// A manifest naming the target's own root through a **non-canonical
+    /// absolute path** — an ancestor reached through a symlink, exactly
+    /// how `/tmp` reaches `/private/tmp` on macOS or a symlinked home or
+    /// automount does on Linux. Nothing inside the project is symlinked
+    /// and nothing on disk moved: the recorded text names the root, and
+    /// the refusal must say so.
+    ///
+    /// Mutation this catches: compare the two paths with
+    /// `linker::manifest::resolve` instead of `resolve_lexical` in
+    /// `decide_created_dir` (what the previous fix wave shipped). The
+    /// refusal then reads "resolves onto the target's own root … something
+    /// on the filesystem does", sending the user to inspect a directory
+    /// where there is nothing to find — the false accusation issue #348
+    /// exists to remove, reintroduced by the fix for it.
+    #[test]
+    #[cfg(unix)]
+    fn a_manifest_naming_the_root_by_a_non_canonical_path_blames_the_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        // The project sits under `real/`; `alias/` is a second spelling of
+        // `real/`, above the project root — nothing within the project is
+        // a symlink.
+        let root = dir.path().join("real/project");
+        let agents = root.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: solo\nlink:\n  target: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("solo.md"),
+            "# solo\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work alone.\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink("real", dir.path().join("alias")).unwrap();
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let solo_file = root.join(".claude/agents/solo.md");
+        let solo_digest = sha256_digest(&std::fs::read(&solo_file).unwrap());
+        let through_the_alias = dir.path().join("alias/project/.claude");
+        assert_eq!(
+            std::fs::canonicalize(&through_the_alias).unwrap(),
+            std::fs::canonicalize(root.join(".claude")).unwrap(),
+            "the alias must really be another spelling of the target root"
+        );
+
+        let forged_manifest = [
+            "version: 1".to_string(),
+            "targets:".to_string(),
+            "  claude:".to_string(),
+            "    linked_at: \"2026-01-01T00:00:00Z\"".to_string(),
+            "    root: .claude".to_string(),
+            "    created_dirs:".to_string(),
+            format!("      - {}", through_the_alias.display()),
+            "    entries:".to_string(),
+            "      - path: .claude/agents/solo.md".to_string(),
+            "        produced_by: { kind: agent, name: solo }".to_string(),
+            "        outcome: created".to_string(),
+            format!("        digest: \"{solo_digest}\""),
+            String::new(),
+        ]
+        .join("\n");
+        std::fs::write(manifest_path(&root), forged_manifest).unwrap();
+
+        let (unlink_ok, _, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(
+            !unlink_ok,
+            "unlink must refuse the recorded root: stderr={unlink_stderr}"
+        );
+        assert!(
+            unlink_stderr.contains("names the target's own root"),
+            "the manifest names the root — a second spelling of a directory is still \
+             that directory: stderr={unlink_stderr}"
+        );
+        assert!(
+            unlink_stderr.contains("corrupt or forged"),
+            "and that is the manifest's own fault: stderr={unlink_stderr}"
+        );
+        assert!(
+            !unlink_stderr.contains("something on the filesystem does"),
+            "nothing on the filesystem moved — the user must not be sent to inspect \
+             a directory where there is nothing to find: stderr={unlink_stderr}"
+        );
+        assert!(
+            root.join(".claude").is_dir(),
+            "and the target root must survive either way"
+        );
+    }
+
+    /// Fixture for the ordering test above: a skill with a subdirectory,
+    /// which is what makes `link` record a parent directory before a
+    /// deeper descendant of it.
+    fn project_with_a_nested_skill() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let agents = root.join("agents");
+        let skill_dir = root.join(".armadai/skills/notes");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::create_dir_all(skill_dir.join("refs")).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: solo\nskills:\n  - name: notes\nlink:\n  target: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("solo.md"),
+            "# solo\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work alone.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: notes\ndescription: take notes\n---\n\nTake notes.\n",
+        )
+        .unwrap();
+        std::fs::write(skill_dir.join("refs/style.md"), "reference material\n").unwrap();
+        dir
     }
 }

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -6,8 +6,11 @@ The `armadai link` command generates native configuration files for your preferr
 
 ```bash
 armadai link <target>           # Generate config for a specific CLI
-armadai link <target> --dry-run # Preview without writing files
+armadai link <target> --dry-run # Preview: writes no files and no manifest
 armadai link <target> --force   # Overwrite existing files
+
+armadai unlink <target>           # Remove what link wrote, and only that
+armadai unlink <target> --dry-run # Preview the removals, same guards, same exit code
 ```
 
 ## Supported Targets
@@ -83,7 +86,34 @@ Generates:
 
 ## Conflict Detection
 
-By default, `armadai link` warns before overwriting existing files. Use `--force` to skip confirmation, or `--dry-run` to preview first.
+By default, `armadai link` warns before overwriting existing files. Use `--force` to skip confirmation, or `--dry-run` to preview first. A pre-existing file whose content differs from what would be generated is left untouched and recorded as `skipped` in the link manifest (below), which is what keeps `armadai unlink` from ever removing it.
+
+## The Link Manifest
+
+`armadai link` records what it wrote in `.armadai/link-manifest.yaml`, grouped by target: the target's output root, the directories `link` itself created, and one entry per file with its `produced_by`, its `outcome` (`created` or `skipped`), and — for `created` — the `sha256:` digest of the bytes written.
+
+`armadai unlink` reads that manifest and applies the inverse of each recorded outcome, so it removes exactly what `link` produced and nothing else — including files whose agent has since been removed from the project config, which is the case no amount of regeneration can recover.
+
+The manifest is data on disk, so `unlink` treats it as untrusted input: it re-derives the target's output directory from the project config and refuses the manifest wholesale if the two disagree, and it refuses any individual entry or recorded directory that resolves outside the target's own root, onto that root itself, or that corresponds to no file `link` recorded creating.
+
+`--dry-run` writes no manifest. When no usable manifest exists — a fresh clone, a deleted `.armadai/`, or a project linked before the manifest existed — `unlink` says so and falls back to a content-match guard: it regenerates what `link` would write today and removes a file only when its bytes still match byte for byte. In that degraded mode a file linked with different options (an explicit `--model`, or an interactive prompt answer) is kept rather than reclaimed; re-run `link` to write a manifest.
+
+## Unlink Output
+
+Each file `unlink` considers is reported as one of:
+
+| Outcome | Meaning |
+|---|---|
+| `deleted` | recorded as `created` and still byte-for-byte what `link` wrote |
+| `kept (hand-written — link recorded it as skipped)` | `link` found it already there and left it alone |
+| `kept (content differs from what link wrote)` | edited since linking; removing it would be data loss |
+| `kept (cannot verify …)` | unreadable, or a digest algorithm this build doesn't recognise |
+| `kept (broken symlink …)` | the link is on disk but its target is gone, so its content can't be checked. It is **not** "already absent" |
+| `already absent` | nothing at that path at all |
+
+Refusals — a manifest item outside its trusted root, one naming the target's own root, or one matching no recorded file — are reported on stderr, and each one names *which side* is at fault: the manifest's own text ("the manifest may be corrupt or forged"), or the filesystem having moved under an intact manifest (a symlink that appeared after `link` ran). The two call for different follow-up.
+
+**A refused item makes `unlink` exit non-zero**, and `--dry-run` mirrors that: it applies the same guards, prints the same refusals, and exits non-zero wherever a real run would — a preview that cannot fail is not a preview. Only one thing it deliberately does not mirror: whether a recorded directory is still empty on disk. The real pass checks that *after* deleting the files inside it, so the preview reports directories as "recorded for cleanup", not "will be removed".
 
 ## Agent-to-Format Mapping
 

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -106,14 +106,14 @@ Each file `unlink` considers is reported as one of:
 |---|---|
 | `deleted` | recorded as `created` and still byte-for-byte what `link` wrote |
 | `kept (hand-written — link recorded it as skipped)` | `link` found it already there and left it alone |
-| `kept (content differs from what link wrote)` | edited since linking; removing it would be data loss |
+| `kept (content differs from what link wrote)` | edited since linking; removing it would be data loss. Without a manifest the fallback says only `kept (content differs)` — it compares against freshly generated content, not a recorded digest, so it cannot claim the file ever *was* what `link` wrote |
 | `kept (cannot verify …)` | unreadable, or a digest algorithm this build doesn't recognise |
 | `kept (broken symlink …)` | the link is on disk but its target is gone, so its content can't be checked. It is **not** "already absent" |
 | `already absent` | nothing at that path at all |
 
-Refusals — a manifest item outside its trusted root, one naming the target's own root, or one matching no recorded file — are reported on stderr, and each one names *which side* is at fault: the manifest's own text ("the manifest may be corrupt or forged"), or the filesystem having moved under an intact manifest (a symlink that appeared after `link` ran). The two call for different follow-up.
+Refusals — a manifest item outside its trusted root, one naming the target's own root, or one matching no recorded file — go to **stderr** in both the real pass and `--dry-run`, beside the summary line that points at them, while the per-file outcomes and the closing `Unlinked '<target>': …` counts stay on stdout. Each refusal names *which side* is at fault: the manifest's own text ("the manifest may be corrupt or forged"), or the filesystem ("something on the filesystem does, most likely a symlink along the path") under a manifest that is intact. The two call for different follow-up. Note what `unlink` deliberately does *not* claim: **when** a filesystem cause appeared. It compares the recorded text against the filesystem as it is now, and keeps no record of how the filesystem looked when `link` ran, so it can say which side puts a path where it is — never that anything changed since.
 
-**A refused item makes `unlink` exit non-zero**, and `--dry-run` mirrors that: it applies the same guards, prints the same refusals, and exits non-zero wherever a real run would — a preview that cannot fail is not a preview. Only one thing it deliberately does not mirror: whether a recorded directory is still empty on disk. The real pass checks that *after* deleting the files inside it, so the preview reports directories as "recorded for cleanup", not "will be removed".
+**A refused item makes `unlink` exit non-zero**, and `--dry-run` mirrors that: it applies the same guards, prints the same refusals, and exits non-zero wherever a real run would — a preview that cannot fail is not a preview. Only one thing it deliberately does not mirror: whether a recorded directory is still empty on disk. The real pass checks that *after* deleting the files inside it, so the preview reports directories as "eligible for cleanup" — the number that passed its guards — rather than "recorded" (which would deny a record it holds for a directory it refuses) or "will be removed".
 
 ## Agent-to-Format Mapping
 


### PR DESCRIPTION
Ferme **#348** — les résidus non bloquants relevés par la revue finale du manifeste de link (#338). Chaque changement de comportement arrive avec le test qui l'épingle, et les trois correctifs antérieurs livrés sans test en ont maintenant un.

## Comportements (sortie utilisateur — à valider visuellement)

| Avant | Après |
|---|---|
| `--dry-run` annonçait « 2 directories recorded for cleanup », exit **0** ; le vrai passage refusait, exit **1** | le dry-run applique la même garde `created_dirs` et le même code de sortie |
| un symlink apparu **entre** `link` et `unlink` était rapporté « manifest corrupt or forged » | deux causes, deux messages : le manifeste est intact, c'est le disque qui a bougé |
| un symlink cassé était rapporté « already absent », exit 0, lien pendant laissé sur disque | rapporté comme conservé-et-non-vérifiable |
| un `created_dirs` forgé nommant un répertoire vide **préexistant de l'utilisateur** pouvait le faire supprimer | refusé |

Le premier point est le plus net : un pré-contrôle qui ne montre pas ce que fera le vrai passage ne sert pas de pré-contrôle.

## Filet sur les correctifs livrés sans test

- **R4** — l'évasion `a/../b` via un intermédiaire manquant, corrigée et donc libre de régresser.
- **`resolve_real` / `root_confirmed`** — les deux fonctions qui *portent* la frontière de confiance n'avaient aucun test unitaire, seulement une couverture boîte-noire indirecte. 6 unitaires ajoutés.
- **`.claude/` utilisateur préexistant** survit à `link` puis `unlink` — le pire cas d'origine de #338, jusqu'ici vérifié seulement à la main.

## Gate

`link_manifest.rs` passe de 17 à **24 tests**. Local complet vert : fmt + **5 modes clippy** + **4 modes de test** + gaveldrop **13 cas · 83/83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Vague de correctifs — revue indépendante (CHANGES REQUESTED)

| Point | Correctif |
|---|---|
| **I1** — `IsTargetRoot` gardait une cause **codée en dur** ; atteignable par pure mutation du disque (`rm -rf .claude/agents && ln -s . .claude/agents`), manifeste intact | même partage lexical/réel que `diagnose_trust_failure`, via un `fault_side` partagé ; le verbe suit la cause (« names » / « now resolves to ») ; corrigé sur les **deux** chemins (réel + dry-run) |
| **I2** — la puce « symlink cassé » n'était corrigée que sur le chemin manifeste | le repli #342 rapporte aussi « kept (broken symlink) » au lieu de « already absent », passe réelle **et** dry-run ; le libellé de résumé perd `(content differs)`, qui n'était plus vrai de tous les fichiers conservés |
| **I3** — test qui ne peut pas échouer | la mutation composée proposée par la revue laisse **5** autres tests rouges et celui-là **vert** (mesuré) : les deux gardes citées sont inatteignables pour un `.claude/` préexistant. L'invariant portant est une couche plus tôt — `link` ne doit pas **enregistrer** un répertoire utilisateur préexistant — donc la fixture pré-crée `.claude/agents/` vide et le test assert `created_dirs: []`. Rouge sous une mutation d'une ligne, sur l'assertion **et** sur la survie du répertoire, que cette mutation supprime réellement |
| **I4** — changement de `link` non déclaré | **gardé et déclaré ici.** `previous_digests`/`still_own_output` répond à la « coordination note 2 », l'une des quatre notes laissées par la revue de #338 et que le brief de cette PR mettait explicitement dans le périmètre (« for note 2, decide and justify ») — mais ni le corps de la PR ni le message de commit ne le disaient. L'auto-guérison perdue est réelle et documentée dans le commit ; le défaut qu'il ferme est reproduit et non adversarial. Le garde-fou manquant existe : un fichier écrit à la main reste `skipped` sans digest à travers 3 `link`, aux deux niveaux |
| **m1** | `decide_created_dir`'s `Untrusted` supprimable en restant vert → épinglé (`created_dir_is_plausible` ne compense pas : une entrée forgée rend « plausible » un répertoire hors projet) |
| **m2** | mutant survivant sur la branche `is_symlink()` du dry-run → épinglé |
| **m3** | `forged_manifest_entry_…` n'assertait jamais la cause → l'assert et son opposé, donc aucune valeur codable en dur |
| **m4** | le résumé des refus passe sur **stderr**, là où partent les raisons qu'il désigne |
| **m5** | `deepest_first` extrait et partagé (l'ordre divergeait) ; le docstring ne prétend plus appliquer « exactly the same guards » — il applique les mêmes **décisions**, pas le contrôle de vacuité sur disque |
| **m7** | `docs/wiki/link.md` : le manifeste, le vocabulaire de sortie de `unlink`, les deux causes de refus, et le fait qu'un `--dry-run` peut sortir en 1 |

**Chaque test ajouté ou modifié a été vérifié rouge sous la mutation qu'il nomme** (13 expériences), puis restauré.

`link_manifest.rs` : 24 → **28** tests ; unitaires `linker::manifest` : 35 → **39**.
Gate local complet vert : fmt + 5/5 clippy + 4/4 modes de test (1380/1423/1408/1440, 0 échec) + gaveldrop **13 cas · 83/83**.


---

## Troisième ronde — re-revue du delta (CHANGES REQUESTED)

### I1 — RÉGRESSION : `IsTargetRoot` accusait le disque quand seul le manifeste était fautif

La vague précédente décidait la cause par une **égalité lexicale** (`resolve`), et `resolve` ne suit pas les symlinks. Une racine nommée par un chemin absolu **non canonique** — `/tmp/...` pour `/private/tmp/...` sur macOS, un home ou un automount symlinké sur Linux — n'est pas lexicalement égale à la racine, alors que le texte du manifeste la **nomme littéralement**. Mesuré, manifeste forgé `created_dirs: [/tmp/…/project/.claude]`, cwd `/private/tmp/…/project` :

```
predelta (90e4afe)   names the target's own root … the manifest may be corrupt or forged     ✅
postdelta (713c464)  now resolves to the target's own root … something on the filesystem
                     has changed since link ran … inspect the target directory               ❌
ce commit            names the target's own root … the manifest may be corrupt or forged     ✅
```

Cas canonique (`created_dirs: [.claude]`) : les trois binaires disent `names … corrupt or forged`. Sens inverse (symlink `.claude/agents -> .`, manifeste intact) : `resolves onto … something on the filesystem does` — toujours le disque, comme il faut.

**Deux gestes, comme demandé.**

1. **Le prédicat.** La moitié lexicale passe par un nouveau `resolve_lexical`, qui intègre **un seul** fait du système de fichiers — l'orthographe de la racine du projet — et ne suit toujours **aucun** symlink *à l'intérieur* du projet, ce qui laisse le verdict opposé intact. `diagnose_trust_failure` utilise la même résolution : le même piège existait pour les entrées, à deux composants près.

   ⚠️ **La suggestion « comparer après canonicalisation des deux côtés » ne peut pas marcher, et je le mesure** : c'est ce que fait déjà `resolve_real`, et c'est précisément parce que `resolve_real(dir) == resolve_real(target_root)` qu'on entre dans `IsTargetRoot`. Le prédicat serait donc **toujours vrai**, `FilesystemDiverged` deviendrait injoignable, et le test frère `a_symlink_merging_a_recorded_dir_into_the_target_root_blames_the_filesystem` rouge. C'est la clause « ou tout autre moyen » qui est suivie.

2. **Le message.** `FilesystemDiverged` ne date plus rien : le code compare « texte » à « système de fichiers **tel qu'il est maintenant** », jamais « avant `link` » à « après `link` », et ne garde aucun instantané du disque à l'heure du link. Nouvelle raison : *« the manifest's own text does not put it there — something on the filesystem does, most likely a symlink along the path »*. Verbe : `resolves onto` (sans `now`). Corrigé **aux deux endroits** (`trust_failure_reason` portait déjà la surpromesse pour les entrées ; le delta n'y avait fait que router `IsTargetRoot`).

### I2 — divergence preview/réel des flux, et la doc qui affirmait la moitié fausse

`m4` avait mis le résumé des refus du **vrai** passage sur stderr et laissé la preview entière sur stdout. Mesuré : un appelant qui journalise `2>errors.log` obtenait les raisons en réel et **rien** en preview ; celui qui parse stdout, l'inverse.

Les **cinq** impressions de refus de `print_manifest_dry_run` (entrée hors racine + les trois arms de `decide_created_dir` + le résumé) passent sur **stderr**, là où le vrai passage met les siennes. Les deux résumés partagent désormais une seule phrase (`… were/would be refused and left untouched; each refusal above names the item and why.`). Après :

```
$ armadai unlink --target claude --dry-run 2>/dev/null   → listing + compteurs
$ armadai unlink --target claude --dry-run 1>/dev/null   → refus + résumé + Error
```

`Unlinked '<target>': N deleted, N kept, N already absent.` **reste sur stdout**, chemin manifeste comme repli, sous `2>/dev/null` comme sous `1>/dev/null` — vérifié, et désormais épinglé.

`docs/wiki/link.md` dit maintenant le vrai : refus sur stderr **dans les deux passes**, compteurs et résumé de run sur stdout, ce que `unlink` ne prétend pas savoir (le *quand*), et le libellé plus court `kept (content differs)` du repli, qui n'a pas de digest à invoquer.

### I3 — `deepest_first` extrait, partagé… et non épinglé

Sur un projet ordinaire — une skill avec un sous-répertoire — `link` enregistre `.claude/skills` **avant** `.claude/skills/notes/refs`. Sans le tri, `unlink` laisse `.claude/skills` et `.claude/skills/notes` en résidus vides : la classe de bug qui donne son nom à la branche.

Deux tests bout-en-bout, chacun vérifié rouge **sur son propre site d'appel** :

| Mutation | Test rouge |
|---|---|
| `deepest_first` retiré de `unlink.rs:413` (passe réelle) | `a_skill_with_a_subdirectory_leaves_no_empty_directories_behind` (+ la moitié « réel » de l'autre) |
| `deepest_first` retiré de `unlink.rs:708` (preview) | `preview_and_real_pass_walk_recorded_directories_in_the_same_order`, moitié « preview » uniquement |

La preview n'imprime rien pour un répertoire qu'elle nettoierait : son ordre n'est observable que sur les refus, d'où le second test (deux répertoires refusés à des profondeurs différentes, listés du moins profond au plus profond dans le manifeste).

### Minors

| Point | Correctif |
|---|---|
| `(N director{y,ies} recorded for cleanup)` faux **dans les deux sens** (le compteur est `Eligible`) | `eligible for cleanup` |
| pied de page du chemin manifeste : liste **fermée de trois** motifs omettant le symlink cassé qu'il émet lui-même | un `KEPT_FILE_REASONS` partagé par les **deux** pieds de page (réel + preview), ouvert et incluant ce motif ; chaque pied épinglé séparément |
| `docs/wiki/link.md:109` ne distinguait pas `kept (content differs from what link wrote)` du `kept (content differs)` du repli | distingué, avec la raison (le repli n'a pas de digest) |
| docstring de I3 : « Both guards could be deleted outright with that test still green » vrai de ce test, faux de la suite | reformulé, avec ma propre mesure : muter le filtre `created != target_root` rend **19** tests rouges (`--no-fail-fast` ; sans lui cargo s'arrête au premier target et on n'en voit que 3) |

Le docstring de m5 est vrai, non retouché.

### Méthode

Six expériences de mutation, chacune vérifiée rouge puis restaurée : prédicat lexical (unitaire **et** boîte noire), `deepest_first` par site d'appel (×2), les cinq `eprintln!` de la preview remis en `println!`, les deux messages remis à leur version datée, le compteur + chaque pied de page.

`link_manifest.rs` : 28 → **31** tests ; unitaires `linker::manifest` : 39 → **40**.
Gate local complet vert : fmt + **5/5 clippy** + **4/4 modes de test** (1384 / 1412 / 1444 / 1427, 0 échec) + gaveldrop **13 cas · 83/83**.
