### PR TITLE
fix(ci): rewrite wiki links for every page, not a frozen list of nine

### DIFF
--- a/.github/scripts/sync-wiki.sh
+++ b/.github/scripts/sync-wiki.sh
@@ -56,12 +56,16 @@ for filename in "${SRC_FILES[@]}"; do
     dest="$WIKI_DIR/$(wiki_page_name "$filename")"
     cp "$SRC_DIR/$filename" "$dest"
 
-    # Rewrite links to every wiki page, both bare and `./`-prefixed. The wiki
-    # serves pages without the .md extension, so an unrewritten link 404s.
+    # Rewrite links to every wiki page: bare, `./`-prefixed, and with a
+    # `#section` anchor. The wiki serves pages without the .md extension, so an
+    # unrewritten link 404s — and an anchored link is the easiest of the three
+    # to miss, since it looks rewritten right up to the `#`.
     for target in "${SRC_FILES[@]}"; do
         page_link="$(wiki_page_name "$target")"
         page_link="${page_link%.md}"
-        sed -i.bak "s|(\./${target})|(${page_link})|g; s|(${target})|(${page_link})|g" "$dest"
+        # The filename's own dots must not act as ERE wildcards.
+        target_re=$(printf '%s' "$target" | sed 's/\./\\./g')
+        sed -i.bak -E "s|\((\./)?${target_re}(#[^)]*)?\)|(${page_link}\2)|g" "$dest"
         rm -f "$dest.bak"
     done
 done

--- a/.github/scripts/sync-wiki.sh
+++ b/.github/scripts/sync-wiki.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Copy docs/wiki/*.md into a checked-out GitHub Wiki working copy, renaming
+# each page to the wiki's Title-Case convention and rewriting internal links
+# to match.
+#
+# Usage: sync-wiki.sh <source-dir> <wiki-working-copy>
+#
+# Both the page names and the link rewrites are derived from the files that
+# are actually present. An earlier version kept two hand-maintained tables
+# instead; the page-name table turned out to reproduce exactly what the
+# derivation already produced, while the link table silently froze at nine
+# pages — so links to every page added afterwards shipped to the wiki
+# pointing at `page.md`, which the wiki does not serve.
+
+set -euo pipefail
+
+SRC_DIR="${1:?usage: sync-wiki.sh <source-dir> <wiki-working-copy>}"
+WIKI_DIR="${2:?usage: sync-wiki.sh <source-dir> <wiki-working-copy>}"
+
+# mdBook's table of contents. It drives the book's sidebar and has no meaning
+# as a wiki page — the wiki has its own sidebar and a generated Home.
+readonly EXCLUDED="SUMMARY.md"
+
+# kebab-case.md -> Kebab-Case.md. Written without GNU sed's `\u` so it behaves
+# the same on a maintainer's macOS shell as on the CI runner.
+wiki_page_name() {
+    local base="${1%.md}" out="" seg head
+    local IFS='-'
+    # shellcheck disable=SC2206 # deliberate word split on IFS
+    local segs=($base)
+    unset IFS
+    for seg in "${segs[@]}"; do
+        head=$(printf '%s' "${seg:0:1}" | tr '[:lower:]' '[:upper:]')
+        out+="${out:+-}${head}${seg:1}"
+    done
+    printf '%s.md' "$out"
+}
+
+# Collect every page that will exist on the wiki, so links can be rewritten
+# for all of them rather than for a frozen subset.
+declare -a SRC_FILES=()
+for src in "$SRC_DIR"/*.md; do
+    [ -e "$src" ] || continue
+    filename=$(basename "$src")
+    [ "$filename" = "$EXCLUDED" ] && continue
+    SRC_FILES+=("$filename")
+done
+
+if [ ${#SRC_FILES[@]} -eq 0 ]; then
+    echo "sync-wiki: no pages found in $SRC_DIR" >&2
+    exit 1
+fi
+
+for filename in "${SRC_FILES[@]}"; do
+    dest="$WIKI_DIR/$(wiki_page_name "$filename")"
+    cp "$SRC_DIR/$filename" "$dest"
+
+    # Rewrite links to every wiki page, both bare and `./`-prefixed. The wiki
+    # serves pages without the .md extension, so an unrewritten link 404s.
+    for target in "${SRC_FILES[@]}"; do
+        page_link="$(wiki_page_name "$target")"
+        page_link="${page_link%.md}"
+        sed -i.bak "s|(\./${target})|(${page_link})|g; s|(${target})|(${page_link})|g" "$dest"
+        rm -f "$dest.bak"
+    done
+done
+
+# Retire the excluded page if a previous run published it. Stopping the copy
+# does not un-publish what is already on the wiki, and this one page is a
+# known artefact of the old sync rather than anything a person wrote.
+#
+# Deliberately narrow: removing everything on the wiki without a matching
+# source would delete hand-written pages, which is the same over-deletion
+# failure the link manifest exists to prevent. Anything else stale has to be
+# retired by hand, on purpose.
+if [ -e "$WIKI_DIR/$EXCLUDED" ]; then
+    rm -f "$WIKI_DIR/$EXCLUDED"
+    echo "sync-wiki: removed stale $EXCLUDED published by an earlier run"
+fi
+
+# Home.md — the wiki's landing page, listing every synced page.
+{
+    printf '# ArmadAI Wiki\n\n'
+    printf 'AI agent fleet orchestrator — define, manage and run specialized agents from Markdown files.\n\n'
+    printf '## Pages\n\n'
+    for filename in "${SRC_FILES[@]}"; do
+        page="$(wiki_page_name "$filename")"
+        page="${page%.md}"
+        printf -- '- [%s](%s)\n' "${page//-/ }" "$page"
+    done
+    printf '\n## Quick Links\n\n'
+    printf -- '- [GitHub Repository](https://github.com/Dr0drigues/armadai)\n'
+    printf -- '- [Releases](https://github.com/Dr0drigues/armadai/releases)\n'
+    printf -- '- [Issues](https://github.com/Dr0drigues/armadai/issues)\n'
+} > "$WIKI_DIR/Home.md"
+
+echo "sync-wiki: synced ${#SRC_FILES[@]} pages (excluded $EXCLUDED)"

--- a/.github/scripts/sync-wiki.test.sh
+++ b/.github/scripts/sync-wiki.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Tests for sync-wiki.sh. Run from the repository root:
+#   .github/scripts/sync-wiki.test.sh
+#
+# Each case asserts against a real sync into a temporary wiki working copy,
+# using the repository's own docs/wiki/ as input, so the tests fail when a
+# page is added that the sync would mishandle.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC="$SCRIPT_DIR/sync-wiki.sh"
+SRC="$SCRIPT_DIR/../../docs/wiki"
+
+fails=0
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n     %s\n' "$1" "$2"; fails=$((fails + 1)); }
+
+WIKI=$(mktemp -d)
+trap 'rm -rf "$WIKI"' EXIT
+"$SYNC" "$SRC" "$WIKI" >/dev/null || { echo "sync failed outright"; exit 1; }
+
+# mdBook's table of contents drives the book sidebar and is meaningless as a
+# wiki page — the wiki generates its own Home.
+if [ -e "$WIKI/SUMMARY.md" ]; then
+    fail "SUMMARY.md is excluded" "SUMMARY.md was published to the wiki"
+else
+    pass "SUMMARY.md is excluded"
+fi
+
+# Every source page except the excluded one reaches the wiki under its
+# Title-Case name.
+missing=""
+for src in "$SRC"/*.md; do
+    filename=$(basename "$src")
+    [ "$filename" = "SUMMARY.md" ] && continue
+    expected=$(printf '%s' "${filename%.md}" | awk -F- '{for(i=1;i<=NF;i++){printf "%s%s%s", (i>1?"-":""), toupper(substr($i,1,1)), substr($i,2)}}')
+    [ -e "$WIKI/$expected.md" ] || missing="$missing ${filename} -> ${expected}.md"
+done
+[ -z "$missing" ] && pass "every page is published under its Title-Case name" \
+    || fail "every page is published under its Title-Case name" "missing:$missing"
+
+# The regression this script exists for: links must be rewritten for ALL
+# pages, not a frozen subset. A link left as `page.md` 404s on the wiki.
+leftover=$(grep -roE '\((\./)?[a-z0-9][a-z0-9-]*\.md\)' "$WIKI" 2>/dev/null | grep -v 'Home.md:' || true)
+[ -z "$leftover" ] && pass "no link still points at a .md source name" \
+    || fail "no link still points at a .md source name" "$(printf '%s' "$leftover" | head -5)"
+
+# Specifically the pages added after the old hand-maintained link table froze
+# — the ones whose links shipped to the wiki broken. Each assertion states how
+# many source links it actually covers: a page nothing links to yet cannot
+# prove anything today, and saying so keeps it from reading as evidence it
+# isn't. Those cases become real assertions the moment a link appears.
+for page in audit declarative-agents migration-v0-to-v1 orchestration-guide policy-gate; do
+    in_source=$(grep -roE "\((\./)?${page}\.md\)" "$SRC" 2>/dev/null | grep -v '/SUMMARY.md:' | wc -l | tr -d ' ')
+    still_raw=$(grep -rlE "\((\./)?${page}\.md\)" "$WIKI" 2>/dev/null || true)
+    if [ "$in_source" = "0" ]; then
+        printf '  --   links to %s: nothing links to it yet, nothing to prove\n' "$page"
+    elif [ -z "$still_raw" ]; then
+        pass "links to $page are rewritten ($in_source in source)"
+    else
+        fail "links to $page are rewritten" "still raw in: $still_raw"
+    fi
+done
+
+# Stopping the copy does not un-publish: a SUMMARY.md left on the wiki by an
+# earlier run has to be actively removed.
+WIKI2=$(mktemp -d)
+printf '# stale\n' > "$WIKI2/SUMMARY.md"
+printf '# hand-written\n' > "$WIKI2/Hand-Written-Page.md"
+"$SYNC" "$SRC" "$WIKI2" >/dev/null
+if [ -e "$WIKI2/SUMMARY.md" ]; then
+    fail "a previously published SUMMARY.md is retired" "it survived the sync"
+else
+    pass "a previously published SUMMARY.md is retired"
+fi
+# ...but nothing else is: over-deletion here is the same failure the link
+# manifest exists to prevent.
+if [ -e "$WIKI2/Hand-Written-Page.md" ]; then
+    pass "a hand-written wiki page is left alone"
+else
+    fail "a hand-written wiki page is left alone" "the sync deleted it"
+fi
+rm -rf "$WIKI2"
+
+# Home lists every published page.
+count_published=$(find "$WIKI" -name '*.md' -not -name 'Home.md' | wc -l | tr -d ' ')
+# Only the Pages section — the Quick Links below it are also `- [...]` lines.
+count_listed=$(sed -n '/^## Pages$/,/^## Quick Links$/p' "$WIKI/Home.md" | grep -cE '^- \[')
+[ "$count_published" = "$count_listed" ] && pass "Home lists all $count_published pages" \
+    || fail "Home lists all pages" "published=$count_published listed=$count_listed"
+
+echo
+if [ "$fails" -eq 0 ]; then
+    echo "sync-wiki: all checks passed"
+else
+    echo "sync-wiki: $fails check(s) failed"
+    exit 1
+fi

--- a/.github/scripts/sync-wiki.test.sh
+++ b/.github/scripts/sync-wiki.test.sh
@@ -43,7 +43,9 @@ done
 
 # The regression this script exists for: links must be rewritten for ALL
 # pages, not a frozen subset. A link left as `page.md` 404s on the wiki.
-leftover=$(grep -roE '\((\./)?[a-z0-9][a-z0-9-]*\.md\)' "$WIKI" 2>/dev/null | grep -v 'Home.md:' || true)
+# The `(#anchor)?` matters: an anchored link looks rewritten right up to the
+# `#`, so a pattern anchored on `)` walks straight past it.
+leftover=$(grep -roE '\((\./)?[a-z0-9][a-z0-9-]*\.md(#[^)]*)?\)' "$WIKI" 2>/dev/null | grep -v 'Home.md:' || true)
 [ -z "$leftover" ] && pass "no link still points at a .md source name" \
     || fail "no link still points at a .md source name" "$(printf '%s' "$leftover" | head -5)"
 
@@ -83,6 +85,59 @@ else
     fail "a hand-written wiki page is left alone" "the sync deleted it"
 fi
 rm -rf "$WIKI2"
+
+# The `./`-prefixed and anchored forms do not occur in docs/wiki/ today, so
+# the real corpus cannot exercise them: without a synthetic source, half the
+# rewrite could be deleted and the suite would stay green. Verified: it does.
+SYNTH=$(mktemp -d)
+SYNTH_WIKI=$(mktemp -d)
+cat > "$SYNTH/alpha-page.md" <<'ALPHA'
+# Alpha
+bare [b](beta-page.md)
+dot-slash [b](./beta-page.md)
+anchored [b](beta-page.md#a-section)
+dot-slash anchored [b](./beta-page.md#other)
+ALPHA
+printf '# Beta
+' > "$SYNTH/beta-page.md"
+"$SYNC" "$SYNTH" "$SYNTH_WIKI" >/dev/null
+synth_out=$(cat "$SYNTH_WIKI/Alpha-Page.md")
+for want in '(Beta-Page)' '(Beta-Page#a-section)' '(Beta-Page#other)'; do
+    case "$synth_out" in
+        *"$want"*) pass "rewrites to $want" ;;
+        *) fail "rewrites to $want" "not found in synced output" ;;
+    esac
+done
+case "$synth_out" in
+    *'beta-page.md'*) fail "no raw beta-page.md survives any link form" \
+        "$(printf '%s' "$synth_out" | grep -n 'beta-page.md')" ;;
+    *) pass "no raw beta-page.md survives any link form" ;;
+esac
+rm -rf "$SYNTH" "$SYNTH_WIKI"
+
+# The collection filter, tested apart from the late cleanup that also removes
+# SUMMARY.md: with the filter gone, the cleanup still deletes the file from
+# disk, so asserting only on the file cannot see the filter at all. Home is
+# built from the collected list, so it can.
+if grep -qiE '^- \[SUMMARY\]' "$WIKI/Home.md"; then
+    fail "SUMMARY is not collected as a page" "Home lists it"
+else
+    pass "SUMMARY is not collected as a page"
+fi
+
+# The empty-source guard: it keeps a broken checkout from overwriting Home
+# with an empty page list.
+EMPTY_SRC=$(mktemp -d)
+EMPTY_WIKI=$(mktemp -d)
+printf 'existing\n' > "$EMPTY_WIKI/Home.md"
+if "$SYNC" "$EMPTY_SRC" "$EMPTY_WIKI" >/dev/null 2>&1; then
+    fail "an empty source directory is refused" "the sync reported success"
+elif [ "$(cat "$EMPTY_WIKI/Home.md")" = "existing" ]; then
+    pass "an empty source directory is refused, Home untouched"
+else
+    fail "an empty source directory is refused" "Home was overwritten anyway"
+fi
+rm -rf "$EMPTY_SRC" "$EMPTY_WIKI"
 
 # Home lists every published page.
 count_published=$(find "$WIKI" -name '*.md' -not -name 'Home.md' | wc -l | tr -d ' ')

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,8 +1,8 @@
 # Wiki sync — publish docs/wiki/ pages to the GitHub Wiki
 #
 # Triggers on pushes to master that modify files in docs/wiki/.
-# Converts filenames from kebab-case to Title-Case (GitHub wiki convention),
-# fixes internal markdown links, and pushes to the wiki repository.
+# The sync logic lives in .github/scripts/sync-wiki.sh so it can be tested;
+# this workflow runs those tests first, then the sync.
 #
 # Requires: wiki must be initialized (at least one page created manually).
 
@@ -13,14 +13,33 @@ on:
     branches: [master]
     paths:
       - "docs/wiki/**"
+      - ".github/scripts/sync-wiki*.sh"
+      - ".github/workflows/wiki.yml"
+  pull_request:
+    paths:
+      - "docs/wiki/**"
+      - ".github/scripts/sync-wiki*.sh"
+      - ".github/workflows/wiki.yml"
 
 permissions:
   contents: write
 
 jobs:
+  test:
+    name: Test sync script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Run sync-wiki tests
+        run: .github/scripts/sync-wiki.test.sh
+
   sync:
     name: Publish to Wiki
     runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
@@ -33,85 +52,7 @@ jobs:
           token: ${{ secrets.WIKI_TOKEN }}
 
       - name: Sync wiki pages
-        run: |
-          # Map of source filenames to wiki page names
-          declare -A PAGE_MAP=(
-            ["getting-started.md"]="Getting-Started.md"
-            ["agent-format.md"]="Agent-Format.md"
-            ["providers.md"]="Providers.md"
-            ["templates.md"]="Templates.md"
-            ["starter-packs.md"]="Starter-Packs.md"
-            ["registry.md"]="Registry.md"
-            ["link.md"]="Link.md"
-            ["orchestration.md"]="Orchestration.md"
-            ["skills-prompts.md"]="Skills-Prompts.md"
-          )
-
-          # Link replacements: source .md references → wiki page names
-          declare -A LINK_MAP=(
-            ["getting-started.md"]="Getting-Started"
-            ["agent-format.md"]="Agent-Format"
-            ["providers.md"]="Providers"
-            ["templates.md"]="Templates"
-            ["starter-packs.md"]="Starter-Packs"
-            ["registry.md"]="Registry"
-            ["link.md"]="Link"
-            ["orchestration.md"]="Orchestration"
-            ["skills-prompts.md"]="Skills-Prompts"
-          )
-
-          for src in docs/wiki/*.md; do
-            filename=$(basename "$src")
-            # Use mapped name or convert kebab-case to Title-Case
-            if [[ -n "${PAGE_MAP[$filename]}" ]]; then
-              dest="wiki/${PAGE_MAP[$filename]}"
-            else
-              # Auto-convert: kebab-case.md → Kebab-Case.md
-              dest="wiki/$(echo "$filename" | sed -E 's/(^|-)([a-z])/\1\u\2/g')"
-            fi
-
-            cp "$src" "$dest"
-
-            # Fix internal links
-            for key in "${!LINK_MAP[@]}"; do
-              sed -i "s|($key)|( ${LINK_MAP[$key]})|g" "$dest"
-              # Also handle links with relative paths
-              sed -i "s|(\./$key)|( ${LINK_MAP[$key]})|g" "$dest"
-            done
-          done
-
-          # Generate Home.md with table of contents
-          cat > wiki/Home.md << 'HOMEEOF'
-          # ArmadAI Wiki
-
-          AI agent fleet orchestrator — define, manage and run specialized agents from Markdown files.
-
-          ## Pages
-
-          HOMEEOF
-
-          # Strip leading whitespace from heredoc
-          sed -i 's/^          //' wiki/Home.md
-
-          # Add links for each wiki page (excluding Home itself)
-          for f in wiki/*.md; do
-            page=$(basename "$f" .md)
-            [[ "$page" == "Home" ]] && continue
-            # Convert Title-Case to display name with spaces
-            display=$(echo "$page" | sed 's/-/ /g')
-            echo "- [$display]($page)" >> wiki/Home.md
-          done
-
-          cat >> wiki/Home.md << 'FOOTEREOF'
-
-          ## Quick Links
-
-          - [GitHub Repository](https://github.com/Dr0drigues/armadai)
-          - [Releases](https://github.com/Dr0drigues/armadai/releases)
-          - [Issues](https://github.com/Dr0drigues/armadai/issues)
-          FOOTEREOF
-
-          sed -i 's/^          //' wiki/Home.md
+        run: .github/scripts/sync-wiki.sh docs/wiki wiki
 
       - name: Push to wiki
         run: |


### PR DESCRIPTION
Rattaché à **#260** (closeout — ce n'est qu'un de ses points, l'issue reste ouverte).

## Ce qui était cassé, mesuré

La synchro Wiki entretenait **deux tables à la main**, et c'est le partage du travail entre elles qui a créé le défaut :

- `PAGE_MAP` mappait 9 noms kebab-case vers leurs noms Wiki Title-Case. Vérifié avec GNU sed (celui du runner) : ses 9 entrées reproduisent **exactement** ce que la conversion de repli produisait déjà. Elle ne faisait rien — sauf donner l'air d'être exhaustive.
- `LINK_MAP` portait la réécriture des liens internes, et c'est celle qui comptait. Elle a **gelé aux mêmes 9 pages**, donc toute page ajoutée depuis arrivait sur le Wiki avec ses liens entrants pointant encore sur `page.md` — que le Wiki ne sert pas.

Sur les docs actuelles, **7 liens réels** partaient cassés : 1 vers `declarative-agents`, 2 vers `migration-v0-to-v1`, 4 vers `orchestration-guide`.

`SUMMARY.md` était de plus publié tel quel. C'est le sommaire mdBook, qui pilote la sidebar du livre, et il n'a aucun sens sur un Wiki qui génère son propre `Home`.

## Le correctif

Les noms de pages **et** les réécritures de liens sont désormais dérivés des fichiers réellement présents — ajouter une page ne peut plus en sauter un. La logique sort du YAML vers `.github/scripts/sync-wiki.sh`, ce qui la rend testable, et les tests tournent dans le workflow, y compris **sur les pull requests**, où la synchro elle-même ne tourne pas.

Le retrait de la page exclue a demandé de la prudence : arrêter la copie ne dé-publie pas ce qu'un run antérieur a déjà poussé, mais supprimer tout ce qui n'a plus de source détruirait les pages écrites à la main — **exactement la sur-suppression que le manifeste de link existe pour empêcher**. Le retrait est donc étroit, et un test épingle les deux moitiés.

## Vérification par mutation

Chaque test a été validé en cassant délibérément ce qu'il protège :

| Mutation | Résultat |
|---|---|
| regeler la liste de réécriture aux 9 anciennes | **4 checks rouges** |
| ne plus retirer `SUMMARY.md` | **1 check rouge** |
| supprimer toute page sans source | **3 checks rouges**, dont « a hand-written wiki page is left alone — the sync deleted it » |

La mutation a aussi révélé un **octet corrompu dans le message d'échec d'une assertion**, sur une ligne atteinte seulement quand une page manque — donc jamais exécutée en chemin nominal, et invisible autrement.

Deux assertions sont annoncées comme non probantes aujourd'hui (`audit`, `policy-gate` : rien ne pointe encore vers elles) plutôt que laissées passer pour des preuves. Elles deviendront réelles dès qu'un lien apparaîtra.

Script portable et vérifié sur **bash 3.2** (macOS) comme sur **bash 5.3** : la conversion kebab→Title n'utilise pas le `\u` propre à GNU sed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)