### PR TITLE
build(deps): bump sha2 to 0.11 and pin the digest spelling against it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.11.0",
  "strip-ansi-escapes",
  "tempfile",
  "thiserror 2.0.20",
@@ -354,6 +354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +636,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -726,8 +750,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1142,6 +1177,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2582,7 +2626,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2872,7 +2927,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -3489,7 +3544,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 rusqlite = { version = "0.40", features = ["bundled"] }
 uuid = { version = "1" }
 tempfile = "3"
-sha2 = "0.10"
+sha2 = "0.11"

--- a/crates/armadai/src/linker/manifest.rs
+++ b/crates/armadai/src/linker/manifest.rs
@@ -159,10 +159,24 @@ pub struct Manifest {
 }
 
 /// `sha256:<hex>` of `content`.
+///
+/// The hex is written out byte by byte rather than through `{:x}`: sha2 0.11
+/// returns a `hybrid_array::Array`, which does not implement `LowerHex`. The
+/// output must stay identical across that change — every `digest:` already
+/// written into a project's `.armadai/link-manifest.yaml` is compared against
+/// it, and a different spelling would make `unlink` refuse to reclaim the very
+/// files `link` wrote. `digest_of_matches_the_canonical_sha256_vectors` pins
+/// that against published SHA-256 test vectors, so it holds for any version.
 pub fn digest_of(content: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content);
-    format!("sha256:{:x}", hasher.finalize())
+    let mut out = String::with_capacity(7 + 64);
+    out.push_str("sha256:");
+    for byte in hasher.finalize() {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
 }
 
 /// The result of checking a `Created` entry's digest against what is
@@ -843,6 +857,27 @@ pub fn write_files(
 
 #[cfg(test)]
 mod tests {
+
+    /// Published SHA-256 vectors (FIPS 180-4 / RFC 6234). They are properties
+    /// of the algorithm, not of the crate, so this test is what makes a sha2
+    /// major bump safe: a digest spelling that drifted would break every
+    /// manifest already on disk, and `unlink` would refuse to reclaim files
+    /// `link` itself wrote.
+    #[test]
+    fn digest_of_matches_the_canonical_sha256_vectors() {
+        assert_eq!(
+            digest_of(b""),
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            digest_of(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            digest_of(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "sha256:248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        );
+    }
     use super::*;
 
     fn entry(path: &str, agent: &str, content: &[u8]) -> ManifestEntry {

--- a/crates/armadai/tests/link_manifest.rs
+++ b/crates/armadai/tests/link_manifest.rs
@@ -57,7 +57,16 @@ mod tests {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(content);
-        format!("sha256:{:x}", hasher.finalize())
+        // Byte-wise, like `manifest::digest_of`: sha2 0.11's `finalize()`
+        // returns a type without `LowerHex`. Kept as an independent
+        // re-implementation so this stays a real cross-check of the
+        // production digest rather than a call to it.
+        let mut out = String::from("sha256:");
+        for byte in hasher.finalize() {
+            use std::fmt::Write as _;
+            let _ = write!(out, "{byte:02x}");
+        }
+        out
     }
 
     fn read_manifest(root: &std::path::Path) -> String {


### PR DESCRIPTION
Reprend **#353** (Dependabot), qui échouait sur **Build, Clippy et Test**.

## Pourquoi ça cassait

sha2 0.11 rend un `hybrid_array::Array` depuis `finalize()`, qui **n'implémente pas `LowerHex`** — donc `format!("{:x}", …)` ne compile plus :

```
error[E0277]: the trait bound `Array<u8, UInt<…>>: LowerHex` is not satisfied
```

## Le vrai risque n'est pas la compilation

`digest_of` produit le champ `digest:` de chaque `.armadai/link-manifest.yaml`, et `unlink` ne récupère un fichier que si son contenu hache toujours vers ce que `link` a enregistré. **Un digest dont l'orthographe change ferait refuser à `unlink` la suppression des fichiers que `link` a lui-même écrits** — exactement la forme de perte de données que #338 existe pour empêcher, arrivant cette fois par un bump de dépendance.

## La garantie, épinglée sur l'algorithme et non sur la crate

`digest_of_matches_the_canonical_sha256_vectors` assère trois vecteurs SHA-256 publiés (FIPS 180-4 / RFC 6234). Il a été **écrit et exécuté vert sous sha2 0.10 d'abord**, puis de nouveau après le bump :

```
sous 0.10 : test linker::manifest::tests::digest_of_matches_the_canonical_sha256_vectors ... ok
sous 0.11 : test linker::manifest::tests::digest_of_matches_the_canonical_sha256_vectors ... ok
```

Même sortie des deux côtés — **aucun manifeste déjà sur disque n'est invalidé**. Et comme les vecteurs sont une propriété de l'algorithme, la garantie vaut pour toute version future.

Le helper de test de `link_manifest.rs` portait le même `{:x}` et est corrigé pareillement, gardé comme ré-implémentation **indépendante** plutôt qu'un appel à `digest_of`, pour rester un vrai contrôle croisé du digest de production.

## Gate

fmt + **5 modes clippy** + **4 modes de test** + gaveldrop **13 cas · 83/83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)