### PR TITLE
docs: move the repeated constraints from briefs into the agent definitions

### DIFF
--- a/.claude/agents/cli-specialist.md
+++ b/.claude/agents/cli-specialist.md
@@ -32,3 +32,42 @@ Provide implementation with:
 2. Full execute function implementation
 3. User-facing output format (what the user sees)
 4. Integration points with core modules
+
+## Non-negotiables (you own these; a brief will not repeat them)
+
+**Never use a background job** (`&`, `run_in_background`, `nohup`). Foreground only, wait for
+each command — a `cargo test` of several minutes included. Seventeen agents have stalled here.
+Do not fork: do the work yourself.
+
+**Measure, don't reason.** For every test you add or change: break the code it protects,
+confirm it goes red, restore, and report the mutation with the output you saw. A test still
+green under mutation proves nothing — this repo has 10 measured occurrences of that defect.
+The same applies to a fix handed to you by a code review: **it is a hypothesis, not a
+validated instruction** — mutate it before adopting it. Twice, a review's own proposed fix was
+itself a test that could not fail.
+
+**Measurement traps on this repo** (each has already invalidated someone's conclusion):
+- `crates/armadai` is **binary-only**: `cargo test --lib` returns `0 passed` with **no error**.
+  Use `--bin armadai` for its unit tests, `--test <name>` for integration. A "0 passed" is an
+  alarm, not a success. Library crates (`armadai-core`, `-providers`, `-storage`) take `-p`.
+- **Always `--no-fail-fast`**: without it cargo stops at the first failing target, so a mutation
+  that breaks 19 tests can look like it breaks 3.
+- `--exact` needs the **full** test path, or the filter selects nothing and "N passed" can mean
+  "zero tests ran".
+- Env-mutating tests share one lock via `armadai_core::test_support::env_lock()`, which is
+  **not reentrant** — two guards on one thread deadlock, with no error message.
+
+**Gate before pushing** — fmt, clippy `-D warnings` in **5** feature modes, tests in **4**,
+and gaveldrop must stay **13 cases · 83/83**. The exact commands are in the root `CLAUDE.md`.
+
+**Conventions**: Conventional Commits, **one type only** per subject (`docs/test(x):` is
+invalid). Commit trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`. Code,
+comments and commit messages in **English**; PR bodies in **French**. Open the PR, never merge —
+that decision is not yours.
+
+**rust-analyzer is unreliable here** (false ABI mismatches, stale mid-edit snapshots). Verify
+everything at the compiler.
+
+**Report honestly.** If part of the scope turns out bigger than briefed, deliver the rest in
+full and say precisely what you left and why. Never narrow silently. If you judge a briefed
+point wrong, say so — with the measurement that makes you say it.

--- a/.claude/agents/core-specialist.md
+++ b/.claude/agents/core-specialist.md
@@ -39,3 +39,42 @@ Provide implementation with:
 2. New types/traits with full signatures
 3. Integration points with other modules
 4. Edge cases and error handling considerations
+
+## Non-negotiables (you own these; a brief will not repeat them)
+
+**Never use a background job** (`&`, `run_in_background`, `nohup`). Foreground only, wait for
+each command — a `cargo test` of several minutes included. Seventeen agents have stalled here.
+Do not fork: do the work yourself.
+
+**Measure, don't reason.** For every test you add or change: break the code it protects,
+confirm it goes red, restore, and report the mutation with the output you saw. A test still
+green under mutation proves nothing — this repo has 10 measured occurrences of that defect.
+The same applies to a fix handed to you by a code review: **it is a hypothesis, not a
+validated instruction** — mutate it before adopting it. Twice, a review's own proposed fix was
+itself a test that could not fail.
+
+**Measurement traps on this repo** (each has already invalidated someone's conclusion):
+- `crates/armadai` is **binary-only**: `cargo test --lib` returns `0 passed` with **no error**.
+  Use `--bin armadai` for its unit tests, `--test <name>` for integration. A "0 passed" is an
+  alarm, not a success. Library crates (`armadai-core`, `-providers`, `-storage`) take `-p`.
+- **Always `--no-fail-fast`**: without it cargo stops at the first failing target, so a mutation
+  that breaks 19 tests can look like it breaks 3.
+- `--exact` needs the **full** test path, or the filter selects nothing and "N passed" can mean
+  "zero tests ran".
+- Env-mutating tests share one lock via `armadai_core::test_support::env_lock()`, which is
+  **not reentrant** — two guards on one thread deadlock, with no error message.
+
+**Gate before pushing** — fmt, clippy `-D warnings` in **5** feature modes, tests in **4**,
+and gaveldrop must stay **13 cases · 83/83**. The exact commands are in the root `CLAUDE.md`.
+
+**Conventions**: Conventional Commits, **one type only** per subject (`docs/test(x):` is
+invalid). Commit trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`. Code,
+comments and commit messages in **English**; PR bodies in **French**. Open the PR, never merge —
+that decision is not yours.
+
+**rust-analyzer is unreliable here** (false ABI mismatches, stale mid-edit snapshots). Verify
+everything at the compiler.
+
+**Report honestly.** If part of the scope turns out bigger than briefed, deliver the rest in
+full and say precisely what you left and why. Never narrow silently. If you judge a briefed
+point wrong, say so — with the measurement that makes you say it.

--- a/.claude/agents/provider-specialist.md
+++ b/.claude/agents/provider-specialist.md
@@ -29,3 +29,42 @@ Provide implementation with:
 2. Trait implementations with full method signatures
 3. Error handling strategy (anyhow for fallible, Option for optional data)
 4. Cache/network interaction patterns
+
+## Non-negotiables (you own these; a brief will not repeat them)
+
+**Never use a background job** (`&`, `run_in_background`, `nohup`). Foreground only, wait for
+each command — a `cargo test` of several minutes included. Seventeen agents have stalled here.
+Do not fork: do the work yourself.
+
+**Measure, don't reason.** For every test you add or change: break the code it protects,
+confirm it goes red, restore, and report the mutation with the output you saw. A test still
+green under mutation proves nothing — this repo has 10 measured occurrences of that defect.
+The same applies to a fix handed to you by a code review: **it is a hypothesis, not a
+validated instruction** — mutate it before adopting it. Twice, a review's own proposed fix was
+itself a test that could not fail.
+
+**Measurement traps on this repo** (each has already invalidated someone's conclusion):
+- `crates/armadai` is **binary-only**: `cargo test --lib` returns `0 passed` with **no error**.
+  Use `--bin armadai` for its unit tests, `--test <name>` for integration. A "0 passed" is an
+  alarm, not a success. Library crates (`armadai-core`, `-providers`, `-storage`) take `-p`.
+- **Always `--no-fail-fast`**: without it cargo stops at the first failing target, so a mutation
+  that breaks 19 tests can look like it breaks 3.
+- `--exact` needs the **full** test path, or the filter selects nothing and "N passed" can mean
+  "zero tests ran".
+- Env-mutating tests share one lock via `armadai_core::test_support::env_lock()`, which is
+  **not reentrant** — two guards on one thread deadlock, with no error message.
+
+**Gate before pushing** — fmt, clippy `-D warnings` in **5** feature modes, tests in **4**,
+and gaveldrop must stay **13 cases · 83/83**. The exact commands are in the root `CLAUDE.md`.
+
+**Conventions**: Conventional Commits, **one type only** per subject (`docs/test(x):` is
+invalid). Commit trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`. Code,
+comments and commit messages in **English**; PR bodies in **French**. Open the PR, never merge —
+that decision is not yours.
+
+**rust-analyzer is unreliable here** (false ABI mismatches, stale mid-edit snapshots). Verify
+everything at the compiler.
+
+**Report honestly.** If part of the scope turns out bigger than briefed, deliver the rest in
+full and say precisely what you left and why. Never narrow silently. If you judge a briefed
+point wrong, say so — with the measurement that makes you say it.

--- a/.claude/agents/qa-specialist.md
+++ b/.claude/agents/qa-specialist.md
@@ -77,3 +77,42 @@ Provide:
 2. Clippy/format fixes if needed
 3. CI configuration changes if pipeline needs updates
 4. Feature gate correctness verification
+
+## Non-negotiables (you own these; a brief will not repeat them)
+
+**Never use a background job** (`&`, `run_in_background`, `nohup`). Foreground only, wait for
+each command — a `cargo test` of several minutes included. Seventeen agents have stalled here.
+Do not fork: do the work yourself.
+
+**Measure, don't reason.** For every test you add or change: break the code it protects,
+confirm it goes red, restore, and report the mutation with the output you saw. A test still
+green under mutation proves nothing — this repo has 10 measured occurrences of that defect.
+The same applies to a fix handed to you by a code review: **it is a hypothesis, not a
+validated instruction** — mutate it before adopting it. Twice, a review's own proposed fix was
+itself a test that could not fail.
+
+**Measurement traps on this repo** (each has already invalidated someone's conclusion):
+- `crates/armadai` is **binary-only**: `cargo test --lib` returns `0 passed` with **no error**.
+  Use `--bin armadai` for its unit tests, `--test <name>` for integration. A "0 passed" is an
+  alarm, not a success. Library crates (`armadai-core`, `-providers`, `-storage`) take `-p`.
+- **Always `--no-fail-fast`**: without it cargo stops at the first failing target, so a mutation
+  that breaks 19 tests can look like it breaks 3.
+- `--exact` needs the **full** test path, or the filter selects nothing and "N passed" can mean
+  "zero tests ran".
+- Env-mutating tests share one lock via `armadai_core::test_support::env_lock()`, which is
+  **not reentrant** — two guards on one thread deadlock, with no error message.
+
+**Gate before pushing** — fmt, clippy `-D warnings` in **5** feature modes, tests in **4**,
+and gaveldrop must stay **13 cases · 83/83**. The exact commands are in the root `CLAUDE.md`.
+
+**Conventions**: Conventional Commits, **one type only** per subject (`docs/test(x):` is
+invalid). Commit trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`. Code,
+comments and commit messages in **English**; PR bodies in **French**. Open the PR, never merge —
+that decision is not yours.
+
+**rust-analyzer is unreliable here** (false ABI mismatches, stale mid-edit snapshots). Verify
+everything at the compiler.
+
+**Report honestly.** If part of the scope turns out bigger than briefed, deliver the rest in
+full and say precisely what you left and why. Never narrow silently. If you judge a briefed
+point wrong, say so — with the measurement that makes you say it.

--- a/.claude/agents/ui-specialist.md
+++ b/.claude/agents/ui-specialist.md
@@ -30,3 +30,42 @@ Provide implementation with:
 2. State changes needed in App struct (TUI) or API types (Web)
 3. View/handler implementation
 4. Keyboard bindings or API routes added
+
+## Non-negotiables (you own these; a brief will not repeat them)
+
+**Never use a background job** (`&`, `run_in_background`, `nohup`). Foreground only, wait for
+each command — a `cargo test` of several minutes included. Seventeen agents have stalled here.
+Do not fork: do the work yourself.
+
+**Measure, don't reason.** For every test you add or change: break the code it protects,
+confirm it goes red, restore, and report the mutation with the output you saw. A test still
+green under mutation proves nothing — this repo has 10 measured occurrences of that defect.
+The same applies to a fix handed to you by a code review: **it is a hypothesis, not a
+validated instruction** — mutate it before adopting it. Twice, a review's own proposed fix was
+itself a test that could not fail.
+
+**Measurement traps on this repo** (each has already invalidated someone's conclusion):
+- `crates/armadai` is **binary-only**: `cargo test --lib` returns `0 passed` with **no error**.
+  Use `--bin armadai` for its unit tests, `--test <name>` for integration. A "0 passed" is an
+  alarm, not a success. Library crates (`armadai-core`, `-providers`, `-storage`) take `-p`.
+- **Always `--no-fail-fast`**: without it cargo stops at the first failing target, so a mutation
+  that breaks 19 tests can look like it breaks 3.
+- `--exact` needs the **full** test path, or the filter selects nothing and "N passed" can mean
+  "zero tests ran".
+- Env-mutating tests share one lock via `armadai_core::test_support::env_lock()`, which is
+  **not reentrant** — two guards on one thread deadlock, with no error message.
+
+**Gate before pushing** — fmt, clippy `-D warnings` in **5** feature modes, tests in **4**,
+and gaveldrop must stay **13 cases · 83/83**. The exact commands are in the root `CLAUDE.md`.
+
+**Conventions**: Conventional Commits, **one type only** per subject (`docs/test(x):` is
+invalid). Commit trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`. Code,
+comments and commit messages in **English**; PR bodies in **French**. Open the PR, never merge —
+that decision is not yours.
+
+**rust-analyzer is unreliable here** (false ABI mismatches, stale mid-edit snapshots). Verify
+everything at the compiler.
+
+**Report honestly.** If part of the scope turns out bigger than briefed, deliver the rest in
+full and say precisely what you left and why. Never narrow silently. If you judge a briefed
+point wrong, say so — with the measurement that makes you say it.


### PR DESCRIPTION
Application de la doc *context engineering pour les modèles Claude 5* : « put instructions on how to use tools in the tool descriptions rather than the system prompt » — les modèles avancés n'ont pas besoin de redondance, et la répétition est l'anti-pattern.

## La mesure

Sur une nuit de délégation (17 agents), **aucune** des six définitions d'agents ne portait la règle anti-job-en-arrière-plan, les pièges de mesure, ni le gate :

```
cli-specialist       gate:0  anti-background:0  pieges-mesure:0
core-specialist      gate:0  anti-background:0  pieges-mesure:0
provider-specialist  gate:3  anti-background:0  pieges-mesure:0
qa-specialist        gate:4  anti-background:0  pieges-mesure:0
ui-specialist        gate:2  anti-background:0  pieges-mesure:0
```

Chaque brief les redisait donc — la règle anti-background **dix-sept fois**, soit ~400 mots de répétition pure par brief. Ces contraintes appartiennent à l'endroit où elles se chargent **une fois**.

## Le contenu est ce qui a réellement coûté du temps

Pas des conseils génériques. Chaque piège de mesure listé a déjà invalidé une conclusion réelle cette nuit :

- `cargo test --lib` qui rend « 0 passed » **sans erreur** sur un crate binaire seul — un relecteur a failli conclure à un mutant survivant
- un `--no-fail-fast` manquant faisant passer une mutation qui casse **19** tests pour une qui en casse 3
- `--exact` avec un chemin partiel qui ne sélectionne rien tout en rapportant « 240 PASS »
- le garde d'environnement **non réentrant** qui bloque sans message — 10 minutes de timeout

Plus la règle que cette nuit a produite : **un correctif fourni par une revue est une hypothèse, pas une consigne validée**, et doit être muté avant adoption. Deux fois le correctif proposé par une revue était lui-même un test qui ne peut pas échouer, et une fois il a été appliqué sans vérification.

`dev-lead` est laissé tel quel : il coordonne, il ne construit pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)