### PR TITLE
fix(cli): résoudre toute la chaîne --pipe avant d'exécuter le premier maillon

### DIFF
--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -798,18 +798,27 @@ async fn run_inner(
     let mut agg_tout = 0u32;
     let mut agg_cost = 0.0f64;
 
-    // Resolve EVERY link of the chain before running the first one (#366).
-    // See [`load_chain`] for why the loop is no longer allowed to do it.
-    let chain_agents = load_chain(&resolution, &chain)?;
+    // Resolve EVERY link of the chain — and build its provider — before
+    // running the first one (#366). See [`load_chain`] for why the loop is no
+    // longer allowed to do either.
+    let chain_links = load_chain(&resolution, &chain)?;
 
-    for (i, (name, agent)) in chain.iter().zip(chain_agents).enumerate() {
+    for (i, (name, link)) in chain.iter().zip(chain_links).enumerate() {
         if chain.len() > 1 && !json {
             let h = crate::cli::style::header();
             anstream::eprintln!("{h}--- [{}/{} {}] ---{h:#}", i + 1, chain.len(), name);
         }
+        // Under this link's own header, not in a block ahead of the first
+        // one: a warning that names an agent belongs where that agent is
+        // announced (#373 review, m5).
+        if let Some(w) = &link.warning {
+            let s = crate::cli::style::warn();
+            anstream::eprintln!("{s}  warn: {w}{s:#}");
+        }
 
         let (output, metrics) = run_single_agent(
-            agent,
+            link.agent,
+            link.provider,
             name,
             &current_input,
             project_defaults,
@@ -894,12 +903,37 @@ fn project_display_string(resolution: &AgentResolution) -> Option<String> {
 /// armed for the next call site.
 ///
 /// Called from the single-agent path (`chain.len() == 1`, the common
-/// `armadai run <name>` invocation), the `--pipe` chain loop, the
-/// `--orchestrate` roster loader (`run_orchestrated`), and `--resume`'s
-/// roster reload (`resume_run`) — the last three in a loop, which is why the
-/// loop-invariant half of the work (the prompt fragments) is memoised on
-/// `AgentResolution` rather than recomputed here per call.
+/// `armadai run <name>` invocation), the `--orchestrate` roster loader
+/// (`run_orchestrated`), and `--resume`'s roster reload (`resume_run`) — the
+/// last two in a loop, as is [`load_chain`], which is why the loop-invariant
+/// half of the work (the prompt fragments) is memoised on `AgentResolution`
+/// rather than recomputed per call. `--pipe` goes through
+/// [`load_agent_reporting_warning`] instead, for the reason given there.
 fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow::Result<Agent> {
+    let (agent, warning) = load_agent_reporting_warning(resolution, agent_name)?;
+    // Core returns the warning rather than printing it (see
+    // `load_agent_by_name`'s own doc) precisely so it renders here, in the
+    // CLI's own voice, instead of a bare `tracing::warn!` line reaching the
+    // user's terminal directly from core.
+    if let Some(w) = warning {
+        let s = crate::cli::style::warn();
+        anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
+    }
+    Ok(agent)
+}
+
+/// [`load_agent_for_run`] without the printing: the load warning is handed
+/// back instead.
+///
+/// Split out for [`load_chain`], which resolves the whole chain *before* the
+/// first link's `--- [1/N …] ---` header exists to print under. Printing
+/// from in here would put every link's warning in one block ahead of the
+/// first header, losing the positional anchoring that says which link each
+/// one is about (#373 review, m5).
+fn load_agent_reporting_warning(
+    resolution: &AgentResolution,
+    agent_name: &str,
+) -> anyhow::Result<(Agent, Option<armadai_core::agent_source::LoadWarning>)> {
     match resolution {
         AgentResolution::Project {
             root,
@@ -908,29 +942,30 @@ fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow:
         } => {
             let fragments =
                 fragments.get_or_init(|| armadai_core::agent_source::project_fragments(root));
-            let (agent, warning) = armadai_core::agent_source::load_agent_by_name(
-                agent_name, config, root, fragments,
-            )?;
-            // Core returns the warning rather than printing it (see
-            // `load_agent_by_name`'s own doc) precisely so it renders here,
-            // in the CLI's own voice, instead of a bare `tracing::warn!`
-            // line reaching the user's terminal directly from core.
-            if let Some(w) = warning {
-                let s = crate::cli::style::warn();
-                anstream::eprintln!("{s}  warn: {}{s:#}", w.message());
-            }
-            Ok(agent)
+            armadai_core::agent_source::load_agent_by_name(agent_name, config, root, fragments)
         }
         AgentResolution::Default(agents_dir) => {
             let path = Agent::find_file(agents_dir, agent_name).ok_or_else(|| {
                 anyhow::anyhow!("Agent '{agent_name}' not found in {}", agents_dir.display())
             })?;
-            armadai_core::parser::parse_agent_file(&path)
+            armadai_core::parser::parse_agent_file(&path).map(|a| (a, None))
         }
     }
 }
 
-/// Resolve every link of a `--pipe` chain up front, before any of them runs.
+/// One resolved link of a `--pipe` chain: everything the execution loop
+/// needs, so that loop can no longer fail on anything but the call itself.
+struct ChainLink {
+    agent: Agent,
+    provider: Box<dyn armadai_core::provider::Provider>,
+    /// The load warning, if any, deferred so the loop can print it under
+    /// this link's own `--- [i/N name] ---` header — and already deduplicated
+    /// by [`load_chain`].
+    warning: Option<String>,
+}
+
+/// Resolve every link of a `--pipe` chain up front — agent *and* provider —
+/// before any of them runs.
 ///
 /// The chain used to be resolved lazily, one link at a time, inside the
 /// execution loop: a typo on link N was only discovered after links 1..N-1
@@ -940,24 +975,61 @@ fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow:
 /// the sequential chain the same shape, and leaves the loop purely
 /// executional.
 ///
+/// **Provider construction belongs here too**, for the same reason and not
+/// merely by symmetry with `run_orchestrated`: `create_provider` fails
+/// deterministically, on the agent's own metadata, with nothing a preceding
+/// link could change — a misspelled `provider:`, an API provider whose key
+/// is nowhere to be found, `provider: cli` with no `command:`. Resolving the
+/// definition but not the provider left #366's exact bill one gate further
+/// on: `agent_start`/`agent_end` for link 1, *then* `Unknown provider:
+/// 'gtp'` (#373 review, i3). It is safe to hoist because nothing
+/// `create_provider` does is ordered against a run: it reads env/config,
+/// probes `which` for unified names, and constructs clients — no connection
+/// is opened, and the rate limiters it takes are either process-global and
+/// memoised or per-agent buckets that start full, so building one earlier
+/// can only ever leave it *more* permissive by the time it is used.
+///
 /// The failure names the link's position as well as its name: with several
 /// names on one command line, `'x' not found` alone leaves the user counting
 /// them. The resolver's own message is kept inline rather than as an
 /// `anyhow` context layer, because the headless error event reports only
 /// `Error::to_string()` (the outermost layer) — wrapping would drop the part
 /// that names `.armadai/agents.yaml` for a project that declares its agents
-/// (#339).
-fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<Vec<Agent>> {
+/// (#339). Inlining it costs the *chain* of causes, though, which is why the
+/// interpolation is `{e:#}` (alternate `Display` = every layer, joined by
+/// `: `) and not `{e}`: with `{e}` a chain link failing on an unreadable
+/// `.md` reported `reading <path>` and dropped the `Permission denied (os
+/// error 13)` that says why, where the single-agent path kept it (#373
+/// review, i1).
+fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<Vec<ChainLink>> {
+    // `LoadWarning::DeclarationsUnreadable` states a *project* fact — this
+    // one `.armadai/agents.yaml` cannot be parsed — with only the served
+    // agent's name varying at the tail. Every link re-reads the same file in
+    // the same loop, so N links restate it N times, ~380 characters apiece,
+    // byte-identical whenever two links name the same agent. Said once
+    // (#373 review, m5).
+    let mut declarations_reported = false;
     chain
         .iter()
         .enumerate()
         .map(|(i, name)| {
-            load_agent_for_run(resolution, name).map_err(|e| {
-                anyhow::anyhow!(
-                    "chain link {}/{} ('{name}') could not be resolved, so no agent was run: {e}",
-                    i + 1,
-                    chain.len()
-                )
+            let position = format!("chain link {}/{} ('{name}')", i + 1, chain.len());
+            let (agent, warning) = load_agent_reporting_warning(resolution, name).map_err(|e| {
+                anyhow::anyhow!("{position} could not be resolved, so no agent was run: {e:#}")
+            })?;
+            let provider = create_provider(&agent).map_err(|e| {
+                anyhow::anyhow!("{position} has no usable provider, so no agent was run: {e:#}")
+            })?;
+            let warning = warning.and_then(|w| match w {
+                armadai_core::agent_source::LoadWarning::DeclarationsUnreadable(m) => {
+                    (!std::mem::replace(&mut declarations_reported, true)).then_some(m)
+                }
+                other => Some(other.message().to_string()),
+            });
+            Ok(ChainLink {
+                agent,
+                provider,
+                warning,
             })
         })
         .collect()
@@ -971,9 +1043,15 @@ fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<
 /// `run_single_agent_es` has. Loading is the caller's job (via
 /// [`load_agent_for_run`]) precisely because an agent declared in
 /// `.armadai/agents.yaml` has no file to hand down here (#339).
+///
+/// It takes an already-built `provider` for the same reason: its only caller
+/// is the `--pipe` loop, and a provider this fn built itself could only fail
+/// after the links before it had already been billed (#373 review, i3). See
+/// [`load_chain`].
 #[allow(clippy::too_many_arguments)]
 async fn run_single_agent(
     mut agent: Agent,
+    provider: Box<dyn armadai_core::provider::Provider>,
     agent_name: &str,
     input: &str,
     project_defaults: Option<&ProjectDefaults>,
@@ -1007,8 +1085,11 @@ async fn run_single_agent(
         crate::linker::model_resolution::warn_unknown_model(model, &agent.metadata.provider);
     }
 
-    // 2. Create provider
-    let provider = create_provider(&agent)?;
+    // 2. Provider: built by `load_chain` before the chain's first link ran.
+    // `create_provider` reads none of the metadata step 1b rewrites (only
+    // `provider`/`command`/`args`/`timeout`/`rate_limit`), so hoisting it
+    // ahead of the deprecation resolution changes nothing about the provider
+    // it returns.
 
     // 4. Resolve effective mode and build system prompt
     let effective_mode = agent

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -798,13 +798,16 @@ async fn run_inner(
     let mut agg_tout = 0u32;
     let mut agg_cost = 0.0f64;
 
-    for (i, name) in chain.iter().enumerate() {
+    // Resolve EVERY link of the chain before running the first one (#366).
+    // See [`load_chain`] for why the loop is no longer allowed to do it.
+    let chain_agents = load_chain(&resolution, &chain)?;
+
+    for (i, (name, agent)) in chain.iter().zip(chain_agents).enumerate() {
         if chain.len() > 1 && !json {
             let h = crate::cli::style::header();
             anstream::eprintln!("{h}--- [{}/{} {}] ---{h:#}", i + 1, chain.len(), name);
         }
 
-        let agent = load_agent_for_run(&resolution, name)?;
         let (output, metrics) = run_single_agent(
             agent,
             name,
@@ -925,6 +928,39 @@ fn load_agent_for_run(resolution: &AgentResolution, agent_name: &str) -> anyhow:
             armadai_core::parser::parse_agent_file(&path)
         }
     }
+}
+
+/// Resolve every link of a `--pipe` chain up front, before any of them runs.
+///
+/// The chain used to be resolved lazily, one link at a time, inside the
+/// execution loop: a typo on link N was only discovered after links 1..N-1
+/// had already run. Those are real provider calls — billed, irreversible —
+/// spent on a run that could never have completed (#366). `run_orchestrated`
+/// already built its whole roster before dispatching anything; this gives
+/// the sequential chain the same shape, and leaves the loop purely
+/// executional.
+///
+/// The failure names the link's position as well as its name: with several
+/// names on one command line, `'x' not found` alone leaves the user counting
+/// them. The resolver's own message is kept inline rather than as an
+/// `anyhow` context layer, because the headless error event reports only
+/// `Error::to_string()` (the outermost layer) — wrapping would drop the part
+/// that names `.armadai/agents.yaml` for a project that declares its agents
+/// (#339).
+fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<Vec<Agent>> {
+    chain
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            load_agent_for_run(resolution, name).map_err(|e| {
+                anyhow::anyhow!(
+                    "chain link {}/{} ('{name}') could not be resolved, so no agent was run: {e}",
+                    i + 1,
+                    chain.len()
+                )
+            })
+        })
+        .collect()
 }
 
 /// Execute a single agent with given input and configuration. Parameters represent

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1288,6 +1288,16 @@ async fn execute_pipeline_steps(
     let mut aggregated_tokens_in: Option<u64> = None;
     let mut aggregated_tokens_out: u64 = 0;
     let mut aggregated_cost: f64 = 0.0;
+    // Whether any step ever *replaced* `current_input`, which starts out as
+    // the user's own message. Every skip path below (`NotRelayable`, an
+    // unresolvable agent, a step with no providers, a spawn that failed)
+    // deliberately leaves `current_input` alone so the next link reads what
+    // it would have read anyway — but if they all skip, what reaches
+    // `record_turn` at the bottom is the user's input, filed as the
+    // assistant's answer (#373 review, i2). Tracked rather than compared
+    // against `input`, so a step that genuinely echoes the input back still
+    // counts as having answered.
+    let mut any_step_produced_output = false;
 
     for (i, step) in steps.iter().enumerate() {
         let is_last = i == total_steps - 1;
@@ -1559,6 +1569,7 @@ async fn execute_pipeline_steps(
 
                         app.update_last_assistant_with_label(&label, &parsed.content);
                         current_input = parsed.content;
+                        any_step_produced_output = true;
 
                         // Aggregate real metrics from result_event. Pipeline steps run in
                         // series on different inputs, so tokens_in is summed across steps
@@ -1608,6 +1619,22 @@ async fn execute_pipeline_steps(
     }
 
     let duration = start_time.elapsed();
+
+    // Not one step answered. Recording a turn here would file
+    // `current_input` — still the user's own message — as the *assistant's*,
+    // persist it with the session, and feed it back as context on the next
+    // turn (`max_history_turns`). The `return Ok(())` this loop used to take
+    // on a spawn failure hid that by never reaching the bottom of the
+    // function; `continue`ing is right for the chain, but it makes the
+    // all-steps-skipped case reachable for the first time (#373 review, i2).
+    if !any_step_produced_output {
+        app.add_system_message(
+            "No pipeline step produced any output — nothing was recorded for this turn.",
+        );
+        app.set_loading(false);
+        return Ok(());
+    }
+
     if let Some(tokens_in) = aggregated_tokens_in {
         runner.record_turn_exact(
             input,
@@ -2289,6 +2316,37 @@ mod tests {
         }
     }
 
+    /// A terminal to drive `execute_pipeline_steps` with when there is no
+    /// controlling terminal: a *fixed, empty* viewport.
+    ///
+    /// Fixed, because `Terminal::new` asks the backend for a size and the
+    /// crossterm backend needs a controlling terminal to answer — CI has
+    /// none. Empty, because this backend writes to the real `io::Stdout`,
+    /// which libtest does NOT capture (it only redirects the `print!`
+    /// macros): a viewport with cells in it repaints an 80x24 frame over
+    /// whatever terminal is running the suite. Nothing here asserts on
+    /// pixels — only on what the session was told — so zero area costs the
+    /// tests nothing.
+    fn headless_terminal() -> Terminal<CrosstermBackend<io::Stdout>> {
+        Terminal::with_options(
+            CrosstermBackend::new(io::stdout()),
+            ratatui::TerminalOptions {
+                viewport: ratatui::Viewport::Fixed(ratatui::layout::Rect::new(0, 0, 0, 0)),
+            },
+        )
+        .unwrap()
+    }
+
+    /// Two steps naming binaries that cannot exist: deliberately implausible
+    /// so no machine can happen to have one on its PATH, and mutually
+    /// unconfusable so an assertion cannot mistake one step for the other.
+    fn two_absent_binary_steps() -> Vec<armadai_core::project::PipelineStep> {
+        vec![
+            provider_step("first", "armadai-absent-binary-alpha"),
+            provider_step("second", "armadai-absent-binary-omega"),
+        ]
+    }
+
     #[tokio::test]
     async fn a_step_whose_binary_is_missing_costs_that_step_not_the_rest_of_the_chain() {
         // `StepPlan::NotRelayable` (#364) already skips a step the relay can
@@ -2299,32 +2357,10 @@ mod tests {
         // outcome: one step lost, chain intact.
         let _config = IsolatedConfigDir::enter();
 
-        // A *fixed, empty* viewport, for two reasons. Fixed, because
-        // `Terminal::new` asks the backend for a size and the crossterm
-        // backend needs a controlling terminal to answer — CI has none.
-        // Empty, because this backend writes to the real `io::Stdout`,
-        // which libtest does NOT capture (it only redirects the `print!`
-        // macros): a viewport with cells in it repaints an 80x24 frame over
-        // whatever terminal is running the suite. Nothing here asserts on
-        // pixels — only on what the session was told — so zero area costs
-        // the test nothing.
-        let mut terminal = Terminal::with_options(
-            CrosstermBackend::new(io::stdout()),
-            ratatui::TerminalOptions {
-                viewport: ratatui::Viewport::Fixed(ratatui::layout::Rect::new(0, 0, 0, 0)),
-            },
-        )
-        .unwrap();
+        let mut terminal = headless_terminal();
         let mut app = ShellApp::new("test".into());
         let mut runner = ShellRunner::new(super::super::runner::RunnerConfig::default());
-
-        // Deliberately implausible names so no machine can happen to have
-        // one on its PATH, and mutually unconfusable so the assertions
-        // cannot mistake one step for the other.
-        let steps = vec![
-            provider_step("first", "armadai-absent-binary-alpha"),
-            provider_step("second", "armadai-absent-binary-omega"),
-        ];
+        let steps = two_absent_binary_steps();
 
         execute_pipeline_steps(
             &mut terminal,
@@ -2363,6 +2399,83 @@ mod tests {
         assert!(
             shown.contains("Pipeline step 2/2"),
             "the second step must be announced, i.e. reached at all, got: {shown}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pipeline_where_every_step_skips_records_no_turn_at_all() {
+        // The other half of turning that `return Ok(())` into a `continue`:
+        // the function now reaches its own bottom with `current_input` never
+        // reassigned — i.e. still holding the *user's* message — and files it
+        // as the assistant's answer. Measured before the fix, on this exact
+        // fixture: `turns=1 history=[("Assistant", "hello")]`, persisted by
+        // `save_current_session` and replayed as context on the next turn
+        // (`max_history_turns: 5`).
+        //
+        // The partial case (one step lost, the rest answering) is
+        // deliberately NOT this test's subject: it is the bargain #373
+        // wanted, and a step that really runs enters the stream loop, which
+        // reads crossterm events.
+        let _config = IsolatedConfigDir::enter();
+
+        let mut terminal = headless_terminal();
+        let mut app = ShellApp::new("test".into());
+        let mut runner = ShellRunner::new(super::super::runner::RunnerConfig::default());
+        let steps = two_absent_binary_steps();
+
+        execute_pipeline_steps(
+            &mut terminal,
+            &mut app,
+            &mut runner,
+            "hello",
+            &steps,
+            "test-session",
+            "/tmp",
+            "test",
+            "test-model",
+        )
+        .await
+        .unwrap();
+
+        let history: Vec<(&str, &str)> = runner
+            .history()
+            .iter()
+            .map(|m| {
+                let role = match m.role {
+                    super::super::runner::MessageRole::User => "User",
+                    super::super::runner::MessageRole::Assistant => "Assistant",
+                    super::super::runner::MessageRole::System => "System",
+                };
+                (role, m.content.as_str())
+            })
+            .collect();
+
+        assert!(
+            !history
+                .iter()
+                .any(|(role, content)| *role == "Assistant" && *content == "hello"),
+            "the user's own message must never be recorded as the assistant's answer — \
+             it is persisted with the session and replayed as context on the next turn, \
+             got: {history:?}"
+        );
+        assert_eq!(
+            runner.session_metrics().turn_count,
+            0,
+            "no step answered, so no turn happened: counting one bills the session for \
+             a turn that produced nothing, got history: {history:?}"
+        );
+        assert!(
+            history.is_empty(),
+            "nothing at all belongs in the conversation history when every step skipped, \
+             got: {history:?}"
+        );
+        assert!(
+            app.message_contents()
+                .iter()
+                .any(|m| m.contains("No pipeline step produced any output")),
+            "the user typed something and got nothing back: the session must say so \
+             rather than fall silent, got: {:?}",
+            app.message_contents()
         );
     }
 }

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1390,10 +1390,24 @@ async fn execute_pipeline_steps(
             .spawn()
         {
             Ok(child) => child,
+            // One step lost, chain intact — the same bargain
+            // `StepPlan::NotRelayable` strikes for a step the relay can see
+            // in advance it cannot run (#364). A binary an agent declares
+            // and the machine simply does not have is only discoverable
+            // here, and answering it with `return Ok(())` charged every
+            // remaining link for one missing executable (#366).
+            //
+            // `current_input` is left untouched, so the next link reads what
+            // it would have read anyway. The message names the step and the
+            // command, because a bare "Failed to spawn" in a multi-step
+            // pipeline says neither which step lost nor what was missing.
             Err(e) => {
-                app.update_last_assistant(&format!("Failed to spawn: {}", e));
-                app.set_loading(false);
-                return Ok(());
+                app.update_last_assistant(&format!(
+                    "Skipping step '{}' ('{}'): failed to spawn: {}",
+                    step.name, resolved.cmd, e
+                ));
+                terminal.draw(|f| app.render(f))?;
+                continue;
             }
         };
 
@@ -2204,5 +2218,151 @@ mod tests {
                 );
             }
         }
+    }
+
+    // -----------------------------------------------------------------
+    // #366, adjacent 1: a step whose binary is genuinely missing costs
+    // that step, not every step after it.
+    //
+    // `execute_pipeline_steps` takes a concrete
+    // `Terminal<CrosstermBackend<Stdout>>` and, once a step has spawned,
+    // reads real crossterm events — which is why this exercises only
+    // steps that *fail* to spawn: that path returns before the stream
+    // loop, so no terminal input is ever read. A fixed viewport is used
+    // (rather than `Terminal::new`, which asks the backend for a size)
+    // so the test needs no controlling terminal, in CI as locally.
+    // -----------------------------------------------------------------
+
+    /// Points `ARMADAI_CONFIG_DIR` at a fresh temp dir for the guard's
+    /// lifetime, restoring it on drop, serialised on the workspace-wide
+    /// `ENV_MUTEX` (see `shell::wizard`'s own guard). Without it,
+    /// `execute_pipeline_steps`'s closing `save_current_session` would
+    /// write this test's session into the developer's real
+    /// `~/.config/armadai/sessions/` (#267).
+    struct IsolatedConfigDir {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        orig: Option<String>,
+        _tmp: tempfile::TempDir,
+    }
+
+    impl IsolatedConfigDir {
+        fn enter() -> Self {
+            // Poison-tolerant: `ENV_MUTEX` guards `()` only, so a panicking
+            // prior holder leaves no inconsistent state — only phantom
+            // failures if the poison is honoured.
+            let lock = armadai_core::config::ENV_MUTEX
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
+            let tmp = tempfile::tempdir().unwrap();
+            // SAFETY: serialised via ENV_MUTEX above.
+            unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path()) };
+            Self {
+                _lock: lock,
+                orig,
+                _tmp: tmp,
+            }
+        }
+    }
+
+    impl Drop for IsolatedConfigDir {
+        fn drop(&mut self) {
+            // SAFETY: still under the guard held by `self._lock`.
+            unsafe {
+                match &self.orig {
+                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
+                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
+                }
+            }
+        }
+    }
+
+    /// A pipeline step in `provider:` mode naming `cmd`.
+    fn provider_step(name: &str, cmd: &str) -> armadai_core::project::PipelineStep {
+        armadai_core::project::PipelineStep {
+            name: name.to_string(),
+            prompt: None,
+            providers: vec![armadai_core::project::ShellProviderEntry {
+                provider: cmd.to_string(),
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn a_step_whose_binary_is_missing_costs_that_step_not_the_rest_of_the_chain() {
+        // `StepPlan::NotRelayable` (#364) already skips a step the relay can
+        // see in advance it cannot run. A binary that an agent *declares*
+        // and the machine simply does not have is only discovered at spawn
+        // time — and that was answered with `return Ok(())`, so one missing
+        // executable cancelled every remaining link. Same bargain, same
+        // outcome: one step lost, chain intact.
+        let _config = IsolatedConfigDir::enter();
+
+        // A *fixed, empty* viewport, for two reasons. Fixed, because
+        // `Terminal::new` asks the backend for a size and the crossterm
+        // backend needs a controlling terminal to answer — CI has none.
+        // Empty, because this backend writes to the real `io::Stdout`,
+        // which libtest does NOT capture (it only redirects the `print!`
+        // macros): a viewport with cells in it repaints an 80x24 frame over
+        // whatever terminal is running the suite. Nothing here asserts on
+        // pixels — only on what the session was told — so zero area costs
+        // the test nothing.
+        let mut terminal = Terminal::with_options(
+            CrosstermBackend::new(io::stdout()),
+            ratatui::TerminalOptions {
+                viewport: ratatui::Viewport::Fixed(ratatui::layout::Rect::new(0, 0, 0, 0)),
+            },
+        )
+        .unwrap();
+        let mut app = ShellApp::new("test".into());
+        let mut runner = ShellRunner::new(super::super::runner::RunnerConfig::default());
+
+        // Deliberately implausible names so no machine can happen to have
+        // one on its PATH, and mutually unconfusable so the assertions
+        // cannot mistake one step for the other.
+        let steps = vec![
+            provider_step("first", "armadai-absent-binary-alpha"),
+            provider_step("second", "armadai-absent-binary-omega"),
+        ];
+
+        execute_pipeline_steps(
+            &mut terminal,
+            &mut app,
+            &mut runner,
+            "hello",
+            &steps,
+            "test-session",
+            "/tmp",
+            "test",
+            "test-model",
+        )
+        .await
+        .unwrap();
+
+        let messages = app.message_contents();
+        let shown = messages.join("\n");
+        let skipped = |step: &str, cmd: &str| {
+            messages
+                .iter()
+                .any(|m| m.contains(&format!("Skipping step '{step}'")) && m.contains(cmd))
+        };
+
+        assert!(
+            skipped("first", "armadai-absent-binary-alpha"),
+            "the first step's failure must be reported, naming both the step that \
+             lost and the binary that was missing — a bare 'Failed to spawn' in a \
+             multi-step pipeline says neither, got: {shown}"
+        );
+        assert!(
+            skipped("second", "armadai-absent-binary-omega"),
+            "the SECOND step must still have been attempted, and reported the same \
+             way, after the first failed to spawn — a missing executable costs its \
+             own step, not every step after it, got: {shown}"
+        );
+        assert!(
+            shown.contains("Pipeline step 2/2"),
+            "the second step must be announced, i.e. reached at all, got: {shown}"
+        );
     }
 }

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -2260,49 +2260,16 @@ mod tests {
     // so the test needs no controlling terminal, in CI as locally.
     // -----------------------------------------------------------------
 
-    /// Points `ARMADAI_CONFIG_DIR` at a fresh temp dir for the guard's
-    /// lifetime, restoring it on drop, serialised on the workspace-wide
-    /// `ENV_MUTEX` (see `shell::wizard`'s own guard). Without it,
-    /// `execute_pipeline_steps`'s closing `save_current_session` would
-    /// write this test's session into the developer's real
-    /// `~/.config/armadai/sessions/` (#267).
-    struct IsolatedConfigDir {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        orig: Option<String>,
-        _tmp: tempfile::TempDir,
-    }
-
-    impl IsolatedConfigDir {
-        fn enter() -> Self {
-            // Poison-tolerant: `ENV_MUTEX` guards `()` only, so a panicking
-            // prior holder leaves no inconsistent state — only phantom
-            // failures if the poison is honoured.
-            let lock = armadai_core::config::ENV_MUTEX
-                .lock()
-                .unwrap_or_else(|p| p.into_inner());
-            let orig = std::env::var("ARMADAI_CONFIG_DIR").ok();
-            let tmp = tempfile::tempdir().unwrap();
-            // SAFETY: serialised via ENV_MUTEX above.
-            unsafe { std::env::set_var("ARMADAI_CONFIG_DIR", tmp.path()) };
-            Self {
-                _lock: lock,
-                orig,
-                _tmp: tmp,
-            }
-        }
-    }
-
-    impl Drop for IsolatedConfigDir {
-        fn drop(&mut self) {
-            // SAFETY: still under the guard held by `self._lock`.
-            unsafe {
-                match &self.orig {
-                    Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
-                    None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
-                }
-            }
-        }
-    }
+    // Points `ARMADAI_CONFIG_DIR` at a fresh temp dir for the guard's
+    // lifetime, restoring it on drop, while holding the workspace-wide env
+    // lock. Without it, `execute_pipeline_steps`'s closing
+    // `save_current_session` would write this test's session into the
+    // developer's real `~/.config/armadai/sessions/` (#267).
+    //
+    // The shared guard from #365/#372, not a local copy: that PR made
+    // `ENV_MUTEX` private precisely so no test could acquire it — or fail to
+    // tolerate its poisoning — on its own terms.
+    use armadai_core::test_support::IsolatedConfigDir;
 
     /// A pipeline step in `provider:` mode naming `cmd`.
     fn provider_step(name: &str, cmd: &str) -> armadai_core::project::PipelineStep {

--- a/crates/armadai/src/shell/tui.rs
+++ b/crates/armadai/src/shell/tui.rs
@@ -265,6 +265,16 @@ impl ShellApp {
         }
     }
 
+    /// Every message's content, in display order.
+    ///
+    /// Test-only: the shell otherwise only ever *renders* its messages, so a
+    /// test that needs to know what the session was told has no other window
+    /// on it than parsing a rendered frame.
+    #[cfg(test)]
+    pub(crate) fn message_contents(&self) -> Vec<&str> {
+        self.messages.iter().map(|m| m.content.as_str()).collect()
+    }
+
     /// Get content of the last assistant message
     pub fn get_last_assistant_content(&self) -> String {
         self.messages

--- a/crates/armadai/tests/pipe_declarative_agents.rs
+++ b/crates/armadai/tests/pipe_declarative_agents.rs
@@ -378,3 +378,58 @@ fn a_broken_prompt_fragment_is_reported_once_for_the_whole_chain() {
         "the one warning must still name the fragment it could not load, got: {warnings:#?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #366: the whole chain is resolved before the first link runs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pipe_resolves_every_link_before_running_the_first() {
+    // The chain used to be resolved lazily, one link at a time, *inside* the
+    // execution loop: a typo on link N was only discovered after links
+    // 1..N-1 had already run — real provider calls, billed, on a chain that
+    // could never complete. Measured on this exact fixture: `agent_start`
+    // and `agent_end` for `m3-a` and `m3-b`, and only then the `error`.
+    //
+    // The `echo` provider makes those calls free here, which is precisely
+    // why the assertion is on the events and not on a bill: with a real
+    // provider the same two `agent_start`s are two model calls.
+    let (_dir, root) = project(&["m3-a", "m3-b", "m3-c"], &[]);
+    let out = run_pipe(
+        &root,
+        "m3-a",
+        "TASK-LATE-TYPO",
+        &["m3-b", "typo-agent", "m3-c"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        !out.status.success(),
+        "a chain naming an unknown agent must fail.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        agents_started(&stdout),
+        Vec::<String>::new(),
+        "NO agent may start when a later link of the chain cannot be resolved — every \
+         one of them is a billed provider call on a run that cannot complete.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        combined.contains("typo-agent"),
+        "the failure must name the link it could not resolve, got: {combined}"
+    );
+    assert!(
+        combined.contains("3/4"),
+        "the failure must place the bad link in the chain (link 3 of 4) — with four \
+         names on one command line, the name alone leaves the user counting, \
+         got: {combined}"
+    );
+    assert!(
+        combined.contains(".armadai/agents.yaml") || combined.contains(".armadai\\agents.yaml"),
+        "positioning the bad link must not swallow the resolution message: a project \
+         that declares agents must still be told the declarations file was looked in \
+         (#339), got: {combined}"
+    );
+}

--- a/crates/armadai/tests/pipe_declarative_agents.rs
+++ b/crates/armadai/tests/pipe_declarative_agents.rs
@@ -109,6 +109,23 @@ fn project(declared: &[&str], file_backed: &[&str]) -> (tempfile::TempDir, std::
 /// library, and without the latter `record_run` would write this test's runs
 /// into the developer's real SQLite database (#267).
 fn run_pipe(root: &Path, head: &str, input: &str, rest: &[&str]) -> std::process::Output {
+    run_pipe_inner(root, head, input, rest, true)
+}
+
+/// [`run_pipe`] without `--json`: the plain human invocation, whose failures
+/// go through `main`'s `Debug`-formatted `anyhow::Error` (`Error: …` plus a
+/// `Caused by:` section) rather than through an `error` event.
+fn run_pipe_human(root: &Path, head: &str, input: &str, rest: &[&str]) -> std::process::Output {
+    run_pipe_inner(root, head, input, rest, false)
+}
+
+fn run_pipe_inner(
+    root: &Path,
+    head: &str,
+    input: &str,
+    rest: &[&str],
+    json: bool,
+) -> std::process::Output {
     let sandbox = root.parent().unwrap();
     let config = sandbox.join("config");
     let data = sandbox.join("data");
@@ -120,8 +137,10 @@ fn run_pipe(root: &Path, head: &str, input: &str, rest: &[&str]) -> std::process
         .env("ARMADAI_CONFIG_DIR", &config)
         .env("XDG_DATA_HOME", &data)
         .args(["run", head, input, "--pipe"])
-        .args(rest)
-        .arg("--json");
+        .args(rest);
+    if json {
+        cmd.arg("--json");
+    }
     cmd.output().unwrap()
 }
 
@@ -431,5 +450,196 @@ fn pipe_resolves_every_link_before_running_the_first() {
         "positioning the bad link must not swallow the resolution message: a project \
          that declares agents must still be told the declarations file was looked in \
          (#339), got: {combined}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #373 review, i1 + m4: the human error path keeps the whole chain of causes.
+//
+// Every test above passes `--json`, which is exactly how the regression got
+// in: the headless `error` event reports `Error::to_string()` — one layer —
+// so a flattened error looks identical there, while `main`'s `Debug`-printed
+// `anyhow::Error` on the human path lost its whole `Caused by:` section.
+// ---------------------------------------------------------------------------
+
+/// Overwrite one of [`project`]'s file-backed agents with Markdown carrying
+/// `extra_metadata` as an additional `## Metadata` line, leaving the
+/// `armadai.yaml` entry `project` already wrote for it in place.
+fn break_file_agent(root: &Path, agent: &str, extra_metadata: &str) {
+    let md = file_agent_markdown(agent).replace(
+        "- command: echo\n",
+        &format!("- command: echo\n{extra_metadata}\n"),
+    );
+    std::fs::write(root.join("agents").join(format!("{agent}.md")), md).unwrap();
+}
+
+/// `armadai run <agent> <input>` — the single-agent path, whose error
+/// reporting `--pipe`'s must not be worse than.
+fn run_single_human(root: &Path, agent: &str, input: &str) -> std::process::Output {
+    let sandbox = root.parent().unwrap();
+    let config = sandbox.join("config");
+    let data = sandbox.join("data");
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+
+    Command::cargo_bin("armadai")
+        .unwrap()
+        .current_dir(root)
+        .env("ARMADAI_CONFIG_DIR", &config)
+        .env("XDG_DATA_HOME", &data)
+        .args(["run", agent, input])
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn a_chain_link_that_fails_to_load_reports_why_not_just_what() {
+    // `- temperature: warm` fails deep in the parser: `invalid temperature`
+    // wrapping `invalid float literal`. The outer layer alone names the field
+    // but not what was wrong with it — and a user who can already see
+    // `temperature: warm` in the file learns nothing from it.
+    let (_dir, root) = project(&[], &["m4-head", "m4-broken"]);
+    break_file_agent(&root, "m4-broken", "- temperature: warm");
+
+    let single = run_single_human(&root, "m4-broken", "TASK-CAUSE-CHAIN");
+    let single_err = String::from_utf8_lossy(&single.stderr).to_string();
+    assert!(
+        single_err.contains("invalid temperature") && single_err.contains("invalid float literal"),
+        "fixture check: the single-agent path must report both layers, otherwise this \
+         test cannot tell a flattened chain from an already-flat one, got: {single_err}"
+    );
+
+    let out = run_pipe_human(&root, "m4-head", "TASK-CAUSE-CHAIN", &["m4-broken"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "a chain whose second link cannot be parsed must fail.\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("m4-broken") && stderr.contains("2/2"),
+        "the failure must still place and name the bad link, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("invalid temperature"),
+        "the failure must carry the resolver's own message, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("invalid float literal"),
+        "the failure must carry the ROOT cause too, not only the outermost layer: \
+         positioning the bad link inlines the resolver's message into a new error, and a \
+         non-alternate `{{e}}` there silently drops everything under it — the same \
+         `armadai run m4-broken` prints under `Caused by:`, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #373 review, i3: the up-front pass validates the provider too, not just the
+// agent definition — otherwise #366's own bill survives one gate further on.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pipe_builds_every_link_provider_before_running_the_first() {
+    // `create_provider` fails deterministically on the agent's own metadata,
+    // with nothing an earlier link could have changed. Resolving definitions
+    // up front but leaving provider construction inside `run_single_agent`
+    // meant a misspelled `provider:` on link 2 was discovered only after link
+    // 1 had run: measured as `agent_start`/`agent_end` for the head, then
+    // `error: Unknown provider: 'gtp'` — a billed call on a chain that could
+    // never complete, which is the exact defect #366 is about.
+    let (_dir, root) = project(&[], &["m5-head", "m5-typo-prov", "m5-tail"]);
+    break_file_agent(&root, "m5-typo-prov", "- provider: gtp");
+
+    let out = run_pipe(
+        &root,
+        "m5-head",
+        "TASK-BAD-PROVIDER",
+        &["m5-typo-prov", "m5-tail"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        !out.status.success(),
+        "a chain naming an unconstructible provider must fail.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        agents_started(&stdout),
+        Vec::<String>::new(),
+        "NO agent may start when a later link's provider cannot be built — the failure \
+         is decided by that agent's own metadata, so nothing the head produces could \
+         have changed it, and running the head only bills a chain that cannot \
+         complete.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        combined.contains("m5-typo-prov") && combined.contains("2/3"),
+        "the failure must name and place the offending link — `Unknown provider: 'gtp'` \
+         on its own names neither, got: {combined}"
+    );
+    assert!(
+        combined.contains("Unknown provider"),
+        "the failure must still carry the provider factory's own reason, got: {combined}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #373 review, m5: a per-link warning is printed under its own link's header,
+// and a project-wide one is printed once.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_project_wide_load_warning_is_printed_once_under_the_first_link() {
+    // An unparsable `.armadai/agents.yaml` makes `load_agent_by_name` return
+    // `DeclarationsUnreadable` for EVERY link that falls back to a file —
+    // ~380 characters restating one project fact, differing only in the
+    // served agent's name at the very end, and byte-identical whenever two
+    // links name the same agent. Resolving the chain up front also moved the
+    // whole block ahead of `--- [1/3 …] ---`, so nothing said which link any
+    // of them was about.
+    let (_dir, root) = project(&[], &["m6-one", "m6-two"]);
+    std::fs::write(
+        root.join(".armadai/agents.yaml"),
+        "agents:\n  - name: [unterminated\n",
+    )
+    .unwrap();
+
+    let out = run_pipe_human(&root, "m6-one", "TASK-ONE-WARNING", &["m6-two", "m6-one"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "an unparsable declarations file must not fail a chain of file-backed agents.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let lines: Vec<&str> = stderr.lines().collect();
+    let warnings: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains("ignoring unparsable"))
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "the unparsable declarations file is one project fact, not one per link: three \
+         links restated it three times, twice byte for byte. Got {} line(s): {:#?}",
+        warnings.len(),
+        warnings.iter().map(|&i| lines[i]).collect::<Vec<_>>()
+    );
+
+    let first_header = lines
+        .iter()
+        .position(|l| l.contains("[1/3"))
+        .unwrap_or_else(|| panic!("no chain header on stderr: {stderr}"));
+    assert!(
+        warnings[0] > first_header,
+        "the warning must sit UNDER the header of the link it is about, not in a block \
+         ahead of the whole chain — with the header above it, the trailing agent name is \
+         what anchors it. Got the warning at line {} and `[1/3 …]` at line {}: {stderr}",
+        warnings[0],
+        first_header
     );
 }

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -282,6 +282,18 @@ spawn at all. Such a step is **skipped with an explanation** and the rest of the
 step is lost, not the pipeline. Run those agents with `armadai run <name>`, which builds the API
 client instead of relaying a CLI.
 
+A command that *is* named but is not installed on this machine gets the same treatment. It can only
+be discovered when the spawn fails, and that used to end the whole pipeline; now it costs its own
+step, naming the step and the missing binary, and the next link reads what it would have read
+anyway:
+
+```
+Skipping step 'review' ('opencode'): failed to spawn: No such file or directory (os error 2)
+```
+
+A step that spawns and then *exits non-zero* is a different case and still stops the pipeline: it
+ran, and what it printed on stderr is reported with the failure.
+
 ## Parity with the `.md` format — and its limits
 
 A declared agent and its hand-written `.md` twin are proven, by test

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -195,9 +195,19 @@ not undoable — spent on a chain that could never have completed. If you are us
 first links produce output before a later typo surfaced, that is the behaviour that changed: you
 now get the error immediately, and nothing runs.
 
-Only *resolution* moves up front. A link that resolves fine and then fails while running still
-fails where it always did, part-way through the chain, and the earlier links' calls are already
-spent — that is inherent to running them.
+Each link's **provider** is built up front too, not only its definition. An agent whose
+`provider:` is misspelled, whose API key is nowhere to be found, or which asks for `provider: cli`
+without naming a `command:`, fails on its own metadata — nothing an earlier link produces could
+change the outcome — so it is caught in the same pass, and the failure names the link the same way:
+
+```
+chain link 2/3 ('summariser') has no usable provider, so no agent was run: No API key found for
+'anthropic'. Set ANTHROPIC_API_KEY or add to config/providers.secret.yaml
+```
+
+What stays where it was is *running*. A link that resolves and builds fine and then fails during
+its call still fails part-way through the chain, and the earlier links' calls are already spent —
+that is inherent to running them.
 
 ## Long compositions still get audited
 

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -160,10 +160,11 @@ fine elsewhere. But the three commands that can hit one don't all react the same
   naming both `agents.yaml` and the colliding `.md` file. A command that is about to execute or
   describe one agent must not silently pick a winner between a declaration and a file.
 - `armadai run --pipe` refuses a colliding name in **any** position of the chain, and refuses it
-  before running the first link — so a collision costs no provider call at all. It used to let the
-  chain through while the single-agent path refused the very same name, because the chain loop
-  resolved agents by file path and so never consulted the declarations; routing it through the same
-  by-name loader removed that inconsistency.
+  before running the first link — so a collision costs no provider call at all (see [a chain is
+  resolved before it runs](#a-chain-is-resolved-before-it-runs)). It used to let the chain through
+  while the single-agent path refused the very same name, because the chain loop resolved agents by
+  file path and so never consulted the declarations; routing it through the same by-name loader
+  removed that inconsistency.
 - Because that check is scoped to just the one name you asked for, `armadai inspect
   <some-other-name>` says **nothing** about an unrelated collision sitting elsewhere in the fleet —
   it doesn't scan the whole project the way `list` does. Don't rely on `inspect` to surface
@@ -172,6 +173,31 @@ fine elsewhere. But the three commands that can hit one don't all react the same
   write **anything** when the collision falls inside what you asked it to link (the whole fleet by
   default, or the names passed to `--agents`) — a command that writes config must not silently ship
   a smaller fleet than the one you declared.
+
+## A chain is resolved before it runs
+
+`armadai run <head> <task> --pipe b c d` resolves **every** link — declared or file-backed — before
+it runs the first one. A name that resolves nowhere, or a name caught by the collision check above,
+fails the whole command at once, with no agent started:
+
+```
+chain link 3/4 ('reviwer') could not be resolved, so no agent was run: agent
+'reviwer' not found: not resolvable as a file (…), and not declared in
+/path/to/project/.armadai/agents.yaml
+```
+
+The failure names the link's **position** as well as its name, because with several names on one
+command line the name alone leaves you counting them.
+
+This used to happen link by link, inside the execution loop: a typo on the third of four links was
+only discovered after the first two had already run. Those are real provider calls — billed, and
+not undoable — spent on a chain that could never have completed. If you are used to seeing the
+first links produce output before a later typo surfaced, that is the behaviour that changed: you
+now get the error immediately, and nothing runs.
+
+Only *resolution* moves up front. A link that resolves fine and then fails while running still
+fails where it always did, part-way through the chain, and the earlier links' calls are already
+spent — that is inherent to running them.
 
 ## Long compositions still get audited
 

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -304,6 +304,12 @@ Skipping step 'review' ('opencode'): failed to spawn: No such file or directory 
 A step that spawns and then *exits non-zero* is a different case and still stops the pipeline: it
 ran, and what it printed on stderr is reported with the failure.
 
+If **every** step of a pipeline skips, the turn is not recorded at all — the shell says so and
+leaves the conversation history untouched. Skipping deliberately leaves the running input alone so
+the next link reads what it would have read anyway; with nothing left to answer, that input is
+still your own message, and filing it as the assistant's answer would persist it with the session
+and replay it as context on your next turn.
+
 ## Parity with the `.md` format — and its limits
 
 A declared agent and its hand-written `.md` twin are proven, by test


### PR DESCRIPTION
Ferme #366.

## Le défaut

`armadai run <agent> <task> --pipe a b c` résolvait chaque maillon **à l'intérieur** de la boucle
d'exécution. Une faute de frappe sur le maillon N n'était donc découverte qu'après avoir exécuté
les N-1 précédents — des appels provider réels, facturés, pour un run qui ne peut pas aboutir.

Mesuré sur une chaîne de 4 dont le 3ᵉ maillon est erroné (agents hermétiques
`provider: cli` / `command: echo`, aucune clé, aucun réseau) :

```
{"t":"run_start","agents":["m3-a","m3-b","typo-agent","m3-c"]}
{"t":"agent_start","agent":"m3-a"}
{"t":"agent_end","agent":"m3-a"}
{"t":"agent_start","agent":"m3-b"}
{"t":"agent_end","agent":"m3-b"}
{"t":"error","code":"agent_failed","msg":"agent 'typo-agent' not found: …"}
```

## Le correctif

`load_chain` résout **tous** les maillons — définition **et** provider — avant d'exécuter le
premier ; la boucle ne fait plus qu'exécuter le roster déjà chargé. C'est la forme que
`run_orchestrated` et `resume_run` avaient déjà : seule la chaîne séquentielle était paresseuse.

Le message nomme la **position** du maillon fautif autant que son nom — avec quatre noms sur une
ligne de commande, le nom seul oblige l'utilisateur à compter :

```
Error: chain link 3/4 ('reviwer') could not be resolved, so no agent was run: agent 'reviwer'
not found: not resolvable as a file (…), and not declared in /…/.armadai/agents.yaml
```

**Le piège évité, et il était réel.** Le message du résolveur est *inliné*, pas ajouté comme couche
`anyhow::Context` : l'événement d'erreur headless ne rapporte que le `Error::to_string()` le plus
externe. La version `with_context` — celle qu'on écrit spontanément — fait disparaître à la fois la
mention de `.armadai/agents.yaml` (correctif #339) et le refus de collision déclaré/écrit (#364).
Vérifié par mutation : les **trois** tests concernés passent au rouge.

## Point adjacent traité : le spawn impossible n'avorte plus la chaîne

Dans le pipeline en session du shell, un `spawn` raté était répondu par un `return Ok(())` : un seul
binaire absent annulait tous les maillons restants. `StepPlan::NotRelayable` (#364) avait déjà fixé
le bon marché pour une étape qu'on sait d'avance non relayable — une étape perdue, chaîne intacte.
Un binaire déclaré mais absent de la machine n'est découvrable qu'au spawn ; il suit désormais le
même chemin. Le message nomme l'étape et la commande (`Failed to spawn` seul ne disait ni laquelle
avait échoué, ni ce qui manquait).

Une étape qui *démarre* puis sort en code non nul reste délibérément bloquante : elle a tourné, et
sa stderr est rapportée avec l'échec.

Le test appelle `execute_pipeline_steps` directement (le défaut est dans son flot de contrôle, pas
dans une fonction pure extractible) **sans rendre la fonction générique sur son `Terminal`** :
- il n'utilise que des étapes qui échouent au spawn, lesquelles sortent avant la boucle de stream,
  donc aucun événement crossterm n'est jamais lu ;
- il pilote un viewport **fixe et vide**, donc aucun terminal de contrôle n'est nécessaire (CI
  comprise, `Terminal::new` interrogerait le backend pour une taille) et le vrai `io::Stdout` —
  que libtest ne capture pas — n'est jamais repeint.

---

# Vague de correctifs — revue indépendante (CHANGES REQUESTED)

Les trois *Important* et deux *Minor* de la revue, chacun mesuré avant/après.

## I1 — `{e}` aplatissait la chaîne de causes (`run.rs`)

`anyhow!("… : {e}")` utilise le `Display` **non-alterné** : seule la couche externe survit, et
l'erreur créée n'a pas de `source`. Le raisonnement portait sur `Error::to_string()` de l'événement
headless, mais oubliait que le chemin **humain** (`main` → `Debug` d'anyhow) imprimait, lui, la
chaîne complète. Les 7 tests d'intégration existants passent tous `--json` : c'est exactement pour
ça que la régression est passée au vert.

| entrée | `run m3-x` (référence) | `--pipe m3-x` **avant** | `--pipe m3-x` **après** |
|---|---|---|---|
| `.md` en `chmod 000` | `reading …m3-x.md` + `Caused by: Permission denied (os error 13)` | `… so no agent was run: reading …m3-x.md` | `… so no agent was run: reading …m3-x.md: Permission denied (os error 13)` |
| `- temperature: warm` | `invalid temperature` + `Caused by: invalid float literal` | `… so no agent was run: invalid temperature` | `… so no agent was run: invalid temperature: invalid float literal` |

Correctif : **un caractère**, `{e:#}`. La surface `--json` y gagne aussi une cause qu'elle n'avait
jamais eue :

```
avant : {"t":"error","msg":"chain link 2/2 ('m3-x') … : invalid temperature"}
après : {"t":"error","msg":"chain link 2/2 ('m3-x') … : invalid temperature: invalid float literal"}
```

Nouveau test (M4) : `a_chain_link_that_fails_to_load_reports_why_not_just_what` couvre le chemin
**humain** (sans `--json`), et vérifie d'abord sur la référence mono-agent que le fixture produit
bien deux couches — sinon le test ne distinguerait pas une chaîne aplatie d'une chaîne déjà plate.

## I2 — le `continue` enregistrait un tour d'assistant fabriqué (`shell/app.rs`)

L'ancien `return Ok(())` sortait **avant** `record_turn` et `save_current_session`. Le `continue`
ne le fait plus : si **toutes** les étapes échouent au spawn, `current_input` vaut encore l'entrée
de l'utilisateur, et la fonction va au bout.

Mesuré en instrumentant le test de la PR :

```
PROBE turns=1 history=[("Assistant", "hello")]
```

L'utilisateur tape `hello`, aucun binaire n'existe, la session enregistre **`Assistant: hello`** —
persisté par `save_current_session`, puis réinjecté comme contexte au tour suivant
(`max_history_turns: 5`).

Correctif : un drapeau posé exactement là où `current_input` est réellement remplacé par la sortie
d'une étape ; si aucune étape n'a répondu, **aucun tour n'est enregistré** et le shell le dit. Le
cas **partiel** (une étape sur trois échoue) est laissé tel quel : c'est le marché voulu.

## I3 — la pré-passe validait la définition, pas le provider

`create_provider` restait dans `run_single_agent`, donc **à l'exécution**, alors que
`run_orchestrated` — le modèle invoqué — fait les deux dans la même boucle. #366 survivait donc une
porte plus loin :

```
avant : {"t":"agent_start","agent":"m3-a"}          ← maillon 1 consommé et facturé
        {"t":"agent_end","agent":"m3-a"}
        {"t":"error","msg":"Unknown provider: 'gtp'"}   ← ne nomme même pas l'agent fautif

après : {"t":"error","msg":"chain link 2/3 ('m3-typo-prov') has no usable provider,
         so no agent was run: Unknown provider: 'gtp'. Known providers: …"}
```

Les trois cas plausibles, tous mesurés sur le binaire réel, tous désormais attrapés avant le
maillon 1 :

| cas | message |
|---|---|
| `provider: gtp` | `chain link 2/3 ('m3-typo-prov') has no usable provider, … Unknown provider: 'gtp'` |
| `provider: anthropic` sans clé | `chain link 2/3 ('m3-nokey') has no usable provider, … No API key found for 'anthropic'` |
| `provider: cli` sans `command:` | `chain link 2/3 ('m3-cli-nocmd') has no usable provider, … CLI provider requires 'command' in Metadata` |

`openai`/`proxy` n'est pas utilisé comme appui : #374 est en train de l'implémenter.

**Effets de bord de la construction anticipée — vérifiés, aucun indésirable.** `create_provider`
lit l'environnement et la config utilisateur, sonde `which` pour les noms unifiés, et construit des
clients : **aucune connexion n'est ouverte** (`AnthropicProvider::new`/`GoogleProvider::new` ne font
qu'un `reqwest::Client::new()`). La vérification de modèle déprécié n'y est pas : l'interactive
(`auto_check_and_prompt`) était déjà **plus haut**, dans `resolve_agents_dir`, et
`resolve_model_deprecations` reste par maillon dans `run_single_agent` — hisser `create_provider`
au-dessus ne change rien puisqu'elle ne lit ni `model` ni `model_fallback` (seulement
`provider`/`command`/`args`/`timeout`/`rate_limit`). Le limiteur partagé par provider est
process-global et mémoïsé (premier écrit gagne) ; le limiteur par agent est un seau qui démarre
**plein**. Le construire plus tôt ne peut donc que le rendre **plus permissif** au moment de
l'appel, jamais plus restrictif. Le nombre d'appels à `create_provider` est inchangé : un par
maillon, avant au lieu de pendant.

## M5 — les `warn:` sortaient en bloc avant le premier en-tête (+ N lignes dupliquées)

Mesuré sur une chaîne de 3 maillons dans un projet dont `.armadai/agents.yaml` est illisible :
trois lignes de ~380 caractères, **byte-identiques** pour les maillons 1 et 3 (même agent),
toutes avant `--- [1/3 …] ---`.

Après : la ligne est rendue **sous l'en-tête de son maillon**, et le fait *projet* (« ce
`agents.yaml` est illisible ») n'est dit **qu'une fois** — c'est le même fichier relu N fois dans
la même boucle, seul le nom d'agent en suffixe variait.

```
--- [1/3 m3-a] ---
  warn: ignoring unparsable /…/.armadai/agents.yaml: … (serving the file-backed agent 'm3-a' instead)
--- [2/3 m3-b] ---
--- [3/3 m3-a] ---
```

## M2 — empoisonnement d'`ENV_MUTEX` : **résolu par adoption du garde de #372**

Choix initial : ne rien faire, #372 couvrant exactement ça. Le risque d'ordre de merge signalé
s'est réalisé pendant la vague : **#372 a été mergée sur master** (`b3bf372`), qui supprime
`ENV_MUTEX` de `armadai_core::config`, le rend **privé** dans `armadai_core::test_support`, et
expose un `IsolatedConfigDir` partagé et tolérant au poison. La copie locale de `shell/app.rs` ne
compilait donc plus — et ne devait plus compiler, c'est le but de la privatisation.

La branche est **rebasée sur master** (rebase propre, aucun conflit) et le garde local est remplacé
par `armadai_core::test_support::IsolatedConfigDir` (commit `refactor(test)` dédié). Les deux sites
intolérants que la revue citait (`shell::config`, `tui::app`) sont réécrits par #372 elle-même :
plus rien à faire ici.

## Point adjacent laissé : le re-parse de `.armadai/agents.yaml` par maillon

**La justification précédente était fausse et la revue l'a mesuré.** Elle affirmait que ce re-parse
« ne produit aucune sortie répétée » : c'est faux, il produit bien N lignes
`ignoring unparsable …/agents.yaml` — un fait *projet*, avec le nom d'agent en simple suffixe — et
deux tests étaient possibles (comptage d'avertissements, ou preuve directe de mémoïsation en
réécrivant le fichier entre deux résolutions). Ces N lignes étaient un **vrai défaut à part**,
traité ci-dessus en M5.

La **conclusion** (ne pas hisser le parse) reste valide, mais pour d'autres raisons :
- les N parses sont désormais **consécutifs dans une boucle serrée** — la fenêtre passe de « toute
  la durée du run » à quelques microsecondes, et le coût est microscopique ;
- un test de mémoïsation épinglerait une **sémantique de péremption que personne n'a arbitrée**
  (que doit-il se passer si le fichier change *pendant* un run ?) ;
- hisser demande de remodeler la signature de `load_agent_by_name` chez ~5 appelants de production
  dans deux crates, plus 6 sites de test. La `ProjectAgentSource`-handle qu'évoque l'issue est un
  choix de conception qui mérite sa propre issue.

## Méthode

TDD, rouge vérifié pour la bonne raison, puis mutations délibérées — chacune confirmée rouge avec
la bonne cible et `--no-fail-fast` :

| # | Mutation | Test qui tombe |
|---|---|---|
| 1 | résolution remise dans la boucle | `pipe_resolves_every_link_before_running_the_first` (`left: ["m3-a","m3-b"]`, `right: []`) |
| 1b | position `{}/{}` retirée du message | même test, assertion `3/4` |
| 1c | `map_err` inline → `with_context` | **trois** tests : #339, collision #364, et le nouveau |
| 2 | `continue` → `return Ok(())` au spawn | `a_step_whose_binary_is_missing_costs_that_step_not_the_rest_of_the_chain` |
| 2b | message de skip anonyme | même test, assertion « nomme l'étape et la commande » |
| **3 (i1)** | `{e:#}` → `{e}` | `a_chain_link_that_fails_to_load_reports_why_not_just_what` : `got: … invalid temperature` (sans la cause) |
| **4 (i2)** | garde « aucune étape n'a répondu » désactivée | `a_pipeline_where_every_step_skips_records_no_turn_at_all` : `got: [("Assistant", "hello")]` |
| **5 (i3)** | `create_provider` redifférée dans la boucle | `pipe_builds_every_link_provider_before_running_the_first` : `left: ["m5-head"]`, `right: []` |
| **5b (i3)** | préfixe `chain link i/N ('nom')` retiré de l'échec provider | même test, assertion « nomme et place le maillon » |
| **6 (m5)** | dédup supprimée | `a_project_wide_load_warning_is_printed_once_under_the_first_link` : `left: 3`, `right: 1` |
| **6b (m5)** | avertissement réimprimé pendant la résolution | même test, assertion de position vs `[1/3 …]` |

## Doc

`docs/wiki/declarative-agents.md` : « A chain is resolved before it runs » dit maintenant que le
**provider** de chaque maillon est construit d'avance lui aussi (avec l'exemple de la clé absente),
et le paragraphe « seule la résolution monte » est corrigé en conséquence ; la section du relais en
session ajoute le cas « toutes les étapes sautent → aucun tour enregistré ».

## Gate

- `cargo fmt --all -- --check` — OK
- clippy **5/5** modes, `-D warnings` — OK
- tests **4/4** modes (`--no-fail-fast`) — 0 échec
- gaveldrop — **13 cas · 13 passed · 0 failed · score 83/83**
- `cargo build --release --no-default-features --features tui,storage` — OK

Gate rejoué **après le rebase sur master** (`b0850c6`, qui inclut #370, #372 et #377) : fmt OK,
clippy 5/5 OK, tests 4/4 sans échec, gaveldrop 13 cas · 83/83, release build OK.

Vérifié aussi à la main sur le binaire réel : chaîne valide de 3 maillons dans l'ordre, chaîne
fautive (définition **ou** provider) qui échoue sans démarrer un seul agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
