### PR TITLE
feat(providers): implémente le protocole OpenAI pour openai et proxy

### DIFF
--- a/crates/armadai-core/src/orchestration/es/state.rs
+++ b/crates/armadai-core/src/orchestration/es/state.rs
@@ -327,6 +327,82 @@ pub fn fold(events: &[ExecutionEvent]) -> ExecutionState {
     state
 }
 
+/// Warning code emitted when a configured budget was fed no usage at all.
+pub const UNREPORTED_USAGE_CODE: &str = "budget_usage_unreported";
+
+/// `Some(message)` when a configured `token_budget`/`cost_limit` cannot
+/// possibly do its job, because the provider reported no usage whatsoever
+/// for the whole run.
+///
+/// The budget counters here are fed exclusively by `AgentObserved`'s
+/// `tokens_in`/`tokens_out`/`cost`, which come straight from
+/// `CompletionResponse`. That type has no way to say "unknown": a provider
+/// that does not report usage — many OpenAI-compatible gateways and local
+/// runtimes simply omit the `usage` block, and `CliProvider` reports nothing
+/// for a plain-text CLI — is indistinguishable from one reporting a free,
+/// zero-token call. Reporting `0.0` is the right choice (inventing a median
+/// price would put dollars into `armadai costs` that were never spent), but
+/// downstream every zero reads as "free":
+///
+/// - `token_budget`/`cost_limit` never breach, so a run that should have
+///   halted keeps going up to `max_iterations`/`max_depth`;
+/// - the per-hop partition (`remaining = total - consumed`) hands **every**
+///   nested delegation the full original ceiling — the very defect #345
+///   closed, reopened through the data;
+/// - `remaining_ratio` stays at `1.0`, so `budget_downgrade_ratio` never
+///   engages.
+///
+/// None of that is unbounded — `max_iterations` (50) and `max_depth` (5) are
+/// checked before the budget branches, and the socle's `MAX_ITERATIONS`
+/// (500) is the outer net — but a silently inoperative limit is worth one
+/// line of warning. The real fix is an `Option` for unknown usage carried
+/// end to end (`CliResponse` in `json_runner.rs` already distinguishes
+/// them); that reaches `CompletionResponse`, the event log and the SQLite
+/// schema, and is deliberately not attempted here.
+///
+/// Returns `None` when no budget is configured, when any usage at all was
+/// reported, or when no agent ever answered (nothing to measure). A run in
+/// which every call *failed* also reports no usage; the notice is still
+/// literally true there, only less interesting.
+pub fn unreported_usage_warning(
+    token_budget: Option<u64>,
+    cost_limit: Option<f64>,
+    state: &ExecutionState,
+) -> Option<String> {
+    let mut configured: Vec<&str> = Vec::new();
+    if token_budget.is_some_and(|b| b > 0) {
+        configured.push("token_budget");
+    }
+    if cost_limit.is_some_and(|c| c > 0.0) {
+        configured.push("cost_limit");
+    }
+    if configured.is_empty() {
+        return None;
+    }
+
+    if state.budget_tokens_in > 0 || state.budget_tokens_out > 0 || state.budget_cost > 0.0 {
+        return None;
+    }
+
+    let anyone_answered = state
+        .conversations
+        .values()
+        .flatten()
+        .any(|m| m.role == "assistant");
+    if !anyone_answered {
+        return None;
+    }
+
+    Some(format!(
+        "{} is configured, but the provider reported no usage for this run \
+         (0 tokens, $0.00) — the limit can never trigger, and each nested \
+         delegation receives the full ceiling instead of its share. \
+         Endpoints that omit `usage` (many OpenAI-compatible gateways and \
+         local runtimes) make budget limits inoperative.",
+        configured.join(" and ")
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -528,5 +604,72 @@ mod tests {
         ];
         let state = fold(&events);
         assert_eq!(state.config_json.as_deref(), Some("{\"max_rounds\":5}"));
+    }
+    // --- unreported usage (#374 review, I3) ---
+
+    fn state_with(tokens_in: u64, tokens_out: u64, cost: f64) -> ExecutionState {
+        let mut state = ExecutionState::default();
+        state.conversations.insert(
+            "lead".to_string(),
+            vec![ChatMessage {
+                role: "assistant".to_string(),
+                content: "answered".to_string(),
+            }],
+        );
+        state.budget_tokens_in = tokens_in;
+        state.budget_tokens_out = tokens_out;
+        state.budget_cost = cost;
+        state
+    }
+
+    #[test]
+    fn a_configured_budget_fed_no_usage_at_all_is_reported() {
+        let state = state_with(0, 0, 0.0);
+        let warning = unreported_usage_warning(Some(10_000), None, &state)
+            .expect("a token_budget with zero reported usage must be reported");
+        assert!(warning.contains("token_budget"), "{warning}");
+
+        let warning = unreported_usage_warning(None, Some(5.0), &state)
+            .expect("a cost_limit with zero reported usage must be reported");
+        assert!(warning.contains("cost_limit"), "{warning}");
+
+        let warning = unreported_usage_warning(Some(10_000), Some(5.0), &state).expect("both");
+        assert!(warning.contains("token_budget"), "{warning}");
+        assert!(warning.contains("cost_limit"), "{warning}");
+    }
+
+    /// The three ways this must stay quiet. Without them the notice would
+    /// fire on every run that configures nothing, on every healthy run, and
+    /// on a run where nothing was ever invoked.
+    #[test]
+    fn nothing_is_reported_when_there_is_nothing_to_report() {
+        // No budget configured at all.
+        assert!(unreported_usage_warning(None, None, &state_with(0, 0, 0.0)).is_none());
+        // A budget of zero is not a budget.
+        assert!(unreported_usage_warning(Some(0), Some(0.0), &state_with(0, 0, 0.0)).is_none());
+        // Usage really was reported — any one of the three counters is enough.
+        assert!(unreported_usage_warning(Some(10), None, &state_with(1, 0, 0.0)).is_none());
+        assert!(unreported_usage_warning(Some(10), None, &state_with(0, 1, 0.0)).is_none());
+        assert!(unreported_usage_warning(None, Some(1.0), &state_with(0, 0, 0.01)).is_none());
+        // Nothing ran: no usage to miss.
+        assert!(
+            unreported_usage_warning(Some(10), Some(1.0), &ExecutionState::default()).is_none()
+        );
+    }
+
+    /// An invoked-but-unanswered run (only the `user` turn recorded) must
+    /// not warn either — otherwise the notice fires before the first
+    /// provider call has had a chance to report anything.
+    #[test]
+    fn a_run_with_no_assistant_turn_yet_is_not_reported() {
+        let mut state = ExecutionState::default();
+        state.conversations.insert(
+            "lead".to_string(),
+            vec![ChatMessage {
+                role: "user".to_string(),
+                content: "go".to_string(),
+            }],
+        );
+        assert!(unreported_usage_warning(Some(10_000), None, &state).is_none());
     }
 }

--- a/crates/armadai-core/src/test_support.rs
+++ b/crates/armadai-core/src/test_support.rs
@@ -76,6 +76,9 @@ pub fn env_lock() -> MutexGuard<'static, ()> {
 pub struct IsolatedConfigDir {
     _lock: MutexGuard<'static, ()>,
     orig_config_dir: Option<String>,
+    /// Extra variables set through [`IsolatedConfigDir::with_var`], in the
+    /// order they were set, each paired with the value it displaced.
+    saved_vars: Vec<(String, Option<String>)>,
     config_tmp: tempfile::TempDir,
 }
 
@@ -91,8 +94,35 @@ impl IsolatedConfigDir {
         Self {
             _lock: lock,
             orig_config_dir,
+            saved_vars: Vec::new(),
             config_tmp,
         }
+    }
+
+    /// Set (`Some`) or unset (`None`) one more environment variable for this
+    /// guard's lifetime, restoring whatever it displaced on drop. Chainable.
+    ///
+    /// Code under test reads more than `ARMADAI_CONFIG_DIR` — a provider's
+    /// `*_API_KEY` or `*_BASE_URL`, say — and a test that wants to pin those
+    /// needs the same save/restore discipline, under the same
+    /// [`env_lock`]. Without this the test writes its own guard, which is
+    /// the duplication this module exists to end: `providers::factory`'s
+    /// `EnvScope` (#368) was a ~50-line copy of exactly this, and it stopped
+    /// compiling the moment #372 moved the lock.
+    ///
+    /// Setting the same name twice is fine: the values are restored in
+    /// reverse order, so the original still wins.
+    pub fn with_var(mut self, name: &str, value: Option<&str>) -> Self {
+        self.saved_vars
+            .push((name.to_string(), std::env::var(name).ok()));
+        // SAFETY: serialised via the lock held by `self._lock`.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(name, v),
+                None => std::env::remove_var(name),
+            }
+        }
+        self
     }
 
     /// The isolated config dir itself — for a test that wants to plant a
@@ -114,6 +144,13 @@ impl Drop for IsolatedConfigDir {
         // SAFETY: restoring original env state, still under the lock held by
         // `self._lock` until this `Drop` returns.
         unsafe {
+            // Reverse order, so a name set twice ends on its original value.
+            for (name, value) in self.saved_vars.iter().rev() {
+                match value {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
             match &self.orig_config_dir {
                 Some(v) => std::env::set_var("ARMADAI_CONFIG_DIR", v),
                 None => std::env::remove_var("ARMADAI_CONFIG_DIR"),
@@ -287,5 +324,73 @@ mod tests {
             before,
             "the cwd must be back where it started"
         );
+    }
+
+    /// `with_var` must set what it is given, unset what it is given `None`
+    /// for, and put both back — a variable that was present before, and one
+    /// that was not.
+    ///
+    /// Mutation this catches: dropping the `saved_vars` loop from
+    /// `IsolatedConfigDir`'s `Drop`, which leaks the test's `*_API_KEY` into
+    /// every test that runs afterwards.
+    #[test]
+    fn extra_env_vars_are_set_then_restored_present_or_absent() {
+        const PRESENT: &str = "ARMADAI_TEST_SUPPORT_PRESENT";
+        const ABSENT: &str = "ARMADAI_TEST_SUPPORT_ABSENT";
+
+        // A value that exists before the guard, so restoration has something
+        // to put back rather than merely something to remove.
+        {
+            let _lock = env_lock();
+            // SAFETY: serialised via the lock held above.
+            unsafe {
+                std::env::set_var(PRESENT, "original");
+                std::env::remove_var(ABSENT);
+            }
+        }
+
+        {
+            let guard = IsolatedConfigDir::enter()
+                .with_var(PRESENT, Some("overridden"))
+                .with_var(ABSENT, Some("invented"));
+            assert_eq!(std::env::var(PRESENT).as_deref(), Ok("overridden"));
+            assert_eq!(std::env::var(ABSENT).as_deref(), Ok("invented"));
+            drop(guard);
+        }
+
+        let (present, absent) =
+            undisturbed(|| (std::env::var(PRESENT).ok(), std::env::var(ABSENT).ok()));
+        assert_eq!(
+            present.as_deref(),
+            Some("original"),
+            "a variable that existed before must come back with its own value"
+        );
+        assert_eq!(
+            absent, None,
+            "a variable invented by the guard must be gone again"
+        );
+
+        // And `None` really unsets for the guard's lifetime.
+        {
+            let _lock = env_lock();
+            // SAFETY: serialised via the lock held above.
+            unsafe { std::env::set_var(PRESENT, "original") };
+        }
+        {
+            let _guard = IsolatedConfigDir::enter().with_var(PRESENT, None);
+            assert!(
+                std::env::var(PRESENT).is_err(),
+                "`None` must remove the variable, not set it to the empty string"
+            );
+        }
+        assert_eq!(
+            undisturbed(|| std::env::var(PRESENT).ok()).as_deref(),
+            Some("original")
+        );
+        {
+            let _lock = env_lock();
+            // SAFETY: serialised via the lock held above.
+            unsafe { std::env::remove_var(PRESENT) };
+        }
     }
 }

--- a/crates/armadai-providers/src/api/mod.rs
+++ b/crates/armadai-providers/src/api/mod.rs
@@ -1,4 +1,7 @@
 pub mod anthropic;
 pub mod google;
 pub mod openai;
+pub(crate) mod openai_compatible;
 pub(crate) mod retry;
+#[cfg(test)]
+pub(crate) mod test_server;

--- a/crates/armadai-providers/src/api/openai.rs
+++ b/crates/armadai-providers/src/api/openai.rs
@@ -51,10 +51,19 @@ impl Provider for OpenAiProvider {
     fn metadata(&self) -> ProviderMetadata {
         ProviderMetadata {
             name: "openai".to_string(),
+            // Every id here must be one `openai_compatible::rates_for_model`
+            // prices — otherwise we advertise a model whose real spend we
+            // would report as `$0.00`. Enforced by
+            // `every_advertised_model_is_one_the_cost_table_prices`.
             models: vec![
                 "gpt-4o".to_string(),
                 "gpt-4o-mini".to_string(),
+                "gpt-4.1".to_string(),
+                "gpt-4.1-mini".to_string(),
+                "gpt-4.1-nano".to_string(),
                 "o1".to_string(),
+                "o1-mini".to_string(),
+                "o3-mini".to_string(),
             ],
             supports_streaming: true,
         }
@@ -634,4 +643,20 @@ mod tests {
         assert!(meta.supports_streaming);
     }
 
+    /// The advertised list and the cost table are two lists of the same
+    /// thing, and #368 shipped them out of step: `metadata()` named three
+    /// ids while the table priced eight. A model we advertise but cannot
+    /// price reports `$0.00` for a real spend, which is the one wrong number
+    /// `rates_for_model` exists to avoid.
+    #[test]
+    fn every_advertised_model_is_one_the_cost_table_prices() {
+        let meta = OpenAiProvider::new("k".to_string()).metadata();
+        assert!(!meta.models.is_empty());
+        for model in &meta.models {
+            assert!(
+                crate::api::openai_compatible::rates_for_model(model).is_some(),
+                "advertised model {model:?} has no entry in the cost table"
+            );
+        }
+    }
 }

--- a/crates/armadai-providers/src/api/openai.rs
+++ b/crates/armadai-providers/src/api/openai.rs
@@ -1,10 +1,22 @@
+//! OpenAI's own chat-completions endpoint.
+//!
+//! The protocol lives in [`super::openai_compatible`] and is shared
+//! verbatim with [`crate::proxy`]; this file only carries OpenAI's
+//! defaults (public base URL, a required API key, the advertised model
+//! list). See that module for what is and isn't tolerated on the wire, and
+//! for why Azure OpenAI is deliberately not handled here.
+
 use async_trait::async_trait;
+use reqwest::Client;
 
 use armadai_core::provider::*;
+
+use super::openai_compatible::Endpoint;
 
 pub struct OpenAiProvider {
     pub api_key: String,
     pub base_url: String,
+    client: Client,
 }
 
 impl OpenAiProvider {
@@ -12,18 +24,28 @@ impl OpenAiProvider {
         Self {
             api_key,
             base_url: "https://api.openai.com/v1".to_string(),
+            client: Client::new(),
+        }
+    }
+
+    fn endpoint(&self) -> Endpoint<'_> {
+        Endpoint {
+            client: &self.client,
+            base_url: &self.base_url,
+            api_key: Some(&self.api_key),
+            label: "OpenAI",
         }
     }
 }
 
 #[async_trait]
 impl Provider for OpenAiProvider {
-    async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
-        todo!("OpenAI completion")
+    async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        self.endpoint().complete(request).await
     }
 
-    async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
-        todo!("OpenAI streaming")
+    async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
+        self.endpoint().stream(request).await
     }
 
     fn metadata(&self) -> ProviderMetadata {
@@ -36,5 +58,426 @@ impl Provider for OpenAiProvider {
             ],
             supports_streaming: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_server::{ScriptedResponse, ScriptedServer};
+    use tokio_stream::StreamExt;
+
+    fn provider_at(server: &ScriptedServer) -> OpenAiProvider {
+        let mut p = OpenAiProvider::new("sk-test-key".to_string());
+        p.base_url = server.url();
+        p
+    }
+
+    fn request() -> CompletionRequest {
+        CompletionRequest {
+            model: "gpt-4o-mini".to_string(),
+            system_prompt: "You are terse.".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "Hi".to_string(),
+            }],
+            temperature: 0.3,
+            max_tokens: Some(256),
+        }
+    }
+
+    async fn collect(stream: TokenStream) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut stream = stream;
+        while let Some(item) = stream.next().await {
+            out.push(item.expect("stream item"));
+        }
+        out
+    }
+
+    // --- complete() ---
+
+    #[tokio::test]
+    async fn complete_parses_a_nominal_chat_completion() {
+        let body = r#"{
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "model": "gpt-4o-mini-2024-07-18",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "Bonjour"},
+                 "finish_reason": "stop"}
+            ],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+        }"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, body)]);
+
+        let resp = provider_at(&server)
+            .complete(request())
+            .await
+            .expect("nominal completion");
+
+        assert_eq!(resp.content, "Bonjour");
+        assert_eq!(resp.model, "gpt-4o-mini-2024-07-18");
+        assert_eq!(resp.tokens_in, 11);
+        assert_eq!(resp.tokens_out, 7);
+        // gpt-4o-mini: $0.15/M in, $0.60/M out.
+        let expected = (11.0 * 0.15 + 7.0 * 0.60) / 1_000_000.0;
+        assert!(
+            (resp.cost - expected).abs() < f64::EPSILON,
+            "cost {} != {expected}",
+            resp.cost
+        );
+    }
+
+    /// Many OpenAI-compatible gateways and local runtimes omit `usage`
+    /// entirely (or send `usage: null`). That must cost the caller nothing
+    /// but the counters — never the whole call.
+    #[tokio::test]
+    async fn complete_without_a_usage_block_still_returns_the_content() {
+        let body = r#"{
+            "model": "llama3.1",
+            "choices": [{"message": {"content": "local answer"}}]
+        }"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, body)]);
+
+        let resp = provider_at(&server)
+            .complete(request())
+            .await
+            .expect("a response with no usage block must still succeed");
+
+        assert_eq!(resp.content, "local answer");
+        assert_eq!(resp.tokens_in, 0);
+        assert_eq!(resp.tokens_out, 0);
+        assert_eq!(resp.cost, 0.0);
+    }
+
+    /// `usage: null`, no `id`, no `finish_reason`, no `system_fingerprint`:
+    /// the shapes gateways actually send. Also proves an unknown model id
+    /// reports a zero cost rather than a fabricated one.
+    #[tokio::test]
+    async fn complete_tolerates_null_usage_and_missing_optional_fields() {
+        let body = r#"{
+            "model": "mistral-small-latest",
+            "usage": null,
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+        }"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, body)]);
+
+        let resp = provider_at(&server).complete(request()).await.expect("ok");
+        assert_eq!(resp.content, "ok");
+        assert_eq!(resp.model, "mistral-small-latest");
+        assert_eq!(resp.cost, 0.0);
+    }
+
+    /// A 200 with no `choices` at all (a filtered answer, a gateway
+    /// hiccup): empty content, not a failed call.
+    #[tokio::test]
+    async fn complete_with_no_choices_returns_empty_content_not_an_error() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(
+            200,
+            r#"{"model":"gpt-4o","usage":{"prompt_tokens":4,"completion_tokens":0}}"#,
+        )]);
+
+        let resp = provider_at(&server).complete(request()).await.expect("ok");
+        assert_eq!(resp.content, "");
+        assert_eq!(resp.tokens_in, 4);
+    }
+
+    /// A server that omits `model` altogether: fall back to what we asked
+    /// for rather than reporting an empty model.
+    #[tokio::test]
+    async fn complete_falls_back_to_the_requested_model_when_none_is_echoed() {
+        let body = r#"{"choices": [{"message": {"content": "x"}}]}"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, body)]);
+
+        let resp = provider_at(&server).complete(request()).await.expect("ok");
+        assert_eq!(resp.model, "gpt-4o-mini");
+    }
+
+    #[tokio::test]
+    async fn an_http_error_surfaces_the_servers_own_message() {
+        let body = r#"{"error": {"message": "Unsupported parameter: 'max_tokens'",
+                                  "type": "invalid_request_error", "code": null}}"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(400, body)]);
+
+        let err = provider_at(&server)
+            .complete(request())
+            .await
+            .expect_err("a 400 must be an error, not a panic");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Unsupported parameter: 'max_tokens'"),
+            "error must carry the server's message, got: {msg}"
+        );
+        assert!(
+            msg.contains("400"),
+            "error must name the status, got: {msg}"
+        );
+    }
+
+    /// The request actually put on the wire: a `Bearer` key, the system
+    /// prompt as the leading `system` message, and no `stream` flag.
+    #[tokio::test]
+    async fn the_request_carries_a_bearer_key_and_the_system_prompt() {
+        let body = r#"{"choices": [{"message": {"content": "x"}}]}"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, body)]);
+
+        provider_at(&server).complete(request()).await.expect("ok");
+
+        let raw = server.request(0).expect("one request received");
+        assert!(
+            raw.contains("authorization: Bearer sk-test-key")
+                || raw.contains("Authorization: Bearer sk-test-key"),
+            "missing bearer header in:\n{raw}"
+        );
+        assert!(
+            raw.contains("POST /chat/completions "),
+            "wrong path in:\n{raw}"
+        );
+        assert!(
+            raw.contains(r#""role":"system","content":"You are terse.""#),
+            "system prompt not sent as a system message in:\n{raw}"
+        );
+        assert!(
+            raw.contains(r#""max_tokens":256"#),
+            "max_tokens not forwarded in:\n{raw}"
+        );
+    }
+
+    /// `max_tokens` is rejected outright by some models (o1/o3) and some
+    /// gateways, so it must only travel when the agent actually asked for it.
+    #[tokio::test]
+    async fn an_unset_max_tokens_is_not_sent_at_all() {
+        let body = r#"{"choices": [{"message": {"content": "x"}}]}"#;
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, body)]);
+
+        let mut req = request();
+        req.max_tokens = None;
+        provider_at(&server).complete(req).await.expect("ok");
+
+        let raw = server.request(0).expect("one request received");
+        assert!(
+            !raw.contains("max_tokens"),
+            "max_tokens must be absent when unset, found in:\n{raw}"
+        );
+    }
+
+    /// The 429/503/529 handling from `api::retry` (#358) must apply here
+    /// too — this path talks to far more servers than the two first-party
+    /// APIs, so it meets rate limits more often, not less. The server
+    /// answers 429 once and then 200; a single request count would mean the
+    /// call never went through `send_with_retry`.
+    #[tokio::test]
+    async fn complete_retries_a_rate_limited_response_through_the_shared_policy() {
+        let server = ScriptedServer::start(vec![
+            ScriptedResponse::body(429, r#"{"error":{"message":"slow down"}}"#),
+            ScriptedResponse::body(
+                200,
+                r#"{"choices":[{"message":{"content":"after retry"}}]}"#,
+            ),
+        ]);
+
+        let resp = provider_at(&server)
+            .complete(request())
+            .await
+            .expect("the retried attempt must succeed");
+
+        assert_eq!(resp.content, "after retry");
+        assert_eq!(
+            server.request_count(),
+            2,
+            "a 429 must be retried, not surfaced as an error"
+        );
+    }
+
+    // --- stream() ---
+
+    /// The case hand-written SSE readers get wrong: one `data:` line split
+    /// across two TCP packets. The server writes each chunk separately, so
+    /// the halves genuinely arrive as separate reads.
+    #[tokio::test]
+    async fn stream_reassembles_a_data_line_split_across_two_packets() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hel",
+                "lo\"}}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\ndata: [DONE]\n\n",
+            ],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert_eq!(collect(stream).await, vec!["Hello", " world"]);
+    }
+
+    /// A multi-byte UTF-8 character split across two TCP packets. Decoding
+    /// each chunk as it arrives (what `anthropic.rs`/`google.rs` do) turns
+    /// the halves into replacement characters; buffering bytes until a whole
+    /// event is in hand does not. French output makes this a routine case,
+    /// not an exotic one.
+    #[tokio::test]
+    async fn stream_reassembles_a_multibyte_character_split_across_packets() {
+        // "é" is 0xC3 0xA9 — the packet boundary falls between the two bytes.
+        let first_half = b"data: {\"choices\":[{\"delta\":{\"content\":\"caf\xc3";
+        let second_half = b"\xa9\"}}]}\n\ndata: [DONE]\n\n";
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![
+                // Safety of the lossy conversion here is irrelevant: the
+                // server writes the bytes back out verbatim, and what is
+                // being measured is the CLIENT's reassembly.
+                unsafe { String::from_utf8_unchecked(first_half.to_vec()) },
+                unsafe { String::from_utf8_unchecked(second_half.to_vec()) },
+            ],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert_eq!(collect(stream).await, vec!["café"]);
+    }
+
+    /// `data: [DONE]` ends the stream. Anything a chatty gateway appends
+    /// after it must not reach the caller.
+    #[tokio::test]
+    async fn stream_stops_at_the_terminal_done_marker() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+                "data: [DONE]\n\n",
+                "data: {\"choices\":[{\"delta\":{\"content\":\"AFTER\"}}]}\n\n",
+            )],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert_eq!(collect(stream).await, vec!["a"]);
+    }
+
+    /// Empty `choices` on a chunk (Azure's first frame, several gateways'
+    /// usage-only trailer) must be skipped, not indexed into.
+    #[tokio::test]
+    async fn stream_skips_chunks_with_no_choices_and_null_content() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![concat!(
+                "data: {\"choices\":[]}\n\n",
+                "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":null}}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{\"content\":\"\"}}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{\"content\":\"only this\"}}]}\n\n",
+                "data: [DONE]\n\n",
+            )],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert_eq!(collect(stream).await, vec!["only this"]);
+    }
+
+    /// A final event with no trailing blank line before the connection
+    /// closes — several servers end that way — plus the `data:` spelling
+    /// with no space after the colon.
+    #[tokio::test]
+    async fn stream_delivers_a_last_event_that_has_no_trailing_blank_line() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"one\"}}]}\n\n",
+                "data:{\"choices\":[{\"delta\":{\"content\":\"two\"}}]}",
+            )],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert_eq!(collect(stream).await, vec!["one", "two"]);
+    }
+
+    /// CRLF-framed events must be recognised **as they arrive**, not
+    /// rescued at EOF by the end-of-stream flush.
+    ///
+    /// This has to be a timing assertion, and the bound comes from the
+    /// defect rather than from the nominal time: searching only for `\n\n`
+    /// (what `anthropic.rs`/`google.rs` do) leaves a CRLF stream buffered
+    /// until the connection closes, so the first token would arrive only
+    /// after the whole 21-chunk tail — the server pauses 30ms between
+    /// chunks, so ~630ms. Correct framing emits it as soon as chunk 0
+    /// lands. The 250ms bound sits well below the defect's floor and well
+    /// above the correct behaviour's cost. Asserting the *content* alone
+    /// cannot fail here: with the framing broken the same tokens still come
+    /// out at EOF, only later — measured, see the report for #368.
+    #[tokio::test]
+    async fn stream_emits_a_crlf_framed_event_before_the_connection_closes() {
+        let mut chunks =
+            vec!["data: {\"choices\":[{\"delta\":{\"content\":\"one\"}}]}\r\n\r\n".to_string()];
+        // SSE comments: valid frames carrying no token, so only the timing
+        // of the first token is under test.
+        chunks.extend(std::iter::repeat_n(": keep-alive\r\n\r\n".to_string(), 20));
+        chunks.push("data: [DONE]\r\n\r\n".to_string());
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(200, chunks)]);
+
+        let mut stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        let started = std::time::Instant::now();
+        let first = stream.next().await.expect("a first token").expect("ok");
+        let elapsed = started.elapsed();
+
+        assert_eq!(first, "one");
+        assert!(
+            elapsed < std::time::Duration::from_millis(250),
+            "first token took {elapsed:?}: a CRLF-framed event was buffered until EOF"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_reports_an_http_error_instead_of_streaming() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(
+            401,
+            r#"{"error": {"message": "Incorrect API key provided"}}"#,
+        )]);
+
+        let err = match provider_at(&server).stream(request()).await {
+            Ok(_) => panic!("a 401 must fail before any token is produced"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("Incorrect API key provided"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_sets_the_stream_flag_on_the_request() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec!["data: [DONE]\n\n"],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert!(collect(stream).await.is_empty());
+
+        let raw = server.request(0).expect("one request received");
+        assert!(raw.contains(r#""stream":true"#), "in:\n{raw}");
+    }
+
+    #[test]
+    fn metadata_declares_streaming_and_it_is_true() {
+        let meta = OpenAiProvider::new("k".to_string()).metadata();
+        assert_eq!(meta.name, "openai");
+        assert!(meta.supports_streaming);
     }
 }

--- a/crates/armadai-providers/src/api/openai.rs
+++ b/crates/armadai-providers/src/api/openai.rs
@@ -194,6 +194,53 @@ mod tests {
         assert_eq!(resp.model, "gpt-4o-mini");
     }
 
+    /// The defect this guards: a `200` whose body is an error envelope.
+    /// Every field of the response type is optional, so such a body parses
+    /// into an empty completion and the run is recorded as successful, empty
+    /// and free — `Ok(CompletionResponse { content: "", tokens_in: 0, cost:
+    /// 0.0 })`. Ollama and LiteLLM in pass-through mode both answer this way.
+    ///
+    /// `anthropic`/`google` are protected here by accident: their required
+    /// `content`/`candidates` fields make the same body a parse failure. This
+    /// path had to be told.
+    #[tokio::test]
+    async fn complete_rejects_a_success_status_carrying_an_error_envelope() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(
+            200,
+            r#"{"error":{"message":"Rate limit exceeded","type":"rate_limit"}}"#,
+        )]);
+
+        let err = match provider_at(&server).complete(request()).await {
+            Ok(resp) => panic!(
+                "an error envelope was reported as a successful empty run: \
+                 content={:?} tokens_in={} cost={}",
+                resp.content, resp.tokens_in, resp.cost
+            ),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("Rate limit exceeded"), "got: {err}");
+    }
+
+    /// The other side of the same check: a `200` that legitimately carries
+    /// no `choices` (a filtered answer, a usage-only body) must stay a
+    /// success. `is_error_body` is what separates the two, so this is the
+    /// test that would catch it being widened into "any empty response is an
+    /// error".
+    #[tokio::test]
+    async fn complete_still_accepts_an_empty_body_that_is_not_an_error() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(
+            200,
+            r#"{"model":"gpt-4o","error":null,"usage":{"prompt_tokens":4,"completion_tokens":0}}"#,
+        )]);
+
+        let resp = provider_at(&server)
+            .complete(request())
+            .await
+            .expect("an empty-but-successful body must not be rejected");
+        assert_eq!(resp.content, "");
+        assert_eq!(resp.tokens_in, 4);
+    }
+
     #[tokio::test]
     async fn an_http_error_surfaces_the_servers_own_message() {
         let body = r#"{"error": {"message": "Unsupported parameter: 'max_tokens'",
@@ -402,41 +449,147 @@ mod tests {
         assert_eq!(collect(stream).await, vec!["one", "two"]);
     }
 
-    /// CRLF-framed events must be recognised **as they arrive**, not
-    /// rescued at EOF by the end-of-stream flush.
+    /// CRLF-framed events must be recognised **as they arrive**, not rescued
+    /// at EOF by the end-of-stream flush.
     ///
-    /// This has to be a timing assertion, and the bound comes from the
-    /// defect rather than from the nominal time: searching only for `\n\n`
-    /// (what `anthropic.rs`/`google.rs` do) leaves a CRLF stream buffered
-    /// until the connection closes, so the first token would arrive only
-    /// after the whole 21-chunk tail — the server pauses 30ms between
-    /// chunks, so ~630ms. Correct framing emits it as soon as chunk 0
-    /// lands. The 250ms bound sits well below the defect's floor and well
-    /// above the correct behaviour's cost. Asserting the *content* alone
-    /// cannot fail here: with the framing broken the same tokens still come
-    /// out at EOF, only later — measured, see the report for #368.
+    /// Categorical, not a timing measurement: the server writes the first
+    /// event and then *holds the connection open*, sending neither more data
+    /// nor EOF until `release()`. A reader that searches only for `\n\n`
+    /// (what `anthropic.rs`/`google.rs` do) therefore emits nothing at all
+    /// rather than the same tokens a little later, and the `timeout` below
+    /// is an anti-hang guard rather than a threshold to tune. The previous
+    /// version of this test asserted `elapsed < 250ms` against a 21-chunk
+    /// tail; it held (worst case 161ms over 1150 runs) but spent 64% of its
+    /// budget, and a bound that can be approached is a bound that can be
+    /// crossed on a loaded machine.
     #[tokio::test]
-    async fn stream_emits_a_crlf_framed_event_before_the_connection_closes() {
-        let mut chunks =
-            vec!["data: {\"choices\":[{\"delta\":{\"content\":\"one\"}}]}\r\n\r\n".to_string()];
-        // SSE comments: valid frames carrying no token, so only the timing
-        // of the first token is under test.
-        chunks.extend(std::iter::repeat_n(": keep-alive\r\n\r\n".to_string(), 20));
-        chunks.push("data: [DONE]\r\n\r\n".to_string());
-        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(200, chunks)]);
+    async fn stream_emits_a_crlf_framed_event_while_the_connection_is_open() {
+        let server = ScriptedServer::start_gated(vec![ScriptedResponse::streamed(
+            200,
+            vec![
+                "data: {\"choices\":[{\"delta\":{\"content\":\"one\"}}]}\r\n\r\n",
+                "data: [DONE]\r\n\r\n",
+            ],
+        )]);
 
         let mut stream = provider_at(&server)
             .stream(request())
             .await
             .expect("stream");
-        let started = std::time::Instant::now();
-        let first = stream.next().await.expect("a first token").expect("ok");
-        let elapsed = started.elapsed();
-
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .expect("a CRLF-framed event was buffered instead of emitted on arrival")
+            .expect("a first token")
+            .expect("ok");
         assert_eq!(first, "one");
+        server.release();
+    }
+
+    /// A CR-only stream: legal SSE, and a third framing a reader can be
+    /// blind to. Same categorical shape as the CRLF case above — while the
+    /// gate is shut there is no EOF to rescue an unrecognised boundary.
+    #[tokio::test]
+    async fn stream_emits_a_cr_framed_event_while_the_connection_is_open() {
+        let server = ScriptedServer::start_gated(vec![ScriptedResponse::streamed(
+            200,
+            vec![
+                "data: {\"choices\":[{\"delta\":{\"content\":\"cr\"}}]}\r\r",
+                "data: [DONE]\r\r",
+            ],
+        )]);
+
+        let mut stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .expect("a CR-framed event was never recognised as an event")
+            .expect("a first token")
+            .expect("ok");
+        assert_eq!(first, "cr");
+        server.release();
+    }
+
+    /// One `data` field spread over two lines — the spec's own spelling for
+    /// a multi-line payload, joined with `\n`. Read line by line, each half
+    /// is invalid JSON and both are dropped in silence.
+    #[tokio::test]
+    async fn stream_joins_a_data_field_split_across_two_lines() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![concat!(
+                "data: {\"choices\":[{\"delta\":\n",
+                "data: {\"content\":\"joined\"}}]}\n\n",
+                "data: [DONE]\n\n",
+            )],
+        )]);
+
+        let stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        assert_eq!(collect(stream).await, vec!["joined"]);
+    }
+
+    /// The defect this guards: an error frame arriving **after** the stream
+    /// has started. The status line said 200 long ago, so SSE is the only
+    /// channel left — this is OpenAI's documented behaviour for anything
+    /// that fails mid-stream. Dropped silently, it delivers a truncated
+    /// answer as a complete one.
+    #[tokio::test]
+    async fn stream_surfaces_an_error_frame_instead_of_ending_early() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"partial ans\"}}]}\n\n",
+                "data: {\"error\":{\"message\":\"upstream timed out\",\"type\":\"server_error\"}}\n\n",
+            )],
+        )]);
+
+        let mut stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+
+        let first = stream
+            .next()
+            .await
+            .expect("a first token")
+            .expect("the first delta is fine");
+        assert_eq!(first, "partial ans");
+
+        let second = stream
+            .next()
+            .await
+            .expect("the error frame must reach the caller, not end the stream");
+        let err = second.expect_err("the error frame must arrive as an Err");
+        assert!(err.to_string().contains("upstream timed out"), "got: {err}");
+    }
+
+    /// A streaming request answered with a plain JSON error body and a 200
+    /// status — no SSE framing at all. Ollama and LiteLLM in pass-through do
+    /// this. With no `data:` line there is nothing to parse, so the stream
+    /// would simply end empty and successful.
+    #[tokio::test]
+    async fn stream_surfaces_an_unframed_error_body_sent_with_a_200() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![r#"{"error":{"message":"model 'nope' not found"}}"#],
+        )]);
+
+        let mut stream = provider_at(&server)
+            .stream(request())
+            .await
+            .expect("stream");
+        let item = stream
+            .next()
+            .await
+            .expect("an error body must not read as an empty answer");
+        let err = item.expect_err("must be an Err");
         assert!(
-            elapsed < std::time::Duration::from_millis(250),
-            "first token took {elapsed:?}: a CRLF-framed event was buffered until EOF"
+            err.to_string().contains("model 'nope' not found"),
+            "got: {err}"
         );
     }
 
@@ -480,4 +633,5 @@ mod tests {
         assert_eq!(meta.name, "openai");
         assert!(meta.supports_streaming);
     }
+
 }

--- a/crates/armadai-providers/src/api/openai_compatible.rs
+++ b/crates/armadai-providers/src/api/openai_compatible.rs
@@ -1,0 +1,767 @@
+//! The OpenAI chat-completions protocol, implemented once.
+//!
+//! `POST {base_url}/chat/completions` — plus Server-Sent Events for the
+//! streaming variant — is not one vendor's API but the de-facto lingua
+//! franca of LLM serving. The same wire format is spoken by OpenAI itself,
+//! by gateways (LiteLLM, OpenRouter, Groq, Together, Fireworks, DeepSeek,
+//! Mistral) and by local runtimes (Ollama, vLLM, LM Studio, llama.cpp).
+//! `api::openai` and `proxy` differ only in their defaults and in whether
+//! an API key exists at all, so they share this module rather than each
+//! growing a copy — two implementations of one protocol is the defect class
+//! this repo has closed repeatedly.
+//!
+//! ## Written for the dialect, not for `api.openai.com`
+//!
+//! Every optional field is treated as optional, because in practice it is:
+//!
+//! - `usage` is routinely **absent**, or present as `null`, on gateways and
+//!   local runtimes. That costs the caller its token counters, never the
+//!   call: the response still parses and reports zeros.
+//! - `id`, `object`, `system_fingerprint`, `finish_reason`, `created` are
+//!   never read, so a server that omits them is fine.
+//! - `model` may be absent (llama.cpp) — we then report the model that was
+//!   *asked for* rather than an empty string.
+//! - `choices` may be **empty** on a streaming chunk (Azure's leading
+//!   content-filter frame; the usage-only trailer several gateways append),
+//!   and `delta.content` may be `null`. Both are skipped, never indexed.
+//! - SSE events may be separated by `\n\n` **or** `\r\n\r\n`, the `data:`
+//!   prefix may or may not be followed by a space, and the final event may
+//!   arrive with no trailing blank line before the connection closes.
+//! - The response body is buffered as **bytes** and only decoded once a
+//!   whole event is in hand, so a multi-byte UTF-8 character split across
+//!   two TCP packets is reassembled instead of being mangled into
+//!   replacement characters.
+//! - `max_tokens` is sent **only** when the caller set one. Reasoning
+//!   models (`o1`, `o3`) reject it outright, and some gateways reject
+//!   unknown or unsupported parameters wholesale, so an unrequested
+//!   parameter is a compatibility liability, not a harmless default.
+//! - `stream_options: {include_usage: true}` is deliberately **not** sent
+//!   for the same reason: it would buy usage numbers on OpenAI proper at
+//!   the price of a 400 from every server that doesn't know the field.
+//!
+//! ## Deliberately not supported
+//!
+//! **Azure OpenAI** authenticates with an `api-key` header (not
+//! `Authorization: Bearer`), addresses deployments rather than models
+//! (`/openai/deployments/{deployment}/chat/completions`) and requires an
+//! `api-version` query parameter. That is a different enough shape that
+//! bolting it onto this path would mean branching on the vendor in three
+//! places to serve one of them. It is documented as unsupported in
+//! `docs/wiki/providers.md` rather than half-wired and left to fail at
+//! runtime. Azure users can still reach ArmadAI through a gateway
+//! (LiteLLM) that presents an OpenAI-shaped front — that is exactly what
+//! `proxy` is for.
+//!
+//! Tool/function calling, structured outputs, images and audio are out of
+//! scope: `CompletionRequest`/`CompletionResponse` carry plain text, so
+//! there is nothing in the domain model for them to map onto.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::Sender;
+use tokio_stream::StreamExt;
+
+use armadai_core::provider::*;
+
+use super::retry::{RetryPolicy, send_with_retry};
+
+/// Terminal marker of an OpenAI-style SSE stream.
+const DONE_MARKER: &str = "[DONE]";
+
+/// Longest raw (unparsed) error body echoed back to the user. A gateway
+/// that answers with an HTML error page or a stack trace should not paste
+/// the whole thing into a terminal.
+const MAX_RAW_ERROR_CHARS: usize = 500;
+
+/// What a caller sees when the server sends an error status and no body at
+/// all — better than an error line that trails off after the status code.
+const NO_BODY: &str = "no response body";
+
+/// One configured OpenAI-compatible endpoint. Borrowed, not owned: the
+/// provider structs (`OpenAiProvider`, `ProxyProvider`) stay the owners of
+/// their key/URL/client so the factory can keep mutating `base_url` the way
+/// it already does for `anthropic` and `google`.
+pub(crate) struct Endpoint<'a> {
+    pub(crate) client: &'a Client,
+    pub(crate) base_url: &'a str,
+    /// `None` means *send no `Authorization` header at all*. A keyless
+    /// gateway (a local LiteLLM, an Ollama server) is a first-class case,
+    /// and an empty `Bearer ` is actively worse than nothing — several
+    /// servers reject it as malformed instead of ignoring it.
+    pub(crate) api_key: Option<&'a str>,
+    /// Name used in error messages (`"OpenAI"`, `"Proxy"`).
+    pub(crate) label: &'a str,
+}
+
+// --- API request/response types ---
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatRequestMessage>,
+    temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct ChatRequestMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    /// `#[serde(default)]` is load-bearing here and only here: a `Vec` is a
+    /// required field without it, so a server that omits `choices`
+    /// altogether would fail the whole response. (`Option` fields below are
+    /// already optional to serde, and already accept an explicit `null`;
+    /// the attribute on them is documentation, not behaviour.)
+    #[serde(default)]
+    choices: Vec<ChatChoice>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    usage: Option<ChatUsage>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    #[serde(default)]
+    message: Option<ChatChoiceMessage>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoiceMessage {
+    /// `null` whenever the model answered with tool calls instead of text.
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ChatUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+}
+
+// --- Cost calculation ---
+
+/// Public list prices per million tokens, keyed on the model id with any
+/// vendor prefix stripped (`openai/gpt-4o` on OpenRouter is still
+/// `gpt-4o`).
+///
+/// An **unknown** id yields `None`, and the caller then reports a cost of
+/// `0.0`. That is deliberate and different from `anthropic.rs`/`google.rs`,
+/// which fall back to their mid-tier price: those two only ever talk to one
+/// vendor, so a guess is bounded. This path can be pointed at Ollama
+/// serving Llama, or at a gateway serving anything at all — pricing an
+/// unknown model as if it were GPT-4o would invent dollars that were never
+/// spent and feed them into `armadai costs`. A visible `$0.00` is a
+/// recognisable "not priced", a wrong number is not.
+fn rates_for_model(model: &str) -> Option<(f64, f64)> {
+    let id = model
+        .rsplit('/')
+        .next()
+        .unwrap_or(model)
+        .to_ascii_lowercase();
+    // Most specific prefix first: `gpt-4o-mini` also starts with `gpt-4o`.
+    Some(match id.as_str() {
+        m if m.starts_with("gpt-4o-mini") => (0.15, 0.60),
+        m if m.starts_with("gpt-4o") => (2.50, 10.00),
+        m if m.starts_with("gpt-4.1-nano") => (0.10, 0.40),
+        m if m.starts_with("gpt-4.1-mini") => (0.40, 1.60),
+        m if m.starts_with("gpt-4.1") => (2.00, 8.00),
+        m if m.starts_with("o1-mini") => (1.10, 4.40),
+        m if m.starts_with("o1") => (15.00, 60.00),
+        m if m.starts_with("o3-mini") => (1.10, 4.40),
+        _ => return None,
+    })
+}
+
+fn cost_for_model(model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
+    match rates_for_model(model) {
+        Some((input_rate, output_rate)) => {
+            (input_tokens as f64 * input_rate + output_tokens as f64 * output_rate) / 1_000_000.0
+        }
+        None => 0.0,
+    }
+}
+
+// --- Error bodies ---
+
+/// Pull a human-readable message out of an error body, across the shapes
+/// this dialect's servers actually produce:
+///
+/// - `{"error": {"message": "..."}}` — OpenAI, LiteLLM, OpenRouter, Groq
+/// - `{"error": "..."}` — Ollama
+/// - `{"message": "...", "object": "error"}` — vLLM
+/// - `{"detail": "..."}` — bare FastAPI wrappers
+///
+/// Anything else falls back to the raw body, truncated, because a
+/// truncated real answer still tells the user more than "unknown error".
+fn error_message_from_body(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return NO_BODY.to_string();
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        let candidates = [
+            value
+                .get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str()),
+            value.get("error").and_then(|e| e.as_str()),
+            value.get("message").and_then(|m| m.as_str()),
+            value.get("detail").and_then(|m| m.as_str()),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            if !candidate.trim().is_empty() {
+                return candidate.to_string();
+            }
+        }
+    }
+
+    truncate_chars(trimmed, MAX_RAW_ERROR_CHARS)
+}
+
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(max).collect();
+    format!("{head}… (truncated)")
+}
+
+// --- SSE parsing ---
+
+/// Offset and separator length of the first complete SSE event boundary,
+/// or `None` while the buffer still holds a partial event.
+///
+/// Both `\n\n` and `\r\n\r\n` are accepted: the SSE spec allows either, and
+/// searching only for `\n\n` (what `anthropic.rs`/`google.rs` do — safe
+/// against those two servers) would buffer a CRLF stream forever.
+fn find_event_end(buffer: &[u8]) -> Option<(usize, usize)> {
+    let crlf = find_subslice(buffer, b"\r\n\r\n");
+    let lf = find_subslice(buffer, b"\n\n");
+    match (crlf, lf) {
+        (Some(c), Some(l)) => {
+            if c <= l {
+                Some((c, 4))
+            } else {
+                Some((l, 2))
+            }
+        }
+        (Some(c), None) => Some((c, 4)),
+        (None, Some(l)) => Some((l, 2)),
+        (None, None) => None,
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// The payload of a `data:` line, or `None` for any other SSE field
+/// (`event:`, `id:`, `retry:`, comments starting with `:`).
+///
+/// Per the SSE spec a single space after the colon is part of the framing
+/// and is stripped; anything beyond that is payload. Some gateways emit
+/// `data:{...}` with no space at all, which is equally legal.
+fn sse_data_payload(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("data:")?;
+    Some(rest.strip_prefix(' ').unwrap_or(rest))
+}
+
+/// The text delta carried by one streaming chunk, if it carries any.
+///
+/// Returns `None` — never panics, never indexes — for the shapes that
+/// legitimately carry no text: `choices: []`, a `delta` with only a `role`,
+/// `content: null`, an empty `content`, or a body that isn't JSON at all.
+fn parse_content_delta(data: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(data).ok()?;
+    let content = value
+        .get("choices")?
+        .as_array()?
+        .first()?
+        .get("delta")?
+        .get("content")?
+        .as_str()?;
+    if content.is_empty() {
+        return None;
+    }
+    Some(content.to_string())
+}
+
+/// Whether the reader should keep going after an event.
+enum Flow {
+    Continue,
+    Stop,
+}
+
+/// Emit every text delta in one SSE event block. Stops the stream on the
+/// terminal `[DONE]` marker (anything a chatty gateway appends after it is
+/// not the model's answer) or when the receiver has gone away.
+async fn emit_event(event: &str, tx: &Sender<anyhow::Result<String>>) -> Flow {
+    for line in event.lines() {
+        let Some(payload) = sse_data_payload(line) else {
+            continue;
+        };
+        if payload.trim() == DONE_MARKER {
+            return Flow::Stop;
+        }
+        let Some(text) = parse_content_delta(payload) else {
+            continue;
+        };
+        if tx.send(Ok(text)).await.is_err() {
+            return Flow::Stop;
+        }
+    }
+    Flow::Continue
+}
+
+// --- The protocol itself ---
+
+impl Endpoint<'_> {
+    fn url(&self) -> String {
+        // A user who writes `base_url: http://localhost:4000/v1/` should
+        // not get `//chat/completions`; some gateways route that to a 404.
+        format!("{}/chat/completions", self.base_url.trim_end_matches('/'))
+    }
+
+    fn body(&self, request: &CompletionRequest, stream: bool) -> ChatRequest {
+        let mut messages = Vec::with_capacity(request.messages.len() + 1);
+        if !request.system_prompt.is_empty() {
+            messages.push(ChatRequestMessage {
+                role: "system".to_string(),
+                content: request.system_prompt.clone(),
+            });
+        }
+        messages.extend(request.messages.iter().map(|m| ChatRequestMessage {
+            role: m.role.clone(),
+            content: m.content.clone(),
+        }));
+
+        ChatRequest {
+            model: request.model.clone(),
+            messages,
+            temperature: request.temperature,
+            max_tokens: request.max_tokens,
+            stream: stream.then_some(true),
+        }
+    }
+
+    /// Send the request through the shared retry/backoff policy and turn a
+    /// non-success status into a useful `anyhow` error.
+    async fn send(&self, body: &ChatRequest) -> anyhow::Result<reqwest::Response> {
+        let url = self.url();
+        let response = send_with_retry(&RetryPolicy::default(), || {
+            let builder = self.client.post(&url).json(body);
+            match self.api_key {
+                Some(key) => builder.bearer_auth(key),
+                None => builder,
+            }
+        })
+        .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            let message = error_message_from_body(&text);
+            anyhow::bail!("{} API error ({status}): {message}", self.label);
+        }
+
+        Ok(response)
+    }
+
+    pub(crate) async fn complete(
+        &self,
+        request: CompletionRequest,
+    ) -> anyhow::Result<CompletionResponse> {
+        let body = self.body(&request, false);
+        let response = self.send(&body).await?;
+        let api_resp: ChatResponse = response.json().await?;
+
+        let content = api_resp
+            .choices
+            .first()
+            .and_then(|c| c.message.as_ref())
+            .and_then(|m| m.content.clone())
+            .unwrap_or_default();
+
+        let model = api_resp.model.unwrap_or_else(|| request.model.clone());
+
+        let (tokens_in, tokens_out) = api_resp
+            .usage
+            .map(|u| (u.prompt_tokens, u.completion_tokens))
+            .unwrap_or((0, 0));
+
+        let cost = cost_for_model(&model, tokens_in, tokens_out);
+
+        Ok(CompletionResponse {
+            content,
+            model,
+            tokens_in,
+            tokens_out,
+            cost,
+        })
+    }
+
+    pub(crate) async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
+        let body = self.body(&request, true);
+        let response = self.send(&body).await?;
+
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let byte_stream = response.bytes_stream();
+
+        tokio::spawn(async move {
+            // Bytes, not a `String`: an event boundary is ASCII, but the
+            // payload is not, and a chunk can end in the middle of a
+            // multi-byte character. Decoding per chunk (what the two
+            // first-party providers do) would turn that into replacement
+            // characters; decoding per completed event cannot.
+            let mut buffer: Vec<u8> = Vec::new();
+            tokio::pin!(byte_stream);
+
+            while let Some(chunk) = byte_stream.next().await {
+                match chunk {
+                    Ok(bytes) => buffer.extend_from_slice(&bytes),
+                    Err(e) => {
+                        if let Err(send_err) =
+                            tx.send(Err(anyhow::anyhow!("Stream error: {e}"))).await
+                        {
+                            tracing::debug!(
+                                "Failed to send stream error (receiver dropped): {:?}",
+                                send_err
+                            );
+                        }
+                        return;
+                    }
+                }
+
+                while let Some((end, sep)) = find_event_end(&buffer) {
+                    let event = String::from_utf8_lossy(&buffer[..end]).into_owned();
+                    buffer.drain(..end + sep);
+                    if let Flow::Stop = emit_event(&event, &tx).await {
+                        return;
+                    }
+                }
+            }
+
+            // A server may close right after the last event without the
+            // trailing blank line. Whatever is left is a complete event.
+            if !buffer.is_empty() {
+                let event = String::from_utf8_lossy(&buffer).into_owned();
+                let _ = emit_event(&event, &tx).await;
+            }
+        });
+
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- cost table ---
+
+    #[test]
+    fn known_openai_ids_are_priced_and_the_mini_prefix_wins() {
+        // gpt-4o-mini also starts with gpt-4o: order matters.
+        assert_eq!(rates_for_model("gpt-4o-mini"), Some((0.15, 0.60)));
+        assert_eq!(rates_for_model("gpt-4o"), Some((2.50, 10.00)));
+        assert_eq!(rates_for_model("gpt-4o-2024-08-06"), Some((2.50, 10.00)));
+        assert_eq!(rates_for_model("o1"), Some((15.00, 60.00)));
+        assert_eq!(rates_for_model("o1-mini"), Some((1.10, 4.40)));
+        assert_eq!(rates_for_model("o3-mini"), Some((1.10, 4.40)));
+        assert_eq!(rates_for_model("gpt-4.1-nano"), Some((0.10, 0.40)));
+        assert_eq!(rates_for_model("gpt-4.1-mini"), Some((0.40, 1.60)));
+        assert_eq!(rates_for_model("gpt-4.1"), Some((2.00, 8.00)));
+    }
+
+    #[test]
+    fn a_vendor_prefixed_gateway_id_is_priced_like_the_bare_one() {
+        assert_eq!(rates_for_model("openai/gpt-4o-mini"), Some((0.15, 0.60)));
+        assert_eq!(rates_for_model("azure/gpt-4o"), Some((2.50, 10.00)));
+    }
+
+    /// A model this table doesn't know about must report nothing rather
+    /// than a plausible-looking invented price.
+    #[test]
+    fn an_unknown_model_is_not_priced() {
+        assert_eq!(rates_for_model("llama3.1:8b"), None);
+        assert_eq!(rates_for_model("deepseek-chat"), None);
+        assert_eq!(cost_for_model("llama3.1:8b", 100_000, 100_000), 0.0);
+    }
+
+    #[test]
+    fn cost_is_per_million_tokens() {
+        let cost = cost_for_model("gpt-4o", 1_000, 500);
+        let expected = (1_000.0 * 2.50 + 500.0 * 10.00) / 1_000_000.0;
+        assert!((cost - expected).abs() < f64::EPSILON, "{cost}");
+    }
+
+    // --- error bodies ---
+
+    #[test]
+    fn every_error_shape_this_dialect_produces_yields_its_message() {
+        assert_eq!(
+            error_message_from_body(r#"{"error":{"message":"Invalid API key","type":"auth"}}"#),
+            "Invalid API key"
+        );
+        assert_eq!(
+            error_message_from_body(r#"{"error":"model 'x' not found"}"#),
+            "model 'x' not found"
+        );
+        assert_eq!(
+            error_message_from_body(r#"{"object":"error","message":"bad request"}"#),
+            "bad request"
+        );
+        assert_eq!(
+            error_message_from_body(r#"{"detail":"Not Found"}"#),
+            "Not Found"
+        );
+    }
+
+    #[test]
+    fn an_empty_error_body_says_so_rather_than_trailing_off() {
+        assert_eq!(error_message_from_body(""), NO_BODY);
+        assert_eq!(error_message_from_body("   \n "), NO_BODY);
+    }
+
+    #[test]
+    fn a_non_json_error_body_is_echoed_and_bounded() {
+        assert_eq!(
+            error_message_from_body("<html>502 Bad Gateway</html>"),
+            "<html>502 Bad Gateway</html>"
+        );
+
+        let long = "x".repeat(MAX_RAW_ERROR_CHARS + 50);
+        let out = error_message_from_body(&long);
+        assert!(out.ends_with("… (truncated)"), "{out}");
+        assert_eq!(
+            out.chars().count(),
+            MAX_RAW_ERROR_CHARS + "… (truncated)".chars().count()
+        );
+    }
+
+    /// Truncation counts characters, not bytes — slicing a multi-byte
+    /// string by byte index panics.
+    ///
+    /// The fixture uses a **3**-byte character on purpose: with a 2-byte
+    /// one, byte offset 500 happens to land on a character boundary and a
+    /// byte-slicing implementation would pass this test unharmed (measured
+    /// — that was the first version of this test, and it survived the
+    /// mutation). 500 is not a multiple of 3, so `&text[..500]` here is
+    /// squarely inside a character.
+    #[test]
+    fn truncation_does_not_split_a_multibyte_character() {
+        assert_ne!(
+            MAX_RAW_ERROR_CHARS % 3,
+            0,
+            "the fixture below only bites while the cap is not a multiple of the char width"
+        );
+        let text = "€".repeat(MAX_RAW_ERROR_CHARS + 10);
+        let out = truncate_chars(&text, MAX_RAW_ERROR_CHARS);
+        assert!(out.starts_with('€'));
+        assert!(out.ends_with("… (truncated)"));
+        assert_eq!(
+            out.chars().count(),
+            MAX_RAW_ERROR_CHARS + "… (truncated)".chars().count()
+        );
+    }
+
+    // --- SSE framing ---
+
+    #[test]
+    fn an_event_boundary_is_found_for_both_lf_and_crlf_framing() {
+        assert_eq!(find_event_end(b"data: a\n\ndata: b"), Some((7, 2)));
+        assert_eq!(find_event_end(b"data: a\r\n\r\ndata: b"), Some((7, 4)));
+    }
+
+    #[test]
+    fn a_partial_event_is_not_split_early() {
+        assert_eq!(find_event_end(b"data: {\"choices\":[{\"delta\""), None);
+        assert_eq!(find_event_end(b"data: a\r\n\r"), None);
+        assert_eq!(find_event_end(b""), None);
+    }
+
+    #[test]
+    fn the_earliest_boundary_wins_when_both_framings_appear() {
+        // LF boundary at 1, CRLF boundary later: the LF one must be taken.
+        assert_eq!(find_event_end(b"a\n\nb\r\n\r\nc"), Some((1, 2)));
+        // And the reverse ordering.
+        assert_eq!(find_event_end(b"a\r\n\r\nb\n\nc"), Some((1, 4)));
+    }
+
+    #[test]
+    fn a_data_line_is_recognised_with_and_without_the_optional_space() {
+        assert_eq!(sse_data_payload("data: {\"a\":1}"), Some("{\"a\":1}"));
+        assert_eq!(sse_data_payload("data:{\"a\":1}"), Some("{\"a\":1}"));
+        // Only ONE space is framing; the rest is payload.
+        assert_eq!(sse_data_payload("data:  x"), Some(" x"));
+        assert_eq!(sse_data_payload("event: message"), None);
+        assert_eq!(sse_data_payload(": keep-alive comment"), None);
+        assert_eq!(sse_data_payload("id: 42"), None);
+    }
+
+    #[test]
+    fn a_content_delta_is_extracted_and_every_empty_shape_is_skipped() {
+        assert_eq!(
+            parse_content_delta(r#"{"choices":[{"delta":{"content":"Hi"}}]}"#),
+            Some("Hi".to_string())
+        );
+        assert_eq!(parse_content_delta(r#"{"choices":[]}"#), None);
+        assert_eq!(
+            parse_content_delta(r#"{"choices":[{"delta":{"role":"assistant"}}]}"#),
+            None
+        );
+        assert_eq!(
+            parse_content_delta(r#"{"choices":[{"delta":{"content":null}}]}"#),
+            None
+        );
+        assert_eq!(
+            parse_content_delta(r#"{"choices":[{"delta":{"content":""}}]}"#),
+            None
+        );
+        assert_eq!(parse_content_delta("[DONE]"), None);
+        assert_eq!(parse_content_delta("not json at all"), None);
+        // The usage-only trailer some gateways append after the last delta.
+        assert_eq!(
+            parse_content_delta(r#"{"choices":[],"usage":{"prompt_tokens":9}}"#),
+            None
+        );
+    }
+
+    // --- request building ---
+
+    fn base_request() -> CompletionRequest {
+        CompletionRequest {
+            model: "gpt-4o".to_string(),
+            system_prompt: "sys".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "hello".to_string(),
+            }],
+            temperature: 0.4,
+            max_tokens: None,
+        }
+    }
+
+    fn endpoint<'a>(client: &'a Client, base_url: &'a str) -> Endpoint<'a> {
+        Endpoint {
+            client,
+            base_url,
+            api_key: None,
+            label: "Test",
+        }
+    }
+
+    #[test]
+    fn a_trailing_slash_on_the_base_url_does_not_double_up() {
+        let client = Client::new();
+        assert_eq!(
+            endpoint(&client, "http://localhost:4000/v1/").url(),
+            "http://localhost:4000/v1/chat/completions"
+        );
+        assert_eq!(
+            endpoint(&client, "http://localhost:4000/v1").url(),
+            "http://localhost:4000/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn the_system_prompt_becomes_a_leading_system_message() {
+        let client = Client::new();
+        let body = endpoint(&client, "http://x").body(&base_request(), false);
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(
+            json.starts_with(r#"{"model":"gpt-4o","messages":[{"role":"system","content":"sys"}"#),
+            "{json}"
+        );
+        assert!(
+            json.contains(r#"{"role":"user","content":"hello"}"#),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn an_empty_system_prompt_adds_no_message() {
+        let client = Client::new();
+        let mut request = base_request();
+        request.system_prompt = String::new();
+        let body = endpoint(&client, "http://x").body(&request, false);
+        assert_eq!(body.messages.len(), 1);
+        assert_eq!(body.messages[0].role, "user");
+    }
+
+    #[test]
+    fn optional_parameters_are_omitted_rather_than_defaulted() {
+        let client = Client::new();
+        let json =
+            serde_json::to_string(&endpoint(&client, "http://x").body(&base_request(), false))
+                .unwrap();
+        assert!(!json.contains("max_tokens"), "{json}");
+        assert!(!json.contains("stream"), "{json}");
+
+        let mut request = base_request();
+        request.max_tokens = Some(64);
+        let json =
+            serde_json::to_string(&endpoint(&client, "http://x").body(&request, true)).unwrap();
+        assert!(json.contains(r#""max_tokens":64"#), "{json}");
+        assert!(json.contains(r#""stream":true"#), "{json}");
+    }
+
+    // --- response parsing ---
+
+    #[test]
+    fn a_response_missing_every_optional_field_still_parses() {
+        let resp: ChatResponse =
+            serde_json::from_str(r#"{"choices":[{"message":{"content":"x"}}]}"#).unwrap();
+        assert!(resp.model.is_none());
+        assert!(resp.usage.is_none());
+        assert_eq!(
+            resp.choices[0].message.as_ref().unwrap().content.as_deref(),
+            Some("x")
+        );
+    }
+
+    /// A body with no `choices` key at all — `Vec` is a required field
+    /// unless defaulted, so this is the one place the attribute matters.
+    #[test]
+    fn a_response_with_no_choices_key_still_parses() {
+        let resp: ChatResponse =
+            serde_json::from_str(r#"{"model":"m","usage":{"prompt_tokens":1}}"#).unwrap();
+        assert!(resp.choices.is_empty());
+        assert_eq!(resp.model.as_deref(), Some("m"));
+    }
+
+    #[test]
+    fn a_null_usage_parses_as_absent_and_partial_usage_defaults_to_zero() {
+        let resp: ChatResponse = serde_json::from_str(r#"{"choices":[],"usage":null}"#).unwrap();
+        assert!(resp.usage.is_none());
+
+        let resp: ChatResponse =
+            serde_json::from_str(r#"{"choices":[],"usage":{"prompt_tokens":7}}"#).unwrap();
+        let usage = resp.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 7);
+        assert_eq!(usage.completion_tokens, 0);
+    }
+
+    #[test]
+    fn a_tool_call_choice_with_null_content_parses_as_empty_text() {
+        let resp: ChatResponse = serde_json::from_str(
+            r#"{"choices":[{"message":{"role":"assistant","content":null}}]}"#,
+        )
+        .unwrap();
+        assert!(resp.choices[0].message.as_ref().unwrap().content.is_none());
+    }
+}

--- a/crates/armadai-providers/src/api/openai_compatible.rs
+++ b/crates/armadai-providers/src/api/openai_compatible.rs
@@ -24,9 +24,11 @@
 //! - `choices` may be **empty** on a streaming chunk (Azure's leading
 //!   content-filter frame; the usage-only trailer several gateways append),
 //!   and `delta.content` may be `null`. Both are skipped, never indexed.
-//! - SSE events may be separated by `\n\n` **or** `\r\n\r\n`, the `data:`
-//!   prefix may or may not be followed by a space, and the final event may
-//!   arrive with no trailing blank line before the connection closes.
+//! - SSE events may be separated by `\n\n`, `\r\n\r\n` **or** `\r\r`, the
+//!   `data:` prefix may or may not be followed by a space, consecutive
+//!   `data:` lines in one event are one field joined with `\n` (what the
+//!   spec prescribes), and the final event may arrive with no trailing
+//!   blank line before the connection closes.
 //! - The response body is buffered as **bytes** and only decoded once a
 //!   whole event is in hand, so a multi-byte UTF-8 character split across
 //!   two TCP packets is reassembled instead of being mangled into
@@ -35,6 +37,25 @@
 //!   models (`o1`, `o3`) reject it outright, and some gateways reject
 //!   unknown or unsupported parameters wholesale, so an unrequested
 //!   parameter is a compatibility liability, not a harmless default.
+//! - `temperature`, by contrast, is **always** sent, and those same models
+//!   reject any value but `1`. That is an asymmetry in the domain type, not
+//!   in this file: `CompletionRequest::max_tokens` is an `Option`, so "the
+//!   agent asked for nothing" is representable, while `temperature` is a
+//!   plain `f32` defaulting to `0.7` — there is no value meaning "unset",
+//!   and omitting it would mean guessing which `0.7` was deliberate.
+//!   Dropping it for ids that *look* like reasoning models was considered
+//!   and rejected: a gateway serves anything under any name, and silently
+//!   discarding an author's `temperature: 0.2` is worse than the `400`
+//!   OpenAI returns, which names the parameter and the value. The
+//!   workaround (`temperature: 1.0`) is in `docs/wiki/providers.md`;
+//!   representing "unset" properly means an `Option<f32>` reaching every
+//!   provider, which is a domain change, not a protocol one.
+//! - A **success status is not a success**. Several servers answer `200`
+//!   with an error envelope, and after a stream has started an SSE frame is
+//!   the only channel an error has left. Since every field above is
+//!   optional, such a body parses into an empty response — see
+//!   [`is_error_body`] for why that had to be recognised explicitly here
+//!   and not in `anthropic.rs`/`google.rs`.
 //! - `stream_options: {include_usage: true}` is deliberately **not** sent
 //!   for the same reason: it would buy usage numbers on OpenAI proper at
 //!   the price of a 400 from every server that doesn't know the field.
@@ -229,6 +250,36 @@ fn error_message_from_body(body: &str) -> String {
     truncate_chars(trimmed, MAX_RAW_ERROR_CHARS)
 }
 
+/// Whether a body is an **error envelope** rather than a completion.
+///
+/// This dialect reports plenty of errors with a `200` status: Ollama and
+/// LiteLLM in pass-through mode both answer `200` + `{"error": {...}}`, and
+/// OpenAI itself has no other way to report a failure that happens *after* a
+/// stream has started — the status line is long gone by then, so the error
+/// can only arrive as an SSE frame.
+///
+/// That matters here more than for the two single-vendor providers, because
+/// every field of [`ChatResponse`] is optional: such a body deserialises
+/// cleanly into an empty response, and the run would be recorded as
+/// successful, empty and free. `anthropic`/`google` are accidentally
+/// protected by their required fields (`missing field 'content'` /
+/// `'candidates'`); this path has to look.
+///
+/// Recognised: a non-null `error` member (OpenAI, LiteLLM, OpenRouter, Groq,
+/// Ollama) and vLLM's `{"object": "error", ...}`. Deliberately *not* a bare
+/// `message`/`detail`: [`error_message_from_body`] reads those once the
+/// status has already said "error", which is a different question from "is
+/// this an error at all" — a completion body may legitimately carry neither
+/// an `error` member nor an `object: error` marker and still contain the
+/// word.
+fn is_error_body(body: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body.trim()) else {
+        return false;
+    };
+    value.get("error").is_some_and(|e| !e.is_null())
+        || value.get("object").and_then(|o| o.as_str()) == Some("error")
+}
+
 fn truncate_chars(text: &str, max: usize) -> String {
     if text.chars().count() <= max {
         return text.to_string();
@@ -239,27 +290,36 @@ fn truncate_chars(text: &str, max: usize) -> String {
 
 // --- SSE parsing ---
 
+/// The three line-ending pairs that can terminate an SSE event, longest
+/// first. The spec lets a stream be framed with LF, CRLF **or** CR, and a
+/// reader that knows only one of them does not fail — it buffers forever and
+/// then flushes everything at EOF, which reads as "the server was slow" or,
+/// with no EOF, as an empty answer.
+const EVENT_SEPARATORS: [&[u8]; 3] = [b"\r\n\r\n", b"\n\n", b"\r\r"];
+
 /// Offset and separator length of the first complete SSE event boundary,
 /// or `None` while the buffer still holds a partial event.
 ///
-/// Both `\n\n` and `\r\n\r\n` are accepted: the SSE spec allows either, and
-/// searching only for `\n\n` (what `anthropic.rs`/`google.rs` do — safe
-/// against those two servers) would buffer a CRLF stream forever.
+/// The earliest boundary wins; on a tie the longest separator does, so
+/// `\r\n\r\n` is never mistaken for a shorter framing starting at the same
+/// byte.
 fn find_event_end(buffer: &[u8]) -> Option<(usize, usize)> {
-    let crlf = find_subslice(buffer, b"\r\n\r\n");
-    let lf = find_subslice(buffer, b"\n\n");
-    match (crlf, lf) {
-        (Some(c), Some(l)) => {
-            if c <= l {
-                Some((c, 4))
-            } else {
-                Some((l, 2))
+    let mut best: Option<(usize, usize)> = None;
+    for separator in EVENT_SEPARATORS {
+        let Some(at) = find_subslice(buffer, separator) else {
+            continue;
+        };
+        let better = match best {
+            None => true,
+            Some((best_at, best_len)) => {
+                at < best_at || (at == best_at && separator.len() > best_len)
             }
+        };
+        if better {
+            best = Some((at, separator.len()));
         }
-        (Some(c), None) => Some((c, 4)),
-        (None, Some(l)) => Some((l, 2)),
-        (None, None) => None,
     }
+    best
 }
 
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -300,29 +360,100 @@ fn parse_content_delta(data: &str) -> Option<String> {
     Some(content.to_string())
 }
 
+/// Split an SSE event block into lines, accepting LF, CRLF **and** CR
+/// endings. `str::lines` handles the first two; a CR-framed stream would
+/// come through as one unsplittable line, so every field in it would be
+/// invisible.
+///
+/// Splitting on both characters yields an empty string in the middle of each
+/// CRLF pair. That is harmless: an empty line is not a field, and a genuinely
+/// empty line cannot occur inside an event (it would be the event boundary).
+fn sse_lines(event: &str) -> impl Iterator<Item = &str> {
+    event.split(['\n', '\r'])
+}
+
+/// The `data` field of one event: every `data:` line in it, joined with
+/// `\n`, or `None` when the event carries no `data:` line at all (a comment,
+/// an `event:`/`id:`/`retry:`-only frame — or a body that is not SSE).
+///
+/// Joining is what the spec prescribes, and skipping it is another silent
+/// empty: a server that splits its JSON payload across two `data:` lines
+/// would give two fragments that each fail to parse, and
+/// [`parse_content_delta`] would drop both without a word. The trade-off is
+/// that a server writing two *independent* JSON objects as consecutive
+/// `data:` lines inside one block — which no SSE-conforming server does,
+/// since that is precisely how the spec spells a single multi-line field —
+/// is now read as one malformed payload rather than as two chunks.
+fn event_data(event: &str) -> Option<String> {
+    let mut payload: Option<String> = None;
+    for line in sse_lines(event) {
+        let Some(part) = sse_data_payload(line) else {
+            continue;
+        };
+        match &mut payload {
+            Some(acc) => {
+                acc.push('\n');
+                acc.push_str(part);
+            }
+            None => payload = Some(part.to_string()),
+        }
+    }
+    payload
+}
+
 /// Whether the reader should keep going after an event.
 enum Flow {
     Continue,
     Stop,
 }
 
-/// Emit every text delta in one SSE event block. Stops the stream on the
-/// terminal `[DONE]` marker (anything a chatty gateway appends after it is
-/// not the model's answer) or when the receiver has gone away.
-async fn emit_event(event: &str, tx: &Sender<anyhow::Result<String>>) -> Flow {
-    for line in event.lines() {
-        let Some(payload) = sse_data_payload(line) else {
-            continue;
-        };
-        if payload.trim() == DONE_MARKER {
+/// Emit the text delta carried by one SSE event block.
+///
+/// Stops the stream on the terminal `[DONE]` marker (anything a chatty
+/// gateway appends after it is not the model's answer), on an error frame,
+/// and when the receiver has gone away.
+///
+/// The error branch is the streaming half of [`is_error_body`]: once the
+/// `200` status line has gone out, an SSE frame is the *only* way a server
+/// can report a failure, and OpenAI documents exactly that for anything that
+/// goes wrong after the stream starts. Without it a truncated answer is
+/// delivered as a complete one — the stream simply ends.
+async fn emit_event(event: &str, tx: &Sender<anyhow::Result<String>>, label: &str) -> Flow {
+    let Some(payload) = event_data(event) else {
+        // No `data:` line at all. Usually a comment or a keep-alive, but it
+        // is also what a server answering a streaming request with a plain
+        // JSON error body and a 200 status looks like (Ollama, LiteLLM in
+        // pass-through): no framing, so nothing would ever be emitted and
+        // the caller would see an empty, successful answer.
+        if is_error_body(event) {
+            let _ = tx
+                .send(Err(anyhow::anyhow!(
+                    "{label} API error (HTTP 200): {}",
+                    error_message_from_body(event)
+                )))
+                .await;
             return Flow::Stop;
         }
-        let Some(text) = parse_content_delta(payload) else {
-            continue;
-        };
-        if tx.send(Ok(text)).await.is_err() {
-            return Flow::Stop;
-        }
+        return Flow::Continue;
+    };
+
+    if payload.trim() == DONE_MARKER {
+        return Flow::Stop;
+    }
+    if is_error_body(&payload) {
+        let _ = tx
+            .send(Err(anyhow::anyhow!(
+                "{label} stream error: {}",
+                error_message_from_body(&payload)
+            )))
+            .await;
+        return Flow::Stop;
+    }
+    let Some(text) = parse_content_delta(&payload) else {
+        return Flow::Continue;
+    };
+    if tx.send(Ok(text)).await.is_err() {
+        return Flow::Stop;
     }
     Flow::Continue
 }
@@ -387,7 +518,29 @@ impl Endpoint<'_> {
     ) -> anyhow::Result<CompletionResponse> {
         let body = self.body(&request, false);
         let response = self.send(&body).await?;
-        let api_resp: ChatResponse = response.json().await?;
+        // Read the body as text first: `response.json()` would throw the raw
+        // bytes away, and both the error-envelope check below and a readable
+        // parse failure need them.
+        let raw = response.text().await?;
+        let api_resp: ChatResponse = serde_json::from_str(&raw).map_err(|e| {
+            anyhow::anyhow!(
+                "{} API returned an unreadable body ({e}): {}",
+                self.label,
+                error_message_from_body(&raw)
+            )
+        })?;
+
+        // A success status carrying an error envelope. Every field of
+        // `ChatResponse` is optional, so such a body parses into an empty
+        // response and would otherwise be recorded as a successful, free run
+        // that produced nothing. See `is_error_body`.
+        if api_resp.choices.is_empty() && is_error_body(&raw) {
+            anyhow::bail!(
+                "{} API error (HTTP 200): {}",
+                self.label,
+                error_message_from_body(&raw)
+            );
+        }
 
         let content = api_resp
             .choices
@@ -420,6 +573,8 @@ impl Endpoint<'_> {
 
         let (tx, rx) = tokio::sync::mpsc::channel(64);
         let byte_stream = response.bytes_stream();
+        // Owned: the reader outlives this borrow of the provider.
+        let label = self.label.to_string();
 
         tokio::spawn(async move {
             // Bytes, not a `String`: an event boundary is ASCII, but the
@@ -449,7 +604,7 @@ impl Endpoint<'_> {
                 while let Some((end, sep)) = find_event_end(&buffer) {
                     let event = String::from_utf8_lossy(&buffer[..end]).into_owned();
                     buffer.drain(..end + sep);
-                    if let Flow::Stop = emit_event(&event, &tx).await {
+                    if let Flow::Stop = emit_event(&event, &tx, &label).await {
                         return;
                     }
                 }
@@ -459,7 +614,7 @@ impl Endpoint<'_> {
             // trailing blank line. Whatever is left is a complete event.
             if !buffer.is_empty() {
                 let event = String::from_utf8_lossy(&buffer).into_owned();
-                let _ = emit_event(&event, &tx).await;
+                let _ = emit_event(&event, &tx, &label).await;
             }
         });
 
@@ -579,6 +734,46 @@ mod tests {
         );
     }
 
+    // --- error envelopes on a success status ---
+
+    #[test]
+    fn an_error_envelope_is_recognised_whatever_shape_it_takes() {
+        assert!(is_error_body(
+            r#"{"error":{"message":"Rate limit exceeded","type":"rate_limit"}}"#
+        ));
+        // Ollama's flat spelling.
+        assert!(is_error_body(r#"{"error":"model 'x' not found"}"#));
+        // vLLM says so in `object`.
+        assert!(is_error_body(
+            r#"{"object":"error","message":"bad request"}"#
+        ));
+    }
+
+    /// The other half, and the one that decides whether this check can be
+    /// trusted at all: a real completion must never be read as an error.
+    #[test]
+    fn a_real_completion_is_never_taken_for_an_error() {
+        assert!(!is_error_body(
+            r#"{"object":"chat.completion","choices":[{"message":{"content":"hi"}}]}"#
+        ));
+        // Some servers send an explicit `error: null` alongside a result.
+        assert!(!is_error_body(
+            r#"{"error":null,"choices":[{"message":{"content":"hi"}}]}"#
+        ));
+        // A streaming delta that happens to contain the word.
+        assert!(!is_error_body(
+            r#"{"choices":[{"delta":{"content":"an error occurred in my code"}}]}"#
+        ));
+        // `message`/`detail` alone are read by `error_message_from_body`
+        // only once the status already said "error" — they are not evidence
+        // on their own.
+        assert!(!is_error_body(r#"{"message":"all good"}"#));
+        assert!(!is_error_body(r#"{"detail":"nothing to see"}"#));
+        assert!(!is_error_body("[DONE]"));
+        assert!(!is_error_body(": keep-alive comment"));
+        assert!(!is_error_body(""));
+    }
+
     // --- SSE framing ---
 
     #[test]
@@ -600,6 +795,37 @@ mod tests {
         assert_eq!(find_event_end(b"a\n\nb\r\n\r\nc"), Some((1, 2)));
         // And the reverse ordering.
         assert_eq!(find_event_end(b"a\r\n\r\nb\n\nc"), Some((1, 4)));
+    }
+
+    /// A CR-only stream is legal SSE. A reader that knows only LF and CRLF
+    /// never finds a boundary in it, so it emits nothing until EOF — and
+    /// nothing at all if the connection stays open.
+    #[test]
+    fn a_cr_framed_event_boundary_is_found_too() {
+        assert_eq!(find_event_end(b"data: a\r\rdata: b"), Some((7, 2)));
+        // A lone CR is still a partial event.
+        assert_eq!(find_event_end(b"data: a\r"), None);
+    }
+
+    /// Per the spec, consecutive `data:` lines in one event are ONE field,
+    /// joined with `\n`. Reading them as separate payloads gives two
+    /// fragments that each fail to parse — dropped without a word.
+    #[test]
+    fn consecutive_data_lines_are_joined_into_one_field() {
+        assert_eq!(
+            event_data("data: {\"choices\":[{\"delta\":\ndata: {\"content\":\"split\"}}]}"),
+            Some("{\"choices\":[{\"delta\":\n{\"content\":\"split\"}}]}".to_string())
+        );
+        // And the ordinary single-line case is untouched.
+        assert_eq!(event_data("data: {\"a\":1}"), Some("{\"a\":1}".to_string()));
+        // CR-only line endings inside the event, too.
+        assert_eq!(
+            event_data("event: message\rdata: {\"a\":1}"),
+            Some("{\"a\":1}".to_string())
+        );
+        // No `data:` line at all.
+        assert_eq!(event_data(": keep-alive"), None);
+        assert_eq!(event_data("event: ping\nid: 7"), None);
     }
 
     #[test]

--- a/crates/armadai-providers/src/api/openai_compatible.rs
+++ b/crates/armadai-providers/src/api/openai_compatible.rs
@@ -183,7 +183,7 @@ struct ChatUsage {
 /// unknown model as if it were GPT-4o would invent dollars that were never
 /// spent and feed them into `armadai costs`. A visible `$0.00` is a
 /// recognisable "not priced", a wrong number is not.
-fn rates_for_model(model: &str) -> Option<(f64, f64)> {
+pub(crate) fn rates_for_model(model: &str) -> Option<(f64, f64)> {
     let id = model
         .rsplit('/')
         .next()

--- a/crates/armadai-providers/src/api/retry.rs
+++ b/crates/armadai-providers/src/api/retry.rs
@@ -24,11 +24,13 @@
 //!
 //! One shared, provider-agnostic set — `is_retryable` below — covers both
 //! rather than dispatching per provider, and is implemented ONCE here and
-//! used by both `api::anthropic` and `api::google` rather than grown
-//! independently in each — two copies of one policy is the defect class
-//! this repo has fixed repeatedly (see the issue write-up). `openai.rs`/
-//! `proxy.rs` are still `todo!()` stubs and make no HTTP calls yet, so they
-//! have nothing to wire up here.
+//! used by every HTTP provider rather than grown independently in each —
+//! two copies of one policy is the defect class this repo has fixed
+//! repeatedly (see the issue write-up). Since #368 that includes the
+//! OpenAI-compatible path (`api::openai_compatible`, behind both
+//! `api::openai` and `proxy`), which reaches a far wider set of servers
+//! (gateways, local runtimes) than the two first-party APIs — all the more
+//! reason for one shared policy rather than a per-vendor one.
 //!
 //! Bounded by ATTEMPT COUNT, not elapsed time and not a caller-supplied
 //! deadline: neither provider threads `agent.metadata.timeout` (that only
@@ -389,70 +391,11 @@ mod tests {
     // --- end-to-end over real (local-only) HTTP: proves the wiring, not
     // just the decision table ---
 
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicUsize;
-
-    /// Minimal scripted HTTP/1.1 server so `send_with_retry` is exercised
-    /// against REAL wire traffic (real status line, real headers) without
-    /// calling any external API. Each accepted connection gets exactly one
-    /// scripted `(status, headers, body)`, served then closed
-    /// (`Connection: close`, so reqwest never reuses a stale connection
-    /// across scripts). Requests past the end of the script repeat the last
-    /// entry — tests that don't know the exact attempt count (the
-    /// give-up-after-budget case) rely on that.
-    /// (status code, extra headers, body) for one scripted response.
-    type ScriptedResponse = (u16, Vec<(&'static str, String)>, &'static str);
-
-    struct ScriptedServer {
-        addr: std::net::SocketAddr,
-        requests: Arc<AtomicUsize>,
-    }
-
-    impl ScriptedServer {
-        fn start(responses: Vec<ScriptedResponse>) -> Self {
-            let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test server");
-            let addr = listener.local_addr().expect("local addr");
-            let requests = Arc::new(AtomicUsize::new(0));
-            let requests_clone = requests.clone();
-            std::thread::spawn(move || {
-                for stream in listener.incoming() {
-                    let Ok(mut stream) = stream else { break };
-                    let idx = requests_clone.fetch_add(1, Ordering::SeqCst);
-                    let (code, headers, body) = responses
-                        .get(idx)
-                        .or_else(|| responses.last())
-                        .cloned()
-                        .expect("script must have at least one response");
-
-                    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
-                    let mut buf = [0u8; 4096];
-                    let _ = stream.read(&mut buf); // drain the request, ignore its content
-
-                    let mut resp = format!(
-                        "HTTP/1.1 {code} X\r\nConnection: close\r\nContent-Length: {}\r\n",
-                        body.len()
-                    );
-                    for (k, v) in &headers {
-                        resp.push_str(&format!("{k}: {v}\r\n"));
-                    }
-                    resp.push_str("\r\n");
-                    resp.push_str(body);
-                    let _ = stream.write_all(resp.as_bytes());
-                }
-            });
-            Self { addr, requests }
-        }
-
-        fn url(&self) -> String {
-            format!("http://{}", self.addr)
-        }
-
-        fn request_count(&self) -> usize {
-            self.requests.load(Ordering::SeqCst)
-        }
-    }
+    // The scripted local HTTP server used below now lives in
+    // `super::test_server`, shared with `openai_compatible.rs` — see that
+    // module for what it does and why mocking at the client level would not
+    // do instead.
+    use crate::api::test_server::ScriptedServer;
 
     fn tiny_policy() -> RetryPolicy {
         RetryPolicy {

--- a/crates/armadai-providers/src/api/test_server.rs
+++ b/crates/armadai-providers/src/api/test_server.rs
@@ -1,0 +1,219 @@
+//! Minimal scripted HTTP/1.1 server, shared by the API providers' tests.
+//!
+//! Every test that uses it exercises the provider against **real wire
+//! traffic** — a real status line, real headers, a real socket — without
+//! calling any external API and without needing a key. Mocking at the
+//! `reqwest::Client` level would prove nothing about parsing bytes off a
+//! socket, which is exactly where hand-written SSE readers break.
+//!
+//! Originally written inside `retry.rs`'s test module (rate-limit Lot 2,
+//! #358); lifted here when `openai_compatible.rs` needed the same thing,
+//! rather than growing a second copy — two implementations of one test
+//! primitive is the defect class this repo has closed repeatedly.
+//!
+//! What it adds over the original:
+//!
+//! - **Multi-write bodies** (`ScriptedResponse::streamed`): each chunk is
+//!   its own `write_all` + flush, with `TCP_NODELAY` set and a short pause
+//!   in between, so the client really observes several reads. That is what
+//!   makes "a `data:` line split across two TCP packets" a *measured*
+//!   condition instead of a hopeful one.
+//! - **Unframed bodies**: a streamed response sends no `Content-Length`, so
+//!   the body ends when the connection closes — how an SSE response
+//!   actually arrives.
+//! - **Request capture** (`request(i)`): the raw bytes the server received,
+//!   so a test can assert on what was *sent* (e.g. that no `Authorization`
+//!   header went out for a keyless proxy).
+//!
+//! Each accepted connection serves exactly one scripted response and then
+//! closes (`Connection: close`, so reqwest never reuses a stale connection
+//! across scripts). Requests past the end of the script repeat the last
+//! entry — tests that don't know the exact attempt count (the
+//! give-up-after-budget case in `retry.rs`) rely on that.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Extra response headers, as `(name, value)` pairs.
+pub(crate) type ScriptedHeaders = Vec<(&'static str, String)>;
+
+/// One scripted response.
+#[derive(Clone)]
+pub(crate) struct ScriptedResponse {
+    pub(crate) status: u16,
+    pub(crate) headers: ScriptedHeaders,
+    /// Body pieces. Each is written and flushed separately, with a pause in
+    /// between, so a multi-piece body genuinely crosses several packets.
+    pub(crate) chunks: Vec<String>,
+    /// `true` → framed by `Content-Length` (an ordinary JSON response).
+    /// `false` → no framing header at all; the body ends at connection
+    /// close, which is how a streaming SSE response is delimited.
+    pub(crate) framed: bool,
+}
+
+impl ScriptedResponse {
+    /// A whole body in one write, framed by `Content-Length`.
+    pub(crate) fn body(status: u16, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+            chunks: vec![body.into()],
+            framed: true,
+        }
+    }
+
+    /// A body delivered as several separate writes and delimited by the
+    /// connection closing — the shape of a streaming response.
+    pub(crate) fn streamed<S: Into<String>>(status: u16, chunks: Vec<S>) -> Self {
+        Self {
+            status,
+            headers: vec![("Content-Type", "text/event-stream".to_string())],
+            chunks: chunks.into_iter().map(Into::into).collect(),
+            framed: false,
+        }
+    }
+}
+
+/// Keeps `retry.rs`'s existing `(status, headers, body)` tuples working
+/// unchanged after the extraction.
+impl From<(u16, ScriptedHeaders, &'static str)> for ScriptedResponse {
+    fn from((status, headers, body): (u16, ScriptedHeaders, &'static str)) -> Self {
+        Self {
+            status,
+            headers,
+            chunks: vec![body.to_string()],
+            framed: true,
+        }
+    }
+}
+
+pub(crate) struct ScriptedServer {
+    addr: std::net::SocketAddr,
+    requests: Arc<AtomicUsize>,
+    received: Arc<Mutex<Vec<String>>>,
+}
+
+impl ScriptedServer {
+    pub(crate) fn start<R: Into<ScriptedResponse>>(responses: Vec<R>) -> Self {
+        let responses: Vec<ScriptedResponse> = responses.into_iter().map(Into::into).collect();
+        assert!(
+            !responses.is_empty(),
+            "script must have at least one response"
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test server");
+        let addr = listener.local_addr().expect("local addr");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let received = Arc::new(Mutex::new(Vec::new()));
+
+        let requests_clone = requests.clone();
+        let received_clone = received.clone();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+                let idx = requests_clone.fetch_add(1, Ordering::SeqCst);
+                let scripted = responses
+                    .get(idx)
+                    .or_else(|| responses.last())
+                    .cloned()
+                    .expect("script is non-empty");
+
+                let _ = stream.set_nodelay(true);
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+
+                // Drain the whole request (headers, then the declared body).
+                // Leaving unread bytes in the socket makes close() send an
+                // RST on some platforms, which the client would see instead
+                // of the response.
+                let raw = read_request(&mut stream);
+                if let Ok(mut guard) = received_clone.lock() {
+                    guard.push(raw);
+                }
+
+                let mut head = format!("HTTP/1.1 {} X\r\nConnection: close\r\n", scripted.status);
+                if scripted.framed {
+                    let len: usize = scripted.chunks.iter().map(|c| c.len()).sum();
+                    head.push_str(&format!("Content-Length: {len}\r\n"));
+                }
+                for (k, v) in &scripted.headers {
+                    head.push_str(&format!("{k}: {v}\r\n"));
+                }
+                head.push_str("\r\n");
+                if stream.write_all(head.as_bytes()).is_err() {
+                    continue;
+                }
+                let _ = stream.flush();
+
+                for (i, chunk) in scripted.chunks.iter().enumerate() {
+                    if i > 0 {
+                        // Long enough that the client's read loop wakes up
+                        // between writes, short enough to keep the suite fast.
+                        std::thread::sleep(Duration::from_millis(30));
+                    }
+                    if stream.write_all(chunk.as_bytes()).is_err() {
+                        break;
+                    }
+                    let _ = stream.flush();
+                }
+            }
+        });
+
+        Self {
+            addr,
+            requests,
+            received,
+        }
+    }
+
+    pub(crate) fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    pub(crate) fn request_count(&self) -> usize {
+        self.requests.load(Ordering::SeqCst)
+    }
+
+    /// Raw text of the request received at `index` (request line, headers,
+    /// and body), or `None` if that many requests never arrived.
+    pub(crate) fn request(&self, index: usize) -> Option<String> {
+        self.received.lock().ok()?.get(index).cloned()
+    }
+}
+
+/// Read one HTTP request: everything up to the blank line, then exactly the
+/// number of body bytes its `Content-Length` declares (0 when absent).
+fn read_request(stream: &mut std::net::TcpStream) -> String {
+    let mut raw: Vec<u8> = Vec::new();
+    let mut byte = [0u8; 1];
+
+    // Headers, byte by byte so we stop exactly at the blank line and never
+    // swallow part of a body we haven't sized yet.
+    while !raw.ends_with(b"\r\n\r\n") {
+        match stream.read(&mut byte) {
+            Ok(0) | Err(_) => return String::from_utf8_lossy(&raw).into_owned(),
+            Ok(_) => raw.push(byte[0]),
+        }
+    }
+
+    let head = String::from_utf8_lossy(&raw).into_owned();
+    let content_length = head
+        .lines()
+        .find_map(|l| {
+            let (name, value) = l.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        })
+        .unwrap_or(0);
+
+    if content_length > 0 {
+        let mut body = vec![0u8; content_length];
+        if stream.read_exact(&mut body).is_ok() {
+            raw.extend_from_slice(&body);
+        }
+    }
+
+    String::from_utf8_lossy(&raw).into_owned()
+}

--- a/crates/armadai-providers/src/api/test_server.rs
+++ b/crates/armadai-providers/src/api/test_server.rs
@@ -24,6 +24,11 @@
 //! - **Request capture** (`request(i)`): the raw bytes the server received,
 //!   so a test can assert on what was *sent* (e.g. that no `Authorization`
 //!   header went out for a keyless proxy).
+//! - **A gate** (`start_gated`/`release`): the server writes the first body
+//!   chunk and then holds the connection open indefinitely. That turns "was
+//!   this event emitted as it arrived, or only rescued at EOF?" into a
+//!   categorical question — with no EOF to rescue it, a reader that misses
+//!   the boundary produces nothing at all.
 //!
 //! Each accepted connection serves exactly one scripted response and then
 //! closes (`Connection: close`, so reqwest never reuses a stale connection
@@ -33,7 +38,7 @@
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -90,14 +95,49 @@ impl From<(u16, ScriptedHeaders, &'static str)> for ScriptedResponse {
     }
 }
 
+/// How long a gated server waits for [`ScriptedServer::release`] before
+/// giving up and finishing the body anyway. Only reached when a test panics
+/// before releasing — without it that test would leak a thread spinning for
+/// the lifetime of the process.
+const GATE_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub(crate) struct ScriptedServer {
     addr: std::net::SocketAddr,
     requests: Arc<AtomicUsize>,
     received: Arc<Mutex<Vec<String>>>,
+    gate: Arc<AtomicBool>,
 }
 
 impl ScriptedServer {
     pub(crate) fn start<R: Into<ScriptedResponse>>(responses: Vec<R>) -> Self {
+        Self::start_with_gate(responses, Arc::new(AtomicBool::new(true)))
+    }
+
+    /// Like [`ScriptedServer::start`], but the server writes the head and the
+    /// **first** body chunk and then holds the connection open, writing
+    /// nothing more until [`ScriptedServer::release`] is called.
+    ///
+    /// This is what turns "did the client emit the first event as it
+    /// arrived?" from a timing measurement into a categorical one: while the
+    /// gate is shut there is no further data and no EOF, so a client that
+    /// only recognises its event boundary at end-of-stream produces *nothing
+    /// at all* rather than the same tokens a little later. The test then
+    /// bounds the read with a generous `timeout` that is an anti-hang guard,
+    /// not a threshold to tune.
+    pub(crate) fn start_gated<R: Into<ScriptedResponse>>(responses: Vec<R>) -> Self {
+        Self::start_with_gate(responses, Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Open the gate: a server started with [`ScriptedServer::start_gated`]
+    /// finishes writing its body and closes.
+    pub(crate) fn release(&self) {
+        self.gate.store(true, Ordering::SeqCst);
+    }
+
+    fn start_with_gate<R: Into<ScriptedResponse>>(
+        responses: Vec<R>,
+        gate: Arc<AtomicBool>,
+    ) -> Self {
         let responses: Vec<ScriptedResponse> = responses.into_iter().map(Into::into).collect();
         assert!(
             !responses.is_empty(),
@@ -111,6 +151,7 @@ impl ScriptedServer {
 
         let requests_clone = requests.clone();
         let received_clone = received.clone();
+        let gate_clone = gate.clone();
         std::thread::spawn(move || {
             for stream in listener.incoming() {
                 let Ok(mut stream) = stream else { break };
@@ -152,6 +193,7 @@ impl ScriptedServer {
                         // Long enough that the client's read loop wakes up
                         // between writes, short enough to keep the suite fast.
                         std::thread::sleep(Duration::from_millis(30));
+                        wait_for_gate(&gate_clone);
                     }
                     if stream.write_all(chunk.as_bytes()).is_err() {
                         break;
@@ -165,6 +207,7 @@ impl ScriptedServer {
             addr,
             requests,
             received,
+            gate,
         }
     }
 
@@ -180,6 +223,14 @@ impl ScriptedServer {
     /// and body), or `None` if that many requests never arrived.
     pub(crate) fn request(&self, index: usize) -> Option<String> {
         self.received.lock().ok()?.get(index).cloned()
+    }
+}
+
+/// Block until the gate opens, or until [`GATE_TIMEOUT`] elapses.
+fn wait_for_gate(gate: &AtomicBool) {
+    let deadline = std::time::Instant::now() + GATE_TIMEOUT;
+    while !gate.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(1));
     }
 }
 

--- a/crates/armadai-providers/src/factory.rs
+++ b/crates/armadai-providers/src/factory.rs
@@ -271,7 +271,7 @@ fn create_api_provider(provider: &str, _agent: &Agent) -> anyhow::Result<Box<dyn
         "anthropic" => {
             let api_key = get_api_key("ANTHROPIC_API_KEY", "anthropic")?;
             let mut p = super::api::anthropic::AnthropicProvider::new(api_key);
-            if let Ok(url) = std::env::var("ANTHROPIC_BASE_URL") {
+            if let Some(url) = resolve_base_url("anthropic", "ANTHROPIC_BASE_URL") {
                 p.base_url = url;
             }
             Ok(Box::new(p))
@@ -279,7 +279,7 @@ fn create_api_provider(provider: &str, _agent: &Agent) -> anyhow::Result<Box<dyn
         "google" => {
             let api_key = get_api_key("GOOGLE_API_KEY", "google")?;
             let mut p = super::api::google::GoogleProvider::new(api_key);
-            if let Ok(url) = std::env::var("GOOGLE_BASE_URL") {
+            if let Some(url) = resolve_base_url("google", "GOOGLE_BASE_URL") {
                 p.base_url = url;
             }
             Ok(Box::new(p))
@@ -316,15 +316,23 @@ fn create_api_provider(provider: &str, _agent: &Agent) -> anyhow::Result<Box<dyn
 #[cfg(feature = "api")]
 const DEFAULT_PROXY_BASE_URL: &str = "http://localhost:4000/v1";
 
-/// Resolve an OpenAI-compatible provider's base URL: the environment
-/// variable first, then `providers.yaml`'s `providers.<key>.base_url`.
+/// Resolve an API provider's base URL: the environment variable first, then
+/// `providers.yaml`'s `providers.<key>.base_url`.
 ///
-/// `anthropic` and `google` read only their own env var (they predate
-/// this and their vendor URL is fixed); `openai` and `proxy` also honour
-/// `providers.yaml` because pointing them somewhere else — a gateway, a
-/// local runtime — is the normal case rather than the exception, and that
-/// file is where a user would reasonably write it down. Documented in
-/// `docs/wiki/providers.md`.
+/// All four API providers go through this. They did not at first: `openai`
+/// and `proxy` read the file while `anthropic` and `google` kept reading
+/// only their env var — which turned a file `armadai init` writes with a
+/// `base_url` for **all four** (`DEFAULT_PROVIDERS_YAML`) from uniformly
+/// decorative into honoured-for-two-silently-ignored-for-two. A file whose
+/// keys work for half its entries is a worse trap than one whose keys work
+/// for none, so the reading was widened rather than the file trimmed.
+///
+/// A blank value is not a configuration, in either source. The env-var-only
+/// version accepted one (`if let Ok(url) = var(..)`), so
+/// `ANTHROPIC_BASE_URL=""` used to blank the vendor URL and every call then
+/// failed against a relative path; it is now ignored.
+///
+/// Documented in `docs/wiki/providers.md`.
 #[cfg(feature = "api")]
 fn resolve_base_url(config_key: &str, env_var: &str) -> Option<String> {
     if let Ok(url) = std::env::var(env_var)
@@ -540,9 +548,10 @@ mod tests {
         /// doc-comments call out — and stopped compiling the moment #372
         /// moved the lock behind `test_support`.
         fn env_scope(vars: &[(&str, Option<&str>)]) -> IsolatedConfigDir {
-            vars.iter().fold(IsolatedConfigDir::enter(), |scope, (name, value)| {
-                scope.with_var(name, *value)
-            })
+            vars.iter()
+                .fold(IsolatedConfigDir::enter(), |scope, (name, value)| {
+                    scope.with_var(name, *value)
+                })
         }
 
         fn agent_with(provider: &str, command: Option<&str>) -> Agent {
@@ -679,10 +688,149 @@ mod tests {
         }
 
         /// An env var set to the empty string is not a configuration.
+        ///
+        /// Before this went through `resolve_base_url`, `anthropic`'s
+        /// `if let Ok(url) = var(..)` accepted the empty string and blanked
+        /// the vendor URL with it.
         #[test]
         fn an_empty_base_url_env_var_is_ignored() {
-            let _env = env_scope(&[("PROXY_BASE_URL", Some("   "))]);
-            assert_eq!(resolve_base_url("proxy", "PROXY_BASE_URL"), None);
+            // One guard at a time: `env_scope` takes the shared env lock, and
+            // a second one on the same thread would deadlock on it.
+            {
+                let _env = env_scope(&[("PROXY_BASE_URL", Some("   "))]);
+                assert_eq!(resolve_base_url("proxy", "PROXY_BASE_URL"), None);
+            }
+            {
+                let _env = env_scope(&[("ANTHROPIC_BASE_URL", Some(""))]);
+                assert_eq!(resolve_base_url("anthropic", "ANTHROPIC_BASE_URL"), None);
+            }
+        }
+
+        /// `armadai init` writes a `base_url` for all four providers
+        /// (`DEFAULT_PROVIDERS_YAML`). Two of them honouring it and two
+        /// ignoring it is the trap; this pins that all four read the file.
+        #[test]
+        fn providers_yaml_base_url_is_honoured_for_every_api_provider() {
+            let env = env_scope(&[
+                ("ANTHROPIC_BASE_URL", None),
+                ("GOOGLE_BASE_URL", None),
+                ("OPENAI_BASE_URL", None),
+                ("PROXY_BASE_URL", None),
+            ]);
+            std::fs::write(
+                env.config_dir().join("providers.yaml"),
+                "providers:\n  \
+                 anthropic:\n    base_url: http://anthropic.test/v1\n  \
+                 google:\n    base_url: http://google.test/v1\n  \
+                 openai:\n    base_url: http://openai.test/v1\n  \
+                 proxy:\n    base_url: http://proxy.test/v1\n",
+            )
+            .expect("write providers.yaml");
+
+            for (key, env_var, expected) in [
+                (
+                    "anthropic",
+                    "ANTHROPIC_BASE_URL",
+                    "http://anthropic.test/v1",
+                ),
+                ("google", "GOOGLE_BASE_URL", "http://google.test/v1"),
+                ("openai", "OPENAI_BASE_URL", "http://openai.test/v1"),
+                ("proxy", "PROXY_BASE_URL", "http://proxy.test/v1"),
+            ] {
+                assert_eq!(
+                    resolve_base_url(key, env_var).as_deref(),
+                    Some(expected),
+                    "{key} must read its providers.yaml base_url"
+                );
+            }
+        }
+
+        fn probe_request() -> armadai_core::provider::CompletionRequest {
+            armadai_core::provider::CompletionRequest {
+                model: "probe".to_string(),
+                system_prompt: String::new(),
+                messages: vec![armadai_core::provider::ChatMessage {
+                    role: "user".to_string(),
+                    content: "hi".to_string(),
+                }],
+                temperature: 0.0,
+                max_tokens: None,
+            }
+        }
+
+        /// The whole reason the file is read: a provider built through the
+        /// factory must actually **talk to** the URL the file supplies.
+        ///
+        /// Asserting that `resolve_base_url` returns it proves only that the
+        /// helper works — the arm can still ignore it. Measured: the first
+        /// version of this test did exactly that and survived the mutation
+        /// restoring `anthropic`'s env-var-only read. So the assertion is on
+        /// a real socket: the scripted server must receive the call.
+        #[tokio::test]
+        #[allow(clippy::await_holding_lock)]
+        async fn an_anthropic_provider_really_calls_the_file_supplied_base_url() {
+            use crate::api::test_server::{ScriptedResponse, ScriptedServer};
+
+            let server = ScriptedServer::start(vec![ScriptedResponse::body(
+                200,
+                r#"{"content":[{"type":"text","text":"ok"}],"model":"m",
+                    "usage":{"input_tokens":1,"output_tokens":1}}"#,
+            )]);
+            let env = env_scope(&[
+                ("ANTHROPIC_BASE_URL", None),
+                ("ANTHROPIC_API_KEY", Some("sk-ant-test")),
+            ]);
+            std::fs::write(
+                env.config_dir().join("providers.yaml"),
+                format!("providers:\n  anthropic:\n    base_url: {}\n", server.url()),
+            )
+            .expect("write providers.yaml");
+
+            let provider =
+                create_provider(&agent_with("anthropic", None)).expect("anthropic must build");
+            // The answer itself is irrelevant; where the call went is not.
+            let _ = provider.complete(probe_request()).await;
+
+            assert_eq!(
+                server.request_count(),
+                1,
+                "the factory-built provider never called the base URL providers.yaml supplies"
+            );
+            let raw = server.request(0).expect("one request received");
+            assert!(raw.contains("POST /messages "), "wrong path in:\n{raw}");
+        }
+
+        /// Same proof for `google`: a second arm, a second chance to ignore
+        /// the file.
+        #[tokio::test]
+        #[allow(clippy::await_holding_lock)]
+        async fn a_google_provider_really_calls_the_file_supplied_base_url() {
+            use crate::api::test_server::{ScriptedResponse, ScriptedServer};
+
+            let server = ScriptedServer::start(vec![ScriptedResponse::body(
+                200,
+                r#"{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}"#,
+            )]);
+            let env = env_scope(&[
+                ("GOOGLE_BASE_URL", None),
+                ("GOOGLE_API_KEY", Some("g-test")),
+            ]);
+            std::fs::write(
+                env.config_dir().join("providers.yaml"),
+                format!("providers:\n  google:\n    base_url: {}\n", server.url()),
+            )
+            .expect("write providers.yaml");
+
+            let provider = create_provider(&agent_with("google", None)).expect("google must build");
+            let _ = provider.complete(probe_request()).await;
+
+            assert_eq!(
+                server.request_count(),
+                1,
+                "the factory-built provider never called the base URL providers.yaml supplies"
+            );
+            let raw = server.request(0).expect("one request received");
+            assert!(raw.contains("POST /models/probe:"), "wrong path in:\n{raw}");
         }
     }
 }

--- a/crates/armadai-providers/src/factory.rs
+++ b/crates/armadai-providers/src/factory.rs
@@ -284,11 +284,67 @@ fn create_api_provider(provider: &str, _agent: &Agent) -> anyhow::Result<Box<dyn
             }
             Ok(Box::new(p))
         }
-        "openai" | "proxy" => {
-            anyhow::bail!("Provider '{provider}' is not yet implemented")
+        "openai" => {
+            let api_key = get_api_key("OPENAI_API_KEY", "openai")?;
+            let mut p = super::api::openai::OpenAiProvider::new(api_key);
+            if let Some(url) = resolve_base_url("openai", "OPENAI_BASE_URL") {
+                p.base_url = url;
+            }
+            Ok(Box::new(p))
+        }
+        "proxy" => {
+            // A proxy has no universal home: the base URL is the whole
+            // point of the provider. Env var wins, then `providers.yaml`,
+            // then the port `armadai up`'s LiteLLM listens on.
+            let base_url = resolve_base_url("proxy", "PROXY_BASE_URL")
+                .unwrap_or_else(|| DEFAULT_PROXY_BASE_URL.to_string());
+            // Optional on purpose: a gateway on localhost usually has no
+            // key, and `Authorization: Bearer ` (empty) is rejected by some
+            // servers — `ProxyProvider` sends no header at all for `None`.
+            let api_key = optional_api_key("PROXY_API_KEY", "proxy");
+            Ok(Box::new(super::proxy::ProxyProvider::new(
+                base_url, api_key,
+            )))
         }
         other => anyhow::bail!("Unknown API provider: '{other}'"),
     }
+}
+
+/// Where `armadai up`'s LiteLLM listens — the fallback base URL for
+/// `provider: proxy` when neither `PROXY_BASE_URL` nor `providers.yaml`
+/// says otherwise. Matches `DEFAULT_PROVIDERS_YAML`'s `proxy` entry.
+#[cfg(feature = "api")]
+const DEFAULT_PROXY_BASE_URL: &str = "http://localhost:4000/v1";
+
+/// Resolve an OpenAI-compatible provider's base URL: the environment
+/// variable first, then `providers.yaml`'s `providers.<key>.base_url`.
+///
+/// `anthropic` and `google` read only their own env var (they predate
+/// this and their vendor URL is fixed); `openai` and `proxy` also honour
+/// `providers.yaml` because pointing them somewhere else — a gateway, a
+/// local runtime — is the normal case rather than the exception, and that
+/// file is where a user would reasonably write it down. Documented in
+/// `docs/wiki/providers.md`.
+#[cfg(feature = "api")]
+fn resolve_base_url(config_key: &str, env_var: &str) -> Option<String> {
+    if let Ok(url) = std::env::var(env_var)
+        && !url.trim().is_empty()
+    {
+        return Some(url);
+    }
+    armadai_core::config::load_providers_config()
+        .providers
+        .get(config_key)
+        .and_then(|p| p.base_url.clone())
+        .filter(|u| !u.trim().is_empty())
+}
+
+/// Like `get_api_key`, but a missing key is a normal outcome rather than an
+/// error: an OpenAI-compatible gateway or local runtime frequently needs no
+/// authentication at all.
+#[cfg(feature = "api")]
+fn optional_api_key(env_var: &str, provider_name: &str) -> Option<String> {
+    get_api_key(env_var, provider_name).ok()
 }
 
 #[cfg(not(feature = "api"))]
@@ -458,5 +514,175 @@ mod tests {
         // Agent-level "1/sec" burst 1: the 2nd call must wait ~1s.
         assert!(start.elapsed() >= Duration::from_millis(800));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    // --- the four configurations that used to be refused (#368) ---
+    //
+    // Before this change `create_api_provider` answered `openai` and
+    // `proxy` with `bail!("... is not yet implemented")`, which also made
+    // `create_provider`'s documented "CLI not installed -> fall back to the
+    // API" promise false for `gpt` and `aider`. These tests drive the real
+    // `create_provider` entry point for all four.
+
+    #[cfg(feature = "api")]
+    mod api_wiring {
+        use super::*;
+        use armadai_core::agent::AgentMetadata;
+        use armadai_core::test_support::IsolatedConfigDir;
+
+        /// Redirect the config dir (so no real `providers.yaml`/secrets are
+        /// read) and pin the env vars named, restoring everything on drop.
+        ///
+        /// `IsolatedConfigDir` is the workspace's shared guard (#372): it
+        /// already holds the env lock, plants a temp `ARMADAI_CONFIG_DIR`
+        /// and restores it. The first version of these tests re-implemented
+        /// all of that privately — the very duplication this module's own
+        /// doc-comments call out — and stopped compiling the moment #372
+        /// moved the lock behind `test_support`.
+        fn env_scope(vars: &[(&str, Option<&str>)]) -> IsolatedConfigDir {
+            vars.iter().fold(IsolatedConfigDir::enter(), |scope, (name, value)| {
+                scope.with_var(name, *value)
+            })
+        }
+
+        fn agent_with(provider: &str, command: Option<&str>) -> Agent {
+            Agent {
+                name: "t".into(),
+                source: std::path::PathBuf::from("t.md"),
+                metadata: AgentMetadata {
+                    provider: provider.into(),
+                    model: None,
+                    command: command.map(str::to_string),
+                    args: None,
+                    temperature: 0.7,
+                    max_tokens: None,
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: String::new(),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        #[test]
+        fn provider_openai_builds_a_real_provider_instead_of_being_refused() {
+            let _env = env_scope(&[
+                ("OPENAI_API_KEY", Some("sk-test")),
+                ("OPENAI_BASE_URL", None),
+            ]);
+
+            let provider = create_provider(&agent_with("openai", None))
+                .expect("provider: openai must build now");
+            assert_eq!(provider.metadata().name, "openai");
+            assert!(provider.metadata().supports_streaming);
+        }
+
+        /// A missing key must be reported as a missing key — the actionable
+        /// error — not as "not yet implemented".
+        #[test]
+        fn provider_openai_without_a_key_names_the_key_not_the_feature() {
+            let _env = env_scope(&[("OPENAI_API_KEY", None)]);
+
+            let err = match create_provider(&agent_with("openai", None)) {
+                Ok(_) => panic!("no key configured, yet a provider was built"),
+                Err(e) => e.to_string(),
+            };
+            assert!(err.contains("OPENAI_API_KEY"), "got: {err}");
+            assert!(!err.contains("not yet implemented"), "got: {err}");
+        }
+
+        /// The whole point of `proxy`: a gateway with no credentials at all
+        /// must still produce a usable provider.
+        #[test]
+        fn provider_proxy_builds_with_no_api_key_at_all() {
+            let _env = env_scope(&[
+                ("PROXY_API_KEY", None),
+                ("PROXY_BASE_URL", None),
+                ("OPENAI_API_KEY", None),
+            ]);
+
+            let provider =
+                create_provider(&agent_with("proxy", None)).expect("keyless proxy must build");
+            assert_eq!(provider.metadata().name, "proxy");
+        }
+
+        /// `create_provider` documents "CLI installed -> CLI, otherwise ->
+        /// API". With the CLI absent, the API fallback used to dead-end in
+        /// the `bail!`; `gpt` and `aider` now really reach the OpenAI path.
+        #[test]
+        fn gpt_and_aider_fall_back_to_the_api_when_their_cli_is_missing() {
+            let _env = env_scope(&[("OPENAI_API_KEY", Some("sk-test"))]);
+            let missing = "this_command_does_not_exist_xyz";
+            assert!(!cli_available(missing));
+
+            for tool in ["gpt", "aider"] {
+                let provider = create_provider(&agent_with(tool, Some(missing)))
+                    .unwrap_or_else(|e| panic!("{tool} API fallback failed: {e}"));
+                assert_eq!(
+                    provider.metadata().name,
+                    "openai",
+                    "{tool} must fall back to the OpenAI API backend"
+                );
+            }
+        }
+
+        #[test]
+        fn the_base_url_env_var_wins_over_providers_yaml() {
+            let env = env_scope(&[("PROXY_BASE_URL", Some("http://from-env:9/v1"))]);
+            std::fs::write(
+                env.config_dir().join("providers.yaml"),
+                "providers:\n  proxy:\n    base_url: http://from-file:8/v1\n",
+            )
+            .expect("write providers.yaml");
+
+            assert_eq!(
+                resolve_base_url("proxy", "PROXY_BASE_URL").as_deref(),
+                Some("http://from-env:9/v1")
+            );
+        }
+
+        #[test]
+        fn providers_yaml_supplies_the_base_url_when_no_env_var_is_set() {
+            let env = env_scope(&[("PROXY_BASE_URL", None)]);
+            std::fs::write(
+                env.config_dir().join("providers.yaml"),
+                "providers:\n  proxy:\n    base_url: http://from-file:8/v1\n",
+            )
+            .expect("write providers.yaml");
+
+            assert_eq!(
+                resolve_base_url("proxy", "PROXY_BASE_URL").as_deref(),
+                Some("http://from-file:8/v1")
+            );
+        }
+
+        /// Neither source configured: the caller falls back to the LiteLLM
+        /// port `armadai up` starts.
+        #[test]
+        fn a_proxy_with_nothing_configured_lands_on_the_documented_default() {
+            let _env = env_scope(&[("PROXY_BASE_URL", None)]);
+            assert_eq!(resolve_base_url("proxy", "PROXY_BASE_URL"), None);
+            assert_eq!(DEFAULT_PROXY_BASE_URL, "http://localhost:4000/v1");
+        }
+
+        /// An env var set to the empty string is not a configuration.
+        #[test]
+        fn an_empty_base_url_env_var_is_ignored() {
+            let _env = env_scope(&[("PROXY_BASE_URL", Some("   "))]);
+            assert_eq!(resolve_base_url("proxy", "PROXY_BASE_URL"), None);
+        }
     }
 }

--- a/crates/armadai-providers/src/proxy.rs
+++ b/crates/armadai-providers/src/proxy.rs
@@ -1,27 +1,59 @@
+//! Any OpenAI-compatible endpoint that isn't `api.openai.com`.
+//!
+//! Gateways (LiteLLM, OpenRouter, Groq, Together, Fireworks, DeepSeek,
+//! Mistral) and local runtimes (Ollama, vLLM, LM Studio, llama.cpp) all
+//! speak the same chat-completions dialect, so this provider is exactly
+//! [`crate::api::openai`] with two differences: the base URL is supplied by
+//! the user (it has no sensible universal default), and the API key is
+//! **optional** — a gateway on localhost usually has none, and sending an
+//! empty `Bearer ` is worse than sending no header at all.
+//!
+//! The protocol itself lives in [`crate::api::openai_compatible`] and is
+//! shared verbatim; see that module for the wire-level tolerances and for
+//! what is deliberately unsupported (Azure OpenAI's `api-key` +
+//! `api-version` shape — reachable through a gateway instead).
+
 use async_trait::async_trait;
+use reqwest::Client;
 
 use armadai_core::provider::*;
 
-/// Proxy provider that routes through LiteLLM or OpenRouter (OpenAI-compatible API).
+use crate::api::openai_compatible::Endpoint;
+
+/// Proxy provider that routes through any OpenAI-compatible server.
 pub struct ProxyProvider {
     pub base_url: String,
     pub api_key: Option<String>,
+    client: Client,
 }
 
 impl ProxyProvider {
     pub fn new(base_url: String, api_key: Option<String>) -> Self {
-        Self { base_url, api_key }
+        Self {
+            base_url,
+            api_key,
+            client: Client::new(),
+        }
+    }
+
+    fn endpoint(&self) -> Endpoint<'_> {
+        Endpoint {
+            client: &self.client,
+            base_url: &self.base_url,
+            api_key: self.api_key.as_deref(),
+            label: "Proxy",
+        }
     }
 }
 
 #[async_trait]
 impl Provider for ProxyProvider {
-    async fn complete(&self, _request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
-        todo!("Proxy completion (OpenAI-compatible)")
+    async fn complete(&self, request: CompletionRequest) -> anyhow::Result<CompletionResponse> {
+        self.endpoint().complete(request).await
     }
 
-    async fn stream(&self, _request: CompletionRequest) -> anyhow::Result<TokenStream> {
-        todo!("Proxy streaming (OpenAI-compatible)")
+    async fn stream(&self, request: CompletionRequest) -> anyhow::Result<TokenStream> {
+        self.endpoint().stream(request).await
     }
 
     fn metadata(&self) -> ProviderMetadata {
@@ -30,5 +62,124 @@ impl Provider for ProxyProvider {
             models: vec![],
             supports_streaming: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_server::{ScriptedResponse, ScriptedServer};
+    use tokio_stream::StreamExt;
+
+    fn request() -> CompletionRequest {
+        CompletionRequest {
+            model: "openai/gpt-4o-mini".to_string(),
+            system_prompt: String::new(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "Hi".to_string(),
+            }],
+            temperature: 0.2,
+            max_tokens: None,
+        }
+    }
+
+    const OK_BODY: &str = r#"{"model":"openai/gpt-4o-mini",
+        "choices":[{"message":{"content":"routed"}}],
+        "usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
+
+    /// A keyless gateway (a local LiteLLM, an Ollama server) must receive NO
+    /// `Authorization` header at all — an empty `Bearer ` is rejected by
+    /// several servers and is worse than sending nothing.
+    #[tokio::test]
+    async fn a_keyless_proxy_sends_no_authorization_header() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, OK_BODY)]);
+        let provider = ProxyProvider::new(server.url(), None);
+
+        let resp = provider.complete(request()).await.expect("keyless call");
+        assert_eq!(resp.content, "routed");
+
+        let raw = server.request(0).expect("one request received");
+        assert!(
+            !raw.to_lowercase().contains("authorization"),
+            "a keyless proxy must send no Authorization header, got:\n{raw}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_proxy_with_a_key_sends_it_as_a_bearer_token() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, OK_BODY)]);
+        let provider = ProxyProvider::new(server.url(), Some("sk-gateway".to_string()));
+
+        provider.complete(request()).await.expect("keyed call");
+
+        let raw = server.request(0).expect("one request received");
+        assert!(
+            raw.to_lowercase()
+                .contains("authorization: bearer sk-gateway"),
+            "missing bearer header in:\n{raw}"
+        );
+    }
+
+    /// The proxy speaks the same protocol as `openai` — same endpoint, same
+    /// parsing, same token/cost extraction — because it runs the same code.
+    #[tokio::test]
+    async fn proxy_speaks_the_same_openai_protocol() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(200, OK_BODY)]);
+        let provider = ProxyProvider::new(server.url(), None);
+
+        let resp = provider.complete(request()).await.expect("call");
+        assert_eq!(resp.model, "openai/gpt-4o-mini");
+        assert_eq!(resp.tokens_in, 3);
+        assert_eq!(resp.tokens_out, 2);
+        // A vendor-prefixed OpenRouter-style id still prices as gpt-4o-mini.
+        let expected = (3.0 * 0.15 + 2.0 * 0.60) / 1_000_000.0;
+        assert!((resp.cost - expected).abs() < f64::EPSILON, "{}", resp.cost);
+
+        let raw = server.request(0).expect("one request received");
+        assert!(raw.contains("POST /chat/completions "), "in:\n{raw}");
+    }
+
+    #[tokio::test]
+    async fn proxy_streams_sse_like_openai_does() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::streamed(
+            200,
+            vec![concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"pro\"}}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{\"content\":\"xied\"}}]}\n\n",
+                "data: [DONE]\n\n",
+            )],
+        )]);
+        let provider = ProxyProvider::new(server.url(), None);
+
+        let mut stream = provider.stream(request()).await.expect("stream");
+        let mut out = Vec::new();
+        while let Some(item) = stream.next().await {
+            out.push(item.expect("stream item"));
+        }
+        assert_eq!(out, vec!["pro", "xied"]);
+    }
+
+    #[tokio::test]
+    async fn a_gateway_error_body_is_reported_verbatim() {
+        // vLLM / FastAPI-style error shape: no nested `error` object.
+        let server = ScriptedServer::start(vec![ScriptedResponse::body(
+            404,
+            r#"{"object":"error","message":"The model `nope` does not exist.","type":"NotFoundError"}"#,
+        )]);
+        let provider = ProxyProvider::new(server.url(), None);
+
+        let err = provider.complete(request()).await.expect_err("404");
+        assert!(
+            err.to_string().contains("The model `nope` does not exist."),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn metadata_declares_streaming_and_it_is_true() {
+        let meta = ProxyProvider::new("http://localhost:4000/v1".to_string(), None).metadata();
+        assert_eq!(meta.name, "proxy");
+        assert!(meta.supports_streaming);
     }
 }

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -2075,6 +2075,7 @@ async fn run_orchestrated_inner(
                 println!("{outcome_text}");
             }
 
+            warn_unreported_usage(sink, Some(config.token_budget), cost_limit, &state);
             sink.emit(&RunEvent::Result {
                 content: outcome_text,
                 tin: u32::try_from(state.budget_tokens_in).unwrap_or(u32::MAX),
@@ -2157,6 +2158,7 @@ async fn run_orchestrated_inner(
                 println!("{outcome_text}");
             }
 
+            warn_unreported_usage(sink, Some(config.token_budget), cost_limit, &state);
             sink.emit(&RunEvent::Result {
                 content: outcome_text,
                 tin: u32::try_from(state.budget_tokens_in).unwrap_or(u32::MAX),
@@ -2177,6 +2179,12 @@ async fn run_orchestrated_inner(
                 }
                 _ => OrchestrationConfig::default(),
             };
+
+            // Captured before `orch_config` is moved into the dispatch below:
+            // the post-run budget notice needs the ceilings that were asked
+            // for, not the ones the run consumed.
+            let (declared_token_budget, declared_cost_limit) =
+                (orch_config.token_budget, orch_config.cost_limit);
 
             // Validate the config
             if let Err(errors) = armadai_core::orchestration::validate_config(&orch_config) {
@@ -2263,6 +2271,7 @@ async fn run_orchestrated_inner(
                 println!("{}", result.content);
             }
 
+            warn_unreported_usage(sink, declared_token_budget, declared_cost_limit, &state);
             sink.emit(&RunEvent::Result {
                 content: result.content,
                 tin: result.total_tokens_in,
@@ -2279,6 +2288,33 @@ async fn run_orchestrated_inner(
     }
 
     Ok(())
+}
+
+/// Surface, once per orchestrated run, that a configured budget was fed no
+/// usage at all — see `armadai_core::orchestration::es::state::
+/// unreported_usage_warning` for what makes that worth saying.
+///
+/// Both channels, because they reach different readers: the structured
+/// `RunEvent::Warning` is what `--json` and the Workroom consume (the same
+/// vehicle `deprecated_model` and `routing_ignored_hierarchical` already
+/// use), and `tracing::warn!` is what a plain `armadai run` shows.
+fn warn_unreported_usage(
+    sink: &Arc<dyn EventSink>,
+    token_budget: Option<u64>,
+    cost_limit: Option<f64>,
+    state: &armadai_core::orchestration::es::state::ExecutionState,
+) {
+    use armadai_core::orchestration::es::state::{UNREPORTED_USAGE_CODE, unreported_usage_warning};
+
+    let Some(message) = unreported_usage_warning(token_budget, cost_limit, state) else {
+        return;
+    };
+    tracing::warn!("{message}");
+    sink.emit(&RunEvent::Warning {
+        code: UNREPORTED_USAGE_CODE.to_string(),
+        from: None,
+        to: None,
+    });
 }
 
 /// Resolve the top-level `orchestration:` block's `cost_limit` for a

--- a/crates/armadai/tests/budget_usage_warning.rs
+++ b/crates/armadai/tests/budget_usage_warning.rs
@@ -1,0 +1,147 @@
+//! Black-box regression for the notice that a configured budget is being fed
+//! no usage at all (#374 review, I3).
+//!
+//! `token_budget`/`cost_limit` are enforced from `ExecutionState`'s counters,
+//! which come from `CompletionResponse`. A provider that reports no usage —
+//! the OpenAI-compatible path #368 adds reaches plenty of them, and
+//! `CliProvider` does it for any plain-text CLI — leaves those counters at
+//! zero, so the limit never breaches and each nested delegation is handed the
+//! full original ceiling. The notice is the minimal answer: say once that the
+//! budget is inoperative.
+//!
+//! Spawned as the real binary rather than unit-tested, because the substance
+//! under test is the *wiring*: `unreported_usage_warning` is pure and has its
+//! own unit tests in `armadai-core`, and a run that never calls it would keep
+//! those green. `provider: cli` + `command: echo` gives a real provider
+//! reporting real zeros with no API key, no network and no fake-binary
+//! feature.
+
+use assert_cmd::Command;
+use std::path::Path;
+
+/// A hierarchical project with a coordinator and one team member. `budget` is
+/// spliced into the `orchestration:` block, so the same fixture serves the
+/// configured and the unconfigured case — hierarchical is the only pattern
+/// whose `token_budget` is genuinely optional (`blackboard`/`ring` default
+/// theirs to a non-zero value, so "no budget configured" cannot exist there).
+fn project(budget: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("project");
+    std::fs::create_dir_all(root.join("agents")).unwrap();
+
+    std::fs::write(
+        root.join("armadai.yaml"),
+        format!(
+            "agents:\n  - name: lead\n  - name: worker\n\
+             orchestration:\n  enabled: true\n  pattern: hierarchical\n  \
+             coordinator: lead\n  teams:\n    - agents: [worker]\n{budget}"
+        ),
+    )
+    .unwrap();
+    // `true`, not `echo`: `CliProvider` passes the composed input as the last
+    // argv, and the coordinator's composed prompt contains the delegation
+    // *syntax example* (`@agent-name: …`). Echoing it back makes the
+    // coordinator appear to delegate to an agent called `agent-name`, and the
+    // run dies before it can report anything. `true` answers with an empty
+    // string, which is enough: what this file measures is the usage the
+    // provider reports (zero, and reported as such), not the content.
+    for agent in ["lead", "worker"] {
+        std::fs::write(
+            root.join(format!("agents/{agent}.md")),
+            format!(
+                "# {agent}\n\n## Metadata\n- provider: cli\n- command: true\n\n\
+                 ## System Prompt\nYou are {agent}. Answer directly.\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    (dir, root)
+}
+
+/// `armadai run lead <input> --json` in a project whose `orchestration:`
+/// block selects the hierarchical pattern (`--orchestrate` only accepts
+/// `blackboard`/`ring`), with both the config dir and the data dir redirected
+/// into the sandbox — else the shadowing check reads the developer's global
+/// agent library and `record_run` writes their real SQLite database.
+///
+/// Returns stdout, having first insisted the run succeeded: a mistyped flag
+/// or a missing agent would otherwise leave every "no warning was emitted"
+/// assertion below trivially true.
+fn run_orchestrated(root: &Path) -> String {
+    let sandbox = root.parent().unwrap();
+    let config = sandbox.join("config");
+    let data = sandbox.join("data");
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+
+    let out = Command::cargo_bin("armadai")
+        .unwrap()
+        .current_dir(root)
+        .env("ARMADAI_CONFIG_DIR", &config)
+        .env("XDG_DATA_HOME", &data)
+        .args(["run", "lead", "TASK-BUDGET", "--json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "the run must succeed — the notice is a warning, not a failure\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.lines().any(|l| l.contains("\"t\":\"result\"")),
+        "the run must have reached its result event\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    stdout
+}
+
+/// Every `warning` event carrying `code`, in emission order.
+fn warnings_with_code(stdout: &str, code: &str) -> Vec<serde_json::Value> {
+    stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(|v| v["t"] == "warning" && v["code"] == code)
+        .collect()
+}
+
+const CODE: &str = "budget_usage_unreported";
+
+#[test]
+fn a_budget_fed_no_usage_is_reported_exactly_once() {
+    let (_dir, root) = project("  token_budget: 100000\n");
+    let stdout = run_orchestrated(&root);
+
+    assert_eq!(
+        warnings_with_code(&stdout, CODE).len(),
+        1,
+        "expected exactly one {CODE} warning\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn a_cost_limit_fed_no_usage_is_reported_too() {
+    let (_dir, root) = project("  cost_limit: 5.0\n");
+    let stdout = run_orchestrated(&root);
+
+    assert_eq!(
+        warnings_with_code(&stdout, CODE).len(),
+        1,
+        "a cost_limit is as inoperative as a token_budget when usage is never \
+         reported\nstdout: {stdout}"
+    );
+}
+
+/// The half that keeps the notice honest: a project that configures no
+/// ceiling has nothing inoperative, so it must stay silent.
+#[test]
+fn a_run_with_no_budget_configured_says_nothing() {
+    let (_dir, root) = project("");
+    let stdout = run_orchestrated(&root);
+
+    assert!(
+        warnings_with_code(&stdout, CODE).is_empty(),
+        "no budget was configured, so nothing is inoperative\nstdout: {stdout}"
+    );
+}

--- a/docs/ai-agent-prompt.md
+++ b/docs/ai-agent-prompt.md
@@ -45,7 +45,7 @@ An ArmadAI agent is a Markdown file (`.md`) that defines an AI-powered specialis
 | `openai` | API only | `model` field, `OPENAI_API_KEY` env var |
 | `google` | API only | `model` field, `GOOGLE_API_KEY` env var |
 | `cli` | CLI only | `command` field (e.g. `command: claude`) |
-| `proxy` | API proxy | `model` field, proxy running via `armadai up` |
+| `proxy` | Any OpenAI-compatible server | `model` field, `PROXY_BASE_URL` (or `providers.proxy.base_url`) pointing at the gateway or local runtime |
 
 ## Known Models
 

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -90,7 +90,10 @@ Available models: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku
 - temperature: 0.7
 ```
 
-Available models: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `o1`, `o3-mini` — plus anything else your endpoint serves.
+Available models: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`,
+`gpt-4.1-nano`, `o1`, `o1-mini`, `o3-mini` — plus anything else your endpoint
+serves. That is the same list `metadata().models` advertises and the same one
+the cost table prices; a test keeps the two from drifting apart.
 
 Requires `OPENAI_API_KEY` (see [Secret Management](#secret-management)). Both
 `complete()` and streaming are supported.
@@ -101,8 +104,18 @@ same code path.
 
 > **Reasoning models (`o1`, `o3`).** They reject `max_tokens` and any
 > `temperature` other than `1`. ArmadAI only sends `max_tokens` when the agent
-> declares one, so leave it out for those models; `temperature` is always sent,
-> so set `temperature: 1.0`.
+> declares one, so leave it out for those models. `temperature` **is** always
+> sent, so set `temperature: 1.0` explicitly.
+>
+> The asymmetry is a property of the domain type, not an oversight:
+> `max_tokens` is an `Option` in an agent's metadata, so "the author did not
+> ask for one" is representable and the field can simply be left off the wire.
+> `temperature` is a plain number defaulting to `0.7`, so there is no value
+> that means "unset" — omitting it would require guessing which `0.7` was
+> deliberate. Dropping it for model ids that look like reasoning models was
+> considered and rejected: a gateway can serve anything under any name, and
+> silently discarding an author's `temperature: 0.2` is worse than the clear
+> `400` OpenAI returns, which names the parameter and the value.
 
 ### Google
 
@@ -193,9 +206,12 @@ Resolved in this order, first match wins:
 2. `providers.proxy.base_url` in `providers.yaml`
 3. `http://localhost:4000/v1` (the default LiteLLM port)
 
-`openai` follows the same two-step override with `OPENAI_BASE_URL` /
-`providers.openai.base_url`. `anthropic` and `google` honour only their own
-`ANTHROPIC_BASE_URL` / `GOOGLE_BASE_URL` variable.
+All four API providers follow the same two-step override — the environment
+variable first, then `providers.<name>.base_url` in `providers.yaml`:
+`OPENAI_BASE_URL`, `PROXY_BASE_URL`, `ANTHROPIC_BASE_URL`, `GOOGLE_BASE_URL`.
+`armadai init` writes a `base_url` for all four in that file, so a value put
+there is honoured whichever provider it belongs to. A blank value is not a
+configuration and is ignored, in either source.
 
 ### Authentication is optional
 
@@ -265,6 +281,33 @@ export PROXY_BASE_URL=http://localhost:4000/v1
   `$0.00` in `armadai costs` rather than an invented figure. A response that
   carries no `usage` block at all — common on gateways and local runtimes —
   reports zero tokens and zero cost; the call itself still succeeds.
+
+  One consequence is worth knowing before you rely on a ceiling: an
+  orchestrated run's `token_budget` and `cost_limit` are enforced from those
+  same numbers, so against an endpoint that never reports `usage` they never
+  trigger, and each nested delegation is handed the full ceiling rather than
+  what is left of it. ArmadAI says so once per run — a `budget_usage_unreported`
+  warning on `--json`, and a log line otherwise — rather than letting the limit
+  look enforced.
+
+### Errors that arrive with a `200`
+
+Not every failure on this path comes with a failing status code. Ollama and
+LiteLLM in pass-through mode answer `200` with `{"error": {...}}` in the body,
+and once a *stream* has started the status line is already gone — OpenAI's own
+documented behaviour for anything that fails mid-stream is to send the error as
+an SSE frame. ArmadAI treats both as errors rather than as an empty answer:
+
+- a non-streaming `200` whose body carries an error envelope and no `choices`
+  fails with the server's own message;
+- an error frame mid-stream ends the stream with that message, instead of
+  quietly delivering the tokens received so far as if they were the whole
+  answer.
+
+The reason this needs saying is that every field of an OpenAI-shaped response
+is optional here (`usage`, `model`, even `choices`, because real servers omit
+them), so an error envelope would otherwise parse cleanly into a successful,
+empty, free run.
 
 ### Rate limits and retries
 

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -1,6 +1,6 @@
 # Providers
 
-ArmadAI supports three types of providers for executing agents, plus **unified tool names** that auto-detect the best backend.
+ArmadAI supports three types of providers for executing agents — **API** (direct HTTP), **CLI** (run a command-line tool) and **proxy** (any OpenAI-compatible server) — plus **unified tool names** that auto-detect the best backend.
 
 ## Unified Tool Names (Recommended)
 
@@ -58,35 +58,58 @@ When using `armadai new -i` (interactive wizard), the model selection step fetch
 
 Direct HTTP calls to LLM APIs. Use these when you want explicit API control.
 
+> **Write a concrete model id for an API provider.** The tier placeholders
+> `latest:fast` / `latest:pro` / `latest:max` are resolved when ArmadAI
+> *generates a native CLI config* (`armadai link`) and by `armadai shell` — not
+> on the `armadai run` path, where only `latest:auto` is resolved (by the
+> router). A literal `latest:pro` on `provider: anthropic|openai|google|proxy`
+> — or on a unified name (`claude`, `gpt`, …) that has fallen back to the API
+> because its CLI is not installed — is sent to the server verbatim as the
+> model name, and the server rejects it. Measured on the current code, not a
+> hypothetical. Keeping `latest:pro` in an agent you link into a native CLI
+> config is fine and intended; it is the API path that takes it literally.
+
 ### Anthropic
 
 ```markdown
 ## Metadata
 - provider: anthropic
-- model: latest:pro
+- model: claude-sonnet-4-5-20250929
 - temperature: 0.3
 - max_tokens: 4096
 ```
 
-Available models: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001` — or use `latest:max`, `latest:pro`, `latest:fast`
+Available models: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`
 
 ### OpenAI
 
 ```markdown
 ## Metadata
 - provider: openai
-- model: latest:pro
+- model: gpt-4o-mini
 - temperature: 0.7
 ```
 
-Available models: `gpt-4o`, `gpt-4o-mini`, `o1` — or use `latest:pro`, `latest:fast`, `latest:max`
+Available models: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `o1`, `o3-mini` — plus anything else your endpoint serves.
+
+Requires `OPENAI_API_KEY` (see [Secret Management](#secret-management)). Both
+`complete()` and streaming are supported.
+
+The base URL defaults to `https://api.openai.com/v1` and can be redirected —
+see [OpenAI-compatible servers](#openai-compatible-servers) below, which is the
+same code path.
+
+> **Reasoning models (`o1`, `o3`).** They reject `max_tokens` and any
+> `temperature` other than `1`. ArmadAI only sends `max_tokens` when the agent
+> declares one, so leave it out for those models; `temperature` is always sent,
+> so set `temperature: 1.0`.
 
 ### Google
 
 ```markdown
 ## Metadata
 - provider: google
-- model: latest:pro
+- model: gemini-2.5-pro
 - temperature: 0.7
 ```
 
@@ -97,8 +120,8 @@ Declare fallback models for automatic retry when the primary model is unavailabl
 ```markdown
 ## Metadata
 - provider: google
-- model: latest:max
-- model_fallback: [latest:pro, latest:fast]
+- model: gemini-2.5-pro
+- model_fallback: [gemini-2.5-flash, gemini-2.0-flash]
 ```
 
 If the primary model returns a "model not found" error, ArmadAI automatically retries with each fallback in order. Non-model errors (auth, rate limit) are not retried.
@@ -142,25 +165,118 @@ eventually.
 
 > **Note:** For standard tools (claude, gemini, gpt, aider), prefer using the unified tool name (`provider: claude`) instead of `provider: cli` + `command: claude`. The unified names auto-detect CLI availability and provide sensible defaults.
 
-## Proxy Provider
+## OpenAI-compatible servers
 
-Route requests through an OpenAI-compatible proxy like LiteLLM or OpenRouter.
+`POST {base_url}/chat/completions` (plus SSE for streaming) is spoken by far
+more than OpenAI itself. `provider: proxy` is exactly the `openai` provider
+with a user-supplied base URL and an **optional** API key, so a single
+implementation reaches:
+
+| Kind | Examples | Base URL shape |
+|---|---|---|
+| Gateways | LiteLLM, OpenRouter, Groq, Together, Fireworks | `https://openrouter.ai/api/v1` |
+| Vendor endpoints | DeepSeek, Mistral | `https://api.deepseek.com/v1` |
+| Local runtimes | Ollama, vLLM, LM Studio, llama.cpp | `http://localhost:11434/v1` |
 
 ```markdown
 ## Metadata
 - provider: proxy
-- model: latest:pro
+- model: openai/gpt-4o-mini
+- temperature: 0.7
 ```
 
-### Setting up LiteLLM
+### Where the base URL comes from
 
-Start the proxy with Docker Compose:
+Resolved in this order, first match wins:
+
+1. `PROXY_BASE_URL` (environment variable)
+2. `providers.proxy.base_url` in `providers.yaml`
+3. `http://localhost:4000/v1` (the default LiteLLM port)
+
+`openai` follows the same two-step override with `OPENAI_BASE_URL` /
+`providers.openai.base_url`. `anthropic` and `google` honour only their own
+`ANTHROPIC_BASE_URL` / `GOOGLE_BASE_URL` variable.
+
+### Authentication is optional
+
+`PROXY_API_KEY` (or a `proxy:` entry in the secrets file) is sent as
+`Authorization: Bearer …`. If neither is set, **no `Authorization` header is
+sent at all** — which is what a keyless local gateway or an Ollama server
+expects. An empty `Bearer ` would be rejected by several servers, so it is
+never sent.
+
+### Example: a hosted gateway (OpenRouter)
 
 ```bash
-armadai up
+export PROXY_BASE_URL=https://openrouter.ai/api/v1
+export PROXY_API_KEY=sk-or-v1-…
 ```
 
-This starts LiteLLM on port 4000 (configured in `docker-compose.yml`).
+```markdown
+## Metadata
+- provider: proxy
+- model: anthropic/claude-sonnet-4.5
+```
+
+### Example: a local runtime (Ollama)
+
+Ollama exposes an OpenAI-compatible surface and needs no key:
+
+```bash
+ollama serve            # listens on 11434
+export PROXY_BASE_URL=http://localhost:11434/v1
+```
+
+```markdown
+## Metadata
+- provider: proxy
+- model: llama3.1
+- temperature: 0.7
+```
+
+The same shape works for vLLM (`http://localhost:8000/v1`), LM Studio
+(`http://localhost:1234/v1`) and llama.cpp's server.
+
+### Example: LiteLLM via Docker Compose
+
+`docker-compose.yml` ships a LiteLLM service, but it sits behind the `proxy`
+compose profile and mounts a config file you provide, so plain `armadai up`
+does **not** start it:
+
+```bash
+# write your own config/litellm.yaml first (model_list: …)
+docker compose --profile proxy up -d litellm
+export PROXY_BASE_URL=http://localhost:4000/v1
+```
+
+### What is not supported
+
+- **Azure OpenAI.** It diverges from the dialect on three axes: an `api-key`
+  header instead of `Authorization: Bearer`, deployment-scoped paths
+  (`/openai/deployments/{deployment}/chat/completions`) and a mandatory
+  `api-version` query parameter. ArmadAI does not handle it, and pointing
+  `base_url` at an Azure endpoint will fail. Reach Azure through a gateway
+  (LiteLLM) that presents an OpenAI-shaped front instead.
+- **Tool/function calling, structured outputs, images, audio.** An ArmadAI
+  agent exchanges plain text, so these have nothing to map onto.
+- **Cost for unknown models.** Only OpenAI's own model ids are priced
+  (`gpt-4o`, `gpt-4o-mini`, the `gpt-4.1` family, `o1`, `o1-mini`, `o3-mini`,
+  with any vendor prefix such as `openai/` stripped). Anything else reports
+  `$0.00` in `armadai costs` rather than an invented figure. A response that
+  carries no `usage` block at all — common on gateways and local runtimes —
+  reports zero tokens and zero cost; the call itself still succeeds.
+
+### Rate limits and retries
+
+Every HTTP provider, this one included, goes through the same retry policy:
+`429`, `503` and `529` are retried with exponential backoff (up to 3 retries),
+honouring the server's `Retry-After` header when it sends one in
+delta-seconds form. Other statuses — `400`, `401`, `404` — are terminal and
+surfaced immediately with the server's own message.
+
+An agent can also throttle itself before it hits the wire with the
+`rate_limit` metadata field (`"10/min"`), and a per-provider ceiling can be
+set under `rate_limits` in `config.yaml`.
 
 ## Secret Management
 
@@ -228,16 +344,27 @@ Shows configured providers, secrets status (encrypted/unencrypted/missing), and 
 
 ## Provider Configuration
 
-Global provider settings are in `config/providers.yaml`:
+Global provider settings live in `providers.yaml` (`~/.config/armadai/providers.yaml`,
+falling back to a project-local `config/providers.yaml`):
 
 ```yaml
 providers:
-  anthropic:
-    base_url: https://api.anthropic.com
-    default_model: latest:pro
   openai:
     base_url: https://api.openai.com/v1
-    default_model: latest:pro
+    models:
+      - gpt-4o
+      - gpt-4o-mini
   proxy:
-    base_url: http://localhost:4000
+    base_url: http://localhost:11434/v1
+    models: []
 ```
+
+Two keys are read, and only these two:
+
+| Key | Read by |
+|---|---|
+| `base_url` | provider construction, for `openai` and `proxy` only (see [above](#where-the-base-url-comes-from)) |
+| `models` | the `armadai new -i` wizard, as the fallback model list when models.dev is unreachable |
+
+There is no `default_model` key — the model comes from the agent's `## Metadata`
+(or `defaults.model` in `config.yaml`).


### PR DESCRIPTION
Ferme #368.

## Le point de départ, corrigé

L'issue dit que les `todo!()` de `openai.rs`/`proxy.rs` font paniquer l'utilisateur. **Ce n'est pas ce qui se passait** : `factory.rs` interceptait les deux noms en amont avec `bail!("... is not yet implemented")`, donc les deux providers n'étaient jamais construits et leurs `todo!()` jamais atteints. L'utilisateur recevait une erreur propre — mais un cul-de-sac quand même, et sur **quatre** configurations, parce que le repli API documenté par `create_provider` (« CLI absent → API ») ne menait nulle part pour `gpt` et `aider`.

Il y avait donc **trois** endroits à traiter, pas deux : les deux stubs, plus le bras `"openai" | "proxy"` de `create_api_provider`.

## Ce qui est implémenté

Une seule implémentation du protocole, dans `crates/armadai-providers/src/api/openai_compatible.rs` : `POST {base_url}/chat/completions` + SSE. `OpenAiProvider` et `ProxyProvider` s'y branchent tous les deux via un `Endpoint` emprunté ; ils ne diffèrent que par leurs valeurs par défaut et par l'existence ou non d'une clé. Une implémentation ouvre OpenAI, les passerelles (LiteLLM, OpenRouter, Groq, Together, Fireworks, DeepSeek, Mistral) et les runtimes locaux (Ollama, vLLM, LM Studio, llama.cpp).

Écrit pour le dialecte, pas pour `api.openai.com` :

- `usage` absent ou `null` → compteurs à zéro, l'appel réussit ;
- `id`, `model`, `finish_reason`, `system_fingerprint` peuvent manquer ; sans `model`, on rend celui demandé ;
- `choices: []` (réponse **et** chunk de streaming) et `delta.content: null` sont ignorés, jamais indexés ;
- SSE : séparateurs `\n\n`, `\r\n\r\n` **ou** `\r\r`, `data:` avec ou sans espace, lignes `data:` consécutives jointes par `\n` (ce que la spec impose), dernier événement sans ligne vide terminale ;
- le corps est bufferisé en **octets** et décodé par événement complet, donc un caractère UTF-8 coupé entre deux paquets est recollé (les deux providers existants le massacreraient) ;
- `max_tokens` n'est envoyé que si l'agent en déclare un (o1/o3 le refusent), et `stream_options` n'est pas envoyé du tout : il achèterait les tokens chez OpenAI au prix d'un 400 chez tous les serveurs qui ignorent le champ ;
- `proxy` sans clé → **aucun** en-tête `Authorization` (un `Bearer ` vide est rejeté par plusieurs serveurs).

Les deux exigences non négociables : tout passe par `api::retry::send_with_retry` (429/503/529, backoff, `Retry-After`), et `metadata().supports_streaming` reste `true` — désormais vrai.

## Câblage

`create_api_provider` construit les deux providers. `openai` et `proxy` résolvent leur `base_url` par variable d'environnement (`OPENAI_BASE_URL` / `PROXY_BASE_URL`), puis `providers.yaml`, puis un défaut — c'est ce levier qui rend `proxy` capable de viser une passerelle ou un runtime local. La clé de `proxy` est optionnelle.

Effet de bord utile : `linker/model_resolution.rs:19` classe la cible **`codex`** en `LlmEditor { provider: "openai" }` ; sa résolution de modèle repose donc sur ce provider.

## Vérifié à l'exécution, pas seulement au compilateur

Sonde sur le binaire réel (`target/debug/armadai run`) contre un serveur OpenAI-compatible local — les quatre configurations de l'issue, toutes exit 0 :

| Config | Chemin reçu | Authorization | Modèle envoyé |
|---|---|---|---|
| `provider: openai` | `/v1/chat/completions` | `Bearer sk-probe` | `gpt-4o-mini` |
| `provider: proxy` (sans clé) | `/v1/chat/completions` | **absent** | `llama3.1` |
| `provider: gpt` (CLI absent) | `/v1/chat/completions` | `Bearer sk-gpt` | `gpt-4o-mini` |
| `provider: aider` (CLI absent) | `/v1/chat/completions` | `Bearer sk-aider` | `gpt-4o-mini` |

La réponse de la sonde n'a **pas** de bloc `usage` : la tolérance passerelle est prouvée de bout en bout, pas seulement en test unitaire.

## Tests : vrai trafic, aucune clé, aucun réseau externe

Le `ScriptedServer` de `retry.rs` est **extrait** dans `api/test_server.rs` (partagé, pas dupliqué) et étendu : corps écrits en plusieurs `write_all` séparés avec `TCP_NODELAY` et une pause (fragmentation réelle), corps non framés délimités par la fermeture de connexion (forme d'une réponse SSE), et capture de la requête reçue (pour prouver l'absence d'en-tête `Authorization`).

**48 tests ajoutés**, et chacun vérifié par mutation : **29 mutations, toutes rouges**. Deux mutations ont survécu au premier essai et ont révélé de vrais tests inertes, corrigés :

- le test de troncature multi-octets utilisait un caractère de **2** octets, si bien que l'offset 500 tombait pile sur une frontière — une implémentation qui tranche par octet le passait indemne. Fixture repassée sur un caractère de 3 octets ;
- le test CRLF de bout en bout passait même en supprimant le support CRLF, parce que le vidage de fin de flux le rattrapait. Scindé, puis borné **par le défaut** (premier token < 250 ms là où le défaut le repousserait à ~630 ms). Cette borne a tenu — 1150 exécutions, pire cas 161 ms — mais la vague de revue ci-dessous l'a remplacée par une forme catégorielle.

Une troisième mutation a montré que deux de mes `#[serde(default)]` étaient redondants et qu'un cas — réponse **sans clé `choices`** — n'était couvert par rien ; commentaire corrigé (il affirmait quelque chose de faux) et test ajouté.

## Documentation

`docs/wiki/providers.md` était l'origine de l'issue. Trois autres affirmations fausses y sont corrigées plutôt que laissées en place :

- `armadai up` ne démarre **pas** LiteLLM (service derrière le profil compose `proxy`, montant un `config/litellm.yaml` que le dépôt ne fournit pas) ;
- `providers.yaml` était documenté avec une clé `default_model` que rien ne lit ;
- `latest:pro` / `latest:fast` / `latest:max` étaient proposés comme modèles pour les providers API. **Seul `latest:auto` est résolu sur le chemin `armadai run`** — mesuré : un `latest:pro` part littéralement comme nom de modèle. Les paliers sont résolus par `armadai link` et `armadai shell`.

Ajouté : passerelles et runtimes atteignables, ordre de résolution de `base_url`, authentification optionnelle, un exemple passerelle (OpenRouter) et un exemple local (Ollama), et ce qui n'est **pas** supporté — Azure OpenAI (en-tête `api-key`, chemins de déploiement, `api-version` en query : forme trop divergente pour la traiter sans brancher sur le vendeur en trois endroits ; passer par une passerelle), les tool calls, et le coût des modèles hors identifiants OpenAI (`$0.00` plutôt qu'un prix inventé).

## Vague de correctifs de revue (CHANGES REQUESTED)

Rebasée sur `master` à jour. #372 supprime `armadai_core::config::ENV_MUTEX` ; le rebase ne signale **aucun conflit** et la compilation cassait ensuite (`E0432: unresolved import`), parce que le commit de fonctionnalité s'était écrit son propre `EnvScope` — une n-ième copie du garde que #372 existe précisément pour supprimer, pendant que mes propres doc-comments dénonçaient deux fois cette classe de défaut. `EnvScope` est supprimé ; les tests passent par `armadai_core::test_support::IsolatedConfigDir`, qui gagne un `with_var(name, value)` pour les variables que le code sous test lit en plus de `ARMADAI_CONFIG_DIR`.

**Un `200` porteur d'une enveloppe d'erreur ne passe plus pour une réponse vide.** Trois variantes, même cause — tous les champs de la réponse sont optionnels ici (à dessein : les vrais serveurs les omettent), donc plus rien ne fait échouer un corps qui n'est pas une complétion. `anthropic`/`google` sont protégés par accident (`missing field 'content'` / `'candidates'`).

1. Non-streaming : `{"error":{...}}` avec un statut 200 rendait `Ok(content: "", tokens_in: 0, cost: 0.0)` — un run enregistré comme réussi et gratuit. Ollama et LiteLLM en pass-through répondent réellement ainsi.
2. Trame d'erreur en cours de flux : indistinguable d'un keep-alive, donc réponse tronquée présentée comme complète. Ce n'est pas exotique : une fois le 200 parti, une trame SSE est le seul canal qui reste, et c'est le comportement documenté d'OpenAI.
3. Requête streaming répondue par un corps JSON d'erreur sans cadrage SSE : aucune ligne `data:`, donc flux vide et réussi.

`is_error_body` tranche les trois et reste étroit : membre `error` non nul, ou `{"object":"error"}` de vLLM. Un `message`/`detail` seul n'est pas une preuve.

**Deux autres modes « vide silencieux » fermés dans le même geste** : le cadrage `\r` seul (SSE légal — un lecteur qui l'ignore n'émet rien jusqu'à EOF, et rien du tout si la connexion reste ouverte) et les lignes `data:` consécutives, qui forment **un** champ joint par `\n`.

**Le test d'arrivée CRLF est devenu catégoriel.** `ScriptedServer` gagne une grille : il écrit le premier chunk puis garde la connexion ouverte jusqu'à `release()`. Sans EOF pour rattraper une frontière non reconnue, un lecteur aveugle ne produit **rien** au lieu des mêmes tokens plus tard ; le `timeout(5 s)` est un garde anti-blocage, pas un seuil. Mesuré sous mutation : échec en 5,02 s (le flux ne rend rien et ne se termine jamais), contre un échec immédiat sur assertion de contenu.

**`providers.yaml` : les quatre providers lisent `base_url`.** `armadai init` en écrit un pour les quatre ; avant cette PR aucun n'était lu (fichier uniformément décoratif), après elle deux l'étaient et deux l'ignoraient en silence — pire que les deux extrémités. C'est la PR qui créait l'incohérence, donc c'est la lecture qui est élargie, pas le fichier qui est amputé. Effet de bord : une valeur vide n'est plus une configuration (`ANTHROPIC_BASE_URL=""` blanchissait l'URL du vendeur).

**Une liste de modèles, pas trois.** `metadata().models` porte exactement les identifiants que la table de prix connaît, et un test tient l'invariant plutôt que de recopier la liste. Le sens compte : un modèle annoncé mais non tarifé rapporte `$0.00` pour une dépense réelle.

**Un budget qui ne reçoit aucun usage est signalé une fois.** `token_budget`/`cost_limit` s'appliquent depuis des compteurs alimentés par `CompletionResponse`, qui ne sait pas dire « inconnu ». Face à un endpoint qui omet `usage`, le plafond ne se déclenche jamais **et chaque sous-délégation reçoit le plafond d'origine intégral** — le défaut que #345 vient de fermer, rouvert par les données ; `remaining_ratio` reste à 1.0, donc `budget_downgrade_ratio` n'engage pas. Rien n'est non borné (`max_iterations`, `max_depth`, `MAX_ITERATIONS`), mais un plafond qui a l'air appliqué sans l'être mérite une ligne : un `RunEvent::Warning{code: "budget_usage_unreported"}` par run orchestré, plus une ligne de log. Le correctif de fond (`Option` de bout en bout jusqu'au schéma SQLite) n'est pas tenté ici.

**`temperature` : asymétrie assumée, et enfin justifiée.** `max_tokens` est un `Option` dans les métadonnées d'un agent, donc « non demandé » est représentable ; `temperature` est un nombre valant 0.7 par défaut, donc aucune valeur ne signifie « non défini ». Le supprimer pour les identifiants qui *ressemblent* à des modèles de raisonnement a été envisagé et écarté : une passerelle sert n'importe quoi sous n'importe quel nom, et jeter en silence un `temperature: 0.2` d'auteur est pire que le `400` d'OpenAI, qui nomme le paramètre et la valeur.

Chaque test ajouté a été vérifié par mutation (15 mutations dans cette vague, toutes rouges sur le test visé). Une a survécu au premier essai et a révélé un test inerte : la première version du test `base_url` assertait le retour de `resolve_base_url`, jamais le bras du factory — remplacée par deux tests qui construisent le provider via `create_provider` et le font appeler un serveur local scripté.

## Gate

- `cargo fmt --all -- --check` : propre
- clippy `-D warnings` : **5/5 modes** verts
- tests : **4/4 modes** verts — 1420 / 1463 / 1515 / 1547 réussis, 0 échec
- gaveldrop : **13 cas · 83/83**, inchangé

## Laissé de côté, sciemment

- **Azure OpenAI** : documenté comme non supporté (voir ci-dessus).
- **Résolution de `latest:*` sur le chemin `run`** : défaut préexistant, indépendant de ce protocole, qui touche `cli/run.rs` et les quatre runners event-sourcés. Documenté ici, mérite son issue.
- **Usage inconnu porté comme `Option` de bout en bout** : `json_runner.rs`'s `CliResponse` distingue déjà « absent » de « zéro », mais propager cette distinction atteint `CompletionResponse`, le journal d'événements et le schéma SQLite. Mérite son issue ; l'avertissement ci-dessus est le palliatif minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
