### PR TITLE
refactor(test): share one poison-tolerant env isolation guard

### DIFF
--- a/crates/armadai-core/Cargo.toml
+++ b/crates/armadai-core/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "ArmadAI — reusable orchestration core: domain types, Provider/EventLog traits, parser, event-sourced engine."
 
 [features]
-test-support = []
+test-support = ["dep:tempfile"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -23,6 +23,7 @@ pulldown-cmark = { workspace = true }
 include_dir = { workspace = true }
 tracing = { workspace = true }
 dialoguer = { workspace = true }
+tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/armadai-core/src/agent_source.rs
+++ b/crates/armadai-core/src/agent_source.rs
@@ -737,13 +737,13 @@ agents:
     /// included). A test exercising `load_all_agents` without isolating
     /// this can pass — or fail — for a reason that has nothing to do with
     /// its own fixture, and would behave differently on a machine that has
-    /// never run those commands. Serialised via `ENV_MUTEX` since it
+    /// never run those commands. Serialised via `env_lock()` since it
     /// mutates a process-global env var.
     fn with_isolated_global_library<T>(f: impl FnOnce() -> T) -> T {
-        let _guard = crate::config::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         let empty = tempfile::tempdir().unwrap();
-        // SAFETY: serialised via ENV_MUTEX above.
+        // SAFETY: serialised via `env_lock()` above.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", empty.path());
         }

--- a/crates/armadai-core/src/config.rs
+++ b/crates/armadai-core/src/config.rs
@@ -446,21 +446,6 @@ providers:
 ";
 
 // ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-/// Global mutex to serialise tests that mutate `ARMADAI_CONFIG_DIR`.
-///
-/// Test-only. Exposed behind the `test-support` feature (and `cfg(test)` for
-/// this crate's own tests) so downstream crates can serialise their env-var
-/// tests against the same lock — a downstream test build enables
-/// `armadai-core/test-support` via its `[dev-dependencies]`. It is NOT part of
-/// the production public API (absent unless a test build pulls it in).
-#[cfg(any(test, feature = "test-support"))]
-pub static ENV_MUTEX: std::sync::LazyLock<std::sync::Mutex<()>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -501,11 +486,11 @@ mod tests {
 
     #[test]
     fn test_config_dir_respects_env() {
-        let _guard = super::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         // Save and restore env
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         // SAFETY: This test modifies the global environment which is unsafe in Rust 2024.
-        // Serialised via ENV_MUTEX to avoid data races with other tests.
+        // Serialised via `env_lock()` to avoid data races with other tests.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", "/tmp/test-armadai-config");
         }
@@ -582,10 +567,10 @@ providers:
 
     #[test]
     fn test_user_dirs() {
-        let _guard = super::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         // SAFETY: This test modifies the global environment which is unsafe in Rust 2024.
-        // Serialised via ENV_MUTEX to avoid data races with other tests.
+        // Serialised via `env_lock()` to avoid data races with other tests.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", "/tmp/armadai-test");
         }

--- a/crates/armadai-core/src/lib.rs
+++ b/crates/armadai-core/src/lib.rs
@@ -22,3 +22,5 @@ pub mod routing;
 pub mod skill;
 pub mod starter;
 pub mod template;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;

--- a/crates/armadai-core/src/registries.rs
+++ b/crates/armadai-core/src/registries.rs
@@ -359,9 +359,9 @@ registries:
 
     #[test]
     fn load_user_registries_missing_file_returns_default() {
-        let _guard = crate::config::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var(
                 "ARMADAI_CONFIG_DIR",

--- a/crates/armadai-core/src/skill.rs
+++ b/crates/armadai-core/src/skill.rs
@@ -295,10 +295,10 @@ mod tests {
 
     #[test]
     fn test_install_embedded_skills() {
-        let _guard = crate::config::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         // SAFETY: This test modifies the global environment which is unsafe in Rust 2024.
-        // Serialised via ENV_MUTEX to avoid data races with other tests.
+        // Serialised via `env_lock()` to avoid data races with other tests.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }

--- a/crates/armadai-core/src/starter.rs
+++ b/crates/armadai-core/src/starter.rs
@@ -571,12 +571,12 @@ description: Minimal pack
 
     #[test]
     fn test_install_pack() {
-        let _guard = crate::config::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         let config_dir = tempfile::tempdir().unwrap();
 
         // Override config dir for test.
         // SAFETY: This test modifies the global environment which is unsafe in Rust 2024.
-        // Serialised via ENV_MUTEX to avoid data races with other tests.
+        // Serialised via `env_lock()` to avoid data races with other tests.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", config_dir.path());
         }
@@ -668,11 +668,11 @@ skills:
 
     #[test]
     fn test_install_rejects_path_traversal_agent_name() {
-        let _guard = crate::config::ENV_MUTEX.lock().unwrap();
+        let _guard = crate::test_support::env_lock();
         let config_dir = tempfile::tempdir().unwrap();
 
         // SAFETY: This test modifies the global environment which is unsafe in Rust 2024.
-        // Serialised via ENV_MUTEX to avoid data races with other tests.
+        // Serialised via `env_lock()` to avoid data races with other tests.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", config_dir.path());
         }

--- a/crates/armadai-core/src/test_support.rs
+++ b/crates/armadai-core/src/test_support.rs
@@ -43,10 +43,24 @@ fn lock_ignoring_poison<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 /// restoration each guard's own `Drop` already performs — and `Drop` runs
 /// during unwinding, before the poison is even set.
 ///
-/// Measured (issue #365, `--test-threads=1`): with `.unwrap()` here, a single
-/// deliberately failing test holding this lock turned into **48 failing
-/// tests**, 47 of them phantom `PoisonError`s spread over nine unrelated
-/// modules, burying the one real failure.
+/// That reasoning holds for the RAII guards below. It does **not** hold for
+/// the ~19 call sites that take this lock and then restore by hand, with no
+/// `Drop`: there, tolerating poison trades a cascade of phantom
+/// `PoisonError`s for one leaked env var propagating quietly into whichever
+/// tests run next. Measured (#372 review): 3 downstream tests read a value
+/// leaked by a deliberately failed `skill::tests` case — against 5 before
+/// this change, so an improvement rather than a regression, and it cannot
+/// turn CI falsely green (a test must already be failing for anything to
+/// leak at all). The real fix for those sites is `IsolatedConfigDir`, which
+/// does exactly what they open-code, safely.
+///
+/// Measured (issue #365, `--test-threads=1`, `--bin armadai`): with
+/// `.unwrap()` here, one deliberately failing test holding this lock turned
+/// into a cascade of phantom `PoisonError`s across unrelated modules, burying
+/// the one real failure — 74 with the red test early in the run, 8 with it
+/// late, since the blast radius is a function of how many sites still take
+/// the lock afterwards. With the tolerance, the same mutation gives
+/// `693 passed; 1 failed` and zero phantoms.
 pub fn env_lock() -> MutexGuard<'static, ()> {
     lock_ignoring_poison(&ENV_MUTEX)
 }
@@ -156,9 +170,33 @@ mod tests {
     /// [`env_lock`]'s `unwrap_or_else`. Tested against a private mutex rather
     /// than `ENV_MUTEX`, so proving it costs the rest of the suite nothing.
     ///
+    /// This covers the *delegate*, not the delegation — see
+    /// [`the_real_env_lock_tolerates_poisoning`], which covers `env_lock`
+    /// itself. Reverting `env_lock` alone to `.unwrap()` left 1281 tests green
+    /// (#372 review): a proxy for the property is not the property.
+    ///
     /// Mutation this catches: `lock_ignoring_poison`'s body reverted to
     /// `mutex.lock().unwrap()` — this test then panics with `PoisonError`
     /// instead of returning.
+    /// The property the whole module exists for, asserted on the **real**
+    /// `env_lock()` rather than through a stand-in. Once the tolerance is in
+    /// place, poisoning `ENV_MUTEX` is precisely harmless — which is what
+    /// makes this test affordable, and what makes it fail loudly across the
+    /// suite if the tolerance ever regresses.
+    #[test]
+    fn the_real_env_lock_tolerates_poisoning() {
+        let panicked = std::panic::catch_unwind(|| {
+            let _held = env_lock();
+            panic!("deliberate panic while holding the shared env lock");
+        });
+        assert!(panicked.is_err(), "the helper panic must have unwound");
+        assert!(
+            ENV_MUTEX.lock().is_err(),
+            "ENV_MUTEX must actually be poisoned now, otherwise this test proves nothing"
+        );
+        let _recovered = env_lock();
+    }
+
     #[test]
     fn a_poisoned_mutex_is_still_acquirable() {
         static POISONED: std::sync::LazyLock<Mutex<u32>> =

--- a/crates/armadai-core/src/test_support.rs
+++ b/crates/armadai-core/src/test_support.rs
@@ -1,0 +1,253 @@
+//! Shared test-only environment isolation.
+//!
+//! Tests across this workspace mutate process-global state — the
+//! `ARMADAI_CONFIG_DIR` env var, `HOME`, the current directory — and so must
+//! be serialised against each other. They all serialise on the single
+//! [`ENV_MUTEX`], but they used to each acquire it, and each re-implement the
+//! save/restore guard around it, on their own. That duplication had already
+//! diverged: one copy tolerated poisoning while every other copy did not (see
+//! [`env_lock`]), and two ~50-line `ProjectDirGuard` copies differed only by a
+//! doc sentence.
+//!
+//! Everything here is test-only: gated behind `cfg(test)` for this crate and
+//! the `test-support` feature for downstream crates (enabled from their
+//! `[dev-dependencies]`, so a release build never pulls it in).
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+/// Global mutex serialising every test that mutates process-global
+/// environment state.
+///
+/// Private on purpose: acquire it through [`env_lock`], never directly. A
+/// direct `ENV_MUTEX.lock().unwrap()` is exactly the defect issue #365
+/// measured, and making the static unreachable is what stops it coming back.
+static ENV_MUTEX: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| Mutex::new(()));
+
+/// Acquire `mutex`, recovering the guard instead of panicking when a previous
+/// holder panicked while holding it.
+///
+/// Split out from [`env_lock`] so the poison-tolerance itself can be tested
+/// against a throwaway mutex, without poisoning the process-wide [`ENV_MUTEX`]
+/// that every other test in the run depends on.
+fn lock_ignoring_poison<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Acquire the shared environment lock, tolerating poisoning.
+///
+/// Poison-tolerant because [`ENV_MUTEX`] guards `()`: there is no shared data
+/// a panicking holder could have left inconsistent, only the env-var/cwd
+/// restoration each guard's own `Drop` already performs — and `Drop` runs
+/// during unwinding, before the poison is even set.
+///
+/// Measured (issue #365, `--test-threads=1`): with `.unwrap()` here, a single
+/// deliberately failing test holding this lock turned into **48 failing
+/// tests**, 47 of them phantom `PoisonError`s spread over nine unrelated
+/// modules, burying the one real failure.
+pub fn env_lock() -> MutexGuard<'static, ()> {
+    lock_ignoring_poison(&ENV_MUTEX)
+}
+
+/// Points `ARMADAI_CONFIG_DIR` at a fresh, empty temp dir for the guard's
+/// lifetime, restoring the previous value (present or absent) on drop — while
+/// holding [`env_lock`] throughout.
+///
+/// Without it, anything reading the user config (`AppPaths::resolve`, the
+/// global agent library `load_all_agents` scans for shadowing collisions, …)
+/// reads whatever `~/.config/armadai/` happens to hold on the machine running
+/// the test.
+pub struct IsolatedConfigDir {
+    _lock: MutexGuard<'static, ()>,
+    orig_config_dir: Option<String>,
+    config_tmp: tempfile::TempDir,
+}
+
+impl IsolatedConfigDir {
+    pub fn enter() -> Self {
+        let lock = env_lock();
+        let orig_config_dir = std::env::var("ARMADAI_CONFIG_DIR").ok();
+        let config_tmp = tempfile::tempdir().expect("temp config dir");
+        // SAFETY: serialised via the lock held above.
+        unsafe {
+            std::env::set_var("ARMADAI_CONFIG_DIR", config_tmp.path());
+        }
+        Self {
+            _lock: lock,
+            orig_config_dir,
+            config_tmp,
+        }
+    }
+
+    /// The isolated config dir itself — for a test that wants to plant a
+    /// `config.yaml` in it (redirecting storage, say).
+    pub fn config_dir(&self) -> &Path {
+        self.config_tmp.path()
+    }
+
+    /// The isolated global agent library (`<ARMADAI_CONFIG_DIR>/agents`) — for
+    /// a test that wants to plant a same-named `.md` there to trigger a
+    /// declared/global shadowing collision deliberately.
+    pub fn global_agents_dir(&self) -> PathBuf {
+        self.config_tmp.path().join("agents")
+    }
+}
+
+impl Drop for IsolatedConfigDir {
+    fn drop(&mut self) {
+        // SAFETY: restoring original env state, still under the lock held by
+        // `self._lock` until this `Drop` returns.
+        unsafe {
+            match &self.orig_config_dir {
+                Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
+                None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
+            }
+        }
+    }
+}
+
+/// [`IsolatedConfigDir`] plus a process cwd moved to `project_root`, restored
+/// on drop.
+///
+/// Composed rather than merged: plenty of tests need only the config-dir half,
+/// and moving the cwd is the strictly stronger, strictly rarer need — a
+/// surface resolving its project through the cwd-reading
+/// `project::find_project_config()` (as opposed to its `_from(start)` twin,
+/// which needs no guard at all).
+pub struct IsolatedProjectDir {
+    config: IsolatedConfigDir,
+    orig_cwd: PathBuf,
+}
+
+impl IsolatedProjectDir {
+    pub fn enter(project_root: &Path) -> Self {
+        let config = IsolatedConfigDir::enter();
+        let orig_cwd = std::env::current_dir().expect("readable cwd");
+        std::env::set_current_dir(project_root).expect("cwd to project root");
+        Self { config, orig_cwd }
+    }
+
+    /// See [`IsolatedConfigDir::config_dir`].
+    pub fn config_dir(&self) -> &Path {
+        self.config.config_dir()
+    }
+
+    /// See [`IsolatedConfigDir::global_agents_dir`].
+    pub fn global_agents_dir(&self) -> PathBuf {
+        self.config.global_agents_dir()
+    }
+}
+
+impl Drop for IsolatedProjectDir {
+    fn drop(&mut self) {
+        // Runs before `self.config` drops, so the cwd is restored while the
+        // env lock is still held.
+        let _ = std::env::set_current_dir(&self.orig_cwd);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A poisoned lock must still be acquirable: this is the whole point of
+    /// [`env_lock`]'s `unwrap_or_else`. Tested against a private mutex rather
+    /// than `ENV_MUTEX`, so proving it costs the rest of the suite nothing.
+    ///
+    /// Mutation this catches: `lock_ignoring_poison`'s body reverted to
+    /// `mutex.lock().unwrap()` — this test then panics with `PoisonError`
+    /// instead of returning.
+    #[test]
+    fn a_poisoned_mutex_is_still_acquirable() {
+        static POISONED: std::sync::LazyLock<Mutex<u32>> =
+            std::sync::LazyLock::new(|| Mutex::new(0));
+
+        // Poison it exactly the way a legitimately failing test does: panic
+        // while holding the guard.
+        let panicked = std::panic::catch_unwind(|| {
+            let mut held = lock_ignoring_poison(&POISONED);
+            *held = 7;
+            panic!("deliberate panic while holding the lock");
+        });
+        assert!(panicked.is_err(), "the helper panic must have unwound");
+        assert!(
+            POISONED.lock().is_err(),
+            "the mutex must actually be poisoned, otherwise this test proves nothing"
+        );
+
+        let recovered = lock_ignoring_poison(&POISONED);
+        assert_eq!(
+            *recovered, 7,
+            "the guard must be recovered from the poison, carrying the value the \
+             panicking holder left"
+        );
+    }
+
+    /// Read process-global state that other tests temporarily mutate, at a
+    /// moment no guard holds it — i.e. under the lock, where by construction
+    /// every guard has already restored what it changed. Reading it unguarded
+    /// races: the reader can observe another test's temp dir as if it were the
+    /// baseline, and then "restored" fails against a value that was never the
+    /// original. (Measured: that is exactly how the first version of the two
+    /// tests below failed in the full suite while passing in isolation.)
+    fn undisturbed<T>(read: impl FnOnce() -> T) -> T {
+        let _lock = env_lock();
+        read()
+    }
+
+    /// The guard's contract is that it restores what it changed — including
+    /// after the panic that poisoned the lock in the first place.
+    ///
+    /// Mutation this catches: deleting either arm of `IsolatedConfigDir`'s
+    /// `Drop` (the `set_var` restore or the `remove_var` one).
+    #[test]
+    fn the_config_dir_guard_restores_the_previous_value() {
+        let before = undisturbed(|| std::env::var("ARMADAI_CONFIG_DIR").ok());
+        {
+            let guard = IsolatedConfigDir::enter();
+            assert_eq!(
+                std::env::var("ARMADAI_CONFIG_DIR").ok().as_deref(),
+                guard.config_dir().to_str(),
+                "the guard must point ARMADAI_CONFIG_DIR at its own temp dir"
+            );
+            assert_ne!(
+                Some(guard.config_dir().to_string_lossy().to_string()),
+                before,
+                "the temp dir must differ from whatever was set before"
+            );
+        }
+        assert_eq!(
+            undisturbed(|| std::env::var("ARMADAI_CONFIG_DIR").ok()),
+            before,
+            "ARMADAI_CONFIG_DIR must be exactly as it was, present or absent"
+        );
+    }
+
+    /// Mutation this catches: deleting `IsolatedProjectDir`'s `Drop` (or its
+    /// `set_current_dir` call), which leaves the whole test binary sitting in
+    /// a deleted temp dir.
+    #[test]
+    fn the_project_dir_guard_restores_the_previous_cwd() {
+        let before = undisturbed(|| std::env::current_dir().unwrap());
+        let project = tempfile::tempdir().unwrap();
+        // macOS puts temp dirs under a symlinked /var, so compare canonical
+        // paths — `set_current_dir` resolves the link, the fixture path does
+        // not.
+        let expected = project.path().canonicalize().unwrap();
+        {
+            let _guard = IsolatedProjectDir::enter(project.path());
+            assert_eq!(
+                std::env::current_dir().unwrap().canonicalize().unwrap(),
+                expected,
+                "the guard must move the process into the project root"
+            );
+        }
+        assert_eq!(
+            undisturbed(|| std::env::current_dir().unwrap()),
+            before,
+            "the cwd must be back where it started"
+        );
+    }
+}

--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -507,14 +507,14 @@ impl Provider for CliProvider {
 mod tests {
     use super::*;
 
-    /// Run `fut` while holding `ENV_MUTEX`, serialising the child-process spawn's
+    /// Run `fut` while holding `env_lock()`, serialising the child-process spawn's
     /// read of `environ` against tests that mutate it via `std::env::set_var`
     /// (otherwise a data race — the reason `set_var` is `unsafe`). Holding the
     /// guard across `.await` is safe here: no other async task contends for
-    /// `ENV_MUTEX`, so there is no deadlock risk.
+    /// `env_lock()`, so there is no deadlock risk.
     #[allow(clippy::await_holding_lock)]
     async fn with_env_lock<T>(fut: impl std::future::Future<Output = T>) -> T {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         fut.await
     }
 
@@ -690,7 +690,7 @@ mod tests {
     async fn steady_stream_survives_past_the_old_static_ceiling() {
         let old_static_ceiling = std::time::Duration::from_secs(1);
         // `start` MUST be taken inside `with_env_lock`, after the global
-        // `ENV_MUTEX` is actually held — not before. `with_env_lock` blocks
+        // `env_lock()` is actually held — not before. `with_env_lock` blocks
         // on that mutex, shared by every test in this module that spawns a
         // real subprocess; under a loaded parallel `cargo test`, queueing
         // for it can itself take seconds. Timing from outside the lock
@@ -743,7 +743,7 @@ mod tests {
     async fn silent_subprocess_dies_near_the_inactivity_ceiling_not_later() {
         // `start` inside `with_env_lock`, not outside — see the identical
         // note on `steady_stream_survives_past_the_old_static_ceiling`
-        // (#270 review round 3: queue-wait for the shared `ENV_MUTEX` must
+        // (#270 review round 3: queue-wait for the shared `env_lock()` must
         // not be counted as part of the measured duration).
         let (result, elapsed) = with_env_lock(async {
             let start = std::time::Instant::now();
@@ -763,7 +763,7 @@ mod tests {
         // magnitude). Upper bound: tight now that `start` is measured
         // inside the lock (well under the 60s sleep, but no longer needs
         // to absorb queue-wait time from other tests contending for
-        // `ENV_MUTEX`).
+        // `env_lock()`).
         assert!(
             elapsed >= std::time::Duration::from_millis(500),
             "should wait close to the configured 1s ceiling before dying, not fire near-instantly: {elapsed:?}"
@@ -797,7 +797,7 @@ mod tests {
     #[tokio::test]
     async fn complete_does_not_hang_when_stdout_closes_but_the_child_keeps_running() {
         // `start` inside `with_env_lock`, not outside (#270 review round 3
-        // / round 4): the shared `ENV_MUTEX` is contended by every
+        // / round 4): the shared `env_lock()` is contended by every
         // subprocess-spawning test in this module, and queue-wait for it
         // must not be counted toward "did this call hang". The margin here
         // is coarse (correct ~1s vs a hang toward 30s) so the bound itself

--- a/crates/armadai-providers/src/model_registry/fetch.rs
+++ b/crates/armadai-providers/src/model_registry/fetch.rs
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     #[cfg(feature = "api")]
     fn source_cache_path_is_stable_and_distinct_per_source() {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let a = source_cache_path("https://models.dev/api.json");
         let b = source_cache_path("https://example.com/custom-models.json");
         assert_ne!(a, b);
@@ -499,10 +499,10 @@ mod tests {
         // Exercises the real `resolved_model_sources()` glue (not just the
         // pure `resolved_sources` helper) with a `RegistriesConfig` loaded
         // from disk, per the B2 Task 2 review follow-up.
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }

--- a/crates/armadai/src/audit/usage/discovery.rs
+++ b/crates/armadai/src/audit/usage/discovery.rs
@@ -264,8 +264,8 @@ mod tests {
 
     impl ProjectsDirGuard {
         fn set(path: &Path) -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            let lock = armadai_core::test_support::env_lock();
+            // SAFETY: modifies the global environment; serialised via `env_lock()`.
             unsafe { std::env::set_var("ARMADAI_CLAUDE_PROJECTS_DIR", path) }
             Self { _lock: lock }
         }
@@ -280,7 +280,7 @@ mod tests {
 
     /// Removes `ARMADAI_CLAUDE_PROJECTS_DIR` and `HOME` for the test's
     /// duration, restoring both original values (present or absent) on drop.
-    /// Serialises via `ENV_MUTEX`, like `ProjectsDirGuard` — the rest of the
+    /// Serialises via `env_lock()`, like `ProjectsDirGuard` — the rest of the
     /// suite needs `HOME` back, since other tests rely on it implicitly.
     struct NoHomeGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -290,10 +290,10 @@ mod tests {
 
     impl NoHomeGuard {
         fn set() -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
+            let lock = armadai_core::test_support::env_lock();
             let original_home = std::env::var("HOME").ok();
             let original_projects_dir = std::env::var("ARMADAI_CLAUDE_PROJECTS_DIR").ok();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            // SAFETY: modifies the global environment; serialised via `env_lock()`.
             unsafe {
                 std::env::remove_var("HOME");
                 std::env::remove_var("ARMADAI_CLAUDE_PROJECTS_DIR");

--- a/crates/armadai/src/audit/usage/scan.rs
+++ b/crates/armadai/src/audit/usage/scan.rs
@@ -319,8 +319,8 @@ mod tests {
     }
     impl ProjectsDirGuard {
         fn set(path: &Path) -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            let lock = armadai_core::test_support::env_lock();
+            // SAFETY: modifies the global environment; serialised via `env_lock()`.
             unsafe { std::env::set_var("ARMADAI_CLAUDE_PROJECTS_DIR", path) }
             Self { _lock: lock }
         }

--- a/crates/armadai/src/claude_adapter/mod.rs
+++ b/crates/armadai/src/claude_adapter/mod.rs
@@ -348,8 +348,8 @@ mod tests {
     fn register_from_reader_appends_index() {
         let dir = tempfile::tempdir().unwrap();
         let idx = dir.path().join("idx.jsonl");
-        // SAFETY: single-threaded test; serialise env via ENV_MUTEX in real cross-test setups.
-        let _g = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        // SAFETY: single-threaded test; serialise env via `env_lock()` in real cross-test setups.
+        let _g = armadai_core::test_support::env_lock();
         unsafe {
             std::env::set_var("ARMADAI_SESSION_INDEX", &idx);
         }
@@ -370,8 +370,8 @@ mod tests {
     fn register_from_reader_stamps_started_at_when_payload_has_no_timestamp() {
         let dir = tempfile::tempdir().unwrap();
         let idx = dir.path().join("idx.jsonl");
-        // SAFETY: single-threaded test; serialise env via ENV_MUTEX.
-        let _g = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        // SAFETY: single-threaded test; serialise env via `env_lock()`.
+        let _g = armadai_core::test_support::env_lock();
         unsafe {
             std::env::set_var("ARMADAI_SESSION_INDEX", &idx);
         }

--- a/crates/armadai/src/cli/audit.rs
+++ b/crates/armadai/src/cli/audit.rs
@@ -253,9 +253,9 @@ mod tests {
 
     impl ProjectsDirGuard {
         fn empty() -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
+            let lock = armadai_core::test_support::env_lock();
             let dir = tempfile::tempdir().unwrap();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            // SAFETY: modifies the global environment; serialised via `env_lock()`.
             unsafe { std::env::set_var("ARMADAI_CLAUDE_PROJECTS_DIR", dir.path()) }
             Self {
                 _dir: dir,
@@ -267,8 +267,8 @@ mod tests {
         /// populated with transcripts (see `usage_scenario`) rather than a
         /// fresh empty one.
         fn at(dir: tempfile::TempDir) -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            let lock = armadai_core::test_support::env_lock();
+            // SAFETY: modifies the global environment; serialised via `env_lock()`.
             unsafe { std::env::set_var("ARMADAI_CLAUDE_PROJECTS_DIR", dir.path()) }
             Self {
                 _dir: dir,

--- a/crates/armadai/src/cli/init.rs
+++ b/crates/armadai/src/cli/init.rs
@@ -452,10 +452,10 @@ mod tests {
         // Backward compat: with no starter registry sources configured (the
         // default — no `registries.yaml`), a miss on an unknown pack name
         // must return None without attempting any sync/network call.
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         let config_dir = tempfile::tempdir().unwrap();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", config_dir.path());
         }

--- a/crates/armadai/src/cli/registry.rs
+++ b/crates/armadai/src/cli/registry.rs
@@ -610,11 +610,11 @@ mod tests {
     async fn sources_add_and_load() {
         use tempfile::tempdir;
 
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
 
         let temp = tempdir().unwrap();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", temp.path());
         }
@@ -637,11 +637,11 @@ mod tests {
     async fn sources_remove_existing() {
         use tempfile::tempdir;
 
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
 
         let temp = tempdir().unwrap();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", temp.path());
         }
@@ -664,11 +664,11 @@ mod tests {
     async fn sources_add_is_idempotent() {
         use tempfile::tempdir;
 
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
 
         let temp = tempdir().unwrap();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", temp.path());
         }

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -3286,50 +3286,7 @@ mod es_switch_tests {
         (capture, dyn_sink)
     }
 
-    /// Redirect `storage` at a throwaway temp DB for the scope of a test, so
-    /// the ES dispatch's persistence (`SqliteLog` via `crate::db::init_db`)
-    /// never writes into the user's real event log (#267). Points
-    /// `ARMADAI_CONFIG_DIR` at a temp `config.yaml` whose `storage.path` is a
-    /// scratch sqlite file; serialised via `ENV_MUTEX` and restored on drop.
-    /// Mirrors the guard in `src/web/api.rs` tests.
-    struct TempStorageGuard {
-        _dir: tempfile::TempDir,
-        orig: Option<String>,
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl TempStorageGuard {
-        fn new() -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
-            let dir = tempfile::tempdir().unwrap();
-            let db_path = dir.path().join("test.sqlite");
-            let config_yaml = format!(
-                "storage:\n  mode: embedded\n  path: \"{}\"\n",
-                db_path.display()
-            );
-            std::fs::write(dir.path().join("config.yaml"), config_yaml).unwrap();
-            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
-            unsafe {
-                std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
-            }
-            Self {
-                _dir: dir,
-                orig,
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for TempStorageGuard {
-        fn drop(&mut self) {
-            match self.orig.take() {
-                // SAFETY: restoring original env state at end of test scope.
-                Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
-                None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
-            }
-        }
-    }
+    use crate::test_support::TempStorageGuard;
 
     // ── T5a: direct ──────────────────────────────────────────────────
 

--- a/crates/armadai/src/cli/watch.rs
+++ b/crates/armadai/src/cli/watch.rs
@@ -65,7 +65,7 @@ mod tests {
         assert_eq!(claude.role, AgentRole::Coordinator);
     }
 
-    /// Holds `ENV_MUTEX` for the duration of `ARMADAI_SESSION_INDEX`
+    /// Holds `env_lock()` for the duration of `ARMADAI_SESSION_INDEX`
     /// mutation, serialising it against other env-mutating tests across the
     /// crate. Wrapped in a struct (rather than a bare local `MutexGuard`)
     /// because these tests are `#[tokio::test]` and hold the lock across an
@@ -78,8 +78,8 @@ mod tests {
 
     impl SessionIndexEnvGuard {
         fn set(path: &std::path::Path) -> Self {
-            let lock = armadai_core::config::ENV_MUTEX.lock().unwrap();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
+            let lock = armadai_core::test_support::env_lock();
+            // SAFETY: modifies the global environment; serialised via `env_lock()`.
             unsafe {
                 std::env::set_var("ARMADAI_SESSION_INDEX", path);
             }

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -394,13 +394,13 @@ mod tests {
     /// from a dev box's real global library instead of the fixture below,
     /// and pass or fail for a reason that has nothing to do with its own
     /// fixture. Mirrors `agent_source.rs`'s own
-    /// `with_isolated_global_library`; serialised via `ENV_MUTEX` since it
+    /// `with_isolated_global_library`; serialised via `env_lock()` since it
     /// mutates a process-global env var.
     fn with_isolated_global_library<T>(f: impl FnOnce() -> T) -> T {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         let empty = tempfile::tempdir().unwrap();
-        // SAFETY: serialised via ENV_MUTEX above.
+        // SAFETY: serialised via `env_lock()` above.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", empty.path());
         }

--- a/crates/armadai/src/linker/model_resolution.rs
+++ b/crates/armadai/src/linker/model_resolution.rs
@@ -461,10 +461,10 @@ mod tests {
         // machine + parallel test runs — see resolve_model_for_tier's
         // doc-comment). With no cache reachable, resolution always takes the
         // hardcoded-fallback path, making the assertion deterministic.
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         let tmp = tempfile::tempdir().expect("tempdir");
-        // SAFETY: env mutation is serialised via ENV_MUTEX for the duration
+        // SAFETY: env mutation is serialised via `env_lock()` for the duration
         // of this test, and the original value is restored before returning.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path());

--- a/crates/armadai/src/main.rs
+++ b/crates/armadai/src/main.rs
@@ -19,6 +19,8 @@ mod registry;
 mod shell;
 mod skills_registry;
 mod starters_registry;
+#[cfg(test)]
+mod test_support;
 #[cfg(feature = "tui")]
 mod theme;
 #[cfg(feature = "tui")]

--- a/crates/armadai/src/registry/cache.rs
+++ b/crates/armadai/src/registry/cache.rs
@@ -350,10 +350,10 @@ mod tests {
     }
 
     fn with_config_dir<F: FnOnce(&std::path::Path)>(f: F) {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of scope.
+        // SAFETY: serialised via `env_lock()`; restored at end of scope.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }

--- a/crates/armadai/src/registry/sync.rs
+++ b/crates/armadai/src/registry/sync.rs
@@ -240,10 +240,10 @@ mod tests {
 
     #[test]
     fn is_stale_true_when_never_synced() {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }
@@ -258,10 +258,10 @@ mod tests {
 
     #[test]
     fn is_stale_false_right_after_mark_synced() {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }
@@ -277,10 +277,10 @@ mod tests {
 
     #[test]
     fn is_stale_true_when_marker_older_than_ttl() {
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }
@@ -310,10 +310,10 @@ mod tests {
         // Exercises the real `effective_sources()` glue (not just the pure
         // `resolved_sources` helper) with a `RegistriesConfig` loaded from
         // disk, per the B2 Task 2 review follow-up.
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let dir = tempfile::tempdir().unwrap();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-        // SAFETY: serialised via ENV_MUTEX; restored at end of test.
+        // SAFETY: serialised via `env_lock()`; restored at end of test.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
         }

--- a/crates/armadai/src/shell/config.rs
+++ b/crates/armadai/src/shell/config.rs
@@ -81,10 +81,10 @@ mod tests {
         // low/fast → Fast tier and high/max → Max tier collapsing invariant
         // this test is meant to guard. Mirrors
         // `armadai_core::model_resolution::test_preview_resolution_with_latest`.
-        let _guard = armadai_core::config::ENV_MUTEX.lock().unwrap();
+        let _guard = armadai_core::test_support::env_lock();
         let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
         let tmp = tempfile::tempdir().expect("tempdir");
-        // SAFETY: env mutation is serialised via ENV_MUTEX for the duration
+        // SAFETY: env mutation is serialised via `env_lock()` for the duration
         // of this test, and the original value is restored before returning.
         unsafe {
             std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path());

--- a/crates/armadai/src/shell/wizard.rs
+++ b/crates/armadai/src/shell/wizard.rs
@@ -650,104 +650,7 @@ fn detect_project_name() -> String {
 #[cfg(test)]
 mod run_link_tests {
     use super::*;
-    use armadai_core::config::ENV_MUTEX;
-
-    /// Points `ARMADAI_CONFIG_DIR` at a fresh, empty temp dir for the
-    /// guard's lifetime, restoring it on drop — serialised on `ENV_MUTEX`
-    /// (shared with the rest of the workspace's env-mutating tests, see
-    /// `armadai_core::config`'s own tests and `web::api`'s
-    /// `load_agents_declarative_tests`). Without this, `load_all_agents`'s
-    /// shadowing check would scan whatever `~/.config/armadai/agents/`
-    /// happens to hold on the machine running the test.
-    struct IsolatedGlobalConfig {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        orig_config_dir: Option<String>,
-        config_tmp: tempfile::TempDir,
-    }
-
-    impl IsolatedGlobalConfig {
-        fn enter() -> Self {
-            // Poison-tolerant: `ENV_MUTEX` only ever guards `()` — there is
-            // no shared data a panicking prior holder could have left
-            // inconsistent, only the env var/cwd restoration each guard's
-            // own `Drop` already performs (and `Drop` still runs during
-            // unwinding, before the poison is even set). Review point 3
-            // (fix round on `fix/wizard-link-write-path`): a single
-            // legitimately failing test elsewhere in this module used to
-            // poison this mutex and cascade every *other* test using this
-            // guard into an unrelated `PoisonError` — recovering the guard
-            // instead keeps a real failure from being buried under
-            // phantom ones.
-            let lock = ENV_MUTEX
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let orig_config_dir = std::env::var("ARMADAI_CONFIG_DIR").ok();
-            let config_tmp = tempfile::tempdir().unwrap();
-            // SAFETY: serialised via ENV_MUTEX above.
-            unsafe {
-                std::env::set_var("ARMADAI_CONFIG_DIR", config_tmp.path());
-            }
-            Self {
-                _lock: lock,
-                orig_config_dir,
-                config_tmp,
-            }
-        }
-
-        /// The isolated global agent library (`<ARMADAI_CONFIG_DIR>/agents`)
-        /// — for a test that wants to plant a same-named `.md` there to
-        /// trigger a declared/global shadowing collision deliberately.
-        fn global_agents_dir(&self) -> std::path::PathBuf {
-            self.config_tmp.path().join("agents")
-        }
-    }
-
-    impl Drop for IsolatedGlobalConfig {
-        fn drop(&mut self) {
-            // SAFETY: still under the guard held by `self._lock`.
-            unsafe {
-                match &self.orig_config_dir {
-                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
-                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
-                }
-            }
-        }
-    }
-
-    /// Extends [`IsolatedGlobalConfig`] with a process cwd change, for the
-    /// one test below that must exercise `cli::unlink::execute` — which,
-    /// unlike [`run_link_at`], has no root-taking variant and resolves its
-    /// project via `project::find_project_config()`'s cwd read. Restores
-    /// the original cwd on drop, still under the same env-mutex guard.
-    struct IsolatedProjectDir {
-        _config: IsolatedGlobalConfig,
-        orig_cwd: std::path::PathBuf,
-    }
-
-    impl IsolatedProjectDir {
-        fn enter(root: &Path) -> Self {
-            let config = IsolatedGlobalConfig::enter();
-            let orig_cwd = std::env::current_dir().unwrap();
-            std::env::set_current_dir(root).unwrap();
-            Self {
-                _config: config,
-                orig_cwd,
-            }
-        }
-
-        /// The isolated global agent library, for a test that wants to
-        /// plant a same-named `.md` there — see
-        /// [`IsolatedGlobalConfig::global_agents_dir`].
-        fn global_agents_dir(&self) -> std::path::PathBuf {
-            self._config.global_agents_dir()
-        }
-    }
-
-    impl Drop for IsolatedProjectDir {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.orig_cwd);
-        }
-    }
+    use armadai_core::test_support::{IsolatedConfigDir, IsolatedProjectDir};
 
     /// A project with two file-backed agents, `keep` and `drop`, no
     /// declarative agents, targeting nothing in particular — `run_link_at`
@@ -883,7 +786,7 @@ mod run_link_tests {
     /// return an error instead of `Ok`.
     #[tokio::test]
     async fn wizard_link_sees_agents_declared_only_in_agents_yaml() {
-        let _isolated = IsolatedGlobalConfig::enter();
+        let _isolated = IsolatedConfigDir::enter();
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("project");
@@ -921,7 +824,7 @@ mod run_link_tests {
     /// call return `Ok` and write `solo.md` — both assertions below fail.
     #[tokio::test]
     async fn wizard_link_refuses_a_write_when_a_declared_agent_is_shadowed() {
-        let isolated = IsolatedGlobalConfig::enter();
+        let isolated = IsolatedConfigDir::enter();
         std::fs::create_dir_all(isolated.global_agents_dir()).unwrap();
         std::fs::write(
             isolated.global_agents_dir().join("collide.md"),
@@ -978,7 +881,7 @@ mod run_link_tests {
     /// both assertions below fail.
     #[tokio::test]
     async fn wizard_link_resolves_latest_placeholders_the_way_link_does() {
-        let _isolated = IsolatedGlobalConfig::enter();
+        let _isolated = IsolatedConfigDir::enter();
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("project");
@@ -1042,7 +945,7 @@ mod run_link_tests {
     /// `"claude"`-targeted tests stay green regardless.
     #[tokio::test]
     async fn wizard_link_resolves_latest_placeholders_for_an_orchestrator_target() {
-        let _isolated = IsolatedGlobalConfig::enter();
+        let _isolated = IsolatedConfigDir::enter();
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("project");

--- a/crates/armadai/src/test_support.rs
+++ b/crates/armadai/src/test_support.rs
@@ -1,0 +1,31 @@
+//! Test-only helpers shared across this binary's modules.
+//!
+//! The generic environment isolation lives in
+//! [`armadai_core::test_support`]; this module holds only what is specific to
+//! the `armadai` binary — currently the storage redirect, which existed as two
+//! byte-for-byte identical copies (`cli::run` and `web::api`) before #365.
+
+/// Redirect `storage` at a throwaway temp DB for the scope of a test, so a
+/// handler's persistence (`SqliteLog` via `crate::db::init_db`) never writes
+/// into the user's real event log (#267).
+///
+/// Wraps [`armadai_core::test_support::IsolatedConfigDir`] — which supplies
+/// the temp `ARMADAI_CONFIG_DIR`, the shared env lock and the restore-on-drop
+/// — and only adds the `config.yaml` whose `storage.path` points at a scratch
+/// sqlite file.
+pub struct TempStorageGuard {
+    _config: armadai_core::test_support::IsolatedConfigDir,
+}
+
+impl TempStorageGuard {
+    pub fn new() -> Self {
+        let config = armadai_core::test_support::IsolatedConfigDir::enter();
+        let db_path = config.config_dir().join("test.sqlite");
+        let config_yaml = format!(
+            "storage:\n  mode: embedded\n  path: \"{}\"\n",
+            db_path.display()
+        );
+        std::fs::write(config.config_dir().join("config.yaml"), config_yaml).unwrap();
+        Self { _config: config }
+    }
+}

--- a/crates/armadai/src/tui/app.rs
+++ b/crates/armadai/src/tui/app.rs
@@ -943,64 +943,7 @@ mod esc_armed_tests {
 #[cfg(test)]
 mod load_agents_declarative_tests {
     use super::*;
-    use armadai_core::config::ENV_MUTEX;
-
-    /// Points `ARMADAI_CONFIG_DIR` at a fresh, empty temp dir and the
-    /// process's cwd at `project_root` for its lifetime, restoring both on
-    /// drop (even on panic via a plain `Drop` impl, not a try/finally).
-    /// `App::load_agents` resolves its project via the cwd-based
-    /// `project::find_project_config()` and its global fallback via the
-    /// env-var-based `user_agents_dir()` -- both process-global state, so
-    /// this is serialised on `ENV_MUTEX` (shared with the rest of the
-    /// workspace's env-mutating tests) to avoid racing a concurrently
-    /// running test that reads either one unguarded.
-    struct ProjectDirGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        orig_cwd: std::path::PathBuf,
-        orig_config_dir: Option<String>,
-        config_tmp: tempfile::TempDir,
-    }
-
-    impl ProjectDirGuard {
-        fn enter(project_root: &std::path::Path) -> Self {
-            let lock = ENV_MUTEX.lock().unwrap();
-            let orig_cwd = std::env::current_dir().unwrap();
-            let orig_config_dir = std::env::var("ARMADAI_CONFIG_DIR").ok();
-            let config_tmp = tempfile::tempdir().unwrap();
-            // SAFETY: serialised via ENV_MUTEX above.
-            unsafe {
-                std::env::set_var("ARMADAI_CONFIG_DIR", config_tmp.path());
-            }
-            std::env::set_current_dir(project_root).unwrap();
-            Self {
-                _lock: lock,
-                orig_cwd,
-                orig_config_dir,
-                config_tmp,
-            }
-        }
-
-        /// The isolated global agent library, for a test that wants to
-        /// plant a same-named `.md` there to check it isn't shadowing a
-        /// declared agent.
-        fn global_agents_dir(&self) -> std::path::PathBuf {
-            self.config_tmp.path().join("agents")
-        }
-    }
-
-    impl Drop for ProjectDirGuard {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.orig_cwd);
-            // SAFETY: restoring original env state, still under the guard
-            // held by `self._lock` until this `Drop` returns.
-            unsafe {
-                match &self.orig_config_dir {
-                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
-                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
-                }
-            }
-        }
-    }
+    use armadai_core::test_support::IsolatedProjectDir;
 
     /// A declarations-only project: no `agents:` list at all (the layout
     /// this format exists to enable), two declared agents -- one plain, one
@@ -1030,7 +973,7 @@ mod load_agents_declarative_tests {
     fn declared_agents_appear_for_a_declarations_only_project() {
         let dir = declared_only_project();
         let root = dir.path().join("project");
-        let _guard = ProjectDirGuard::enter(&root);
+        let _guard = IsolatedProjectDir::enter(&root);
 
         let mut app = App::new();
         app.load_agents();
@@ -1054,7 +997,7 @@ mod load_agents_declarative_tests {
     fn a_declared_agent_is_not_shadowed_by_a_same_named_global_agent() {
         let dir = declared_only_project();
         let root = dir.path().join("project");
-        let guard = ProjectDirGuard::enter(&root);
+        let guard = IsolatedProjectDir::enter(&root);
 
         let global_agents = guard.global_agents_dir();
         std::fs::create_dir_all(&global_agents).unwrap();

--- a/crates/armadai/src/web/api.rs
+++ b/crates/armadai/src/web/api.rs
@@ -916,58 +916,12 @@ pub async fn get_orchestration_topology() -> Json<serde_json::Value> {
 #[cfg(all(test, feature = "storage"))]
 mod tests {
     use super::*;
-    use armadai_core::config::ENV_MUTEX;
+    use crate::test_support::TempStorageGuard;
     use armadai_storage::queries::{
         BoardEntryRecord, DelegationEventRecord, OrchestrationRunRecord, RingVoteRecord, RunRecord,
         insert_board_entry, insert_delegation_event, insert_orchestration_run, insert_ring_vote,
         insert_run_with_id,
     };
-
-    /// Guard that points `ARMADAI_CONFIG_DIR` at a fresh temp dir with a
-    /// `config.yaml` redirecting storage to a scratch sqlite file, so
-    /// `init_db()` (as called by the handler under test) reads/writes there
-    /// instead of the real user config. Restores the original env var and
-    /// releases the shared env-mutation lock (`ENV_MUTEX`) on drop.
-    struct TempStorageGuard {
-        _dir: tempfile::TempDir,
-        orig: Option<String>,
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl TempStorageGuard {
-        fn new() -> Self {
-            let lock = ENV_MUTEX.lock().unwrap();
-            let dir = tempfile::tempdir().unwrap();
-            let db_path = dir.path().join("test.sqlite");
-            let config_yaml = format!(
-                "storage:\n  mode: embedded\n  path: \"{}\"\n",
-                db_path.display()
-            );
-            std::fs::write(dir.path().join("config.yaml"), config_yaml).unwrap();
-
-            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-            // SAFETY: modifies the global environment; serialised via ENV_MUTEX.
-            unsafe {
-                std::env::set_var("ARMADAI_CONFIG_DIR", dir.path());
-            }
-
-            Self {
-                _dir: dir,
-                orig,
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for TempStorageGuard {
-        fn drop(&mut self) {
-            match self.orig.take() {
-                // SAFETY: restoring original env state at end of test scope.
-                Some(v) => unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", v) },
-                None => unsafe { std::env::remove_var("ARMADAI_CONFIG_DIR") },
-            }
-        }
-    }
 
     #[tokio::test]
     async fn test_get_orchestration_trace_detail_returns_run_and_entries() {
@@ -1205,64 +1159,7 @@ mod tests {
 #[cfg(test)]
 mod load_agents_declarative_tests {
     use super::*;
-    use armadai_core::config::ENV_MUTEX;
-
-    /// Points `ARMADAI_CONFIG_DIR` at a fresh, empty temp dir and the
-    /// process's cwd at `project_root` for its lifetime, restoring both on
-    /// drop (even on panic via a plain `Drop` impl, not a try/finally). The
-    /// handler under test resolves its project via the cwd-based
-    /// `project::find_project_config()` and its global fallback via the
-    /// env-var-based `user_agents_dir()` -- both process-global state, so
-    /// this is serialised on `ENV_MUTEX` (shared with the rest of the
-    /// workspace's env-mutating tests) to avoid racing a concurrently
-    /// running test that reads either one unguarded.
-    struct ProjectDirGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        orig_cwd: std::path::PathBuf,
-        orig_config_dir: Option<String>,
-        config_tmp: tempfile::TempDir,
-    }
-
-    impl ProjectDirGuard {
-        fn enter(project_root: &std::path::Path) -> Self {
-            let lock = ENV_MUTEX.lock().unwrap();
-            let orig_cwd = std::env::current_dir().unwrap();
-            let orig_config_dir = std::env::var("ARMADAI_CONFIG_DIR").ok();
-            let config_tmp = tempfile::tempdir().unwrap();
-            // SAFETY: serialised via ENV_MUTEX above.
-            unsafe {
-                std::env::set_var("ARMADAI_CONFIG_DIR", config_tmp.path());
-            }
-            std::env::set_current_dir(project_root).unwrap();
-            Self {
-                _lock: lock,
-                orig_cwd,
-                orig_config_dir,
-                config_tmp,
-            }
-        }
-
-        /// The isolated global agent library, for a test that wants to
-        /// plant a same-named `.md` there to check it isn't shadowing a
-        /// declared agent.
-        fn global_agents_dir(&self) -> std::path::PathBuf {
-            self.config_tmp.path().join("agents")
-        }
-    }
-
-    impl Drop for ProjectDirGuard {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.orig_cwd);
-            // SAFETY: restoring original env state, still under the guard
-            // held by `self._lock` until this `Drop` returns.
-            unsafe {
-                match &self.orig_config_dir {
-                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
-                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
-                }
-            }
-        }
-    }
+    use armadai_core::test_support::IsolatedProjectDir;
 
     /// A declarations-only project: no `agents:` list at all (the layout
     /// this format exists to enable), two declared agents -- one plain, one
@@ -1292,7 +1189,7 @@ mod load_agents_declarative_tests {
     fn declared_agents_appear_for_a_declarations_only_project() {
         let dir = declared_only_project();
         let root = dir.path().join("project");
-        let _guard = ProjectDirGuard::enter(&root);
+        let _guard = IsolatedProjectDir::enter(&root);
 
         let mut names: Vec<String> = load_agents().into_iter().map(|a| a.name).collect();
         names.sort_unstable();
@@ -1316,7 +1213,7 @@ mod load_agents_declarative_tests {
     fn a_declared_agent_is_not_shadowed_by_a_same_named_global_agent() {
         let dir = declared_only_project();
         let root = dir.path().join("project");
-        let guard = ProjectDirGuard::enter(&root);
+        let guard = IsolatedProjectDir::enter(&root);
 
         let global_agents = guard.global_agents_dir();
         std::fs::create_dir_all(&global_agents).unwrap();


### PR DESCRIPTION
Ferme #365.

## 1. La cascade est reproduite (elle n'était que déduite)

L'issue le disait explicitement : « cette cascade est déduite du code, pas
exécutée ». Elle l'est maintenant.

**Protocole** — faire paniquer délibérément un test pendant qu'il tient
`ENV_MUTEX`, puis compter les échecs sur `--bin armadai`, mode
`tui,web,storage,providers-api`.

**Mesure 1 — un test rouge légitime dans `tui`** (mutation du gate de
`tui::App::load_agents`, `agent_source::project_declares_agents` →
`!config.agents.is_empty()`, la régression #339) :

| passe | échecs | dont `PoisonError` fantômes |
|---|---|---|
| 1 | 7 | 6 |
| 2 | 3 | 2 |
| 3 | 3 | 2 |
| 4 | 7 | 6 |
| 5 | 7 | 6 |
| `--test-threads=1` | 7 | 5 |

**5 passes sur 5** reproduisent la cascade ; le nombre varie avec
l'ordonnancement, exactement comme l'issue l'anticipait. Les 2 seuls échecs
réels sont les deux tests `tui` qui nomment le défaut ; tout le reste est du
bruit `web::api`.

**Mesure 2 — le vrai rayon de souffle.** La mesure 1 sous-estime, parce que
`tui::` est presque en fin d'ordre alphabétique : la quasi-totalité des ~40
sites qui prennent ce lock avaient déjà fini. En déplaçant le `panic!` dans un
module tôt dans l'ordre (`claude_adapter::tests::register_from_reader_appends_index`,
qui tient le lock), toujours en `--test-threads=1` :

```
test result: FAILED. 646 passed; 48 failed
```

**1 test délibérément rouge → 48 échecs**, dont **47 `PoisonError` fantômes**
répartis sur neuf modules (`cli::audit`, `cli::registry`, `cli::run`,
`cli::watch`, `linker`, `registry::cache`, `registry::sync`, `shell::config`,
`tui::app`, `web::api`). L'échec réel est enterré.

Détail qui vaut contrôle : `shell::wizard::run_link_tests` — la copie **déjà**
tolérante à l'empoisonnement — n'apparaît dans aucune des deux listes d'échecs.
La prémisse de l'issue est donc confirmée, pas infirmée.

**Après correction, même protocole, même mutation :**

```
test result: FAILED. 693 passed; 1 failed     (--test-threads=1)
```

48 → 1, zéro `PoisonError`. Et en parallèle, 5 passes sur 5 : `1 failed`,
`PoisonError` = 0 (contre 3–7 échecs instables avant). La mutation `tui` donne
elle aussi exactement 2 échecs, ses 2 vrais, stables sur 3 passes.

## 2. Ce qui est unifié, ce qui reste distinct

`armadai_core::test_support`, derrière la feature **`test-support` existante**
(activée depuis les `[dev-dependencies]` d'`armadai` et `armadai-providers`,
donc absente d'un build release — vérifié) :

| Élément | Décision | Raison |
|---|---|---|
| `env_lock()` | **unifié** — un seul point de prise du lock, tolérant | c'est le défaut mesuré ; ~40 sites l'appelaient chacun en `.unwrap()` |
| `IsolatedConfigDir` (`ARMADAI_CONFIG_DIR` → temp dir) | **unifié** — remplace `IsolatedGlobalConfig` du wizard | strictement identique partout |
| `IsolatedProjectDir` (= le précédent + cwd) | **unifié** — remplace les 2 `ProjectDirGuard` (`tui::app`, `web::api`) + celui du wizard | les 2 `ProjectDirGuard` ne différaient que par une phrase de doc |
| `IsolatedConfigDir` vs `IsolatedProjectDir` | **gardés distincts**, composés | responsabilités différentes, comme l'issue le demandait : beaucoup d'appelants n'ont besoin que de la moitié config, et déplacer le cwd est le besoin plus rare et plus fort (une surface qui résout son projet via `find_project_config()` plutôt que via son jumeau `_from(start)`) |
| `TempStorageGuard` | **unifié** dans `crate::test_support` du binaire | il existait en **deux copies octet pour octet** (`cli::run` + `web::api`) — c'était la duplication d'à côté, refermée dans le même geste ; il se construit sur `IsolatedConfigDir` et n'ajoute que le `config.yaml` de redirection storage |
| Gardes sur **d'autres** variables (`HOME`, `ARMADAI_CLAUDE_PROJECTS_DIR`, `ARMADAI_SESSION_INDEX`) | **gardés distincts**, convergent seulement sur `env_lock()` | ils isolent autre chose ; les fusionner de force créerait un garde fourre-tout |

Le static brut **n'est plus `pub`** : il est privé dans `test_support`, joignable
uniquement par `env_lock()`. C'est délibéré — la leçon maison « supprimer la
primitive tentante plutôt que corriger son usage ». Aucun appelant ne peut
réintroduire le `.unwrap()`.

Bilan : **−397 / +371 lignes**, dont ~150 lignes de garde dupliqué supprimées.

## 3. Mutations vérifiées (3 tests ajoutés)

Le dépôt a un défaut récurrent de « tests qui ne peuvent pas échouer » ; chaque
test ajouté a été cassé délibérément, rouge constaté, restauré.

| Test | Mutation | Sortie observée |
|---|---|---|
| `a_poisoned_mutex_is_still_acquirable` | `unwrap_or_else(…into_inner())` → `.unwrap()` | `FAILED … called Result::unwrap() on an Err value: PoisonError { .. }` |
| `the_config_dir_guard_restores_the_previous_value` | suppression du `Drop` de `IsolatedConfigDir` | `left: Some("/var/folders/…/.tmpAFv2gK") right: None` |
| `the_project_dir_guard_restores_the_previous_cwd` | suppression du `set_current_dir` du `Drop` | `left: "/private/var/…/.tmpZrpXQh" right: "…/crates/armadai-core"` |

La tolérance à l'empoisonnement est testée sur un mutex **privé au test**, pas
sur `ENV_MUTEX` : empoisonner le vrai coûterait quelque chose au reste de la
suite, et le prouver ne doit rien coûter.

Note de mesure honnête : la première version des deux tests de restauration
passait isolément et **échouait dans la suite complète** — elle lisait la valeur
de référence hors du lock et pouvait donc observer le répertoire temporaire d'un
autre test comme si c'était la valeur d'origine. Corrigé par un helper
`undisturbed()` qui lit sous le lock ; 8 passes consécutives vertes.

## 4. Effet de bord #364 : rien à faire

La branche « aucun `armadai.yaml` » de `shell::app::resolve_project_agent` est
**déjà couverte sur `master`** : `resolve_project_agent_from(start, name)` a été
livré avec #364 et le test
`a_directory_in_no_project_fails_saying_no_armadai_yaml_was_found` l'exerce sans
toucher au cwd. Aucun garde n'était nécessaire ; rien ajouté.

## 5. Gate

- `cargo fmt --all -- --check` ✅
- clippy `-D warnings`, **5/5** modes : `tui` · `tui,providers-api` ·
  `tui,web,storage` · `tui,web,storage,providers-api` · `tui,storage,e2e-fake` ✅
- tests **4/4** modes (`--no-fail-fast`), 0 échec : `tui` · `tui,providers-api` ·
  `tui,web,storage,providers-api` · `tui,storage,e2e-fake,web` ✅
  (`armadai-core` 587, `--bin armadai` 662→694 selon le mode, +3 nouveaux)
- gaveldrop : `13 cases · 13 passed · 0 failed · score 83/83` ✅
- `cargo build --release --no-default-features --features tui,storage` ✅
- graphe de dépendances release inchangé : `armadai-core` sans feature active,
  `tempfile` déjà tiré par `dialoguer` (pré-existant), `cargo tree -e normal,build -i gaveldrop` vide ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)