### PR TITLE
fix(cli): match unlink's coordinator by name or slug, like link

### DIFF
--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -125,6 +125,27 @@ pub fn slugify(name: &str) -> String {
         .join("-")
 }
 
+/// Does the config reference `reference` designate the agent named
+/// `agent_name`?
+///
+/// Configs name agents both ways: an agent's own name is its H1 title
+/// (`Dev Lead`), while `link.coordinator` — like every path the linker
+/// writes — is usually spelled as the slug (`dev-lead`). Reconciling the
+/// two is exactly what [`slugify`] is for, so every command that resolves a
+/// configured reference against a loaded roster must use this one criterion:
+/// when `link` and `unlink` disagreed on it, `link` wrote a root context
+/// file for a coordinator `unlink` did not recognise, leaving it on disk
+/// with no message even naming it (issue #341).
+///
+/// The two arguments are NOT interchangeable: `reference` is matched
+/// verbatim (case-insensitively) or against the slug of `agent_name`, never
+/// the other way round — `name_matches_reference("Dev Lead", "dev-lead")`
+/// holds while the swapped call does not.
+pub fn name_matches_reference(agent_name: &str, reference: &str) -> bool {
+    agent_name.eq_ignore_ascii_case(reference)
+        || slugify(agent_name).eq_ignore_ascii_case(reference)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipelineConfig {
     /// Agents to chain after this one
@@ -232,5 +253,38 @@ impl Agent {
             .stacks
             .iter()
             .any(|s| s.eq_ignore_ascii_case(stack))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_reference_matches_a_name_spelled_identically() {
+        assert!(name_matches_reference("dev-lead", "dev-lead"));
+        assert!(name_matches_reference("Dev Lead", "dev lead"));
+    }
+
+    /// The case issue #341 is about: `coordinator: dev-lead` beside an
+    /// agent whose H1 title is `Dev Lead`.
+    #[test]
+    fn a_slug_reference_matches_a_title_cased_name() {
+        assert!(name_matches_reference("Dev Lead", "dev-lead"));
+        assert!(name_matches_reference("My_Test Agent", "my-test-agent"));
+    }
+
+    #[test]
+    fn an_unrelated_reference_never_matches() {
+        assert!(!name_matches_reference("Dev Lead", "qa-lead"));
+        assert!(!name_matches_reference("Dev Lead", "dev"));
+    }
+
+    /// The arguments are directional — pinned so a swapped call site is a
+    /// behaviour change, not a silent no-op.
+    #[test]
+    fn the_two_arguments_are_not_interchangeable() {
+        assert!(name_matches_reference("Dev Lead", "dev-lead"));
+        assert!(!name_matches_reference("dev-lead", "Dev Lead"));
     }
 }

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -108,10 +108,9 @@ pub async fn execute(
     let coordinator_name =
         coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
     let mut coordinator = coordinator_name.and_then(|name| {
-        let idx = link_agents.iter().position(|a| {
-            a.name.eq_ignore_ascii_case(&name)
-                || crate::linker::slugify(&a.name).eq_ignore_ascii_case(&name)
-        })?;
+        let idx = link_agents
+            .iter()
+            .position(|a| crate::linker::name_matches_reference(&a.name, &name))?;
         Some(link_agents.remove(idx))
     });
 

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -855,10 +855,16 @@ async fn unlink_via_fallback(
     // Extract coordinator if configured (CLI flag takes priority over config)
     let coordinator_name =
         coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
+    // Matched by name *or* slug, through the same
+    // `name_matches_reference` `link` uses — never by name alone. `link`
+    // resolves `coordinator: dev-lead` to the agent titled `Dev Lead` and
+    // writes its root context file; a narrower criterion here would not
+    // even make that file a candidate for removal, leaving it on disk with
+    // no message naming it (issue #341).
     let mut coordinator = coordinator_name.and_then(|name| {
         let idx = link_agents
             .iter()
-            .position(|a| a.name.eq_ignore_ascii_case(&name))?;
+            .position(|a| crate::linker::name_matches_reference(&a.name, &name))?;
         Some(link_agents.remove(idx))
     });
 

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -104,6 +104,12 @@ pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
 /// crate has to change.
 pub use armadai_core::agent::slugify;
 
+/// Re-exported for the same reason as [`slugify`], which it is built on:
+/// resolving a configured agent reference (`link.coordinator`) against a
+/// loaded roster is one decision, and `link` and `unlink` must not each
+/// keep their own copy of it (issue #341).
+pub use armadai_core::agent::name_matches_reference;
+
 impl From<&Agent> for LinkAgent {
     fn from(agent: &Agent) -> Self {
         let description = agent

--- a/crates/armadai/tests/unlink_content_guard.rs
+++ b/crates/armadai/tests/unlink_content_guard.rs
@@ -434,4 +434,126 @@ mod tests {
             "the fallback must still reclaim a genuinely generated, unmodified file"
         );
     }
+
+    /// Every file (not directory) under `dir`, recursively, sorted — empty
+    /// when `dir` itself does not exist. Lets a round-trip test assert on
+    /// what actually survives rather than on one path it remembered to
+    /// name.
+    fn files_under(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                found.extend(files_under(&path));
+            } else {
+                found.push(path);
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// Same shape as `project_with_coordinator`, but the coordinator is
+    /// referenced by its **slug** (`dev-lead`) while the agent's own name
+    /// — its H1 title — is written in plain words (`Dev Lead`). Naming
+    /// agents in title case and referencing the coordinator in kebab-case
+    /// is exactly the combination `slugify` exists to reconcile.
+    fn project_with_slug_referenced_coordinator() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let agents = root.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: dev-lead\n  - name: member\nlink:\n  target: claude\n  coordinator: dev-lead\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("dev-lead.md"),
+            "# Dev Lead\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou coordinate.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agents.join("member.md"),
+            "# member\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nYou work.\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// Issue #341: `link` matched the configured coordinator against an
+    /// agent's name **or** its slug, the fallback path of `unlink` against
+    /// its name alone. With `coordinator: dev-lead` and an agent named
+    /// `Dev Lead`, `link` recognised the coordinator and wrote
+    /// `.claude/CLAUDE.md`; `unlink` did not, so that file was never even a
+    /// candidate for removal — it stayed on disk, silently, with no message
+    /// naming it.
+    ///
+    /// Deliberately forces the #342 fallback (the manifest is deleted
+    /// before `unlink` runs) because that is where the divergence lives:
+    /// through the manifest, `link`'s own attribution is what `unlink`
+    /// reads back, so the two cannot disagree. Without this the test would
+    /// take the manifest path and prove nothing.
+    #[test]
+    fn unlink_fallback_matches_the_coordinator_by_slug_like_link_does() {
+        let dir = project_with_slug_referenced_coordinator();
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let (link_ok, _, link_stderr) =
+            run_armadai(&root, &config, &["link", "--target", "claude"]);
+        assert!(link_ok, "link must succeed: stderr={link_stderr}");
+
+        let claude_md = root.join(".claude/CLAUDE.md");
+        let member_file = root.join(".claude/agents/member.md");
+        assert!(
+            claude_md.is_file(),
+            "sanity: link resolves `coordinator: dev-lead` to the agent named \
+             `Dev Lead` via its slug, so it must have written the root context file"
+        );
+        assert!(
+            member_file.is_file(),
+            "sanity: link must have generated the non-coordinator member's file"
+        );
+        assert!(
+            !root.join(".claude/agents/dev-lead.md").exists(),
+            "sanity: the coordinator is excluded from the sub-agent files"
+        );
+
+        // Force the fallback: no manifest, exactly like a fresh clone, a
+        // project linked before the manifest landed, or a deleted
+        // `.armadai/`.
+        std::fs::remove_file(root.join(".armadai/link-manifest.yaml"))
+            .expect("link must have written a manifest to delete");
+
+        let (unlink_ok, unlink_stdout, unlink_stderr) =
+            run_armadai(&root, &config, &["unlink", "--target", "claude"]);
+        assert!(unlink_ok, "unlink must succeed: stderr={unlink_stderr}");
+        assert!(
+            unlink_stderr.contains("falling back"),
+            "this test is only meaningful on the fallback path: stderr={unlink_stderr}"
+        );
+
+        assert!(
+            !claude_md.exists(),
+            "the coordinator's own file must be reclaimed: `unlink` has to resolve \
+             `coordinator: dev-lead` to `Dev Lead` exactly as `link` did, or the root \
+             context file survives as a silent orphan: stdout={unlink_stdout}"
+        );
+        assert!(
+            !member_file.exists(),
+            "control: the plain member file must still be reclaimed: stdout={unlink_stdout}"
+        );
+        assert_eq!(
+            files_under(&root.join(".claude")),
+            Vec::<std::path::PathBuf>::new(),
+            "no file may survive the round trip anywhere under the output \
+             directory (the now-empty `.claude/` itself is deliberately left \
+             standing — `remove_empty_ancestors` is bounded by the target root): \
+             stdout={unlink_stdout}"
+        );
+    }
 }

--- a/crates/armadai/tests/unlink_content_guard.rs
+++ b/crates/armadai/tests/unlink_content_guard.rs
@@ -468,7 +468,12 @@ mod tests {
         std::fs::create_dir_all(&agents).unwrap();
         std::fs::write(
             root.join("armadai.yaml"),
-            "agents:\n  - name: dev-lead\n  - name: member\nlink:\n  target: claude\n  coordinator: dev-lead\n",
+            // `member` FIRST, deliberately: with the coordinator at index 0 a
+            // predicate hardcoded to `true` still selects it, so every assertion
+            // below stays green and the match itself is never observed
+            // (measured, #370 review). Listing it second makes a wrong match
+            // land another agent's prompt in the root context file.
+            "agents:\n  - name: member\n  - name: dev-lead\nlink:\n  target: claude\n  coordinator: dev-lead\n",
         )
         .unwrap();
         std::fs::write(
@@ -513,6 +518,17 @@ mod tests {
             claude_md.is_file(),
             "sanity: link resolves `coordinator: dev-lead` to the agent named \
              `Dev Lead` via its slug, so it must have written the root context file"
+        );
+        // Existence alone proves less than it reads: this fixture lists the
+        // coordinator first, so `position()` returns 0 for ANY predicate — a
+        // `name_matches_reference` hardcoded to `true` left the assertion above
+        // green (measured, #370 review). Asserting *whose* prompt landed there
+        // is what makes the match itself observable.
+        assert!(
+            std::fs::read_to_string(&claude_md)
+                .unwrap()
+                .contains("You coordinate."),
+            "the root context file must carry the *coordinator's* prompt, not another agent's"
         );
         assert!(
             member_file.is_file(),

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -32,6 +32,14 @@ More targets (Cursor, Aider, Windsurf, Cline) may be added later.
 3. **Transform** — Converts ArmadAI agents to the target CLI's native format
 4. **Write** — Generates files in the appropriate directories
 
+### The Coordinator
+
+`link.coordinator` in the project config names one agent of the roster: the one whose prompt becomes the target's root instructions file (`.claude/CLAUDE.md`, `.opencode/instructions.md`, …) instead of a per-agent file. It is matched against each agent's name **or** its slug, case-insensitively — so `coordinator: dev-lead` resolves an agent titled `Dev Lead`, the same folding the linker uses to name files on disk.
+
+`unlink` applies that identical rule whenever it has to regenerate (the no-manifest fallback below); a narrower match there would leave the root instructions file on disk as a silent orphan. Through the manifest the question never arises: `link`'s own attribution is what `unlink` reads back.
+
+A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none.
+
 ## Examples
 
 ### Claude Code

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -34,11 +34,13 @@ More targets (Cursor, Aider, Windsurf, Cline) may be added later.
 
 ### The Coordinator
 
-`link.coordinator` in the project config names one agent of the roster: the one whose prompt becomes the target's root instructions file (`.claude/CLAUDE.md`, `.opencode/instructions.md`, …) instead of a per-agent file. It is matched against each agent's name **or** its slug, case-insensitively — so `coordinator: dev-lead` resolves an agent titled `Dev Lead`, the same folding the linker uses to name files on disk.
+`link.coordinator` in the project config names one agent of the roster: the one whose prompt becomes the target's root instructions file (`.claude/CLAUDE.md`, `.opencode/instructions.md`, …) instead of a per-agent file. It is matched against each agent's **H1 title** — the `# Name` heading of its Markdown file — or that title's slug, case-insensitively. So `coordinator: dev-lead` resolves an agent titled `Dev Lead`, the same folding the linker uses to name files on disk.
+
+That target matters: `link.coordinator` is matched against the **title**, *not* against the key used in `agents:` or in `orchestration.coordinator`, which are a separate namespace. When the two differ — a roster entry `- name: lead` on a file titled `# Dev Lead` — `coordinator: lead` matches nothing, and nothing says so.
 
 `unlink` applies that identical rule whenever it has to regenerate (the no-manifest fallback below); a narrower match there would leave the root instructions file on disk as a silent orphan. Through the manifest the question never arises: `link`'s own attribution is what `unlink` reads back.
 
-A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none.
+A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none. It is also not reported, so a typo or a title/key mismatch is silent on both sides: `link` writes the per-agent files and announces success. Check that the root instructions file exists if you expected a coordinator.
 
 ## Examples
 


### PR DESCRIPTION
Ferme #341.

## Le défaut

`link` appariait `link.coordinator` par **nom ou slug**, le chemin de repli de `unlink` par **nom seul**.

- `crates/armadai/src/cli/link.rs:112` — `a.name.eq_ignore_ascii_case(&name) || slugify(&a.name).eq_ignore_ascii_case(&name)`
- `crates/armadai/src/cli/unlink.rs:861` — `.position(|a| a.name.eq_ignore_ascii_case(&name))?`

Avec `coordinator: dev-lead` dans la config et un agent titré `Dev Lead` — référence en kebab-case, H1 en clair, exactement ce que `slugify` existe pour réconcilier — `link` reconnaissait le coordinateur et écrivait `.claude/CLAUDE.md`, `unlink` non. Ce fichier n'était donc **même pas candidat** à la suppression : il restait sur disque sans qu'aucune ligne ne le nomme.

## Le correctif

Un seul point de vérité : `armadai_core::agent::name_matches_reference`, posé à côté de `slugify` dont il dérive, ré-exporté par `linker` et appelé par les deux commandes. C'est le critère exact de `link` avant ce commit — rien qui appariait cesse d'apparier.

Le doc-comment épingle que les deux arguments ne sont **pas** interchangeables (`reference` est comparé verbatim ou au slug de `agent_name`, jamais l'inverse), et un test unitaire fixe cette direction pour qu'un appel inversé soit un changement de comportement, pas un no-op silencieux.

## Le test, et pourquoi il emprunte le repli

`unlink_fallback_matches_the_coordinator_by_slug_like_link_does`, dans `crates/armadai/tests/unlink_content_guard.rs` : `link` puis `unlink` sur un projet dont le coordinateur est référencé par slug, **avec suppression du manifeste entre les deux**.

C'est le point crucial : depuis #349/#362, `unlink` consomme d'abord le manifeste, où il applique l'inverse de ce que `link` a enregistré dans `produced_by` — les deux ne peuvent pas y diverger. Sans forcer le repli (#342), le test serait passé par le manifeste et n'aurait **rien prouvé**. Le motif de forçage est celui que les tests existants de `link_manifest.rs` utilisent déjà.

L'assertion finale ne nomme pas un chemin : elle vérifie qu'**aucun fichier** ne survit nulle part sous le répertoire de sortie (le `.claude/` désormais vide reste debout, `remove_empty_ancestors` étant borné par la racine cible — comportement voulu depuis #338).

### Rouge initial, vérifié

```
panicked at crates/armadai/tests/unlink_content_guard.rs:519:
the coordinator's own file must be reclaimed: ... stdout=  deleted .../.claude/agents/member.md

Unlinked 'claude': 1 deleted, 0 kept, 1 already absent.
```

`.claude/CLAUDE.md` n'apparaît nulle part dans la sortie : il n'a jamais été candidat. C'est exactement l'orphelin silencieux décrit par l'issue.

### Expériences de mutation

Deux mutations délibérées, chacune exécutée sur la suite complète avec `--no-fail-fast` :

| Mutation | Rayon mesuré |
|---|---|
| Site d'appel de `unlink` remis en nom seul | **1 test rouge** — le nouveau, à l'assertion « the coordinator's own file must be reclaimed » (retour exact au comportement d'avant) |
| Bras slug retiré de `name_matches_reference` | **3 tests rouges** — 2 unitaires du cœur + le nouveau, cette fois à son assertion de sanité côté `link` (`link` ne reconnaît plus le coordinateur non plus) |

Effet de bord mesuré au passage : la seconde mutation ne cassait **que** ces trois tests. Le bras slug de `link`, pourtant en place depuis longtemps, n'avait jusqu'ici **aucune couverture**.

## Le même écart ailleurs — mesuré, pas supposé

- **Chemin manifeste de `unlink`** : déjà correct, laissé intact. Il applique l'inverse de `produced_by`, sans jamais ré-apparier. Vérifié en exécutant le vrai binaire sur un aller-retour complet avec coordinateur référencé par slug : 2 écrits, 2 supprimés, 0 survivant.
- **Filtre `--agents`** : apparie par nom seul aux **trois** sites (`link`, chemin manifeste, chemin repli). Mesuré sur le vrai binaire — `--agents dev-lead` est refusé identiquement par les trois, `--agents "Dev Lead"` fait un aller-retour propre. Les trois sont donc d'accord : pas d'orphelin. **Laissés tels quels** : élargir un site sans les deux autres créerait précisément l'asymétrie que cette PR ferme, et élargir les trois est un changement de surface utilisateur hors du périmètre de l'issue.
- **`orchestration.coordinator`** : espace de noms différent (clés de roster de la config, jamais les titres H1 — cf. le commentaire de `run.rs:2076-2082` et `pack_validation.rs:386`). Non concerné.

## Couche au-dessus — une observation, non corrigée

`link.coordinator` n'est validé nulle part : `armadai validate` ne contrôle que `orchestration.coordinator`. Un `coordinator:` qui n'apparie aucun agent (une faute de frappe, un `dev_lead` au lieu de `dev-lead`) reste silencieux — `link` n'écrit alors aucun fichier d'instructions racine, `unlink` n'en supprime aucun. C'est **symétrique**, donc sans orphelin, mais muet. Le documenter explicitement (voir ci-dessous) est ce que fait cette PR ; en faire un avertissement demanderait de toucher les deux commandes à la fois pour rester symétrique, et de changer leur sortie — à traiter séparément si souhaité.

## Doc

`docs/wiki/link.md` (relu après sa réécriture par #362) ne mentionnait pas du tout l'appariement du coordinateur. Une section courte l'énonce maintenant : la règle nom-ou-slug, le fait que `unlink` l'applique à l'identique dans le repli, et le no-op silencieux ci-dessus.

## Gate

| Étape | Résultat |
|---|---|
| `cargo fmt --all -- --check` | OK |
| clippy `-D warnings`, 5 modes | 5/5 OK |
| tests, 4 modes (`--no-fail-fast`) | 0 échec |
| gaveldrop | **13 cas · 83/83** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
