### PR TITLE
fix(cli): resolve --pipe and the shell's pipeline by name, not by file path

### DIFF
--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -845,6 +845,22 @@ enum AgentResolution {
     Project {
         root: PathBuf,
         config: Box<ProjectConfig>,
+        /// The project's prompt fragments, scanned at most once per
+        /// invocation however many agents a run loads.
+        ///
+        /// They are invariant for the whole run — three directories' worth
+        /// of `.md` files, parsed — while every loop that loads agents by
+        /// name (`--pipe`'s chain, `--orchestrate`'s roster,
+        /// `--resume`'s roster reload) needs them once per agent. Computing
+        /// them inside [`load_agent_for_run`] instead re-read and re-parsed
+        /// the same files per link, and re-printed `load_all_prompts`'s
+        /// `warn: failed to load prompt …` once per link — N lines identical
+        /// byte for byte, naming no agent, saying nothing the first did not
+        /// (#364 review, m1; the same defect `eecbd0f` fixed for `unlink`).
+        ///
+        /// Lazy rather than eager so a path that resolves a project without
+        /// loading any agent by name pays nothing.
+        fragments: std::sync::OnceLock<Vec<armadai_core::prompt::Prompt>>,
     },
     /// No project config found — use default paths
     Default(PathBuf),
@@ -877,13 +893,20 @@ fn project_display_string(resolution: &AgentResolution) -> Option<String> {
 /// Called from the single-agent path (`chain.len() == 1`, the common
 /// `armadai run <name>` invocation), the `--pipe` chain loop, the
 /// `--orchestrate` roster loader (`run_orchestrated`), and `--resume`'s
-/// roster reload (`resume_run`).
+/// roster reload (`resume_run`) — the last three in a loop, which is why the
+/// loop-invariant half of the work (the prompt fragments) is memoised on
+/// `AgentResolution` rather than recomputed here per call.
 fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow::Result<Agent> {
     match resolution {
-        AgentResolution::Project { root, config } => {
-            let fragments = armadai_core::agent_source::project_fragments(root);
+        AgentResolution::Project {
+            root,
+            config,
+            fragments,
+        } => {
+            let fragments =
+                fragments.get_or_init(|| armadai_core::agent_source::project_fragments(root));
             let (agent, warning) = armadai_core::agent_source::load_agent_by_name(
-                agent_name, config, root, &fragments,
+                agent_name, config, root, fragments,
             )?;
             // Core returns the warning rather than printing it (see
             // `load_agent_by_name`'s own doc) precisely so it renders here,
@@ -1494,6 +1517,7 @@ fn resolve_agents_dir(headless: bool) -> AgentResolution {
         return AgentResolution::Project {
             root,
             config: Box::new(config),
+            fragments: std::sync::OnceLock::new(),
         };
     }
 
@@ -2668,7 +2692,7 @@ mod tests {
         // resolve_agents_dir should not panic regardless of cwd state
         let resolution = resolve_agents_dir(false);
         match resolution {
-            AgentResolution::Project { root, config } => {
+            AgentResolution::Project { root, config, .. } => {
                 assert!(!root.to_string_lossy().is_empty());
                 assert!(!config.agents.is_empty());
             }
@@ -4220,6 +4244,7 @@ mod es_switch_tests {
         let resolution = AgentResolution::Project {
             root: PathBuf::from("/tmp/project"),
             config: Box::new(config),
+            fragments: std::sync::OnceLock::new(),
         };
 
         run_orchestrated_inner(
@@ -4265,6 +4290,7 @@ mod es_switch_tests {
         let resolution = AgentResolution::Project {
             root: std::path::PathBuf::from("/tmp/project"),
             config: Box::new(config),
+            fragments: std::sync::OnceLock::new(),
         };
         assert_eq!(orchestration_cost_limit(&resolution), Some(2.5));
     }

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -9,7 +9,7 @@ use armadai_core::orchestration::es::bridge::{SinkProjectingLog, to_orchestratio
 use armadai_core::orchestration::es::event::ExecutionEvent;
 use armadai_core::orchestration::es::log::{EventLog, InMemoryLog};
 use armadai_core::orchestration::es::state::ExecutionState;
-use armadai_core::project::{self, AgentRef, ProjectConfig, ProjectDefaults};
+use armadai_core::project::{self, ProjectConfig, ProjectDefaults};
 use armadai_core::provider::{ChatMessage, CompletionRequest};
 #[cfg(test)]
 use armadai_providers::factory::DEFAULT_TIMEOUT_SECS;
@@ -804,9 +804,9 @@ async fn run_inner(
             anstream::eprintln!("{h}--- [{}/{} {}] ---{h:#}", i + 1, chain.len(), name);
         }
 
-        let agent_path = resolve_agent_path(&resolution, name)?;
+        let agent = load_agent_for_run(&resolution, name)?;
         let (output, metrics) = run_single_agent(
-            &agent_path,
+            agent,
             name,
             &current_input,
             project_defaults,
@@ -863,54 +863,21 @@ fn project_display_string(resolution: &AgentResolution) -> Option<String> {
     }
 }
 
-/// Resolve a single agent name to a file path using the resolution context.
-fn resolve_agent_path(resolution: &AgentResolution, agent_name: &str) -> anyhow::Result<PathBuf> {
-    match resolution {
-        AgentResolution::Project { root, config } => {
-            // If the agent is declared in the project config, resolve it
-            if let Some(agent_ref) = config.agents.iter().find(|r| match r {
-                AgentRef::Named { name } => name == agent_name,
-                AgentRef::Path { path } => path.file_stem().is_some_and(|s| s == agent_name),
-                AgentRef::Registry { registry } => registry.ends_with(agent_name),
-                // Matched by name so a later step can report the ref by
-                // name; `resolve_agent` below refuses it because it has no
-                // file to return a path for.
-                AgentRef::Declared { declared } => declared == agent_name,
-            }) {
-                return project::resolve_agent(agent_ref, root);
-            }
-
-            // Not declared in config — try resolving as Named anyway
-            let fallback_ref = AgentRef::Named {
-                name: agent_name.to_string(),
-            };
-            project::resolve_agent(&fallback_ref, root)
-        }
-        AgentResolution::Default(agents_dir) => Agent::find_file(agents_dir, agent_name)
-            .ok_or_else(|| {
-                anyhow::anyhow!("Agent '{agent_name}' not found in {}", agents_dir.display())
-            }),
-    }
-}
-
-/// Load the primary agent for a run, whether it is written as a file or
-/// declared in `.armadai/agents.yaml` — the by-name counterpart to
-/// [`resolve_agent_path`], used where the loaded [`Agent`] itself is needed
-/// rather than a file path to hand to a lower-level step.
+/// Load an agent for a run by name, whether it is written as a file or
+/// declared in `.armadai/agents.yaml`.
+///
+/// The ONLY agent-resolution entry point on the run path, and deliberately
+/// so. It used to have a path-returning sibling (`resolve_agent_path`),
+/// which no declared agent can ever satisfy — a declared agent has no file
+/// — and every surface that kept calling it silently served a smaller
+/// fleet than the project declares (#339). That primitive is gone rather
+/// than merely bypassed: leaving it in place would have left the same trap
+/// armed for the next call site.
 ///
 /// Called from the single-agent path (`chain.len() == 1`, the common
-/// `armadai run <name>` invocation), the `--orchestrate` roster loader
-/// (`run_orchestrated`), and `--resume`'s roster reload (`resume_run`) —
-/// each of those three already parsed the path into an `Agent` immediately
-/// after resolving it, so swapping in the by-name load was a same-shape
-/// change at each site (task 7b review, Finding 7).
-///
-/// `--pipe`'s legacy chain loop (`run_inner`'s multi-agent branch, which
-/// still calls [`resolve_agent_path`] directly into the older
-/// `run_single_agent`) is NOT wired here: `run_single_agent` loads by path
-/// internally rather than accepting an already-loaded `Agent`, so extending
-/// it needs the same signature change `run_single_agent_es` already got —
-/// real, separate follow-up work, reported rather than done here.
+/// `armadai run <name>` invocation), the `--pipe` chain loop, the
+/// `--orchestrate` roster loader (`run_orchestrated`), and `--resume`'s
+/// roster reload (`resume_run`).
 fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow::Result<Agent> {
     match resolution {
         AgentResolution::Project { root, config } => {
@@ -938,11 +905,16 @@ fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow:
 }
 
 /// Execute a single agent with given input and configuration. Parameters represent
-/// environment (path, input), configuration (defaults, rules), and I/O (sink, quiet, max_content);
+/// environment (agent, input), configuration (defaults, rules), and I/O (sink, quiet, max_content);
 /// grouping would obscure distinct concerns in request building and provider creation.
+///
+/// Takes an already-loaded `agent` rather than a path — the same shape
+/// `run_single_agent_es` has. Loading is the caller's job (via
+/// [`load_agent_for_run`]) precisely because an agent declared in
+/// `.armadai/agents.yaml` has no file to hand down here (#339).
 #[allow(clippy::too_many_arguments)]
 async fn run_single_agent(
-    agent_path: &Path,
+    mut agent: Agent,
     agent_name: &str,
     input: &str,
     project_defaults: Option<&ProjectDefaults>,
@@ -957,8 +929,6 @@ async fn run_single_agent(
     // call site) regardless of which features are enabled.
     #[cfg(not(feature = "storage"))]
     let _ = project;
-    // 1. Load agent
-    let mut agent = armadai_core::parser::parse_agent_file(agent_path)?;
 
     // 1b. Resolve deprecated model aliases
     let model_before = agent.metadata.model.clone();
@@ -1323,9 +1293,9 @@ async fn dispatch_direct_es(
 /// (via [`QuietMaxContentSink`] in [`dispatch_direct_es`]), matching
 /// `run_single_agent`'s step 6.
 ///
-/// Takes an already-loaded `agent` rather than a path (unlike
-/// `run_single_agent`, which still loads from a path): the caller resolves
-/// it via [`load_agent_for_run`], which — unlike a bare path — also covers an
+/// Takes an already-loaded `agent` rather than a path, as
+/// `run_single_agent` now does too: the caller resolves it via
+/// [`load_agent_for_run`], which — unlike a bare path — also covers an
 /// agent declared in `.armadai/agents.yaml`.
 #[allow(clippy::too_many_arguments)]
 async fn run_single_agent_es(
@@ -4650,8 +4620,8 @@ mod es_switch_tests {
 
     // ── OH1 Lot 6 whole-branch review, I2: `--resume` RunStart bookend ──
     //
-    // `resume_run` (the CLI wrapper) reloads its roster from real agent
-    // files on disk via `resolve_agents_dir`/`resolve_agent_path` — driving
+    // `resume_run` (the CLI wrapper) reloads its roster from the project it
+    // resolves via `resolve_agents_dir`/`load_agent_for_run` — driving
     // it directly in a hermetic unit test would mean mutating the process
     // CWD/project resolution, racing every other test in this file that
     // also touches `crate::db::init_db()`/project resolution (same

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -3,6 +3,7 @@
 #![cfg(feature = "tui")]
 
 use anyhow::Result;
+use armadai_core::agent::Agent;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind},
     execute,
@@ -1097,78 +1098,76 @@ async fn execute_tandem(
     Ok(())
 }
 
-/// Outcome of looking an agent name up against the project config.
+/// Outcome of looking an agent name up against the project.
 ///
-/// Plain `Option<PathBuf>` used to stand in for this, but that collapses two
-/// different truths into one `None`: "no such agent" and "that agent exists,
-/// declared in `agents.yaml`, but has no file to run from the shell relay".
-/// Only the first one means "not found in project config" — saying that for
-/// the second sends the user hunting through `armadai.yaml` for something
-/// that is, in fact, correctly declared.
-#[derive(Debug, PartialEq)]
+/// One loaded-or-not distinction, because that is the only one the shell
+/// still has to make: an agent declared in `.armadai/agents.yaml` now runs
+/// here exactly like one written as a `.md` file. The enum used to carry a
+/// third `Declared` state whose whole job was to say "correctly declared,
+/// but this surface cannot run it" — replacing that message with the actual
+/// capability is what removed the state (#339).
 enum AgentLookup {
-    /// Resolved to a file, exactly as the three pre-existing `AgentRef`
-    /// variants (`Named`, `Path`, `Registry`) always have.
-    Path(std::path::PathBuf),
-    /// Declared in `.armadai/agents.yaml`, not file-backed. The shell relay
-    /// only runs file-backed agents today — wiring it to
-    /// `agent_source::load_agent_by_name` for declared agents is a later
-    /// task's job.
-    Declared,
-    /// No ref in the project config matches this name at all.
-    NotFound,
+    /// Loaded from the project, whether written as a file or declared.
+    Loaded {
+        agent: Box<Agent>,
+        /// A non-fatal problem core reported while loading (e.g. an
+        /// unparsable `.armadai/agents.yaml` that was ignored in favour of
+        /// a same-named file-backed agent). Surfaced in the transcript
+        /// rather than dropped, so the user knows which fleet answered.
+        warning: Option<String>,
+    },
+    /// The agent could not be loaded — carrying core's own reason, which
+    /// names every place it looked (the declarations file included).
+    Failed(String),
 }
 
-/// Message shown when a step's `--agent` name resolves to a declared
-/// (non-file) agent. Kept as its own function so both the shell and its
-/// tests say the exact same thing.
-fn declared_agent_not_runnable_message(agent_name: &str) -> String {
-    format!(
-        "Agent '{agent_name}' is declared in .armadai/agents.yaml but has no \
-         file — declarative agents can't be run from the shell yet"
-    )
-}
-
-/// Look `name` up against a project config already resolved to `root`. Pure
-/// with respect to the filesystem beyond what `resolve_agent` itself touches
-/// — split out from `resolve_project_agent` so it can be tested without
+/// Look `name` up against a project config already resolved to `root`, via
+/// the same `agent_source::load_agent_by_name` `run`/`inspect`/`link` use —
+/// so a name this surface accepts is exactly a name those accept, and the
+/// four `AgentRef` variants are matched in ONE place rather than re-matched
+/// here.
+///
+/// Split out from `resolve_project_agent` so it can be tested without
 /// depending on (and mutating) the process's current directory.
 fn lookup_agent_in_config(
     config: &armadai_core::project::ProjectConfig,
     root: &std::path::Path,
     name: &str,
 ) -> AgentLookup {
-    for agent_ref in &config.agents {
-        let agent_name = match agent_ref {
-            armadai_core::project::AgentRef::Named { name: n } => n.clone(),
-            armadai_core::project::AgentRef::Path { path } => path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
-            armadai_core::project::AgentRef::Declared { declared } => declared.clone(),
-            _ => continue,
-        };
-        if agent_name != name {
-            continue;
-        }
-        if matches!(agent_ref, armadai_core::project::AgentRef::Declared { .. }) {
-            return AgentLookup::Declared;
-        }
-        return match armadai_core::project::resolve_agent(agent_ref, root) {
-            Ok(path) => AgentLookup::Path(path),
-            Err(_) => AgentLookup::NotFound,
-        };
+    let fragments = armadai_core::agent_source::project_fragments(root);
+    match armadai_core::agent_source::load_agent_by_name(name, config, root, &fragments) {
+        Ok((agent, warning)) => AgentLookup::Loaded {
+            agent: Box::new(agent),
+            warning: warning.map(|w| format!("warn: {}", w.message())),
+        },
+        Err(e) => AgentLookup::Failed(format!("Cannot load agent '{name}': {e}")),
     }
-    AgentLookup::NotFound
 }
 
-/// Resolve an agent file path by name from the current project config.
+/// Load an agent by name from the current project config.
 fn resolve_project_agent(name: &str) -> AgentLookup {
     let Some((root, config)) = armadai_core::project::find_project_config() else {
-        return AgentLookup::NotFound;
+        return AgentLookup::Failed(format!(
+            "Cannot load agent '{name}': no armadai.yaml found from the current directory"
+        ));
     };
     lookup_agent_in_config(&config, &root, name)
+}
+
+/// The command, args, system prompt and display label one pipeline step runs
+/// a loaded agent with.
+///
+/// Pure, and deliberately taking an `Agent` rather than anything file-shaped:
+/// this is the point past which a declared agent and a file-backed one are
+/// provably the same thing to the relay.
+fn step_from_agent(
+    agent_name: &str,
+    agent: &Agent,
+) -> (String, Vec<String>, Option<String>, String) {
+    let cmd = agent.metadata.provider.clone();
+    let args = super::detect::args_for_provider(&cmd);
+    let label = format!("{agent_name} [{cmd}]");
+    (cmd, args, Some(agent.system_prompt.clone()), label)
 }
 
 /// Resolved step data: command, args, combined prompt, display label.
@@ -1217,30 +1216,17 @@ async fn execute_pipeline_steps(
         // Resolve entry to cmd + args + optional agent system prompt
         let (cmd, args, agent_system_prompt, display_label) = if let Some(agent_name) = &entry.agent
         {
-            // Agent mode: load the agent from project config
+            // Agent mode: load the agent from the project, whether it is
+            // written as a `.md` file or declared in `.armadai/agents.yaml`.
             match resolve_project_agent(agent_name) {
-                AgentLookup::Path(path) => match armadai_core::parser::parse_agent_file(&path) {
-                    Ok(agent) => {
-                        let cmd = agent.metadata.provider.clone();
-                        let args = super::detect::args_for_provider(&cmd);
-                        let label = format!("{} [{}]", agent_name, cmd);
-                        (cmd, args, Some(agent.system_prompt.clone()), label)
+                AgentLookup::Loaded { agent, warning } => {
+                    if let Some(w) = warning {
+                        app.add_system_message(&w);
                     }
-                    Err(e) => {
-                        app.add_system_message(&format!(
-                            "Failed to parse agent '{agent_name}': {e}"
-                        ));
-                        continue;
-                    }
-                },
-                AgentLookup::Declared => {
-                    app.add_system_message(&declared_agent_not_runnable_message(agent_name));
-                    continue;
+                    step_from_agent(agent_name, &agent)
                 }
-                AgentLookup::NotFound => {
-                    app.add_system_message(&format!(
-                        "Agent '{agent_name}' not found in project config"
-                    ));
+                AgentLookup::Failed(reason) => {
+                    app.add_system_message(&reason);
                     continue;
                 }
             }
@@ -1723,53 +1709,169 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // AgentLookup: distinguishing "no such agent" from "declared, not
-    // file-backed" so the shell's message stays true. `lookup_agent_in_config`
-    // takes the project config directly, so these don't touch the process's
-    // current directory the way `resolve_project_agent` itself does.
+    // AgentLookup: an in-session pipeline step's `agent:` must load a
+    // declared agent as readily as a file-backed one (#339).
+    // `lookup_agent_in_config` takes the project config and root directly,
+    // so these don't touch the process's current directory the way
+    // `resolve_project_agent` itself does.
+    //
+    // Fixture names are deliberately implausible (`shell-pipeline-fixture-*`)
+    // rather than realistic ones: `load_agent_by_name` resolves file-backed
+    // names against the user's real global library too, so a realistic name
+    // like `core-specialist` would collide with what a developer's
+    // `~/.config/armadai/agents/` actually holds on a machine that has ever
+    // run `armadai extract` from this repo (the same trap
+    // `tests/link_list_gate.rs` documents), and the test's verdict would
+    // depend on the machine.
     // -----------------------------------------------------------------
 
-    #[test]
-    fn a_declared_ref_is_looked_up_as_declared_not_as_a_missing_file() {
-        let config = armadai_core::project::ProjectConfig {
-            agents: vec![armadai_core::project::AgentRef::Declared {
-                declared: "core-specialist".to_string(),
-            }],
-            ..Default::default()
-        };
-        let root = std::path::Path::new("/does/not/matter");
-
-        assert_eq!(
-            lookup_agent_in_config(&config, root, "core-specialist"),
-            AgentLookup::Declared
-        );
+    /// A project root whose only agents are declared: no `.md` anywhere,
+    /// and an `armadai.yaml` with no `agents:` list at all.
+    fn declarations_only_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai/prompts")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/prompts/shell-fixture-base.md"),
+            "You are {{name}}, reporting for pipeline duty.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "defaults:\n  provider: gemini\nagents:\n  \
+             - name: shell-pipeline-fixture-alpha\n    prompt: [shell-fixture-base]\n",
+        )
+        .unwrap();
+        dir
     }
 
     #[test]
-    fn a_name_absent_from_the_config_is_not_found() {
-        let config = armadai_core::project::ProjectConfig {
-            agents: vec![armadai_core::project::AgentRef::Declared {
-                declared: "core-specialist".to_string(),
-            }],
-            ..Default::default()
-        };
-        let root = std::path::Path::new("/does/not/matter");
+    fn a_declared_agent_loads_for_an_in_session_pipeline_step() {
+        let dir = declarations_only_project();
+        let config = armadai_core::project::ProjectConfig::default();
 
-        assert_eq!(
-            lookup_agent_in_config(&config, root, "ghost"),
-            AgentLookup::NotFound
-        );
+        match lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-alpha") {
+            AgentLookup::Loaded { agent, warning } => {
+                assert_eq!(warning, None, "a clean declaration warns about nothing");
+                // The composed prompt, not a placeholder: proves the
+                // declaration's fragment was rendered with its own name.
+                assert_eq!(
+                    agent.system_prompt.trim(),
+                    "You are shell-pipeline-fixture-alpha, reporting for pipeline duty."
+                );
+                assert_eq!(agent.metadata.provider, "gemini");
+            }
+            AgentLookup::Failed(reason) => panic!("declared agent must load, got: {reason}"),
+        }
     }
 
     #[test]
-    fn the_declared_agent_message_is_true_and_names_the_agent() {
-        // Pins the exact wording so a future edit can't silently regress it
-        // back to the false "not found in project config" message this
-        // fix replaced.
+    fn a_declared_agent_yields_the_same_step_data_as_its_file_backed_twin() {
+        // The relay only ever sees `step_from_agent`'s output, so this is
+        // where "declared agents are runnable here" is actually cashed in.
+        // Asserted against the file-backed twin's own step data — not
+        // against `args_for_provider` re-called, which would just restate
+        // the implementation — plus the literal gemini JSON-mode argv, so
+        // the two sides cannot agree on something wrong.
+        let dir = declarations_only_project();
+        std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+        std::fs::write(
+            dir.path().join("agents/shell-pipeline-fixture-twin.md"),
+            "# shell-pipeline-fixture-twin\n\n\
+             ## Metadata\n- provider: gemini\n\n\
+             ## System Prompt\nYou are the twin, reporting for pipeline duty.\n",
+        )
+        .unwrap();
+        let config = armadai_core::project::ProjectConfig::default();
+
+        let AgentLookup::Loaded {
+            agent: declared, ..
+        } = lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-alpha")
+        else {
+            panic!("declared agent must load");
+        };
+        let AgentLookup::Loaded { agent: twin, .. } =
+            lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-twin")
+        else {
+            panic!("file-backed twin must load");
+        };
+
+        let (cmd, args, prompt, label) = step_from_agent("shell-pipeline-fixture-alpha", &declared);
+        let (twin_cmd, twin_args, twin_prompt, twin_label) =
+            step_from_agent("shell-pipeline-fixture-twin", &twin);
+
+        // Same command and argv as the file-backed twin, from the same
+        // `provider:` value — the declared agent is relayed identically.
+        assert_eq!(cmd, twin_cmd);
+        assert_eq!(args, twin_args);
+        assert_eq!(cmd, "gemini");
+        assert_eq!(args, ["-o", "stream-json", "-p"]);
+
+        // And each carries its OWN composed prompt, not the other's: the
+        // shared shape must not come from the two collapsing into one.
         assert_eq!(
-            declared_agent_not_runnable_message("core-specialist"),
-            "Agent 'core-specialist' is declared in .armadai/agents.yaml but has no \
-             file — declarative agents can't be run from the shell yet"
+            prompt.as_deref().map(str::trim),
+            Some("You are shell-pipeline-fixture-alpha, reporting for pipeline duty.")
         );
+        assert_eq!(
+            twin_prompt.as_deref().map(str::trim),
+            Some("You are the twin, reporting for pipeline duty.")
+        );
+        assert_eq!(label, "shell-pipeline-fixture-alpha [gemini]");
+        assert_eq!(twin_label, "shell-pipeline-fixture-twin [gemini]");
+    }
+
+    #[test]
+    fn a_file_backed_agent_still_loads_for_an_in_session_pipeline_step() {
+        // Regression guard for the path this change rewrote: swapping the
+        // lookup onto `load_agent_by_name` must not cost the file-backed
+        // case that always worked.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+        std::fs::write(
+            dir.path().join("agents/shell-pipeline-fixture-beta.md"),
+            "# shell-pipeline-fixture-beta\n\n\
+             ## Metadata\n- provider: gemini\n\n\
+             ## System Prompt\nWritten as a file, not declared.\n",
+        )
+        .unwrap();
+        let config = armadai_core::project::ProjectConfig {
+            agents: vec![armadai_core::project::AgentRef::Named {
+                name: "shell-pipeline-fixture-beta".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        match lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-beta") {
+            AgentLookup::Loaded { agent, .. } => {
+                assert_eq!(
+                    agent.system_prompt.trim(),
+                    "Written as a file, not declared."
+                );
+            }
+            AgentLookup::Failed(reason) => panic!("file-backed agent must load, got: {reason}"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_name_fails_naming_the_declarations_file_it_looked_in() {
+        // The message must not send the user hunting through `armadai.yaml`
+        // alone: the declarations file is a real place the name could have
+        // been, so it belongs in the reason.
+        let dir = declarations_only_project();
+        let config = armadai_core::project::ProjectConfig::default();
+
+        match lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-absent") {
+            AgentLookup::Loaded { .. } => panic!("an absent name must not load"),
+            AgentLookup::Failed(reason) => {
+                assert!(
+                    reason.contains("shell-pipeline-fixture-absent"),
+                    "the reason must name the agent, got: {reason}"
+                );
+                assert!(
+                    reason.contains("agents.yaml"),
+                    "the reason must name the declarations file it also looked in, got: {reason}"
+                );
+            }
+        }
     }
 }

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1144,9 +1144,23 @@ fn lookup_agent_in_config(
     }
 }
 
-/// Load an agent by name from the current project config.
+/// Load an agent by name from the project the process's current directory
+/// sits in.
 fn resolve_project_agent(name: &str) -> AgentLookup {
-    let Some((root, config)) = armadai_core::project::find_project_config() else {
+    let Ok(cwd) = std::env::current_dir() else {
+        return AgentLookup::Failed(format!(
+            "Cannot load agent '{name}': the current directory is unreadable"
+        ));
+    };
+    resolve_project_agent_from(&cwd, name)
+}
+
+/// [`resolve_project_agent`] with an explicit start directory, so the
+/// no-project branch below is reachable from a test without mutating the
+/// process's cwd — `project::find_project_config_from` is the same seam six
+/// `shell::wizard` tests already use.
+fn resolve_project_agent_from(start: &std::path::Path, name: &str) -> AgentLookup {
+    let Some((root, config)) = armadai_core::project::find_project_config_from(start) else {
         return AgentLookup::Failed(format!(
             "Cannot load agent '{name}': no armadai.yaml found from the current directory"
         ));
@@ -1154,20 +1168,91 @@ fn resolve_project_agent(name: &str) -> AgentLookup {
     lookup_agent_in_config(&config, &root, name)
 }
 
-/// The command, args, system prompt and display label one pipeline step runs
-/// a loaded agent with.
+/// Providers `providers::factory` serves over HTTP instead of spawning
+/// anything: `create_api_provider` builds a client from an API key and never
+/// reads `command:`, so there is no executable for this session to relay.
+///
+/// Kept as the exhaustive complement of what CAN be relayed rather than as a
+/// list of relayable names: the relay spawns whatever `command:` names, so a
+/// project is free to point a step at a CLI neither `json_runner` nor
+/// `factory` has heard of, and an allow-list would silently refuse those.
+const API_ONLY_PROVIDERS: [&str; 4] = ["anthropic", "openai", "google", "proxy"];
+
+/// What this session can do with a loaded agent — data, not a spawn attempt.
+///
+/// The distinction exists so a step the relay cannot run costs *that step*
+/// and nothing more. Discovering it at spawn time instead means an
+/// `io::ErrorKind::NotFound` the caller can only report as `Failed to spawn`,
+/// and `execute_pipeline_steps` answers that by returning, killing every
+/// remaining link of the chain (#364 review, I2).
+enum StepPlan {
+    /// Spawn `cmd` with `args`, feeding it `system_prompt` plus the step's
+    /// own input on argv.
+    Relay {
+        cmd: String,
+        args: Vec<String>,
+        system_prompt: String,
+        label: String,
+    },
+    /// Nothing to spawn: the reason to show before skipping this one step.
+    NotRelayable(String),
+}
+
+/// How one pipeline step runs a loaded agent — the command, its args, the
+/// system prompt and the display label — or why it cannot run here.
 ///
 /// Pure, and deliberately taking an `Agent` rather than anything file-shaped:
 /// this is the point past which a declared agent and a file-backed one are
 /// provably the same thing to the relay.
-fn step_from_agent(
-    agent_name: &str,
-    agent: &Agent,
-) -> (String, Vec<String>, Option<String>, String) {
-    let cmd = agent.metadata.provider.clone();
-    let args = super::detect::args_for_provider(&cmd);
+///
+/// Reads `command:`/`args:` the way `providers::factory` does, because those
+/// two fields are the whole of how an agent says *what to spawn*: reading
+/// only `provider:` (as this did until the #364 review) turns every
+/// `provider: cli` agent into an attempt to spawn a binary literally named
+/// `cli`.
+fn step_from_agent(agent_name: &str, agent: &Agent) -> StepPlan {
+    let provider = agent.metadata.provider.as_str();
+
+    if API_ONLY_PROVIDERS.contains(&provider) {
+        return StepPlan::NotRelayable(format!(
+            "Skipping '{agent_name}': provider '{provider}' is an HTTP API and this \
+             session relays a CLI, so there is no command to run it with here. Run \
+             it with `armadai run {agent_name}`, or give the agent a CLI provider."
+        ));
+    }
+
+    // `provider: cli` carries its executable in `command:` and nowhere else —
+    // the same field `factory::create_cli_provider` requires. Missing it is
+    // the agent's own error, reported here as a skip rather than as a failure
+    // to spawn a binary named `cli`.
+    let cmd = match (provider, agent.metadata.command.clone()) {
+        (_, Some(c)) => c,
+        ("cli", None) => {
+            return StepPlan::NotRelayable(format!(
+                "Skipping '{agent_name}': provider 'cli' needs a `command:` naming \
+                 the executable to run, and this agent sets none."
+            ));
+        }
+        (p, None) => p.to_string(),
+    };
+
+    // Explicit `args:` verbatim (as `factory::create_unified_provider` does),
+    // else the canonical JSON-mode argv for whatever `cmd` turned out to be —
+    // keyed on `cmd`, not on `provider`, because the stream parsing below is
+    // keyed on `cmd` too (`supports_json(&resolved.cmd)`), and the two
+    // disagreeing is how a step ends up parsed in the wrong mode.
+    let args = agent
+        .metadata
+        .args
+        .clone()
+        .unwrap_or_else(|| super::detect::args_for_provider(&cmd));
     let label = format!("{agent_name} [{cmd}]");
-    (cmd, args, Some(agent.system_prompt.clone()), label)
+    StepPlan::Relay {
+        cmd,
+        args,
+        system_prompt: agent.system_prompt.clone(),
+        label,
+    }
 }
 
 /// Resolved step data: command, args, combined prompt, display label.
@@ -1223,7 +1308,21 @@ async fn execute_pipeline_steps(
                     if let Some(w) = warning {
                         app.add_system_message(&w);
                     }
-                    step_from_agent(agent_name, &agent)
+                    match step_from_agent(agent_name, &agent) {
+                        StepPlan::Relay {
+                            cmd,
+                            args,
+                            system_prompt,
+                            label,
+                        } => (cmd, args, Some(system_prompt), label),
+                        // One step lost, chain intact: `current_input` still
+                        // holds the previous step's output, so the next link
+                        // reads what it would have read anyway.
+                        StepPlan::NotRelayable(reason) => {
+                            app.add_system_message(&reason);
+                            continue;
+                        }
+                    }
                 }
                 AgentLookup::Failed(reason) => {
                     app.add_system_message(&reason);
@@ -1795,9 +1894,24 @@ mod tests {
             panic!("file-backed twin must load");
         };
 
-        let (cmd, args, prompt, label) = step_from_agent("shell-pipeline-fixture-alpha", &declared);
-        let (twin_cmd, twin_args, twin_prompt, twin_label) =
-            step_from_agent("shell-pipeline-fixture-twin", &twin);
+        let StepPlan::Relay {
+            cmd,
+            args,
+            system_prompt: prompt,
+            label,
+        } = step_from_agent("shell-pipeline-fixture-alpha", &declared)
+        else {
+            panic!("a gemini-backed declared agent must be relayable");
+        };
+        let StepPlan::Relay {
+            cmd: twin_cmd,
+            args: twin_args,
+            system_prompt: twin_prompt,
+            label: twin_label,
+        } = step_from_agent("shell-pipeline-fixture-twin", &twin)
+        else {
+            panic!("a gemini-backed file agent must be relayable");
+        };
 
         // Same command and argv as the file-backed twin, from the same
         // `provider:` value — the declared agent is relayed identically.
@@ -1809,12 +1923,12 @@ mod tests {
         // And each carries its OWN composed prompt, not the other's: the
         // shared shape must not come from the two collapsing into one.
         assert_eq!(
-            prompt.as_deref().map(str::trim),
-            Some("You are shell-pipeline-fixture-alpha, reporting for pipeline duty.")
+            prompt.trim(),
+            "You are shell-pipeline-fixture-alpha, reporting for pipeline duty."
         );
         assert_eq!(
-            twin_prompt.as_deref().map(str::trim),
-            Some("You are the twin, reporting for pipeline duty.")
+            twin_prompt.trim(),
+            "You are the twin, reporting for pipeline duty."
         );
         assert_eq!(label, "shell-pipeline-fixture-alpha [gemini]");
         assert_eq!(twin_label, "shell-pipeline-fixture-twin [gemini]");
@@ -1849,6 +1963,223 @@ mod tests {
                 );
             }
             AgentLookup::Failed(reason) => panic!("file-backed agent must load, got: {reason}"),
+        }
+    }
+
+    /// Write `agents/<name>.md` under `root` with the given `## Metadata`
+    /// body, and load it the way an in-session pipeline step would.
+    fn load_file_agent(root: &std::path::Path, name: &str, metadata: &str) -> Agent {
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+        std::fs::write(
+            root.join("agents").join(format!("{name}.md")),
+            format!("# {name}\n\n## Metadata\n{metadata}\n\n## System Prompt\nRelay me.\n"),
+        )
+        .unwrap();
+        let config = armadai_core::project::ProjectConfig::default();
+        match lookup_agent_in_config(&config, root, name) {
+            AgentLookup::Loaded { agent, .. } => *agent,
+            AgentLookup::Failed(reason) => panic!("fixture must load, got: {reason}"),
+        }
+    }
+
+    #[test]
+    fn a_cli_backed_agent_relays_the_command_it_names_not_the_literal_word_cli() {
+        // `provider: cli` says "spawn what `command:` names" — the shape the
+        // `--pipe` tests in this very PR use, and the shape that used to make
+        // this step try to spawn a binary called `cli` (#364 review, I2).
+        // Asserted on `echo` specifically because it exists everywhere: the
+        // plan is not merely well-formed, it is spawnable.
+        let dir = tempfile::tempdir().unwrap();
+        let agent = load_file_agent(
+            dir.path(),
+            "shell-pipeline-fixture-cli",
+            "- provider: cli\n- command: echo",
+        );
+
+        match step_from_agent("shell-pipeline-fixture-cli", &agent) {
+            StepPlan::Relay { cmd, args, .. } => {
+                assert_eq!(
+                    cmd, "echo",
+                    "the step must spawn the `command:` the agent names"
+                );
+                assert_ne!(
+                    cmd, "cli",
+                    "'cli' is the provider kind, never an executable on anyone's PATH"
+                );
+                assert!(
+                    args.is_empty(),
+                    "`echo` has no JSON mode, so no JSON-mode argv, got: {args:?}"
+                );
+                let out = std::process::Command::new(&cmd)
+                    .args(&args)
+                    .arg("RELAYED")
+                    .output()
+                    .expect("the planned command must actually be spawnable");
+                assert!(String::from_utf8_lossy(&out.stdout).contains("RELAYED"));
+            }
+            StepPlan::NotRelayable(reason) => {
+                panic!("a `command: echo` agent is exactly what this session can relay: {reason}")
+            }
+        }
+    }
+
+    #[test]
+    fn an_explicit_args_list_reaches_the_relay_verbatim() {
+        // `args:` is the second half of how an agent says what to spawn, and
+        // `factory::create_unified_provider` honours it verbatim. A relay that
+        // read `command:` but substituted its own argv would run the user's
+        // binary with flags the user never asked for.
+        let dir = tempfile::tempdir().unwrap();
+        let agent = load_file_agent(
+            dir.path(),
+            "shell-pipeline-fixture-args",
+            "- provider: cli\n- command: echo\n- args: [\"-n\", \"PREFIXED\"]",
+        );
+
+        let StepPlan::Relay { cmd, args, .. } =
+            step_from_agent("shell-pipeline-fixture-args", &agent)
+        else {
+            panic!("an agent naming `echo` must be relayable");
+        };
+        assert_eq!(cmd, "echo");
+        assert_eq!(
+            args,
+            ["-n", "PREFIXED"],
+            "the agent's own `args:` must reach the relay unchanged"
+        );
+    }
+
+    #[test]
+    fn an_api_backed_agent_is_skipped_with_a_reason_rather_than_spawned() {
+        // `providers::factory` serves these over HTTP and never spawns
+        // anything, so there is no command to relay. Before the #364 review
+        // this step tried to spawn a binary named `anthropic`, and
+        // `execute_pipeline_steps` answered the resulting `NotFound` by
+        // returning — killing every remaining link of the chain. The reason
+        // has to be data so the caller can skip one step and carry on.
+        let dir = tempfile::tempdir().unwrap();
+        for provider in API_ONLY_PROVIDERS {
+            let name = format!("shell-pipeline-fixture-{provider}");
+            let agent = load_file_agent(
+                dir.path(),
+                &name,
+                &format!("- provider: {provider}\n- model: some-model"),
+            );
+
+            match step_from_agent(&name, &agent) {
+                StepPlan::Relay { cmd, .. } => panic!(
+                    "'{provider}' has no CLI to relay, yet the step planned to spawn {cmd:?}"
+                ),
+                StepPlan::NotRelayable(reason) => {
+                    assert!(
+                        reason.contains(&name),
+                        "the reason must name the step being skipped, got: {reason}"
+                    );
+                    assert!(
+                        reason.contains(provider),
+                        "the reason must name the provider that cannot run here, got: {reason}"
+                    );
+                    assert!(
+                        reason.contains("armadai run"),
+                        "the reason must say where the agent CAN run, got: {reason}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_cli_agent_without_a_command_is_skipped_naming_the_field_it_lacks() {
+        // `factory::create_cli_provider` refuses this agent for the same
+        // reason. Falling through to `provider.clone()` here would spawn a
+        // binary named `cli` — the very confusion I2 was about.
+        let dir = tempfile::tempdir().unwrap();
+        let agent = load_file_agent(
+            dir.path(),
+            "shell-pipeline-fixture-nocommand",
+            "- provider: cli",
+        );
+
+        match step_from_agent("shell-pipeline-fixture-nocommand", &agent) {
+            StepPlan::Relay { cmd, .. } => {
+                panic!("a `provider: cli` agent with no `command:` names nothing to spawn: {cmd:?}")
+            }
+            StepPlan::NotRelayable(reason) => assert!(
+                reason.contains("command:"),
+                "the reason must name the field the agent is missing, got: {reason}"
+            ),
+        }
+    }
+
+    #[test]
+    fn a_directory_in_no_project_fails_saying_no_armadai_yaml_was_found() {
+        // The one branch of `resolve_project_agent` that never reaches
+        // `lookup_agent_in_config`. A tempdir has no `armadai.yaml` anywhere
+        // above it, so the walk-up finds nothing — and the step must say so
+        // rather than blame the agent name.
+        let dir = tempfile::tempdir().unwrap();
+
+        match resolve_project_agent_from(dir.path(), "shell-pipeline-fixture-orphan") {
+            AgentLookup::Loaded { .. } => {
+                panic!("there is no project here, so nothing can be loaded")
+            }
+            AgentLookup::Failed(reason) => {
+                assert!(
+                    reason.contains("armadai.yaml"),
+                    "the reason must name the project file it could not find, got: {reason}"
+                );
+                assert!(
+                    reason.contains("shell-pipeline-fixture-orphan"),
+                    "the reason must still name the agent the step asked for, got: {reason}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn an_unreadable_declarations_file_surfaces_a_warning_with_the_file_backed_fallback() {
+        // The one capability this PR *adds* beyond running declared agents:
+        // core's non-fatal `LoadWarning` now reaches the transcript instead of
+        // being dropped. Without this test, `warning: None` unconditionally
+        // was a passing implementation (#364 review, I1).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/agents.yaml"),
+            "agents:\n  - name: [not-a-string\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+        std::fs::write(
+            dir.path().join("agents/shell-pipeline-fixture-fallback.md"),
+            "# shell-pipeline-fixture-fallback\n\n## Metadata\n- provider: gemini\n\n\
+             ## System Prompt\nServed from the file, declarations unreadable.\n",
+        )
+        .unwrap();
+        let config = armadai_core::project::ProjectConfig::default();
+
+        match lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-fallback") {
+            AgentLookup::Loaded { agent, warning } => {
+                assert_eq!(
+                    agent.system_prompt.trim(),
+                    "Served from the file, declarations unreadable."
+                );
+                let w = warning.expect(
+                    "an unreadable .armadai/agents.yaml must reach the transcript, \
+                     not be dropped on the floor",
+                );
+                assert!(
+                    w.contains("agents.yaml"),
+                    "must name the file it ignored, got: {w}"
+                );
+                assert!(
+                    w.contains("shell-pipeline-fixture-fallback"),
+                    "must name which fleet answered, got: {w}"
+                );
+            }
+            AgentLookup::Failed(reason) => {
+                panic!("the file-backed homonym must still be served, got: {reason}")
+            }
         }
     }
 

--- a/crates/armadai/tests/cases/declared-agents-orchestrated.yaml
+++ b/crates/armadai/tests/cases/declared-agents-orchestrated.yaml
@@ -21,8 +21,9 @@ setup:
 expect:
   exit_code: 0
   events:
-    # Proves task 7b review Finding 7's `run_orchestrated` roster-loader
-    # swap (`resolve_agent_path` -> `load_agent_for_run`): BOTH agents here
+    # Proves `run_orchestrated`'s roster loader goes through
+    # `load_agent_for_run` (the run path's only agent-resolution entry point
+    # since #364 deleted its path-returning sibling): BOTH agents here
     # are declared in `.armadai/agents.yaml`, not written as `.md` files —
     # a project with none at all. Matching `agent_start`/`board` on each
     # (rather than just `run_start`) also proves each declared agent's

--- a/crates/armadai/tests/pipe_declarative_agents.rs
+++ b/crates/armadai/tests/pipe_declarative_agents.rs
@@ -278,3 +278,103 @@ fn pipe_names_the_declarations_file_when_a_chained_agent_is_missing() {
          it also looked in — `list` and `inspect` already do, got: {combined}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #364 review, m2: a name that is both declared and written as a file is
+// refused on the `--pipe` path too.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pipe_refuses_a_name_that_is_both_declared_and_written_as_a_file() {
+    // `agent_source::load_agent_by_name` gives declarations and files NO
+    // precedence over each other: a colliding name is an error the user has
+    // to resolve, not a coin flip. `armadai run <name>` already refused it,
+    // but `--pipe` reached it through a path-shaped resolver that never
+    // consulted the declarations at all — so the same project refused a
+    // single-agent run and accepted the chain. Routing `--pipe` through the
+    // by-name loader closed that inconsistency; this pins it.
+    let (_dir, root) = project(&["alpha-decl"], &["alpha-decl", "beta-file"]);
+    let out = run_pipe(&root, "alpha-decl", "TASK-COLLIDING", &["beta-file"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        !out.status.success(),
+        "a chain whose head is both declared and written as a file must be refused, \
+         exactly as the single-agent path already refuses it.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        combined.contains("also written as"),
+        "the refusal must be the collision one — naming both places the name lives — \
+         not a generic 'not found', got: {combined}"
+    );
+    assert!(
+        combined.contains("remove one"),
+        "the refusal must say what to do about it, got: {combined}"
+    );
+    assert!(
+        agents_started(&stdout).is_empty(),
+        "the collision must be caught before the head agent burns a provider call, \
+         got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #364 review, m1: loop-invariant work is done once per run, not once per
+// link — measured through the one symptom a user can see.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_broken_prompt_fragment_is_reported_once_for_the_whole_chain() {
+    // `project_fragments` scans and parses three prompt directories, and
+    // `load_all_prompts` prints `warn: failed to load prompt <file>: <err>`
+    // for each one it cannot read. That line names no agent and carries no
+    // per-link information, so printing it once per link — three identical
+    // lines for a three-link chain — is noise, the same defect `eecbd0f`
+    // fixed for `unlink`. One line per broken fragment, however long the
+    // chain.
+    let (_dir, root) = project(&[], &["chain-1", "chain-2", "chain-3"]);
+    std::fs::write(
+        root.join(".armadai/prompts/pipe-broken.md"),
+        "---\nname: [unterminated\n---\nbody\n",
+    )
+    .unwrap();
+
+    let out = run_pipe(
+        &root,
+        "chain-1",
+        "TASK-ONE-WARNING",
+        &["chain-2", "chain-3"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "a broken fragment no agent references must not fail the chain.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        agents_started(&stdout).len(),
+        3,
+        "all three links must still run.\nstdout: {stdout}"
+    );
+
+    let warnings: Vec<&str> = stderr
+        .lines()
+        .filter(|l| l.contains("failed to load prompt"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "the broken fragment must be reported ONCE for the whole chain, not once per \
+         link — the lines are identical and name no agent, so N of them say nothing \
+         the first did not. Got {} line(s): {warnings:#?}",
+        warnings.len()
+    );
+    assert!(
+        warnings[0].contains("pipe-broken.md"),
+        "the one warning must still name the fragment it could not load, got: {warnings:#?}"
+    );
+}

--- a/crates/armadai/tests/pipe_declarative_agents.rs
+++ b/crates/armadai/tests/pipe_declarative_agents.rs
@@ -1,0 +1,280 @@
+//! Black-box regressions for `armadai run --pipe` over agents declared in
+//! `.armadai/agents.yaml` (#339).
+//!
+//! `--resume` and `--orchestrate` were wired onto `agent_source::
+//! load_agent_by_name` in #337, but the historical chaining loop still
+//! resolved a *path* per agent (`resolve_agent_path`), which a declared
+//! agent does not have — so any chain containing one died before its first
+//! provider call, with a message naming the three library directories and
+//! never the `agents.yaml` that declares the agent.
+//!
+//! Spawns the real binary (like `link_list_gate.rs`) because the defect is
+//! in the wiring of `cli::run`'s chain loop, not in any single function:
+//! a unit test on `load_agent_for_run` alone would stay green if the loop
+//! went back to resolving paths.
+//!
+//! Every agent here uses `provider: cli` with `command: echo`, so a chain
+//! runs with no API key, no network and no fake-binary feature — and the
+//! echo makes each agent's composed system prompt visible in the next
+//! agent's input, which is how these tests prove *which* agents ran and in
+//! what order rather than merely that the command exited 0.
+
+use assert_cmd::Command;
+use std::path::Path;
+
+/// The unmistakable string an agent's system prompt carries into the echoed
+/// output. Deliberately keyed on the agent name so two agents in one chain
+/// can never be confused for each other.
+fn marker(agent: &str) -> String {
+    format!("PIPE-AGENT-IS-{agent}")
+}
+
+/// The prompt fragment every declared agent in this file composes from.
+/// `{{name}}` is substituted by `agent_decl::compose_prompt` from the
+/// declaration's own name, so one fragment serves every declared agent.
+const DECLARED_FRAGMENT: &str = "PIPE-AGENT-IS-{{name}}\n\n\
+You are {{name}}. Echo the task back.\n";
+
+/// A file-backed agent's Markdown: the three sections `parse_agent_file`
+/// requires, with the same `echo` provider and the same marker shape the
+/// declared agents get from [`DECLARED_FRAGMENT`].
+fn file_agent_markdown(agent: &str) -> String {
+    format!(
+        "# {agent}\n\
+         \n\
+         ## Metadata\n\
+         - provider: cli\n\
+         - command: echo\n\
+         \n\
+         ## System Prompt\n\
+         PIPE-AGENT-IS-{agent}\n\
+         \n\
+         You are {agent}. Echo the task back.\n"
+    )
+}
+
+/// A project whose only agents are declared — no `.md` anywhere, and an
+/// absent `agents:` list — plus, optionally, file-backed agents written as
+/// `agents/<name>.md` and listed in `armadai.yaml`.
+///
+/// Returns the tempdir (kept alive by the caller) and the project root.
+fn project(declared: &[&str], file_backed: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("project");
+    std::fs::create_dir_all(root.join(".armadai/prompts")).unwrap();
+
+    let agents_block: String = file_backed
+        .iter()
+        .map(|a| format!("  - name: {a}\n"))
+        .collect();
+    let config = if file_backed.is_empty() {
+        String::new()
+    } else {
+        format!("agents:\n{agents_block}")
+    };
+    std::fs::write(root.join("armadai.yaml"), config).unwrap();
+
+    std::fs::write(
+        root.join(".armadai/prompts/pipe-base.md"),
+        DECLARED_FRAGMENT,
+    )
+    .unwrap();
+    let decls: String = declared
+        .iter()
+        .map(|a| format!("  - name: {a}\n    prompt: [pipe-base]\n"))
+        .collect();
+    std::fs::write(
+        root.join(".armadai/agents.yaml"),
+        format!("defaults:\n  provider: cli\n  command: echo\nagents:\n{decls}"),
+    )
+    .unwrap();
+
+    if !file_backed.is_empty() {
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+        for a in file_backed {
+            std::fs::write(
+                root.join("agents").join(format!("{a}.md")),
+                file_agent_markdown(a),
+            )
+            .unwrap();
+        }
+    }
+
+    (dir, root)
+}
+
+/// Runs `armadai run <head> <input> --pipe <rest…> --json` in `root`, with
+/// the config dir AND the data dir redirected into the tempdir: without the
+/// former the shadowing check would scan the developer's real global agent
+/// library, and without the latter `record_run` would write this test's runs
+/// into the developer's real SQLite database (#267).
+fn run_pipe(root: &Path, head: &str, input: &str, rest: &[&str]) -> std::process::Output {
+    let sandbox = root.parent().unwrap();
+    let config = sandbox.join("config");
+    let data = sandbox.join("data");
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+
+    let mut cmd = Command::cargo_bin("armadai").unwrap();
+    cmd.current_dir(root)
+        .env("ARMADAI_CONFIG_DIR", &config)
+        .env("XDG_DATA_HOME", &data)
+        .args(["run", head, input, "--pipe"])
+        .args(rest)
+        .arg("--json");
+    cmd.output().unwrap()
+}
+
+/// The `agent` field of every `agent_start` event on stdout, in emission order.
+fn agents_started(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(|v| v["t"] == "agent_start")
+        .map(|v| v["agent"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+/// The single terminal `result` event on stdout.
+fn result_event(stdout: &str) -> serde_json::Value {
+    let results: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(|v| v["t"] == "result")
+        .collect();
+    assert_eq!(
+        results.len(),
+        1,
+        "expected exactly one result event, got: {stdout}"
+    );
+    results.into_iter().next().unwrap()
+}
+
+/// Asserts that `content` shows `outer`'s prompt wrapping `inner`'s output,
+/// i.e. that `inner` ran first and `outer` consumed it — the property a
+/// chain that merely ran both agents in the wrong order would fail.
+fn assert_wraps(content: &str, outer: &str, inner: &str, input: &str) {
+    let outer_at = content
+        .find(&marker(outer))
+        .unwrap_or_else(|| panic!("'{outer}' never ran: {content}"));
+    let inner_at = content
+        .find(&marker(inner))
+        .unwrap_or_else(|| panic!("'{inner}' never ran: {content}"));
+    assert!(
+        outer_at < inner_at,
+        "'{outer}' must consume '{inner}''s output (so its prompt wraps it), got: {content}"
+    );
+    assert!(
+        content.contains(input),
+        "the original input must survive the chain, got: {content}"
+    );
+}
+
+#[test]
+fn pipe_chains_two_declared_agents() {
+    let (_dir, root) = project(&["alpha-decl", "omega-decl"], &[]);
+    let out = run_pipe(&root, "alpha-decl", "TASK-ALL-DECLARED", &["omega-decl"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "a --pipe chain of two declared agents must run.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        agents_started(&stdout),
+        vec!["alpha-decl".to_string(), "omega-decl".to_string()],
+        "both declared agents must start, in chain order.\nstdout: {stdout}"
+    );
+    let result = result_event(&stdout);
+    assert_eq!(result["agents"], 2);
+    assert_wraps(
+        result["content"].as_str().unwrap(),
+        "omega-decl",
+        "alpha-decl",
+        "TASK-ALL-DECLARED",
+    );
+}
+
+#[test]
+fn pipe_chains_a_file_backed_head_into_a_declared_tail() {
+    let (_dir, root) = project(&["omega-decl"], &["beta-file"]);
+    let out = run_pipe(
+        &root,
+        "beta-file",
+        "TASK-FILE-THEN-DECLARED",
+        &["omega-decl"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "a declared agent must be usable as a non-head link of a chain.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        agents_started(&stdout),
+        vec!["beta-file".to_string(), "omega-decl".to_string()],
+        "stdout: {stdout}"
+    );
+    assert_wraps(
+        result_event(&stdout)["content"].as_str().unwrap(),
+        "omega-decl",
+        "beta-file",
+        "TASK-FILE-THEN-DECLARED",
+    );
+}
+
+#[test]
+fn pipe_chains_a_declared_head_into_a_file_backed_tail() {
+    let (_dir, root) = project(&["alpha-decl"], &["beta-file"]);
+    let out = run_pipe(
+        &root,
+        "alpha-decl",
+        "TASK-DECLARED-THEN-FILE",
+        &["beta-file"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "mixing a declared head with a file-backed tail must run.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        agents_started(&stdout),
+        vec!["alpha-decl".to_string(), "beta-file".to_string()],
+        "stdout: {stdout}"
+    );
+    assert_wraps(
+        result_event(&stdout)["content"].as_str().unwrap(),
+        "beta-file",
+        "alpha-decl",
+        "TASK-DECLARED-THEN-FILE",
+    );
+}
+
+#[test]
+fn pipe_names_the_declarations_file_when_a_chained_agent_is_missing() {
+    let (_dir, root) = project(&["alpha-decl"], &[]);
+    let out = run_pipe(&root, "alpha-decl", "TASK-MISSING", &["nowhere-agent"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        !out.status.success(),
+        "a chain naming an unknown agent must still fail.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        combined.contains("nowhere-agent"),
+        "the failure must name the agent it could not find, got: {combined}"
+    );
+    assert!(
+        combined.contains(".armadai/agents.yaml") || combined.contains(".armadai\\agents.yaml"),
+        "a chain in a project that declares agents must mention the declarations file \
+         it also looked in — `list` and `inspect` already do, got: {combined}"
+    );
+}

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -179,15 +179,15 @@ over-written `.md`.
 
 ## What's wired, and what isn't
 
-Every command that resolves a project's agent fleet was updated to see declared agents alongside
-file-backed ones — except where noted:
+Every surface that resolves a project's agent fleet sees declared agents alongside file-backed
+ones:
 
 | Surface | Sees declared agents? |
 |---|---|
 | `armadai run <name>` (single agent) | Yes |
 | `armadai run --orchestrate` | Yes |
 | `armadai run --resume` | Yes |
-| `armadai run --pipe` (multi-agent chain) | **No** — the legacy chain loop still resolves purely by file path |
+| `armadai run --pipe` (multi-agent chain) | Yes — any position of the chain, mixed freely with file-backed agents |
 | `armadai link` | Yes (and refuses to write on an unresolved collision, see above) |
 | `armadai list` | Yes |
 | `armadai inspect` | Yes |
@@ -197,11 +197,11 @@ file-backed ones — except where noted:
 | TUI dashboard | Yes |
 | Web API | Yes |
 | `armadai shell`'s setup wizard (its own `link`, run once before entering the shell) | Yes |
-| `armadai shell`'s in-session pipeline steps (an `agent:` entry relayed from inside the shell) | **No** — refuses with an explicit message; the shell relay only runs file-backed agents today |
+| `armadai shell`'s in-session pipeline steps (an `agent:` entry relayed from inside the shell) | Yes |
 
-Do not assume a remaining "No" row will discover a declared agent by some other path — it was
-simply not touched by this chantier, and hitting it is the way to find out the hard way if this
-table goes unread.
+There is no longer a "No" row. If one ever reappears, read it as a real capability gap rather than
+a wording problem: a surface that resolves agents by *file path* cannot see a declared agent at all,
+because a declared agent has no file.
 
 The TUI dashboard and Web API used to be worse than an omission: both resolved a project's agents
 via `project::resolve_all_agents`, which only ever returns file paths, so a declared agent (which
@@ -223,15 +223,19 @@ resolution, and `linker::manifest::write_files` — the same function `cli::link
 calls — for the write, so the manifest entry and the exists-guard come from the same place `link`
 gets them rather than a third copy that could drift from both.
 
-That fix is scoped to the wizard's own `link` step — the one-time setup that runs before the shell
-session starts. It says nothing about what happens *inside* a running session: a pipeline step's
-`agent:` entry is resolved by a separate lookup (`shell::app::resolve_project_agent`) that only
-ever returns a file path or `AgentLookup::Declared`/`NotFound` — there is no code path from there
-to `agent_source::load_all_agents` at all. Naming a declared agent in a pipeline step gets an
-explicit, honest refusal (`declared_agent_not_runnable_message`) rather than a silent drop, but it
-still does not run. This is why the table above lists the wizard and the in-session pipeline as two
-separate rows with two separate answers, rather than one `armadai shell` row that would have to say
-both "yes" and "no" at once.
+The last two path-shaped resolvers were `armadai run --pipe`'s chain loop and the shell's
+in-session pipeline lookup (`shell::app::resolve_project_agent`). Both resolved a *path* per agent
+and handed it down to be parsed, which no declared agent can satisfy — the chain loop failed with a
+message naming the three library directories and never the `agents.yaml` that declares the agent,
+and the shell answered a declarations-only project with a false "not found in project config".
+Both now call the same by-name loaders every other surface uses (`load_agent_for_run`, itself
+`agent_source::load_agent_by_name`), and the path-returning helper the chain loop used
+(`cli::run::resolve_agent_path`) was **deleted** rather than left unused, so a future call site
+cannot pick it up and reintroduce the same blind spot. The shell's honest-but-limiting
+"declarative agents can't be run from the shell yet" message is gone because the capability it
+described as missing now exists: a pipeline step's `agent:` entry loads a declared agent and relays
+it exactly as it relays a file-backed one (same command from `provider:`, same composed system
+prompt).
 
 ## Parity with the `.md` format — and its limits
 

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -159,6 +159,11 @@ fine elsewhere. But the three commands that can hit one don't all react the same
   guess which side of a collision you meant: naming a colliding agent **hard-fails** (exit 1),
   naming both `agents.yaml` and the colliding `.md` file. A command that is about to execute or
   describe one agent must not silently pick a winner between a declaration and a file.
+- `armadai run --pipe` refuses a colliding name in **any** position of the chain, and refuses it
+  before running the first link — so a collision costs no provider call at all. It used to let the
+  chain through while the single-agent path refused the very same name, because the chain loop
+  resolved agents by file path and so never consulted the declarations; routing it through the same
+  by-name loader removed that inconsistency.
 - Because that check is scoped to just the one name you asked for, `armadai inspect
   <some-other-name>` says **nothing** about an unrelated collision sitting elsewhere in the fleet —
   it doesn't scan the whole project the way `list` does. Don't rely on `inspect` to surface
@@ -197,7 +202,7 @@ ones:
 | TUI dashboard | Yes |
 | Web API | Yes |
 | `armadai shell`'s setup wizard (its own `link`, run once before entering the shell) | Yes |
-| `armadai shell`'s in-session pipeline steps (an `agent:` entry relayed from inside the shell) | Yes |
+| `armadai shell`'s in-session pipeline steps (an `agent:` entry relayed from inside the shell) | Yes — declared or file-backed alike; an API-only provider is skipped with an explanation, see below |
 
 There is no longer a "No" row. If one ever reappears, read it as a real capability gap rather than
 a wording problem: a surface that resolves agents by *file path* cannot see a declared agent at all,
@@ -234,8 +239,22 @@ Both now call the same by-name loaders every other surface uses (`load_agent_for
 cannot pick it up and reintroduce the same blind spot. The shell's honest-but-limiting
 "declarative agents can't be run from the shell yet" message is gone because the capability it
 described as missing now exists: a pipeline step's `agent:` entry loads a declared agent and relays
-it exactly as it relays a file-backed one (same command from `provider:`, same composed system
-prompt).
+it exactly as it relays a file-backed one — same composed system prompt, and the same command
+resolution described below.
+
+### What the in-session relay can and cannot run
+
+A pipeline step spawns a CLI and hands it the prompt on argv, so the step's command comes from the
+agent's metadata the way `providers::factory` reads it: `provider: cli` spawns whatever `command:`
+names, any other provider spawns `command:` if set and the provider name otherwise, and an explicit
+`args:` list is passed through verbatim (otherwise the canonical JSON-mode argv for that command is
+used). Reading `provider:` alone — which this relay did until it was fixed — turned every
+`provider: cli` agent into an attempt to spawn a binary literally named `cli`.
+
+An agent whose provider is an HTTP API (`anthropic`, `openai`, `google`, `proxy`) has no command to
+spawn at all. Such a step is **skipped with an explanation** and the rest of the chain runs on: the
+step is lost, not the pipeline. Run those agents with `armadai run <name>`, which builds the API
+client instead of relaying a CLI.
 
 ## Parity with the `.md` format — and its limits
 


### PR DESCRIPTION
Ferme #339. Les deux dernières surfaces qui résolvaient un agent de projet par **chemin de fichier** passent enfin par le chargement **par nom** — donc voient les agents déclarés dans `.armadai/agents.yaml` (#337).

## Le défaut

`crates/armadai/src/cli/run.rs`, boucle de chaînage de `--pipe` : `resolve_agent_path()` rendait un `PathBuf`, qu'aucun agent déclaré ne peut satisfaire (il n'a pas de fichier). La chaîne mourait donc avant son premier appel provider, avec un message qui nomme les trois répertoires de bibliothèque et **jamais** l'`agents.yaml` qui déclare l'agent — alors que `list` et `inspect` l'affichent.

`crates/armadai/src/shell/app.rs`, `resolve_project_agent()` : même forme. Pire, la détection ne regardait que `config.agents`, donc dans un projet **purement déclaratif** (liste `agents:` vide) même l'état `AgentLookup::Declared` était inatteignable : le shell répondait « not found in project config », ce qui est faux.

## Ce qui change

- `run_single_agent` prend un `Agent` déjà chargé au lieu d'un `&Path`, exactement comme `run_single_agent_es` :
  - avant : `async fn run_single_agent(agent_path: &Path, agent_name: &str, …)`
  - après : `async fn run_single_agent(mut agent: Agent, agent_name: &str, …)`

  L'étape « 1. Load agent » (`parse_agent_file`) disparaît du corps ; le chargement remonte à l'appelant, via `load_agent_for_run` (le helper que `run` non-pipe, `--orchestrate` et `--resume` utilisent déjà). Un seul appelant existait, donc aucun autre site cassé.

- **`cli::run::resolve_agent_path` est supprimé**, pas simplement contourné. Un résolveur qui rend un chemin *est* le piège : le laisser en place l'aurait laissé armé pour le prochain site d'appel. Suppression de l'import `AgentRef` et de `std::path::Path` devenus inutiles.

- Côté shell, `AgentLookup` perd sa variante `Declared` et `declared_agent_not_runnable_message` est retirée — non pas pour cacher la limite, mais parce que la capacité qu'elle décrivait comme absente **existe maintenant**. `lookup_agent_in_config` appelle `agent_source::load_agent_by_name` (et cesse donc de rematcher les quatre variantes d'`AgentRef` pour son compte), et un nouveau `step_from_agent` pur convertit l'`Agent` chargé en `(cmd, args, system_prompt, label)` — le point où déclaré et fichier deviennent indiscernables pour le relais PTY. Le relais lui-même n'est pas touché : il ne voit que ces quatre valeurs.

- L'avertissement non-fatal que `load_agent_by_name` renvoie (p. ex. `agents.yaml` illisible ignoré au profit d'un homonyme fichier) était jusqu'ici perdu côté shell ; il apparaît maintenant dans le transcript.

## Tests

Nouveau `crates/armadai/tests/pipe_declarative_agents.rs` — boîte noire, binaire réel (idiome de `link_list_gate.rs`). Chaque agent y est `provider: cli` / `command: echo`, donc aucune clé d'API, aucun réseau, aucune feature `e2e-fake` : l'echo rend le prompt composé de chaque agent visible dans l'entrée du suivant, ce qui prouve **quels** agents ont tourné et dans quel ordre, pas seulement un exit 0. `ARMADAI_CONFIG_DIR` **et** `XDG_DATA_HOME` sont redirigés dans le tempdir (sinon la bibliothèque globale réelle du dev est scannée et `record_run` écrit dans sa vraie base, #267).

1. chaîne de deux agents déclarés ;
2. tête fichier → queue déclarée (la position exacte où l'ancien code échouait après avoir déjà fait tourner — et payer — l'agent 1) ;
3. tête déclarée → queue fichier ;
4. un nom introuvable dans la chaîne échoue **en nommant `.armadai/agents.yaml`**.

Côté shell, les 3 anciens tests d'`AgentLookup` sont remplacés par 4 : chargement d'un déclaré, parité `step_from_agent` déclaré/jumeau-fichier, garde de non-régression du cas fichier, et message d'échec nommant le fichier de déclarations. Noms de fixtures volontairement invraisemblables (`shell-pipeline-fixture-*`) : `load_agent_by_name` résout aussi contre `~/.config/armadai/agents/`, donc un nom réaliste ferait dépendre le verdict de la machine.

### Expériences de mutation (exigées, faites, code restauré)

| Mutation | Résultat observé |
|---|---|
| boucle `--pipe` remise en résolution par chemin | **4/4 rouges** — `Agent 'alpha-decl' not found in …/.armadai/agents/…, …/agents/…, …/config/agents/…` |
| `chain.iter()` → `chain.iter().rev()` | **3 rouges** — `left: ["omega-decl", "alpha-decl"] / right: ["alpha-decl", "omega-decl"]` |
| sortie non repassée au maillon suivant (`current_input = output` supprimé) | **3 rouges** — `'omega-decl' never ran: TASK-ALL-DECLARED` |
| `lookup_agent_in_config` remis en `resolve_agent` + `parse_agent_file` | **3 rouges** — la garde du cas fichier reste verte, ce qui prouve qu'elle teste bien l'autre chose |
| `step_from_agent` renvoyant `None` comme prompt | **1 rouge** — `left: None / right: Some("You are shell-pipeline-fixture-alpha, …")` |
| `step_from_agent` renvoyant un argv vide | **1 rouge** — `left: [] / right: ["-o", "stream-json", "-p"]` |

Un test écarté au passage, délibérément : la branche « aucun `armadai.yaml` » de `resolve_project_agent`. La couvrir exige de muter le cwd du processus, et le seul garde sûr existant vit dans le scope de test d'un autre module — un test qui peut se *sauter* en silence vaut moins que pas de test.

## Portée jugée, pas supposée

Le brief autorisait à écarter le reste 2 si brancher le shell débordait dans le relais PTY. Constaté : ça ne déborde pas. La résolution est découplée du relais — celui-ci ne consomme que `cmd`/`args`/`prompt`, et `step_from_agent` isole cette frontière. Fait, donc.

## Gate local

`cargo fmt --all -- --check` · clippy **5/5** modes · tests **4/4** modes (0 échec) · `cargo build --release --features tui,storage` · gaveldrop **inchangé : 13 cas · 13 passés · score 83/83**.

Docs : `docs/wiki/declarative-agents.md` — le tableau « wired » n'a plus aucune ligne **No**, et la prose explique pourquoi (un résolveur par chemin ne peut pas voir un agent déclaré, jamais).

---

# Vague de correctifs — revue indépendante (verdict APPROVE_WITH_MINOR)

La revue a confirmé à l'exécution le défaut d'origine, la suppression propre de `resolve_agent_path`, l'absence de double chargement, l'isolation des tests et le fait que les 4 tests d'intégration mordent. Elle a trouvé en plus deux points **Important** dont **une régression réelle introduite par cette PR**, et trois points mineurs. Tout est corrigé ci-dessous (commit `4a7455c`).

## I2 — régression réelle : `step_from_agent` ignorait `metadata.command`

`crates/armadai/src/shell/app.rs`

`let cmd = agent.metadata.provider.clone()` — `metadata.command` n'était **jamais** consulté, et rien ne vérifiait que le provider soit relayable. Conséquence : un agent `provider: cli` / `command: echo` — **exactement la forme que les tests `--pipe` de cette PR utilisent** — essayait de lancer un binaire nommé littéralement `cli`. Et comme `execute_pipeline_steps` répond à un échec de spawn par `return Ok(())`, ce n'était pas l'étape qui mourait mais **toute la chaîne**.

Mesuré par sonde **avant** :

```
PROBE agent=probe-cli-echo metadata.provider="cli" metadata.command=Some("echo")
PROBE   -> spawn cmd="cli" args=[] label="probe-cli-echo [cli]"
PROBE   -> spawn FAILED: No such file or directory (os error 2)
           (execute_pipeline_steps would `return Ok(())` here, aborting the WHOLE pipeline)
PROBE agent=probe-anthropic metadata.provider="anthropic" metadata.command=None
PROBE   -> spawn cmd="anthropic" args=[] label="probe-anthropic [anthropic]"
PROBE   -> spawn FAILED: No such file or directory (os error 2)
           (execute_pipeline_steps would `return Ok(())` here, aborting the WHOLE pipeline)
PROBE agent=probe-gemini metadata.provider="gemini" metadata.command=None
PROBE   -> spawn cmd="gemini" args=["-o", "stream-json", "-p"]
PROBE   -> spawn OK status=Some(0) stdout="{\"type\":\"init\", … }"
```

**Comparaison avec `master`** : là où l'ancien chemin atteignait cet état (`AgentLookup::Declared`), `master` affichait un message honnête puis faisait `continue` — l'étape sautée, le pipeline continuait. La branche donnait une ligne opaque et abandonnait tout. Pour `provider: claude|gemini|…` la branche est un gain net ; c'est le sous-ensemble `cli` + API qui régressait.

### Correctif : les deux moitiés

`step_from_agent` ne rend plus un tuple en forme de spawn mais un `StepPlan`, et résout la commande **comme `providers::factory` le fait** :

- `provider: cli` lance ce que `command:` nomme (le champ que `create_cli_provider` exige) ;
- tout autre provider lance `command:` s'il est posé, sinon le nom du provider ;
- un `args:` explicite passe **verbatim** (comme `create_unified_provider`), sinon l'argv JSON canonique de la commande — indexé sur `cmd` et non sur `provider`, parce que le parsing de flux en aval l'est aussi (`supports_json(&resolved.cmd)`).

Et la garde honnête : les quatre providers **API-only** (`anthropic`, `openai`, `google`, `proxy`) et un `provider: cli` **sans** `command:` rendent `StepPlan::NotRelayable(raison)`. L'appelant affiche la raison et fait `continue` — **décidé avant tout spawn**, donc une étape perdue et la chaîne intacte, comme `master`. Aucun `Failed to spawn` avortant n'a été introduit là où il y avait une explication.

Mesuré **après**, même sonde :

```
PROBE agent=probe-cli-echo metadata.provider="cli" metadata.command=Some("echo")
PROBE   -> spawn cmd="echo" args=[] label="probe-cli-echo [echo]"
PROBE   -> spawn OK status=Some(0) stdout="hello"
PROBE agent=probe-anthropic metadata.provider="anthropic" metadata.command=None
PROBE   -> NOT RELAYABLE, step SKIPPED, pipeline CONTINUES: Skipping 'probe-anthropic':
           provider 'anthropic' is an HTTP API and this session relays a CLI, so there is
           no command to run it with here. Run it with `armadai run probe-anthropic`, or
           give the agent a CLI provider.
PROBE agent=probe-gemini metadata.provider="gemini" metadata.command=None
PROBE   -> spawn cmd="gemini" args=["-o", "stream-json", "-p"]
PROBE   -> spawn OK status=Some(0) stdout="{\"type\":\"init\", … }"
```

Ce correctif répare **aussi les agents fichier** : un `agents/x.md` en `provider: cli` était cassé de la même façon, sur `master` comme ici.

## I1 — la seule capacité *ajoutée* par la PR n'avait aucun test

La PR revendiquait que l'avertissement non-fatal de `load_agent_by_name` arrive dans le transcript. Mutation qui annule exactement cette revendication :

```rust
warning: { let _ = warning; None },
```

→ **6/6 verts**. Le seul test qui parlait de `warning` assérait `assert_eq!(warning, None)`, ce qu'une implémentation « toujours `None` » satisfait.

Test ajouté (`.armadai/agents.yaml` illisible + homonyme fichier servi), re-vérifié **rouge sous cette mutation** :

```
an_unreadable_declarations_file_surfaces_a_warning_with_the_file_backed_fallback ... FAILED
```

## m1 — IO redondant par maillon, et un message répété à l'identique

`load_agent_for_run` recalculait `project_fragments` (scan des 3 répertoires + parse de chaque fragment) à **chaque itération** des trois boucles qui l'appellent (`--pipe`, `--orchestrate`, `--resume`), alors qu'il est invariant pour tout le run.

Symptôme visible mesuré sur une chaîne de 3 maillons, avec un fragment de prompt cassé :

| | lignes `warn: failed to load prompt` |
|---|---|
| avant (branche) | **3**, strictement identiques octet pour octet, ne nommant aucun agent |
| après | **1** |

C'est exactement le cas que `eecbd0f` a corrigé pour `unlink`. Les fragments vivent maintenant dans un `OnceLock` paresseux porté par `AgentResolution::Project` : **un seul geste** règle les trois boucles (dont celle du roster de `run_orchestrated`, que la revue signalait), et un chemin qui résout un projet sans charger d'agent ne paie rien.

Le fichier de déclarations reste re-parsé par maillon : aucun symptôme visible, et le hisser demande de remodeler la signature de `agent_source::load_agent_by_name` (ou d'introduire une poignée `ProjectAgentSource`) chez ses appelants dans deux crates. Consigné dans #366 plutôt que fait ici.

## m2 — changement de comportement, maintenant déclaré et testé

Avec un agent `alpha-decl` **déclaré** et un `agents/alpha-decl.md` **présent** :

- `master` : `run alpha-decl TASK --pipe beta-file` **passait** (exit 0, 2 agents), alors que le chemin mono-agent refusait déjà avec « is declared in … and also written as … — remove one » ;
- cette branche : `--pipe` refuse aussi, **dans n'importe quelle position** de la chaîne, et **avant** que le maillon de tête ne brûle un appel provider.

C'est le bon sens — la branche supprime une incohérence de `master` — mais ce n'était ni déclaré ni couvert. Test ajouté (`pipe_refuses_a_name_that_is_both_declared_and_written_as_a_file`, qui assère aussi `agent_start` vide) et documenté dans `docs/wiki/declarative-agents.md`.

## m5 — référence morte

`crates/armadai/tests/cases/declared-agents-orchestrated.yaml` citait encore `resolve_agent_path`, que cette PR supprime. Commentaire réécrit.

## m4 — le test écarté ne l'est plus

La revue notait que l'écart était **choisi, pas contraint** : `project::find_project_config_from` existe et sert 6 tests de `shell/wizard.rs`. `resolve_project_agent` est donc scindé en `resolve_project_agent` (cwd) + `resolve_project_agent_from(start, name)`, et la branche « aucun `armadai.yaml` » a son test.

## Expériences de mutation (9, toutes vérifiées rouges, code restauré)

| Mutation | Résultat observé |
|---|---|
| `warning: { let _ = warning; None }` | 1 rouge — le test I1, exclusivement |
| `metadata.command` ignoré (retour au bug I2) | 3 rouges — `cli`/`args`/`no-command` |
| `metadata.args` ignoré | 1 rouge — `an_explicit_args_list_reaches_the_relay_verbatim` |
| garde API-only désactivée | 1 rouge — `an_api_backed_agent_is_skipped_with_a_reason_rather_than_spawned` |
| bras « `cli` sans `command:` » supprimé | 1 rouge — `a_cli_agent_without_a_command_is_skipped_naming_the_field_it_lacks` |
| hissage des fragments annulé | 1 rouge — `Got 3 line(s)`, `left: 3 / right: 1` |
| refus de collision par nom désactivé (core) | 1 rouge — le test m2, exclusivement |
| boucle `--pipe` remise sur un résolveur par chemin | **6/6 rouges** — tous les tests boîte noire du fichier |
| raison « aucun projet » vidée | 1 rouge — `got: Cannot load agent: not found` |

## Limite assumée

La garde I2 est testée unitairement ; le `continue` du site d'appel, lui, n'est pas couvert par un test automatique — `execute_pipeline_steps` prend un `Terminal<CrosstermBackend<Stdout>>` concret et lit de vrais événements crossterm. Mesuré par sonde à la place (sorties ci-dessus). Un échec de spawn sur un binaire *réellement* absent avorte encore la chaîne : forme pré-existante (identique pour les étapes en mode `provider:` sur `master`), consignée dans #366.

## Non corrigé, filé : #366

`--pipe` résout chaque maillon **dans** la boucle d'exécution, donc une faute de frappe sur le maillon N brûle N-1 appels provider. Mesuré sur une chaîne de 4 avec le 3ᵉ erroné :

```
exit=1
  event: run_start
  event: agent_start m3-a   event: agent_end m3-a
  event: agent_start m3-b   event: agent_end m3-b
  event: error
```

Forme pré-existante (`master` a la même structure). #366 porte aussi les deux points adjacents : l'avortement sur spawn impossible, et le re-parse du fichier de déclarations.

## Gate local re-vérifié après la vague

`cargo fmt --all` · clippy **5/5** modes `-D warnings` · tests **4/4** modes, 0 échec · gaveldrop **inchangé : 13 cas · 13 passés · 0 échec · score 83/83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
