### PR TITLE
feat(audit): separate the project audit from the global one

### DIFF
--- a/crates/armadai/src/audit/mod.rs
+++ b/crates/armadai/src/audit/mod.rs
@@ -7,12 +7,14 @@ pub mod proposal;
 pub mod report;
 pub mod reverse;
 pub mod rules;
+pub mod scope;
 pub mod usage;
 
 use std::path::Path;
 
 use report::AuditReport;
 use reverse::ReverseLinker;
+pub use scope::{AuditScope, GlobalLayout, import_global_surfaces};
 
 /// Detect and parse every native surface under `root`.
 /// Shared by the audit run and `--propose` (which needs the raw imports).
@@ -34,26 +36,74 @@ pub fn import_surfaces(root: &Path) -> (Vec<String>, reverse::ImportedConfig) {
     (detected, config)
 }
 
-/// Detect, import and analyse every native surface under `root`.
-pub fn run_audit(
-    root: &Path,
-    settings: &rules::AuditSettings,
-    usage: Option<&usage::UsageFacts>,
-) -> AuditReport {
-    let (detected, config) = import_surfaces(root);
-    let ctx = rules::AuditContext {
-        config: &config,
-        settings,
-        usage,
-    };
-    AuditReport {
-        root: root.to_path_buf(),
-        detected,
-        agent_count: config.agents.len(),
-        skill_count: config.skills.len(),
-        findings: rules::run_rules(&ctx),
-        deep_raw: None,
-        usage: usage.cloned(),
+/// Everything one audit run reads, before any rule sees it.
+///
+/// The two scopes differ only in how this is filled — one repository root, or
+/// the user's own library — so keeping the assembly separate from the analysis
+/// is what lets both share every rule, every renderer and every exit path.
+#[derive(Debug, Clone)]
+pub struct AuditInput {
+    /// What findings paths are displayed relative to: the repository root, or
+    /// `$HOME` in global scope.
+    pub root: std::path::PathBuf,
+    pub scope: AuditScope,
+    pub detected: Vec<String>,
+    pub skipped: Vec<String>,
+    pub config: reverse::ImportedConfig,
+}
+
+impl AuditInput {
+    /// Project scope: the native surfaces under one repository root.
+    pub fn for_project(root: &Path) -> Self {
+        let (detected, config) = import_surfaces(root);
+        Self {
+            root: root.to_path_buf(),
+            scope: AuditScope::Project,
+            detected,
+            skipped: Vec::new(),
+            config,
+        }
+    }
+
+    /// Global scope: the user's own library, assembled from known locations.
+    pub fn for_global(layout: &GlobalLayout) -> Self {
+        let imported = import_global_surfaces(layout);
+        Self {
+            root: layout.home.clone(),
+            scope: AuditScope::Global,
+            detected: imported.detected,
+            skipped: imported.skipped,
+            config: imported.config,
+        }
+    }
+
+    /// Run the rules registered for this input's scope.
+    ///
+    /// `usage` is only ever `Some` in project scope: `U01`-`U04` correlate
+    /// declarations against *one project's* Claude Code transcripts, which is
+    /// why they are the single family the global registry leaves out. Every
+    /// other family reads the assets themselves and holds wherever they live.
+    pub fn analyse(
+        &self,
+        settings: &rules::AuditSettings,
+        usage: Option<&usage::UsageFacts>,
+    ) -> AuditReport {
+        let ctx = rules::AuditContext {
+            config: &self.config,
+            settings,
+            usage,
+        };
+        AuditReport {
+            root: self.root.clone(),
+            scope: self.scope,
+            detected: self.detected.clone(),
+            agent_count: self.config.agents.len(),
+            skill_count: self.config.skills.len(),
+            findings: rules::run_rules(&ctx, self.scope),
+            deep_raw: None,
+            usage: usage.cloned(),
+            skipped: self.skipped.clone(),
+        }
     }
 }
 
@@ -77,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn run_audit_accepts_observed_usage() {
+    fn analyse_accepts_observed_usage() {
         let dir = tempfile::tempdir().unwrap();
         let agents = dir.path().join(".claude/agents");
         std::fs::create_dir_all(&agents).unwrap();
@@ -89,7 +139,9 @@ mod tests {
         let mut usage = usage::UsageFacts::default();
         usage.record_delegation(usage::facts::ROOT_AGENT, "a", "claude-opus-5");
 
-        let report = run_audit(dir.path(), &rules::AuditSettings::default(), Some(&usage));
+        let report = AuditInput::for_project(dir.path())
+            .analyse(&rules::AuditSettings::default(), Some(&usage));
         assert_eq!(report.agent_count, 1);
+        assert_eq!(report.scope, AuditScope::Project);
     }
 }

--- a/crates/armadai/src/audit/mod.rs
+++ b/crates/armadai/src/audit/mod.rs
@@ -41,18 +41,42 @@ pub fn import_surfaces(root: &Path) -> (Vec<String>, reverse::ImportedConfig) {
 /// The two scopes differ only in how this is filled — one repository root, or
 /// the user's own library — so keeping the assembly separate from the analysis
 /// is what lets both share every rule, every renderer and every exit path.
+///
+/// Every field is private, and the two factories below are the only way to
+/// build one. `root` and `scope` are not independent: `Global` means "paths are
+/// shown relative to `$HOME`", and a literal `AuditInput { root: <a project>,
+/// scope: Global, .. }` compiled happily while producing a report titled
+/// `armadai audit (global)` anchored on a repository. Nothing in the type
+/// stopped it; now the constructor is the only door and it does.
 #[derive(Debug, Clone)]
 pub struct AuditInput {
     /// What findings paths are displayed relative to: the repository root, or
     /// `$HOME` in global scope.
-    pub root: std::path::PathBuf,
-    pub scope: AuditScope,
-    pub detected: Vec<String>,
-    pub skipped: Vec<String>,
-    pub config: reverse::ImportedConfig,
+    root: std::path::PathBuf,
+    scope: AuditScope,
+    detected: Vec<String>,
+    skipped: Vec<String>,
+    config: reverse::ImportedConfig,
 }
 
 impl AuditInput {
+    /// Which surface this input covers.
+    pub fn scope(&self) -> AuditScope {
+        self.scope
+    }
+
+    /// Labels of the roots that held at least one readable surface. Empty
+    /// means "nothing to audit", which the CLI reports as such.
+    pub fn detected(&self) -> &[String] {
+        &self.detected
+    }
+
+    /// The imported surfaces, shared with `--propose` and `--deep` so neither
+    /// re-reads the same files.
+    pub fn config(&self) -> &reverse::ImportedConfig {
+        &self.config
+    }
+
     /// Project scope: the native surfaces under one repository root.
     pub fn for_project(root: &Path) -> Self {
         let (detected, config) = import_surfaces(root);

--- a/crates/armadai/src/audit/report.rs
+++ b/crates/armadai/src/audit/report.rs
@@ -1113,6 +1113,62 @@ mod tests {
         );
     }
 
+    /// `skipped` claims, in its own doc comment, to be "rendered in all three
+    /// output formats". Only the terminal was guarded: cutting the markdown
+    /// loop (`.take(0)`) or the HTML one left 752 tests green, and a
+    /// `--global --report audit.md` would then have announced "48 skills, 0
+    /// agents" without a word about the 77 agents it never read — the report
+    /// reading as "you have none", which is the exact failure the field
+    /// exists to prevent.
+    #[test]
+    fn both_file_formats_state_what_was_not_read() {
+        let mut r = report_with(vec![]);
+        r.skipped = vec![
+            "~/.config/armadai/agents (77 file(s)) — ArmadAI-format agents".to_string(),
+            "~/.claude/plugins/cache (17 skill(s)) — installed plugin skills".to_string(),
+        ];
+
+        let md = r.to_markdown();
+        for line in &r.skipped {
+            assert!(
+                md.contains(&format!("Not read: {line}")),
+                "the markdown report must state every omission, missing {line:?}:\n{md}"
+            );
+        }
+
+        let html = r.to_html();
+        for line in &r.skipped {
+            // `—` and `~` survive escaping; the `(` does not need it either,
+            // so the line appears verbatim.
+            assert!(
+                html.contains(&format!("Not read: {line}")),
+                "the HTML report must state every omission, missing {line:?}:\n{html}"
+            );
+        }
+    }
+
+    /// The HTML renderer resolves the title independently of the markdown one,
+    /// so a scope label that is right in one and wrong in the other is a
+    /// single-line mistake. A report that misnames its scope is a trap: the
+    /// two scopes carry identical rule codes over different assets.
+    #[test]
+    fn the_html_report_names_its_scope() {
+        let mut r = report_with(vec![]);
+        r.scope = crate::audit::AuditScope::Global;
+        let html = r.to_html();
+        assert!(
+            html.contains("armadai audit (global)"),
+            "a global HTML report must say so:\n{html}"
+        );
+
+        r.scope = crate::audit::AuditScope::Project;
+        let html = r.to_html();
+        assert!(
+            !html.contains("(global)"),
+            "and a project one must not claim it:\n{html}"
+        );
+    }
+
     #[test]
     fn deep_raw_with_backtick_fence_uses_longer_outer_fence() {
         let mut r = report_with(vec![]);

--- a/crates/armadai/src/audit/report.rs
+++ b/crates/armadai/src/audit/report.rs
@@ -6,6 +6,10 @@ use super::rules::{Finding, Severity};
 /// Assembled result of one audit run.
 pub struct AuditReport {
     pub root: PathBuf,
+    /// Which surface this report describes. A report file that does not say
+    /// whether it covers a repository or the user's whole library is a trap:
+    /// the two carry the same rule codes over different assets.
+    pub scope: crate::audit::AuditScope,
     pub detected: Vec<String>,
     pub agent_count: usize,
     pub skill_count: usize,
@@ -15,6 +19,10 @@ pub struct AuditReport {
     pub deep_raw: Option<String>,
     /// Observed usage, when transcripts were found for this project.
     pub usage: Option<crate::audit::usage::UsageFacts>,
+    /// Locations this run deliberately did not read, each with its reason.
+    /// Rendered in all three output formats: an asset pile the audit skips
+    /// has to be a stated omission, or the report reads as "you have none".
+    pub skipped: Vec<String>,
 }
 
 /// Sorted, truncated view data shared by `AuditReport::usage_markdown` and
@@ -60,6 +68,15 @@ impl AuditReport {
 
     fn count(&self, s: Severity) -> usize {
         self.findings.iter().filter(|f| f.severity == s).count()
+    }
+
+    /// `armadai audit` for a project, `armadai audit (global)` for the user
+    /// library — the one word that tells the two reports apart.
+    fn title(&self) -> &'static str {
+        match self.scope {
+            crate::audit::AuditScope::Project => "armadai audit",
+            crate::audit::AuditScope::Global => "armadai audit (global)",
+        }
     }
 
     fn summary_line(&self) -> String {
@@ -323,7 +340,7 @@ impl AuditReport {
     /// stderr, so this only ever writes to stdout.
     pub fn print_terminal(&self, min_severity: Severity) {
         let h = crate::cli::style::header();
-        anstream::println!("{h}armadai audit - {}{h:#}", self.root.display());
+        anstream::println!("{h}{} - {}{h:#}", self.title(), self.root.display());
         let m = crate::cli::style::muted();
         let a = crate::cli::style::accent();
         anstream::println!(
@@ -332,6 +349,9 @@ impl AuditReport {
             self.agent_count,
             self.skill_count
         );
+        for line in &self.skipped {
+            anstream::println!("  {m}Not read:{m:#} {m}{line}{m:#}");
+        }
         self.print_usage();
         for severity in [Severity::Critical, Severity::Warning, Severity::Info] {
             if severity > min_severity {
@@ -413,7 +433,7 @@ impl AuditReport {
 
     pub fn to_markdown(&self) -> String {
         let mut md = String::new();
-        let _ = writeln!(md, "# armadai audit — {}\n", self.root.display());
+        let _ = writeln!(md, "# {} — {}\n", self.title(), self.root.display());
         let _ = writeln!(
             md,
             "Detected: {} ({} agents, {} skills)\n",
@@ -421,6 +441,9 @@ impl AuditReport {
             self.agent_count,
             self.skill_count
         );
+        for line in &self.skipped {
+            let _ = writeln!(md, "Not read: {line}\n");
+        }
         let _ = writeln!(md, "**Summary: {}**\n", self.summary_line());
         md.push_str(&self.usage_markdown());
         if !self.findings.is_empty() {
@@ -519,6 +542,7 @@ impl AuditReport {
     pub fn to_html(&self) -> String {
         let root = html_escape(&self.root.display().to_string());
         let detected = html_escape(&self.detected.join(", "));
+        let title = self.title();
         let mut html = String::new();
         let _ = write!(
             html,
@@ -527,19 +551,24 @@ impl AuditReport {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>armadai audit — {root}</title>
+<title>{title} — {root}</title>
 <style>
 {css}
 </style>
 </head>
 <body>
 <header>
-<h1>armadai audit — <code>{root}</code></h1>
+<h1>{title} — <code>{root}</code></h1>
 <p class="detected">Detected: {detected} ({agent_count} agent(s), {skill_count} skill(s))</p>
-</header>
+{skipped}</header>
 <p class="summary"><strong>Summary: {summary}</strong></p>
 "#,
             css = HTML_CSS,
+            skipped = self
+                .skipped
+                .iter()
+                .map(|l| format!("<p class=\"detected\">Not read: {}</p>\n", html_escape(l)))
+                .collect::<String>(),
             agent_count = self.agent_count,
             skill_count = self.skill_count,
             summary = html_escape(&self.summary_line()),
@@ -821,12 +850,14 @@ mod tests {
     fn report_with(findings: Vec<Finding>) -> AuditReport {
         AuditReport {
             root: ".".into(),
+            scope: crate::audit::AuditScope::Project,
             detected: vec!["claude".into()],
             agent_count: 2,
             skill_count: 1,
             findings,
             deep_raw: None,
             usage: None,
+            skipped: Vec::new(),
         }
     }
 
@@ -1001,12 +1032,14 @@ mod tests {
 
         let report = AuditReport {
             root: std::path::PathBuf::from("/p"),
+            scope: crate::audit::AuditScope::Project,
             detected: vec!["claude".to_string()],
             agent_count: 1,
             skill_count: 0,
             findings: vec![],
             deep_raw: None,
             usage: Some(usage),
+            skipped: Vec::new(),
         };
         let md = report.to_markdown();
         assert!(md.contains("Observed usage"), "{md}");
@@ -1026,12 +1059,14 @@ mod tests {
 
         let report = AuditReport {
             root: std::path::PathBuf::from("/p"),
+            scope: crate::audit::AuditScope::Project,
             detected: vec!["claude".to_string()],
             agent_count: 1,
             skill_count: 0,
             findings: vec![],
             deep_raw: None,
             usage: Some(usage),
+            skipped: Vec::new(),
         };
         let html = report.to_html();
         assert!(html.contains("Observed usage"), "{html}");
@@ -1057,12 +1092,14 @@ mod tests {
         }
         let report = AuditReport {
             root: std::path::PathBuf::from("/p"),
+            scope: crate::audit::AuditScope::Project,
             detected: vec!["claude".to_string()],
             agent_count: 12,
             skill_count: 0,
             findings: vec![],
             deep_raw: None,
             usage: Some(usage),
+            skipped: Vec::new(),
         };
         let md = report.to_markdown();
         assert!(

--- a/crates/armadai/src/audit/reverse/claude.rs
+++ b/crates/armadai/src/audit/reverse/claude.rs
@@ -68,7 +68,9 @@ impl ReverseLinker for ClaudeReverseLinker {
 /// nested subdirectories (e.g. `.claude/agents/backend/dev.md`).
 const MAX_AGENT_SCAN_DEPTH: u32 = 3;
 
-fn parse_agents(dir: &Path) -> Vec<ImportedAgent> {
+/// `pub(crate)` so the global scope can point the same parser at
+/// `~/.claude/agents` — see `crate::audit::scope`.
+pub(crate) fn parse_agents(dir: &Path) -> Vec<ImportedAgent> {
     let mut files = Vec::new();
     collect_agent_files(dir, MAX_AGENT_SCAN_DEPTH, &mut files);
     let mut agents: Vec<ImportedAgent> = files.iter().map(|p| parse_agent_file(p)).collect();
@@ -103,7 +105,9 @@ struct SkillFm {
     extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
-fn parse_skills(dir: &Path) -> Vec<ImportedSkill> {
+/// `pub(crate)` so the global scope can point the same parser at both
+/// `~/.claude/skills` and `~/.config/armadai/skills`.
+pub(crate) fn parse_skills(dir: &Path) -> Vec<ImportedSkill> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
     };
@@ -163,7 +167,9 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
     }
 }
 
-fn parse_instructions(path: &Path) -> Option<ImportedInstructions> {
+/// `pub(crate)` so the global scope can point the same parser at
+/// `~/.claude/CLAUDE.md`, which is not `~/CLAUDE.md`.
+pub(crate) fn parse_instructions(path: &Path) -> Option<ImportedInstructions> {
     let content = std::fs::read_to_string(path).ok()?;
     Some(ImportedInstructions {
         source_path: path.to_path_buf(),

--- a/crates/armadai/src/audit/rules/mod.rs
+++ b/crates/armadai/src/audit/rules/mod.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use super::AuditScope;
 use super::reverse::ImportedConfig;
 
 mod assets;
@@ -49,13 +50,24 @@ pub struct AuditSettings {
     /// A05: estimated token count above which a prompt is flagged.
     pub prompt_token_threshold: usize,
     /// R01: estimated token count above which a skill with no `references/`
-    /// is flagged. Default derived from a measured distribution: 460 real
-    /// SKILL.md files give a p90 of 2224 words, and the same corpus measures
-    /// **1.84 tokens per word** (median) under the `chars/4` estimate — so
-    /// the p90 is ~4100 tokens, and the p90 of the token distribution read
-    /// directly is 3956. Hence 4000. An earlier 3000 came from assuming one
-    /// token per word — 36% low, and measured on the corpus it flagged 54 of
-    /// the 460 (11.7%) where the p90 criterion promises ~4.6%.
+    /// is flagged.
+    ///
+    /// 4000 is a **context budget**, not a quantile: it is the point past
+    /// which "the whole body enters context the moment this skill triggers"
+    /// stops being a detail and becomes a cost worth naming. That claim holds
+    /// whatever anyone else's skills look like.
+    ///
+    /// It was originally justified as a p90, and that justification was
+    /// wrong twice over. The corpus it was measured on — 461 `SKILL.md`
+    /// files — was 88% `~/.config/armadai/registry`, a synced catalogue of
+    /// other people's assets that no scope audits. On the corpus that *is*
+    /// auditable (the 48 skills installed on the same machine) the p90 is
+    /// 2456, and 48 samples are far too thin a base to derive a threshold
+    /// from anyway. Moving 4000 down to that p90 changes nothing observable:
+    /// measured over those 48 skills, 4000 flags 1 (2%) and so does 2456 —
+    /// only 4 skills exceed 2456 and 3 of them already have `references/`.
+    /// The threshold is not what makes `R01` narrow; the `references/`
+    /// condition is.
     pub skill_token_threshold: usize,
     /// C03: Jaccard similarity above which two activation descriptions are
     /// considered ambiguous for routing.
@@ -167,8 +179,16 @@ pub struct AuditContext<'a> {
 type RuleFn = fn(&AuditContext) -> Vec<Finding>;
 
 /// Static rule registry: adding a rule = one module + one entry here.
-fn registry() -> Vec<RuleFn> {
-    vec![
+///
+/// Every family applies to both scopes — a rule reads the assets themselves,
+/// and a property of an asset holds wherever the asset lives. `usage_rules`
+/// is the single exception, and it is excluded *here* rather than inside the
+/// rules: `U01`-`U04` correlate declarations against one project's Claude
+/// Code transcripts, and a rule that only ever sees `ctx.config` cannot tell
+/// which scope filled it. So the default is "applies", the exception is
+/// registered once, and no rule branches on scope.
+fn registry(scope: AuditScope) -> Vec<RuleFn> {
+    let mut rules: Vec<RuleFn> = vec![
         assets::a01_unparsable,
         assets::a02_missing_fields,
         models::a03_deprecated_model,
@@ -189,16 +209,22 @@ fn registry() -> Vec<RuleFn> {
         collisions::c03_activation_overlap,
         collisions::c04_double_ownership,
         collisions::c05_inconsistent_tools,
-        usage_rules::u01_declared_never_used,
-        usage_rules::u02_used_but_undeclared,
-        usage_rules::u03_coordinator_bypassed,
-        usage_rules::u04_skill_activity,
-    ]
+    ];
+    if scope == AuditScope::Project {
+        rules.extend::<[RuleFn; 4]>([
+            usage_rules::u01_declared_never_used,
+            usage_rules::u02_used_but_undeclared,
+            usage_rules::u03_coordinator_bypassed,
+            usage_rules::u04_skill_activity,
+        ]);
+    }
+    rules
 }
 
-/// Run every registered rule and return findings sorted by severity then file.
-pub fn run_rules(ctx: &AuditContext) -> Vec<Finding> {
-    let mut findings: Vec<Finding> = registry().iter().flat_map(|rule| rule(ctx)).collect();
+/// Run every rule registered for `scope` and return findings sorted by
+/// severity then file.
+pub fn run_rules(ctx: &AuditContext, scope: AuditScope) -> Vec<Finding> {
+    let mut findings: Vec<Finding> = registry(scope).iter().flat_map(|rule| rule(ctx)).collect();
     findings.sort_by(|a, b| (a.severity, &a.file, a.rule).cmp(&(b.severity, &b.file, b.rule)));
     findings
 }
@@ -278,7 +304,8 @@ mod tests {
             settings: &settings,
             usage: None,
         };
-        assert!(run_rules(&ctx).is_empty());
+        assert!(run_rules(&ctx, AuditScope::Project).is_empty());
+        assert!(run_rules(&ctx, AuditScope::Global).is_empty());
     }
 
     #[test]
@@ -304,14 +331,88 @@ mod tests {
         assert_eq!(s.prompt_token_threshold, 4000);
         assert_eq!(
             s.skill_token_threshold, 4000,
-            "R01's default is the measured p90 of 460 real skills, converted at the \
-             corpus's own 1.84 tokens/word — changing it must be a deliberate act"
+            "R01's default is a context budget — the point past which \"the whole \
+             body enters context when this skill triggers\" becomes a cost worth \
+             naming — not a quantile of whatever happens to sit on one machine. \
+             Changing it must be a deliberate act"
         );
         assert!((s.activation_similarity - 0.6).abs() < f64::EPSILON);
         assert_eq!(s.deep_prompt_truncation, 2000);
         assert!(
             s.usage,
             "usage must default to true so existing configs are unaffected"
+        );
+    }
+
+    /// The one rule exclusion of the whole scope design, asserted where it is
+    /// decided: the registry, not a rule body.
+    ///
+    /// The usage facts here are deliberately non-empty and the context
+    /// deliberately carries them, because `U01`-`U04` are *also* silent when
+    /// `ctx.usage` is `None` — which is what the global scope passes in
+    /// practice. Testing the exclusion through that `None` would prove
+    /// nothing about the registry: removing the `scope` guard entirely would
+    /// leave such a test green. So this one hands the rules everything they
+    /// need to fire and asserts the registry still keeps them out.
+    #[test]
+    fn usage_rules_are_registered_for_a_project_and_never_for_the_global_library() {
+        let mut config = crate::audit::reverse::ImportedConfig::default();
+        config
+            .agents
+            .push(test_support::agent("ghost", "never invoked"));
+        let mut usage = crate::audit::usage::UsageFacts {
+            sessions: 1,
+            ..Default::default()
+        };
+        usage.record_delegation(
+            crate::audit::usage::facts::ROOT_AGENT,
+            "general-purpose",
+            "claude-opus-5",
+        );
+        assert!(!usage.is_empty(), "the fixture must be able to fire U0x");
+        let settings = AuditSettings::default();
+        let ctx = AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: Some(&usage),
+        };
+
+        let project: Vec<&str> = run_rules(&ctx, AuditScope::Project)
+            .iter()
+            .map(|f| f.rule)
+            .filter(|r| r.starts_with('U'))
+            .collect();
+        assert_eq!(
+            project,
+            vec!["U01", "U02"],
+            "project scope must run the usage rules: a declared-but-unused              agent (U01) and an undeclared one that ran (U02)"
+        );
+
+        let global: Vec<&str> = run_rules(&ctx, AuditScope::Global)
+            .iter()
+            .map(|f| f.rule)
+            .filter(|r| r.starts_with('U'))
+            .collect();
+        assert!(
+            global.is_empty(),
+            "usage rules correlate one project's transcripts and must not be              registered for the global library, got: {global:?}"
+        );
+    }
+
+    /// The mirror of the above: every *other* family must be registered for
+    /// both scopes. Excluding one family is a whitelist of one, and a
+    /// regression that quietly widened it would otherwise be invisible.
+    #[test]
+    fn every_other_family_is_registered_for_both_scopes() {
+        assert_eq!(
+            registry(AuditScope::Project).len(),
+            registry(AuditScope::Global).len() + 4,
+            "the two registries must differ by exactly the four usage rules"
+        );
+        assert_eq!(
+            registry(AuditScope::Global).len(),
+            20,
+            "global drops U01-U04 and keeps every other rule"
         );
     }
 

--- a/crates/armadai/src/audit/rules/mod.rs
+++ b/crates/armadai/src/audit/rules/mod.rs
@@ -97,7 +97,47 @@ impl Default for AuditSettings {
 impl AuditSettings {
     /// Read the optional `audit:` section of the project config, if any.
     /// Missing file, missing section or unreadable YAML all yield defaults.
+    ///
+    /// Project scope only. The global library has its own source — see
+    /// [`AuditSettings::from_global`] — because thresholds must follow the
+    /// surface being audited, not the folder the command was typed in.
     pub fn from_project(root: &std::path::Path) -> Self {
+        let mut settings = Self::default();
+        for candidate in ["armadai.yaml", ".armadai/config.yaml"] {
+            // The first of the two that *exists* wins, whether or not it
+            // carries an `audit:` section — the second is a fallback for a
+            // missing file, not for a missing key.
+            if settings.apply_audit_section(&root.join(candidate)) {
+                break;
+            }
+        }
+        settings
+    }
+
+    /// Read the optional `audit:` section of the *user-level* config,
+    /// `~/.config/armadai/config.yaml` (or wherever `$ARMADAI_CONFIG_DIR` /
+    /// `$XDG_CONFIG_HOME` puts it).
+    ///
+    /// A global audit reads one fixed set of assets, so it must reach one
+    /// fixed verdict. Sourcing its thresholds from `<cwd>/armadai.yaml` made
+    /// that false: measured on one machine, the same global library produced
+    /// 2 `R01` warnings from a directory carrying `skill_token_threshold: 5`
+    /// and 0 from a neutral one. The library's settings belong next to the
+    /// library.
+    pub fn from_global() -> Self {
+        let mut settings = Self::default();
+        settings.apply_audit_section(&armadai_core::config::config_dir().join("config.yaml"));
+        settings
+    }
+
+    /// Overlay the `audit:` section of one YAML file onto `self`. Returns
+    /// whether the file was *readable* — the caller's "first candidate that
+    /// exists wins" is about the file, not about the section, so a config with
+    /// no `audit:` key still stops the search.
+    ///
+    /// Unparsable YAML leaves the defaults in place: the audit never refuses
+    /// to run over its own configuration.
+    fn apply_audit_section(&mut self, path: &std::path::Path) -> bool {
         #[derive(serde::Deserialize, Default)]
         #[serde(default)]
         struct AuditYaml {
@@ -112,33 +152,29 @@ impl AuditSettings {
             deep_prompt_truncation: Option<usize>,
             usage: Option<bool>,
         }
-        let mut settings = Self::default();
-        for candidate in ["armadai.yaml", ".armadai/config.yaml"] {
-            let Ok(raw) = std::fs::read_to_string(root.join(candidate)) else {
-                continue;
-            };
-            if let Ok(parsed) = serde_yaml_ng::from_str::<AuditYaml>(&raw)
-                && let Some(section) = parsed.audit
-            {
-                if let Some(t) = section.prompt_token_threshold {
-                    settings.prompt_token_threshold = t;
-                }
-                if let Some(t) = section.skill_token_threshold {
-                    settings.skill_token_threshold = t;
-                }
-                if let Some(s) = section.activation_similarity {
-                    settings.activation_similarity = s;
-                }
-                if let Some(t) = section.deep_prompt_truncation {
-                    settings.deep_prompt_truncation = t;
-                }
-                if let Some(u) = section.usage {
-                    settings.usage = u;
-                }
+        let Ok(raw) = std::fs::read_to_string(path) else {
+            return false;
+        };
+        if let Ok(parsed) = serde_yaml_ng::from_str::<AuditYaml>(&raw)
+            && let Some(section) = parsed.audit
+        {
+            if let Some(t) = section.prompt_token_threshold {
+                self.prompt_token_threshold = t;
             }
-            break;
+            if let Some(t) = section.skill_token_threshold {
+                self.skill_token_threshold = t;
+            }
+            if let Some(s) = section.activation_similarity {
+                self.activation_similarity = s;
+            }
+            if let Some(t) = section.deep_prompt_truncation {
+                self.deep_prompt_truncation = t;
+            }
+            if let Some(u) = section.usage {
+                self.usage = u;
+            }
         }
-        settings
+        true
     }
 }
 
@@ -324,6 +360,43 @@ mod tests {
         assert!(!s.usage, "usage: false in config must be honoured");
     }
 
+    /// `.armadai/config.yaml` is the documented second candidate, and the
+    /// refactor that split this loop out into `apply_audit_section` could have
+    /// dropped it in silence — nothing covered it before.
+    #[test]
+    fn from_project_falls_back_to_the_dot_armadai_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/config.yaml"),
+            "audit:\n  skill_token_threshold: 777\n",
+        )
+        .unwrap();
+        let s = AuditSettings::from_project(dir.path());
+        assert_eq!(s.skill_token_threshold, 777);
+    }
+
+    /// The first candidate that *exists* wins — even when it carries no
+    /// `audit:` section at all. The second is a fallback for a missing file,
+    /// not for a missing key, so a project that deliberately empties its
+    /// `armadai.yaml` gets the defaults rather than a stale `.armadai/` value.
+    #[test]
+    fn the_first_existing_candidate_wins_even_with_no_audit_section() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("armadai.yaml"), "name: demo\n").unwrap();
+        std::fs::create_dir_all(dir.path().join(".armadai")).unwrap();
+        std::fs::write(
+            dir.path().join(".armadai/config.yaml"),
+            "audit:\n  skill_token_threshold: 777\n",
+        )
+        .unwrap();
+        let s = AuditSettings::from_project(dir.path());
+        assert_eq!(
+            s.skill_token_threshold, 4000,
+            "armadai.yaml exists and says nothing about audit: that is the answer"
+        );
+    }
+
     #[test]
     fn from_project_defaults_without_config() {
         let dir = tempfile::tempdir().unwrap();
@@ -385,7 +458,8 @@ mod tests {
         assert_eq!(
             project,
             vec!["U01", "U02"],
-            "project scope must run the usage rules: a declared-but-unused              agent (U01) and an undeclared one that ran (U02)"
+            "project scope must run the usage rules: a declared-but-unused \
+             agent (U01) and an undeclared one that ran (U02)"
         );
 
         let global: Vec<&str> = run_rules(&ctx, AuditScope::Global)
@@ -395,7 +469,8 @@ mod tests {
             .collect();
         assert!(
             global.is_empty(),
-            "usage rules correlate one project's transcripts and must not be              registered for the global library, got: {global:?}"
+            "usage rules correlate one project's transcripts and must not be \
+             registered for the global library, got: {global:?}"
         );
     }
 

--- a/crates/armadai/src/audit/rules/rightsizing.rs
+++ b/crates/armadai/src/audit/rules/rightsizing.rs
@@ -17,11 +17,21 @@ use super::{AuditContext, Finding, Severity};
 /// R01 — a `SKILL.md` past the token threshold whose skill directory has no
 /// `references/` at all.
 ///
-/// Size alone is a bad signal, measured: across 460 real skills, 52% of those
-/// above the p90 have a `references/` directory against 32% below it — large
-/// skills are *more* often split, not less. So both conditions are required,
-/// which is also what keeps a correctly-structured 41795-word skill out of
-/// the report.
+/// Both conditions are required, for a definitional reason rather than a
+/// statistical one: a skill that already has a `references/` directory has
+/// used the mechanism this rule's suggestion would recommend, so flagging it
+/// would be advice with no action attached. That also keeps a
+/// correctly-structured 10087-token skill out of the report.
+///
+/// An earlier version of this comment justified the second condition
+/// statistically — "52% of skills above the p90 carry a `references/` against
+/// 32% below it, so large skills are *more* often split". That was measured on
+/// a 461-file corpus that was 88% synced catalogue. Re-measured on the corpus
+/// that is actually auditable — the 48 skills installed on the same machine —
+/// the contrast disappears: 75% above the p90 have `references/` against 77%
+/// at or below it, on 4 samples and 44. There is no signal there, and a
+/// 4-sample rate was never one. The rule is right; that argument for it was
+/// not.
 ///
 /// Counterpart of `A05` for skills (`A05` covers agents' `system_prompt`).
 /// `A09` validates a skill's structure but never its size.
@@ -615,13 +625,24 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = config_of(vec![skill_on_disk(dir.path(), "heavy", 5000)]);
         let settings = AuditSettings::default();
-        let findings = crate::audit::rules::run_rules(&ctx_for(&config, &settings));
-        let r01: Vec<_> = findings.iter().filter(|f| f.rule == "R01").collect();
-        assert_eq!(
-            r01.len(),
-            1,
-            "run_rules must emit R01; all findings: {findings:?}"
-        );
+        // Both scopes: an `R` rule reads the assets themselves, so it must be
+        // registered for the global library exactly as for a project — the
+        // global scope is the *only* one where real skills are found (measured:
+        // three real projects declare zero local skills against 48 installed
+        // globally), so a rule registered for `Project` alone would be inert
+        // where it matters most.
+        for scope in [
+            crate::audit::AuditScope::Project,
+            crate::audit::AuditScope::Global,
+        ] {
+            let findings = crate::audit::rules::run_rules(&ctx_for(&config, &settings), scope);
+            let r01: Vec<_> = findings.iter().filter(|f| f.rule == "R01").collect();
+            assert_eq!(
+                r01.len(),
+                1,
+                "run_rules must emit R01 in {scope:?} scope; all findings: {findings:?}"
+            );
+        }
     }
 
     // ---- R02 -------------------------------------------------------------
@@ -964,13 +985,24 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = instructions_saying(dir.path(), "See `src/gone/mod.rs`.");
         let settings = AuditSettings::default();
-        let findings = crate::audit::rules::run_rules(&ctx_for(&config, &settings));
-        let r02: Vec<_> = findings.iter().filter(|f| f.rule == "R02").collect();
-        assert_eq!(
-            r02.len(),
-            1,
-            "run_rules must emit R02; all findings: {findings:?}"
-        );
+        // Both scopes: an `R` rule reads the assets themselves, so it must be
+        // registered for the global library exactly as for a project — the
+        // global scope is the *only* one where real skills are found (measured:
+        // three real projects declare zero local skills against 48 installed
+        // globally), so a rule registered for `Project` alone would be inert
+        // where it matters most.
+        for scope in [
+            crate::audit::AuditScope::Project,
+            crate::audit::AuditScope::Global,
+        ] {
+            let findings = crate::audit::rules::run_rules(&ctx_for(&config, &settings), scope);
+            let r02: Vec<_> = findings.iter().filter(|f| f.rule == "R02").collect();
+            assert_eq!(
+                r02.len(),
+                1,
+                "run_rules must emit R02 in {scope:?} scope; all findings: {findings:?}"
+            );
+        }
     }
 
     // ---- R04 -------------------------------------------------------------
@@ -1061,12 +1093,23 @@ mod tests {
         // so this assertion depends on the registry alone.
         let config = instructions_saying(dir.path(), &"x".repeat(400));
         let settings = AuditSettings::default();
-        let findings = crate::audit::rules::run_rules(&ctx_for(&config, &settings));
-        let r04: Vec<_> = findings.iter().filter(|f| f.rule == "R04").collect();
-        assert_eq!(
-            r04.len(),
-            1,
-            "run_rules must emit R04; all findings: {findings:?}"
-        );
+        // Both scopes: an `R` rule reads the assets themselves, so it must be
+        // registered for the global library exactly as for a project — the
+        // global scope is the *only* one where real skills are found (measured:
+        // three real projects declare zero local skills against 48 installed
+        // globally), so a rule registered for `Project` alone would be inert
+        // where it matters most.
+        for scope in [
+            crate::audit::AuditScope::Project,
+            crate::audit::AuditScope::Global,
+        ] {
+            let findings = crate::audit::rules::run_rules(&ctx_for(&config, &settings), scope);
+            let r04: Vec<_> = findings.iter().filter(|f| f.rule == "R04").collect();
+            assert_eq!(
+                r04.len(),
+                1,
+                "run_rules must emit R04 in {scope:?} scope; all findings: {findings:?}"
+            );
+        }
     }
 }

--- a/crates/armadai/src/audit/scope.rs
+++ b/crates/armadai/src/audit/scope.rs
@@ -51,17 +51,25 @@ pub struct GlobalLayout {
 }
 
 impl GlobalLayout {
-    /// Resolve from the environment. `$HOME` is read directly, exactly as
-    /// `usage::discovery::projects_root` does for `~/.claude/projects`; the
-    /// ArmadAI root goes through `config_dir()` so `$ARMADAI_CONFIG_DIR` and
-    /// `$XDG_CONFIG_HOME` keep working.
-    pub fn from_env() -> Self {
-        let home = PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".to_string()));
-        Self {
+    /// Resolve from the environment, or `None` when `$HOME` is unset.
+    ///
+    /// Refusing is the only honest answer: a global audit *is* "what is under
+    /// `~`", so with no `~` there is nothing to audit. Defaulting to `.` was
+    /// measured to report the current repository's `.claude/` as the user's
+    /// library, labelled `~/.claude` — indistinguishable, on stdout, from a
+    /// real global run. `usage::discovery::projects_root` takes the same
+    /// refusal (`.ok()?`) for the same reason, and has its own `NoHomeGuard`
+    /// test for it.
+    ///
+    /// The ArmadAI root goes through `config_dir()` so `$ARMADAI_CONFIG_DIR`
+    /// and `$XDG_CONFIG_HOME` keep working.
+    pub fn from_env() -> Option<Self> {
+        let home = PathBuf::from(std::env::var("HOME").ok()?);
+        Some(Self {
             claude_home: home.join(".claude"),
             armadai_config: armadai_core::config::config_dir(),
             home,
-        }
+        })
     }
 }
 
@@ -125,7 +133,32 @@ pub fn import_global_surfaces(layout: &GlobalLayout) -> GlobalImport {
 /// they actually exist on this machine — a note about a directory nobody has
 /// is a lecture, not a fact.
 ///
-/// Three exclusions, three different reasons:
+/// The exclusions themselves are defensible; being silent about them is not.
+/// A user reading "48 skills, 49967 tokens" reads it as the whole bill.
+/// Measured on one real machine, `~/.claude/plugins/cache` alone holds 17
+/// further `SKILL.md` worth ~39177 tokens, so the unqualified total was 44%
+/// short of what is actually installed — and two of those skills cross `R01`.
+///
+/// Under `~/.claude`:
+///
+/// - **`plugins/cache/`** holds the plugins that are *installed*: their skills
+///   are live in the session, exactly like `~/.claude/skills`. This pass does
+///   not read them because knowing which of them are actually enabled means
+///   reading Claude Code's own `installed_plugins.json` and the per-plugin
+///   manifests — a plugin-aware importer, and a separate piece of work. Until
+///   it exists the note carries the count, so the total is visibly a floor.
+/// - **`plugins/marketplaces/`** holds the *catalogue* each plugin is
+///   installed from — every plugin on offer, not the ones in use. Same
+///   category as `registry/` below, and kept a separate line from
+///   `plugins/cache/` precisely because the installed/catalogue distinction is
+///   the one this pass makes everywhere else.
+///
+/// `plugins/data/` gets no line: it is Claude Code's per-plugin *writable
+/// state*, one empty directory per installed plugin (measured: 5 directories,
+/// 0 files, 0 `SKILL.md`). Nothing there is an agentic asset, so a note about
+/// it would be the lecture this doc comment opens by ruling out.
+///
+/// Under `~/.config/armadai`:
 ///
 /// - **`registry/`** is a synced catalogue of *other people's* assets. It is
 ///   also what skewed `R01`'s original calibration: of the 461 `SKILL.md`
@@ -141,6 +174,24 @@ pub fn import_global_surfaces(layout: &GlobalLayout) -> GlobalImport {
 ///   ArmadAI-format reverse importer, which is a separate piece of work.
 fn skipped_locations(layout: &GlobalLayout) -> Vec<String> {
     let mut out = Vec::new();
+
+    let plugin_cache = layout.claude_home.join("plugins/cache");
+    if plugin_cache.is_dir() {
+        out.push(format!(
+            "{} ({} skill(s)) — installed plugin skills, in your session context; reading them \
+             needs a plugin-aware importer, so the counts above are a floor",
+            tildify(layout, &plugin_cache),
+            skill_md_count(&plugin_cache)
+        ));
+    }
+    let marketplaces = layout.claude_home.join("plugins/marketplaces");
+    if marketplaces.is_dir() {
+        out.push(format!(
+            "{} — catalogue of plugin marketplaces, not installed assets",
+            tildify(layout, &marketplaces)
+        ));
+    }
+
     let agents = layout.armadai_config.join("agents");
     if agents.is_dir() {
         out.push(format!(
@@ -180,6 +231,55 @@ fn md_file_count(dir: &Path) -> usize {
         })
         .unwrap_or(0)
 }
+
+/// `SKILL.md` files anywhere under `dir`, to a bounded depth — how many skills
+/// the plugin-cache note is about.
+///
+/// Recursive, unlike [`md_file_count`], because plugin skills sit five levels
+/// down (`<marketplace>/<plugin>/<version>/skills/<name>/SKILL.md`) and the
+/// layout is Claude Code's, not ours, so hard-coding that shape would go stale
+/// silently. Three bounds keep the walk from becoming a liability on a tree we
+/// do not own:
+///
+/// - [`MAX_SKILL_SCAN_DEPTH`] caps the descent;
+/// - entries whose name starts with `.` are skipped, so a plugin checkout that
+///   carries a `.git` never costs a walk through its object store (measured:
+///   `plugins/marketplaces` has one, which is why *that* note carries no
+///   count at all);
+/// - the recursion tests [`std::fs::DirEntry::file_type`], which does not
+///   follow symlinks, so a link pointing back up the tree cannot loop.
+///
+/// `0` when the directory is unreadable — the same answer the caller would
+/// want to print.
+fn skill_md_count(dir: &Path) -> usize {
+    fn walk(dir: &Path, depth: u32) -> usize {
+        if depth > MAX_SKILL_SCAN_DEPTH {
+            return 0;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        let mut count = 0;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with('.') {
+                continue;
+            }
+            match entry.file_type() {
+                Ok(t) if t.is_dir() => count += walk(&entry.path(), depth + 1),
+                Ok(t) if t.is_file() && name == "SKILL.md" => count += 1,
+                _ => {}
+            }
+        }
+        count
+    }
+    walk(dir, 0)
+}
+
+/// Depth cap for [`skill_md_count`]: deeper than the five levels a plugin skill
+/// really sits at, shallow enough that a pathological tree cannot stall the
+/// audit. Same reasoning as `rules::rightsizing::MAX_INDEX_DEPTH`.
+const MAX_SKILL_SCAN_DEPTH: u32 = 8;
 
 /// `~/.config/armadai` rather than `/Users/someone/.config/armadai`, when the
 /// path sits under `$HOME`. Absolute otherwise (a redirected
@@ -370,6 +470,157 @@ mod tests {
         assert!(
             note.contains("2 file(s)"),
             "the note must carry how much was skipped, got: {note}"
+        );
+    }
+
+    /// Plugin skills are *installed* and live in the session, exactly like
+    /// `~/.claude/skills`. This pass cannot read them yet (which plugins are
+    /// enabled lives in Claude Code's own manifests), so the one thing it must
+    /// not do is stay quiet: measured on one real machine, `plugins/cache`
+    /// holds 17 further `SKILL.md` worth ~39177 tokens against a reported
+    /// total of 49967, and two of them cross `R01`.
+    #[test]
+    fn installed_plugin_skills_are_named_with_their_count() {
+        let fake = Fake::new();
+        fake.write(".claude/skills/mine/SKILL.md", &skill_md("mine"));
+        for name in ["brainstorming", "writing-skills"] {
+            fake.write(
+                &format!(".claude/plugins/cache/official/superpowers/6.3.0/skills/{name}/SKILL.md"),
+                &skill_md(name),
+            );
+        }
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        let names: Vec<&str> = imported
+            .config
+            .skills
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["mine"],
+            "plugin skills are not read by this pass — only named"
+        );
+        let note = imported
+            .skipped
+            .iter()
+            .find(|l| l.contains("~/.claude/plugins/cache"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "installed plugin skills must be named, not silent: {:?}",
+                    imported.skipped
+                )
+            });
+        assert!(
+            note.contains("2 skill(s)"),
+            "the note must carry how many were left out, got: {note}"
+        );
+        assert!(
+            note.contains("installed"),
+            "the note must say these are installed, not catalogue, got: {note}"
+        );
+    }
+
+    /// The catalogue is a different claim from the installed set, and gets its
+    /// own line rather than being folded into one `~/.claude/plugins` note:
+    /// merging them would erase the very installed/catalogue distinction this
+    /// pass makes for `~/.config/armadai` (`skills` read, `registry` excluded).
+    /// It carries no count — it holds a `.git` (measured), so counting it means
+    /// walking an object store.
+    #[test]
+    fn the_plugin_marketplace_catalogue_is_a_separate_uncounted_line() {
+        let fake = Fake::new();
+        fake.write(".claude/skills/mine/SKILL.md", &skill_md("mine"));
+        fake.write(
+            ".claude/plugins/marketplaces/official/plugins/receipts/skills/receipts/SKILL.md",
+            &skill_md("receipts"),
+        );
+        fake.write(
+            ".claude/plugins/cache/official/superpowers/6.3.0/skills/x/SKILL.md",
+            &skill_md("x"),
+        );
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        let catalogue: Vec<&String> = imported
+            .skipped
+            .iter()
+            .filter(|l| l.contains("~/.claude/plugins/marketplaces"))
+            .collect();
+        assert_eq!(
+            catalogue.len(),
+            1,
+            "the catalogue must have its own line: {:?}",
+            imported.skipped
+        );
+        assert!(
+            catalogue[0].contains("catalogue"),
+            "the reason must be the catalogue one, got: {}",
+            catalogue[0]
+        );
+        assert!(
+            !catalogue[0].contains("skill(s)"),
+            "the catalogue line must carry no count (it holds a .git), got: {}",
+            catalogue[0]
+        );
+        assert!(
+            imported
+                .skipped
+                .iter()
+                .any(|l| l.contains("~/.claude/plugins/cache")),
+            "and the installed set keeps its own, distinct line: {:?}",
+            imported.skipped
+        );
+    }
+
+    /// `plugins/data` is Claude Code's per-plugin *writable state* — measured
+    /// on one real machine: 5 directories, 0 files. Nothing there is an
+    /// agentic asset, and a `Not read:` line about it would be the lecture the
+    /// "only when it exists" rule is meant to avoid.
+    #[test]
+    fn the_plugin_data_directory_gets_no_note() {
+        let fake = Fake::new();
+        fake.write(".claude/skills/mine/SKILL.md", &skill_md("mine"));
+        std::fs::create_dir_all(fake.dir.path().join(".claude/plugins/data/superpowers")).unwrap();
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        assert!(
+            !imported.skipped.iter().any(|l| l.contains("plugins/data")),
+            "per-plugin writable state is not an asset pile: {:?}",
+            imported.skipped
+        );
+    }
+
+    /// The plugin-cache count walks a tree we do not own, so it skips
+    /// dot-directories. Without that, a plugin checkout carrying a `.git`
+    /// costs a walk through its object store — and any `SKILL.md`-named blob
+    /// in there would be counted as a skill.
+    #[test]
+    fn the_plugin_skill_count_ignores_dot_directories() {
+        let fake = Fake::new();
+        fake.write(".claude/skills/mine/SKILL.md", &skill_md("mine"));
+        fake.write(
+            ".claude/plugins/cache/official/plug/1.0.0/skills/real/SKILL.md",
+            &skill_md("real"),
+        );
+        fake.write(
+            ".claude/plugins/cache/official/plug/.git/objects/skills/x/SKILL.md",
+            "not a skill",
+        );
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        let note = imported
+            .skipped
+            .iter()
+            .find(|l| l.contains("~/.claude/plugins/cache"))
+            .unwrap();
+        assert!(
+            note.contains("1 skill(s)"),
+            "only the real skill counts, got: {note}"
         );
     }
 

--- a/crates/armadai/src/audit/scope.rs
+++ b/crates/armadai/src/audit/scope.rs
@@ -1,0 +1,408 @@
+//! The two scopes an audit can run over, and the assembly of the global one.
+//!
+//! Project scope reads one repository through a [`ReverseLinker`]: everything
+//! it needs sits under a single root, so `detect(root)` / `parse(root)` maps
+//! onto it exactly. The global scope does not fit that shape — the user's
+//! assets live in two unrelated trees (`~/.claude` and `~/.config/armadai`),
+//! neither of which is under the other, and the global instructions file is
+//! `~/.claude/CLAUDE.md` rather than `~/CLAUDE.md`. A `ReverseLinker` for it
+//! would have to take a `root` it then ignores.
+//!
+//! So the global pass is an *assembly over known locations* instead: it calls
+//! the very same three Claude Code parsers ([`parse_agents`], [`parse_skills`],
+//! [`parse_instructions`]), pointed at explicit directories. Same reader, same
+//! findings, no fake root.
+//!
+//! [`ReverseLinker`]: crate::audit::reverse::ReverseLinker
+
+use std::path::{Path, PathBuf};
+
+use super::reverse::{
+    ImportedConfig,
+    claude::{parse_agents, parse_instructions, parse_skills},
+};
+
+/// Which surface an audit run reads. Passed to the rule registry, never to a
+/// rule: a rule that reads only `ctx.config` cannot tell which scope filled
+/// it, so scope must not be something a rule can branch on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditScope {
+    /// One repository: `.claude/agents/`, `.claude/skills/`, `CLAUDE.md`.
+    Project,
+    /// What this user carries into every session, wherever they work.
+    Global,
+}
+
+/// The locations the global pass reads, resolved once.
+///
+/// Taken explicitly rather than read from the environment inside the pass, so
+/// unit tests can point it at a tempdir without touching the process
+/// environment (`env_lock()` is not reentrant, and the audit already reads
+/// `$HOME` from two other places).
+#[derive(Debug, Clone)]
+pub struct GlobalLayout {
+    /// `$HOME` — the anchor findings paths are displayed relative to.
+    pub home: PathBuf,
+    /// Claude Code's own user-level root, `~/.claude`.
+    pub claude_home: PathBuf,
+    /// ArmadAI's user-level root, `~/.config/armadai` (or wherever
+    /// `$ARMADAI_CONFIG_DIR` / `$XDG_CONFIG_HOME` puts it).
+    pub armadai_config: PathBuf,
+}
+
+impl GlobalLayout {
+    /// Resolve from the environment. `$HOME` is read directly, exactly as
+    /// `usage::discovery::projects_root` does for `~/.claude/projects`; the
+    /// ArmadAI root goes through `config_dir()` so `$ARMADAI_CONFIG_DIR` and
+    /// `$XDG_CONFIG_HOME` keep working.
+    pub fn from_env() -> Self {
+        let home = PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".to_string()));
+        Self {
+            claude_home: home.join(".claude"),
+            armadai_config: armadai_core::config::config_dir(),
+            home,
+        }
+    }
+}
+
+/// What the global pass read, and what it deliberately did not.
+#[derive(Debug, Clone)]
+pub struct GlobalImport {
+    /// Labels of the roots that held at least one readable surface. Empty
+    /// means "nothing to audit", which the CLI reports as such.
+    pub detected: Vec<String>,
+    pub config: ImportedConfig,
+    /// Locations left unread, each with its reason. Stated rather than
+    /// silent: a user with 77 agents in a directory the audit skips must be
+    /// told, or the report reads as "you have no agents".
+    pub skipped: Vec<String>,
+}
+
+/// Read every native Claude Code surface the user carries globally.
+///
+/// Two roots, one reader:
+/// - `~/.claude` — `agents/`, `skills/` and `CLAUDE.md`, the same three
+///   surfaces a repository exposes, at user level;
+/// - `~/.config/armadai/skills` — installed skills. These follow the Agent
+///   Skills standard (`SKILL.md` + frontmatter), the same format
+///   `~/.claude/skills` uses, so the same parser reads them.
+///
+/// What it does not read, and why, is in [`skipped_locations`].
+pub fn import_global_surfaces(layout: &GlobalLayout) -> GlobalImport {
+    let mut config = ImportedConfig::default();
+    let mut detected = Vec::new();
+
+    let claude_agents = layout.claude_home.join("agents");
+    let claude_skills = layout.claude_home.join("skills");
+    let claude_md = layout.claude_home.join("CLAUDE.md");
+    if claude_agents.is_dir() || claude_skills.is_dir() || claude_md.is_file() {
+        detected.push(format!("claude ({})", tildify(layout, &layout.claude_home)));
+        config.agents.extend(parse_agents(&claude_agents));
+        config.skills.extend(parse_skills(&claude_skills));
+        config.instructions = parse_instructions(&claude_md);
+    }
+
+    let armadai_skills = layout.armadai_config.join("skills");
+    if armadai_skills.is_dir() {
+        detected.push(format!(
+            "armadai ({})",
+            tildify(layout, &layout.armadai_config)
+        ));
+        config.skills.extend(parse_skills(&armadai_skills));
+    }
+
+    config.agents.sort_by(|a, b| a.name.cmp(&b.name));
+    config.skills.sort_by(|a, b| a.name.cmp(&b.name));
+
+    GlobalImport {
+        detected,
+        config,
+        skipped: skipped_locations(layout),
+    }
+}
+
+/// Global locations the audit deliberately leaves out, described only when
+/// they actually exist on this machine — a note about a directory nobody has
+/// is a lecture, not a fact.
+///
+/// Three exclusions, three different reasons:
+///
+/// - **`registry/`** is a synced catalogue of *other people's* assets. It is
+///   also what skewed `R01`'s original calibration: of the 461 `SKILL.md`
+///   files the threshold was derived from, 407 (88%) came from here. Auditing
+///   them would be noise, and having measured them was a mistake.
+/// - **`starters/`** holds starter packs — assets not installed, so not in
+///   anyone's context. Same category as the catalogue.
+/// - **`agents/`** holds ArmadAI-format agents (H1 + `## Metadata` +
+///   `## System Prompt`), not native Claude Code frontmatter. Measured on the
+///   77 agents of one real library: read through this reverse pass, every one
+///   of them yields an `A01` critical ("missing YAML frontmatter") and the
+///   command exits non-zero on a healthy library. Reading them needs an
+///   ArmadAI-format reverse importer, which is a separate piece of work.
+fn skipped_locations(layout: &GlobalLayout) -> Vec<String> {
+    let mut out = Vec::new();
+    let agents = layout.armadai_config.join("agents");
+    if agents.is_dir() {
+        out.push(format!(
+            "{} ({} file(s)) — ArmadAI-format agents; this pass reads native Claude Code \
+             frontmatter only",
+            tildify(layout, &agents),
+            md_file_count(&agents)
+        ));
+    }
+    for (dir, why) in [
+        ("registry", "synced catalogue of other people's assets"),
+        ("starters", "starter packs, not installed assets"),
+        (
+            "skills-registry",
+            "synced catalogue of other people's assets",
+        ),
+    ] {
+        let path = layout.armadai_config.join(dir);
+        if path.is_dir() {
+            out.push(format!("{} — {why}", tildify(layout, &path)));
+        }
+    }
+    out
+}
+
+/// Top-level `*.md` files in `dir` — how many assets the skipped note is
+/// about. `0` when the directory is unreadable, which is also what the
+/// caller would want to print.
+fn md_file_count(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|e| e.path().is_file())
+                .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// `~/.config/armadai` rather than `/Users/someone/.config/armadai`, when the
+/// path sits under `$HOME`. Absolute otherwise (a redirected
+/// `$ARMADAI_CONFIG_DIR` need not be under the home directory at all).
+fn tildify(layout: &GlobalLayout, p: &Path) -> String {
+    match p.strip_prefix(&layout.home) {
+        Ok(rel) => format!("~/{}", rel.display()),
+        Err(_) => p.display().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A layout over a tempdir. No environment variable is touched: the whole
+    /// point of taking `GlobalLayout` explicitly is that the unit tests can
+    /// stay off `env_lock()` (which is not reentrant) while the black-box
+    /// suite proves `from_env` separately.
+    struct Fake {
+        dir: tempfile::TempDir,
+    }
+
+    impl Fake {
+        fn new() -> Self {
+            Self {
+                dir: tempfile::tempdir().unwrap(),
+            }
+        }
+
+        fn layout(&self) -> GlobalLayout {
+            let home = self.dir.path().to_path_buf();
+            GlobalLayout {
+                claude_home: home.join(".claude"),
+                armadai_config: home.join(".config/armadai"),
+                home,
+            }
+        }
+
+        /// Writes `rel` under the fake home, parents included.
+        fn write(&self, rel: &str, content: &str) {
+            let p = self.dir.path().join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(p, content).unwrap();
+        }
+    }
+
+    fn skill_md(name: &str) -> String {
+        format!("---\nname: {name}\ndescription: {name} does things\n---\nBody.")
+    }
+
+    #[test]
+    fn both_global_homes_are_read_through_the_same_parsers() {
+        let fake = Fake::new();
+        fake.write(
+            ".claude/agents/reviewer.md",
+            "---\nname: reviewer\ndescription: Reviews\n---\nYou review.",
+        );
+        fake.write(".claude/skills/native/SKILL.md", &skill_md("native"));
+        fake.write(".claude/CLAUDE.md", "# Global\nUse @reviewer.");
+        fake.write(
+            ".config/armadai/skills/installed/SKILL.md",
+            &skill_md("installed"),
+        );
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        let names: Vec<&str> = imported
+            .config
+            .skills
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["installed", "native"],
+            "both skill roots must be read, sorted by name"
+        );
+        assert_eq!(
+            imported.config.agents.len(),
+            1,
+            "~/.claude/agents must be read: {:?}",
+            imported.config.agents
+        );
+        let instructions = imported
+            .config
+            .instructions
+            .as_ref()
+            .expect("~/.claude/CLAUDE.md is the global instructions file, not ~/CLAUDE.md");
+        assert!(instructions.content.contains("@reviewer"));
+        assert_eq!(
+            imported.detected,
+            vec![
+                "claude (~/.claude)".to_string(),
+                "armadai (~/.config/armadai)".to_string()
+            ]
+        );
+    }
+
+    /// `~/CLAUDE.md` is *not* the global instructions file — the project pass
+    /// looks for `<root>/CLAUDE.md`, and reusing that mapping for the home
+    /// directory would read the wrong file (or, here, nothing at all).
+    #[test]
+    fn the_home_directory_root_is_not_mistaken_for_the_instructions_file() {
+        let fake = Fake::new();
+        fake.write("CLAUDE.md", "# Wrong place");
+        fake.write(".claude/skills/x/SKILL.md", &skill_md("x"));
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        assert!(
+            imported.config.instructions.is_none(),
+            "~/CLAUDE.md must not be read as the global instructions file"
+        );
+    }
+
+    /// The synced catalogue is what skewed `R01`'s calibration (407 of 461
+    /// files). Neither scope reads it, and this is the guard that says so:
+    /// the two decoys sit exactly where the two plausible mistakes would find
+    /// them — as a direct child of `registry/` (the shape `parse_skills`
+    /// reads) and at the real catalogue's own depth.
+    #[test]
+    fn the_synced_catalogue_is_never_read() {
+        let fake = Fake::new();
+        fake.write(".config/armadai/skills/mine/SKILL.md", &skill_md("mine"));
+        fake.write(
+            ".config/armadai/registry/borrowed/SKILL.md",
+            &skill_md("borrowed"),
+        );
+        fake.write(
+            ".config/armadai/registry/repo/skills/deep-borrowed/SKILL.md",
+            &skill_md("deep-borrowed"),
+        );
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        let names: Vec<&str> = imported
+            .config
+            .skills
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["mine"],
+            "only installed skills are audited; the catalogue is other people's"
+        );
+        assert!(
+            imported
+                .skipped
+                .iter()
+                .any(|l| l.contains("~/.config/armadai/registry")),
+            "the exclusion must be stated, not silent: {:?}",
+            imported.skipped
+        );
+    }
+
+    /// Reading the 77 ArmadAI-format agents of a real library through this
+    /// (Claude Code frontmatter) reverse pass produced 77 `A01` criticals and
+    /// a non-zero exit on a healthy library. They are skipped — and named,
+    /// with their count, so the report never reads as "you have no agents".
+    #[test]
+    fn armadai_format_agents_are_skipped_and_counted() {
+        let fake = Fake::new();
+        fake.write(
+            ".config/armadai/agents/agent-builder.md",
+            "# Agent Builder\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi.",
+        );
+        fake.write(
+            ".config/armadai/agents/dev-lead.md",
+            "# Dev Lead\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi.",
+        );
+        fake.write(".config/armadai/skills/mine/SKILL.md", &skill_md("mine"));
+
+        let imported = import_global_surfaces(&fake.layout());
+
+        assert!(
+            imported.config.agents.is_empty(),
+            "ArmadAI-format agents are not native frontmatter and must not be \
+             parsed as such: {:?}",
+            imported.config.agents
+        );
+        let note = imported
+            .skipped
+            .iter()
+            .find(|l| l.contains("~/.config/armadai/agents"))
+            .unwrap_or_else(|| panic!("the skipped pile must be named: {:?}", imported.skipped));
+        assert!(
+            note.contains("2 file(s)"),
+            "the note must carry how much was skipped, got: {note}"
+        );
+    }
+
+    #[test]
+    fn nothing_installed_means_nothing_detected() {
+        let fake = Fake::new();
+        let imported = import_global_surfaces(&fake.layout());
+        assert!(
+            imported.detected.is_empty(),
+            "an empty library must report nothing detected, so the CLI can say so"
+        );
+        assert!(imported.skipped.is_empty(), "{:?}", imported.skipped);
+    }
+
+    /// A config root outside `$HOME` (a redirected `$ARMADAI_CONFIG_DIR`) has
+    /// no `~/` form, and printing one would be a lie about where the file is.
+    #[test]
+    fn a_config_root_outside_home_is_shown_absolute() {
+        let home = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(elsewhere.path().join("skills/x")).unwrap();
+        std::fs::write(elsewhere.path().join("skills/x/SKILL.md"), skill_md("x")).unwrap();
+        let layout = GlobalLayout {
+            home: home.path().to_path_buf(),
+            claude_home: home.path().join(".claude"),
+            armadai_config: elsewhere.path().to_path_buf(),
+        };
+
+        let imported = import_global_surfaces(&layout);
+
+        assert_eq!(
+            imported.detected,
+            vec![format!("armadai ({})", elsewhere.path().display())]
+        );
+    }
+}

--- a/crates/armadai/src/cli/audit.rs
+++ b/crates/armadai/src/cli/audit.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
 use crate::audit::{
+    AuditInput, AuditScope, GlobalLayout,
     deep::{DeepOutcome, available_cli, run_deep},
-    import_surfaces,
     proposal::generate_proposal,
+    reverse::ImportedConfig,
     rules::{AuditSettings, Severity},
-    run_audit,
 };
 use armadai_core::agent::{Agent, AgentMetadata};
 use armadai_core::provider::{ChatMessage, CompletionRequest};
@@ -89,16 +89,19 @@ fn call_deep_auditor(agent: &Agent, prompt: &str) -> anyhow::Result<String> {
 /// was found in `PATH`); it is passed in rather than re-detected here so
 /// callers (and tests) can inject the detection result instead of mutating
 /// the process environment.
+///
+/// `config` is the surfaces the caller already imported, rather than a root
+/// to import again: the global scope has no single root to re-derive them
+/// from, and re-reading them was a third full pass over the same files.
 async fn apply_deep_pass(
     audit: &mut crate::audit::report::AuditReport,
-    root: &std::path::Path,
+    config: &ImportedConfig,
     settings: &AuditSettings,
     cli: Option<&str>,
 ) -> anyhow::Result<()> {
     let Some(cli) = cli else {
         anyhow::bail!("--deep requires an LLM CLI (claude, gemini); none found in PATH");
     };
-    let (_, config) = import_surfaces(root);
     let agent = build_deep_auditor(cli);
     let run = |prompt: &str| call_deep_auditor(&agent, prompt);
     let w = crate::cli::style::warn();
@@ -107,7 +110,7 @@ async fn apply_deep_pass(
          finding message (U01-U04), to the '{cli}' CLI.{w:#}"
     );
     match run_deep(
-        &config,
+        config,
         &audit.findings,
         settings.deep_prompt_truncation,
         run,
@@ -125,8 +128,14 @@ async fn apply_deep_pass(
     Ok(())
 }
 
+// One parameter per CLI flag, as every other command in this module does
+// (`run`, `link`, `unlink`): the dispatcher in `cli/mod.rs` destructures the
+// clap variant and forwards it, so an args struct here would only move the
+// arity one level up.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     path: Option<PathBuf>,
+    global: bool,
     report: Option<PathBuf>,
     min_severity: String,
     quiet: bool,
@@ -134,6 +143,10 @@ pub async fn execute(
     deep: bool,
     no_usage: bool,
 ) -> anyhow::Result<()> {
+    // The working root, even in global scope, where it is not what gets
+    // audited but still what the command is anchored on: an `audit:` section
+    // in the directory you stand in tunes the thresholds, and `--propose`
+    // writes its pack here rather than into `$HOME`.
     let root = match path {
         Some(p) => p,
         None => std::env::current_dir()?,
@@ -142,32 +155,40 @@ pub async fn execute(
         anyhow::bail!("not a directory: {}", root.display());
     }
     let settings = AuditSettings::from_project(&root);
-    // Detect first: on the "nothing here" path, there is nothing to audit
+    // Import first: on the "nothing here" path, there is nothing to audit
     // and nothing to propose, so the (potentially hundreds-of-megabytes)
-    // transcript scan below must never run for it. `config` is kept around
-    // so `--propose` can reuse it instead of importing the surfaces a
-    // second time.
-    let (detected, config) = import_surfaces(&root);
-    if detected.is_empty() {
+    // transcript scan below must never run for it. The imported surfaces are
+    // kept around so `--propose` and `--deep` reuse them instead of reading
+    // the same files a second and third time.
+    let input = if global {
+        AuditInput::for_global(&GlobalLayout::from_env())
+    } else {
+        AuditInput::for_project(&root)
+    };
+    if input.detected.is_empty() {
         let o = crate::cli::style::ok();
         let m = crate::cli::style::muted();
-        anstream::println!(
-            "{o}No native agentic configuration detected in{o:#} {m}{}.{m:#}",
-            root.display()
-        );
+        let where_ = match input.scope {
+            AuditScope::Global => "your global library".to_string(),
+            AuditScope::Project => format!("{}", root.display()),
+        };
+        anstream::println!("{o}No native agentic configuration detected in{o:#} {m}{where_}.{m:#}");
         return Ok(());
     }
     // The flag always wins over the config key (`audit.usage`); the config
-    // key only takes effect when the flag is absent.
-    let usage_enabled = !no_usage && settings.usage;
+    // key only takes effect when the flag is absent. Global scope never
+    // scans: U01-U04 correlate *one project's* transcripts, and the global
+    // library belongs to no project — so the (potentially very large) scan is
+    // skipped outright rather than run and then ignored.
+    let usage_enabled = !global && !no_usage && settings.usage;
     // Scanned at most once here (only when something was detected and usage
     // measurement is enabled) and bound for the rest of the command —
     // transcripts can run into the hundreds of megabytes.
     let usage = usage_enabled.then(|| crate::audit::usage::scan(&root));
     let usage = usage.filter(|o| !o.is_empty());
-    let mut audit = run_audit(&root, &settings, usage.as_ref());
+    let mut audit = input.analyse(&settings, usage.as_ref());
     if deep {
-        apply_deep_pass(&mut audit, &root, &settings, available_cli()).await?;
+        apply_deep_pass(&mut audit, &input.config, &settings, available_cli()).await?;
     }
     audit.print_terminal(min_severity_from(&min_severity, quiet));
     if let Some(out) = report {
@@ -195,7 +216,7 @@ pub async fn execute(
         }
     }
     if propose {
-        let summary = generate_proposal(&root, &config)?;
+        let summary = generate_proposal(&root, &input.config)?;
         anstream::println!();
         let o = crate::cli::style::ok();
         let m = crate::cli::style::muted();
@@ -331,6 +352,7 @@ mod tests {
     async fn execute_fails_on_missing_path() {
         let result = execute(
             Some(PathBuf::from("/nonexistent/xyz")),
+            false,
             None,
             "info".to_string(),
             false,
@@ -351,6 +373,7 @@ mod tests {
         std::fs::write(agents.join("bad.md"), "---\nname: [broken\n---\nBody").unwrap();
         let result = execute(
             Some(dir.path().to_path_buf()),
+            false,
             None,
             "info".to_string(),
             false,
@@ -376,6 +399,7 @@ mod tests {
         let report_path = dir.path().join("audit.md");
         let result = execute(
             Some(dir.path().to_path_buf()),
+            false,
             Some(report_path.clone()),
             "info".to_string(),
             false,
@@ -403,6 +427,7 @@ mod tests {
         let report_path = dir.path().join("audit.html");
         let result = execute(
             Some(dir.path().to_path_buf()),
+            false,
             Some(report_path.clone()),
             "info".to_string(),
             false,
@@ -429,6 +454,7 @@ mod tests {
         .unwrap();
         let result = execute(
             Some(dir.path().to_path_buf()),
+            false,
             None,
             "info".to_string(),
             false,
@@ -453,6 +479,7 @@ mod tests {
         let report_path = project.path().join("audit.md");
         let result = execute(
             Some(project.path().to_path_buf()),
+            false,
             Some(report_path.clone()),
             "info".to_string(),
             false,
@@ -475,6 +502,7 @@ mod tests {
         let report_path = project.path().join("audit.md");
         let result = execute(
             Some(project.path().to_path_buf()),
+            false,
             Some(report_path.clone()),
             "info".to_string(),
             false,
@@ -503,6 +531,7 @@ mod tests {
         let report_path = project.path().join("audit.md");
         let result = execute(
             Some(project.path().to_path_buf()),
+            false,
             Some(report_path.clone()),
             "info".to_string(),
             false,
@@ -531,6 +560,7 @@ mod tests {
         let report_path = project.path().join("audit.md");
         let result = execute(
             Some(project.path().to_path_buf()),
+            false,
             Some(report_path.clone()),
             "info".to_string(),
             false,
@@ -552,8 +582,9 @@ mod tests {
         std::fs::create_dir_all(&agents).unwrap();
         std::fs::write(agents.join("a.md"), "---\nname: a\ndescription: d\n---\nP.").unwrap();
         let settings = AuditSettings::from_project(dir.path());
-        let mut audit = run_audit(dir.path(), &settings, None);
-        let err = apply_deep_pass(&mut audit, dir.path(), &settings, None)
+        let input = AuditInput::for_project(dir.path());
+        let mut audit = input.analyse(&settings, None);
+        let err = apply_deep_pass(&mut audit, &input.config, &settings, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("--deep requires an LLM CLI"));

--- a/crates/armadai/src/cli/audit.rs
+++ b/crates/armadai/src/cli/audit.rs
@@ -83,6 +83,31 @@ fn call_deep_auditor(agent: &Agent, prompt: &str) -> anyhow::Result<String> {
     Ok(response.content)
 }
 
+/// What `--deep` is about to send, and — in global scope — whose material it
+/// is.
+///
+/// Returned as a `String` rather than printed inline so the wording is
+/// assertable: the two scopes cross a different privacy boundary, and a single
+/// shared sentence silently understated the wider one. In project scope the
+/// excerpts come from a repository's shared config; in global scope they are
+/// the user's own `~/.claude/CLAUDE.md` and the prompts of their global
+/// agents. That is the same boundary that kept `R03` out of the rule set, so
+/// the warning has to name it.
+fn deep_privacy_note(scope: AuditScope, cli: &str) -> String {
+    let mut note = format!(
+        "Note: --deep sends (secret-redacted) prompt excerpts, and any observed-usage \
+         finding message (U01-U04), to the '{cli}' CLI."
+    );
+    if scope == AuditScope::Global {
+        note.push_str(
+            " In global scope those excerpts are your own material: \
+             ~/.claude/CLAUDE.md and the prompts of your global agents, not a \
+             repository's shared config.",
+        );
+    }
+    note
+}
+
 /// Run the `--deep` LLM analysis pass and merge its outcome into `audit`.
 ///
 /// `cli` is the already-detected CLI name (or `None` if no supported LLM CLI
@@ -105,10 +130,8 @@ async fn apply_deep_pass(
     let agent = build_deep_auditor(cli);
     let run = |prompt: &str| call_deep_auditor(&agent, prompt);
     let w = crate::cli::style::warn();
-    anstream::eprintln!(
-        "{w}  Note: --deep sends (secret-redacted) prompt excerpts, and any observed-usage \
-         finding message (U01-U04), to the '{cli}' CLI.{w:#}"
-    );
+    let note = deep_privacy_note(audit.scope, cli);
+    anstream::eprintln!("{w}  {note}{w:#}");
     match run_deep(
         config,
         &audit.findings,
@@ -143,10 +166,9 @@ pub async fn execute(
     deep: bool,
     no_usage: bool,
 ) -> anyhow::Result<()> {
-    // The working root, even in global scope, where it is not what gets
-    // audited but still what the command is anchored on: an `audit:` section
-    // in the directory you stand in tunes the thresholds, and `--propose`
-    // writes its pack here rather than into `$HOME`.
+    // The working root. In global scope it is not what gets audited, and no
+    // longer what tunes the thresholds either (see `settings` below) — it is
+    // only where `--propose` writes its pack, i.e. wherever the user stands.
     let root = match path {
         Some(p) => p,
         None => std::env::current_dir()?,
@@ -154,21 +176,41 @@ pub async fn execute(
     if !root.is_dir() {
         anyhow::bail!("not a directory: {}", root.display());
     }
-    let settings = AuditSettings::from_project(&root);
+    // Thresholds follow the audited surface, not the working directory: a
+    // global audit read from `<cwd>/armadai.yaml` gave a different verdict on
+    // the same library depending on which folder it was launched from
+    // (measured: 2 `R01` warnings from a directory carrying
+    // `skill_token_threshold: 5`, 0 from a neutral one). The global library's
+    // own settings live with it, in `~/.config/armadai/config.yaml`.
+    let settings = if global {
+        AuditSettings::from_global()
+    } else {
+        AuditSettings::from_project(&root)
+    };
     // Import first: on the "nothing here" path, there is nothing to audit
     // and nothing to propose, so the (potentially hundreds-of-megabytes)
     // transcript scan below must never run for it. The imported surfaces are
     // kept around so `--propose` and `--deep` reuse them instead of reading
     // the same files a second and third time.
     let input = if global {
-        AuditInput::for_global(&GlobalLayout::from_env())
+        // No `$HOME`, no `~`, nothing global to audit. Falling back to `.`
+        // reported the current repository's `.claude/` as the user's library,
+        // labelled `~/.claude` — a wrong answer indistinguishable from a right
+        // one, which is worse than a refusal.
+        let Some(layout) = GlobalLayout::from_env() else {
+            anyhow::bail!(
+                "--global audits what lives under ~, and $HOME is not set; \
+                 set it, or audit a path instead"
+            );
+        };
+        AuditInput::for_global(&layout)
     } else {
         AuditInput::for_project(&root)
     };
-    if input.detected.is_empty() {
+    if input.detected().is_empty() {
         let o = crate::cli::style::ok();
         let m = crate::cli::style::muted();
-        let where_ = match input.scope {
+        let where_ = match input.scope() {
             AuditScope::Global => "your global library".to_string(),
             AuditScope::Project => format!("{}", root.display()),
         };
@@ -188,7 +230,7 @@ pub async fn execute(
     let usage = usage.filter(|o| !o.is_empty());
     let mut audit = input.analyse(&settings, usage.as_ref());
     if deep {
-        apply_deep_pass(&mut audit, &input.config, &settings, available_cli()).await?;
+        apply_deep_pass(&mut audit, input.config(), &settings, available_cli()).await?;
     }
     audit.print_terminal(min_severity_from(&min_severity, quiet));
     if let Some(out) = report {
@@ -216,7 +258,7 @@ pub async fn execute(
         }
     }
     if propose {
-        let summary = generate_proposal(&root, &input.config)?;
+        let summary = generate_proposal(&root, input.config())?;
         anstream::println!();
         let o = crate::cli::style::ok();
         let m = crate::cli::style::muted();
@@ -575,6 +617,33 @@ mod tests {
         assert!(!md.contains("U01") && !md.contains("U02"), "{md}");
     }
 
+    /// The two scopes cross a different privacy boundary, and the warning has
+    /// to say which one. A single shared sentence understated the global case:
+    /// it named "prompt excerpts" while what actually leaves the machine is
+    /// the user's own instructions file and their personal agents' prompts.
+    #[test]
+    fn the_deep_warning_names_whose_material_leaves_the_machine() {
+        let project = deep_privacy_note(AuditScope::Project, "claude");
+        assert!(
+            project.contains("'claude' CLI"),
+            "the target CLI must be named: {project}"
+        );
+        assert!(
+            !project.contains("global"),
+            "a project run must not claim to send the user's own library: {project}"
+        );
+
+        let global = deep_privacy_note(AuditScope::Global, "claude");
+        assert!(
+            global.contains("~/.claude/CLAUDE.md"),
+            "a global run must name the user's own instructions file: {global}"
+        );
+        assert!(
+            global.contains("global agents"),
+            "and the prompts of their global agents: {global}"
+        );
+    }
+
     #[tokio::test]
     async fn deep_pass_without_cli_errors_explicitly() {
         let dir = tempfile::tempdir().unwrap();
@@ -584,7 +653,7 @@ mod tests {
         let settings = AuditSettings::from_project(dir.path());
         let input = AuditInput::for_project(dir.path());
         let mut audit = input.analyse(&settings, None);
-        let err = apply_deep_pass(&mut audit, &input.config, &settings, None)
+        let err = apply_deep_pass(&mut audit, input.config(), &settings, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("--deep requires an LLM CLI"));

--- a/crates/armadai/src/cli/mod.rs
+++ b/crates/armadai/src/cli/mod.rs
@@ -181,17 +181,31 @@ pub enum Command {
         path: Option<std::path::PathBuf>,
     },
     /// Audit native agentic configs (Claude Code) and report issues
-    #[command(long_about = "Audit native agentic configs and report issues.\n\n\
+    #[command(
+        long_about = "Audit native agentic configs and report issues.\n\n\
             Scans .claude/agents/, .claude/skills/ and CLAUDE.md (no ArmadAI setup \
             required), runs static rules (deprecated models, oversized prompts, \
             duplicated blocks, broken references, plaintext secrets...) and prints \
             an actionable report. It also reads this project's Claude Code transcripts \
             under ~/.claude/projects/ to measure observed usage (rules U01-U04) — that \
             data never leaves this machine; pass --no-usage or set `audit.usage: false` \
-            in the project config to skip it. Exits non-zero if critical findings exist.")]
+            in the project config to skip it. Exits non-zero if critical findings exist.\n\n\
+            With --global, audits what you carry into every session instead: \
+            ~/.claude/agents/, ~/.claude/skills/, ~/.claude/CLAUDE.md and \
+            ~/.config/armadai/skills/. Every rule family applies except U01-U04, which \
+            correlate one project's transcripts. The synced catalogue \
+            (~/.config/armadai/registry) is never read, in either scope.",
+        after_help = "Examples:\n  \
+            armadai audit\n  \
+            armadai audit --global\n  \
+            armadai audit --report report.html"
+    )]
     Audit {
         /// Project directory to audit (defaults to current directory)
         path: Option<std::path::PathBuf>,
+        /// Audit the user's global library instead of a project
+        #[arg(long, conflicts_with = "path")]
+        global: bool,
         /// Write a report to this file (markdown, or HTML if the extension is .html)
         #[arg(long)]
         report: Option<std::path::PathBuf>,
@@ -643,13 +657,26 @@ pub async fn handle(cli: Cli) -> anyhow::Result<()> {
         Command::Validate { path } => validate::execute(path).await,
         Command::Audit {
             path,
+            global,
             report,
             min_severity,
             quiet,
             propose,
             deep,
             no_usage,
-        } => audit::execute(path, report, min_severity, quiet, propose, deep, no_usage).await,
+        } => {
+            audit::execute(
+                path,
+                global,
+                report,
+                min_severity,
+                quiet,
+                propose,
+                deep,
+                no_usage,
+            )
+            .await
+        }
         Command::History { agent } => history::execute(agent).await,
         Command::Costs { agent, from } => costs::execute(agent, from).await,
         Command::Projections(action) => projections::execute(action).await,

--- a/crates/armadai/tests/audit_scopes.rs
+++ b/crates/armadai/tests/audit_scopes.rs
@@ -102,6 +102,36 @@ mod tests {
                 stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
             }
         }
+
+        /// Same run with `HOME` *removed* from the child's environment.
+        ///
+        /// A spawned binary is the only honest way to test this: `$HOME` is
+        /// process-global, and unsetting it in-process means holding
+        /// `env_lock()`, which is not reentrant and which several tests in
+        /// this crate already take.
+        fn run_without_home(&self, args: &[&str]) -> Output {
+            let out = Command::cargo_bin("armadai")
+                .unwrap()
+                .current_dir(self.work())
+                .arg("audit")
+                .args(args)
+                .env("NO_COLOR", "1")
+                .env_remove("HOME")
+                .env("ARMADAI_CONFIG_DIR", self.home().join(".config/armadai"))
+                .env("XDG_CONFIG_HOME", self.home().join(".config"))
+                .env("XDG_DATA_HOME", self.dir.path().join("data"))
+                .env(
+                    "ARMADAI_CLAUDE_PROJECTS_DIR",
+                    self.dir.path().join("transcripts"),
+                )
+                .output()
+                .unwrap();
+            Output {
+                success: out.status.success(),
+                stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            }
+        }
     }
 
     struct Output {
@@ -348,6 +378,59 @@ mod tests {
         out.has_no_line_with("A01", &["agent-builder"]);
     }
 
+    /// The plugin trees under `~/.claude` are the largest thing the pass does
+    /// not read, and the one it was silent about. Measured on one real machine:
+    /// the report announced "48 skills, ~49967 tokens" while
+    /// `~/.claude/plugins/cache` held 17 further installed `SKILL.md` worth
+    /// ~39177 tokens — the stated total 44% short — two of which cross `R01`.
+    ///
+    /// Two lines, not one, and the distinction is the point: `cache/` is what
+    /// is *installed* and live in the session, `marketplaces/` is the
+    /// catalogue it was installed from. Folding them together would erase the
+    /// installed-vs-catalogue distinction this pass makes everywhere else
+    /// (`~/.config/armadai/skills` read, `registry/` excluded).
+    #[test]
+    fn global_names_the_plugin_skills_it_does_not_read() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/skills/mine/SKILL.md",
+            "---\nname: mine\ndescription: d\n---\nB.",
+        );
+        for name in ["writing-skills", "brainstorming"] {
+            s.write(
+                &format!(
+                    "home/.claude/plugins/cache/official/superpowers/6.3.0/skills/{name}/SKILL.md"
+                ),
+                &heavy_skill(name),
+            );
+        }
+        s.write(
+            "home/.claude/plugins/marketplaces/official/plugins/receipts/skills/receipts/SKILL.md",
+            &heavy_skill("receipts"),
+        );
+
+        let out = s.run(&["--global"]);
+        out.ran();
+
+        let installed = out.line_with("Not read:", &["plugins/cache", "2 skill(s)"]);
+        assert!(
+            installed.contains("installed"),
+            "the installed set must be named as installed, got: {installed}"
+        );
+        let catalogue = out.line_with("Not read:", &["plugins/marketplaces"]);
+        assert!(
+            catalogue.contains("catalogue"),
+            "the catalogue must be named as a catalogue, got: {catalogue}"
+        );
+        assert_ne!(
+            installed, catalogue,
+            "the two must be separate lines, not one note about ~/.claude/plugins"
+        );
+        // Named, not read: the heavy plugin skills must not become findings.
+        out.has_no_line_with("R01", &["writing-skills"])
+            .has_no_line_with("R01", &["receipts"]);
+    }
+
     /// A report file that does not say which scope it covers is a trap: the
     /// two carry identical rule codes over different assets.
     #[test]
@@ -401,11 +484,16 @@ mod tests {
         );
     }
 
-    /// `--propose` in global scope has no project root to write into, and
-    /// writing into `$HOME` unasked would be rude. It writes where the user
-    /// stands.
+    /// `--propose` in global scope has no project root to write into, so it
+    /// writes into the **current directory, whatever that is** — the same place
+    /// project scope would.
+    ///
+    /// Not "never into `$HOME`": if the user stands *in* `$HOME`, that is where
+    /// the pack lands, and correctly so. The invariant is the cwd, and the
+    /// sandbox below stands in `work/`, which is why nothing appears under the
+    /// fake home.
     #[test]
-    fn global_propose_writes_into_the_working_directory_not_home() {
+    fn global_propose_writes_into_the_current_directory() {
         let s = Sandbox::new();
         s.write(
             "home/.claude/agents/reviewer.md",
@@ -426,7 +514,7 @@ mod tests {
         );
         assert!(
             !s.home().join(".armadai-proposal").exists(),
-            "nothing may be written into $HOME"
+            "the pack follows the cwd, and the cwd here is work/, not the home"
         );
     }
 
@@ -442,6 +530,133 @@ mod tests {
                 .contains("No native agentic configuration detected in your global library"),
             "got:\n{}",
             out.stdout
+        );
+    }
+
+    /// With no `$HOME` there is no `~`, so there is nothing global to audit.
+    ///
+    /// The fallback that used to stand there (`unwrap_or_else(|_| ".")`) made
+    /// `--global` report the *current repository's* `.claude/` as the user's
+    /// library, labelled `~/.claude` — a wrong answer indistinguishable from a
+    /// right one on stdout. `usage::discovery::projects_root` refuses in the
+    /// same situation; this is the guard that keeps the two consistent.
+    #[test]
+    fn global_refuses_to_run_without_a_home_rather_than_auditing_the_repository() {
+        let s = Sandbox::new();
+        // A project that would be picked up by the `.` fallback, and a global
+        // library that is *not* it, so the two cannot be confused.
+        s.write(
+            "work/.claude/skills/repo-heavy/SKILL.md",
+            &heavy_skill("repo-heavy"),
+        );
+        s.write(
+            "home/.claude/skills/mine-heavy/SKILL.md",
+            &heavy_skill("mine-heavy"),
+        );
+
+        let out = s.run_without_home(&["--global"]);
+
+        assert!(
+            !out.success,
+            "a global audit with no $HOME must refuse, not improvise:\n{}\n{}",
+            out.stdout, out.stderr
+        );
+        assert!(
+            out.stderr.contains("$HOME"),
+            "the refusal must name the cause, got:\n{}",
+            out.stderr
+        );
+        assert!(
+            !out.stdout.contains("repo-heavy"),
+            "the working repository is not the user's global library:\n{}",
+            out.stdout
+        );
+        assert!(
+            !out.stdout.contains("~/.claude"),
+            "and nothing may be labelled ~/.claude when there is no ~:\n{}",
+            out.stdout
+        );
+        // The control: the very same fixture audits fine with a $HOME, so the
+        // refusal above is about $HOME and not about the fixture.
+        s.run(&["--global"]).ran().line_with("R01", &["mine-heavy"]);
+    }
+
+    /// A global audit reads one fixed set of assets, so it must reach one
+    /// fixed verdict. Its thresholds come from the *global* config
+    /// (`~/.config/armadai/config.yaml`), not from `<cwd>/armadai.yaml`:
+    /// measured before this fix, the same library reported 2 `R01` warnings
+    /// from a directory carrying `skill_token_threshold: 5` and 0 from a
+    /// neutral one.
+    #[test]
+    fn global_thresholds_come_from_the_global_config_not_the_working_directory() {
+        let s = Sandbox::new();
+        // Small enough that the 4000 default never flags it.
+        s.write(
+            "home/.claude/skills/small/SKILL.md",
+            "---\nname: small\ndescription: d\n---\nB.",
+        );
+        s.write(
+            "home/.config/armadai/config.yaml",
+            "audit:\n  skill_token_threshold: 1\n",
+        );
+        // The cwd says the opposite, loudly. It must not be consulted.
+        s.write(
+            "work/armadai.yaml",
+            "audit:\n  skill_token_threshold: 100000\n",
+        );
+
+        let out = s.run(&["--global"]);
+        out.ran().line_with("R01", &["small"]);
+    }
+
+    /// The mirror: a project audit keeps reading the project's own config, and
+    /// the global one must not override it. Without this, "settings follow the
+    /// audited surface" could be satisfied by making *both* scopes read the
+    /// global file.
+    #[test]
+    fn a_project_audit_still_reads_the_project_config_not_the_global_one() {
+        let s = Sandbox::new();
+        s.write(
+            "work/.claude/skills/small/SKILL.md",
+            "---\nname: small\ndescription: d\n---\nB.",
+        );
+        s.write(
+            "work/armadai.yaml",
+            "audit:\n  skill_token_threshold: 1\n  usage: false\n",
+        );
+        // A global config that would silence the finding if it were read.
+        s.write(
+            "home/.config/armadai/config.yaml",
+            "audit:\n  skill_token_threshold: 100000\n",
+        );
+
+        let out = s.run(&[]);
+        out.ran().line_with("R01", &["small"]);
+    }
+
+    /// Findings in a global report are shown relative to `$HOME`, which is what
+    /// makes them readable as `.claude/skills/x/SKILL.md` rather than as a
+    /// twelve-segment absolute path. The anchor is not free-standing: it is
+    /// `AuditScope::Global`'s other half, and swapping it for any other
+    /// directory turns every path in the report absolute.
+    #[test]
+    fn global_findings_are_anchored_on_the_home_directory() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/skills/mine-heavy/SKILL.md",
+            &heavy_skill("mine-heavy"),
+        );
+
+        let out = s.run(&["--global"]);
+        let line = out.ran().line_with("R01", &["mine-heavy"]);
+        assert!(
+            line.contains(".claude/skills/mine-heavy/SKILL.md"),
+            "expected a home-relative path, got: {line}"
+        );
+        let home = s.home().display().to_string();
+        assert!(
+            !line.contains(&home),
+            "the path must be relative to $HOME ({home}), not absolute: {line}"
         );
     }
 

--- a/crates/armadai/tests/audit_scopes.rs
+++ b/crates/armadai/tests/audit_scopes.rs
@@ -1,0 +1,463 @@
+//! Black-box coverage for `armadai audit --global`, on the real binary.
+//!
+//! The unit tests in `audit/scope.rs` and `audit/rules/mod.rs` prove the
+//! assembly and the registry in isolation. They cannot prove the thing the
+//! feature *is*: that a flag on the command line changes which files get
+//! audited. Two measured defects on this repository say why that gap matters —
+//! a rule can be perfect and never registered (#374), and a whole output loop
+//! can be cut while 734 unit tests stay green. So every case below asserts on
+//! the **spawned binary's stdout**, and each one is a *differential*: the same
+//! fixture audited in both scopes, where the two must disagree.
+//!
+//! Nothing here reads the developer's real configuration. Five directories are
+//! redirected (see `Sandbox::run`), `HOME` among them, because the global
+//! scope resolves `~/.claude` from it — a test that skipped that redirection
+//! would pass or fail according to whose machine ran it.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use std::path::{Path, PathBuf};
+
+    /// A `SKILL.md` body big enough to cross `R01`'s 4000-token default
+    /// (`chars / 4`), so the finding is arithmetic rather than a guess.
+    fn heavy_skill(name: &str) -> String {
+        let fm = format!("---\nname: {name}\ndescription: {name} does things\n---\n");
+        format!("{fm}{}", "x".repeat(20_000))
+    }
+
+    /// A sandbox holding a fake `$HOME`, a fake ArmadAI config root under it,
+    /// and a working project — every location either scope can reach.
+    struct Sandbox {
+        dir: tempfile::TempDir,
+    }
+
+    impl Sandbox {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            for sub in [
+                "home",
+                "home/.config/armadai",
+                "data",
+                "transcripts",
+                "work",
+            ] {
+                std::fs::create_dir_all(dir.path().join(sub)).unwrap();
+            }
+            Self { dir }
+        }
+
+        fn home(&self) -> PathBuf {
+            self.dir.path().join("home")
+        }
+
+        fn work(&self) -> PathBuf {
+            self.dir.path().join("work")
+        }
+
+        /// Writes `rel` under the sandbox root, parents included.
+        fn write(&self, rel: &str, content: &str) {
+            let path = self.dir.path().join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, content).unwrap();
+        }
+
+        /// Spawns `armadai audit <args>` from `work/`, fully isolated.
+        ///
+        /// Five redirections, each for a directory one of the two scopes would
+        /// otherwise touch on this machine:
+        /// - `HOME`: the global scope resolves `~/.claude/{agents,skills}` and
+        ///   `~/.claude/CLAUDE.md` from it.
+        /// - `ARMADAI_CONFIG_DIR` **and** `XDG_CONFIG_HOME`: the global scope
+        ///   reads `<config>/skills`, and the second is set as well so the
+        ///   first failing to apply cannot silently fall through to the real
+        ///   `~/.config/armadai`.
+        /// - `XDG_DATA_HOME`: the `#[cfg(test)]` guards inside the crate do
+        ///   not apply to a *spawned* binary, so without it a run could reach
+        ///   `~/.local/share/armadai`.
+        /// - `ARMADAI_CLAUDE_PROJECTS_DIR`: project scope scans transcripts
+        ///   unconditionally; left alone it reads the developer's real
+        ///   `~/.claude/projects`, whose `U0x` findings would land in the very
+        ///   stdout these tests assert on.
+        fn run(&self, args: &[&str]) -> Output {
+            let out = Command::cargo_bin("armadai")
+                .unwrap()
+                .current_dir(self.work())
+                .arg("audit")
+                .args(args)
+                .env("NO_COLOR", "1")
+                .env("HOME", self.home())
+                .env("ARMADAI_CONFIG_DIR", self.home().join(".config/armadai"))
+                .env("XDG_CONFIG_HOME", self.home().join(".config"))
+                .env("XDG_DATA_HOME", self.dir.path().join("data"))
+                .env(
+                    "ARMADAI_CLAUDE_PROJECTS_DIR",
+                    self.dir.path().join("transcripts"),
+                )
+                .output()
+                .unwrap();
+            Output {
+                success: out.status.success(),
+                stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            }
+        }
+    }
+
+    struct Output {
+        success: bool,
+        stdout: String,
+        stderr: String,
+    }
+
+    impl Output {
+        /// Asserts the audit actually produced a report, so that every
+        /// *absence* assertion below means "the rule stayed silent" rather
+        /// than "the command printed nothing" — the failure mode that makes a
+        /// negative assertion worthless.
+        fn ran(&self) -> &Self {
+            assert!(
+                self.stdout.contains("armadai audit"),
+                "the audit must have produced a report (success={}):\n{}\n{}",
+                self.success,
+                self.stdout,
+                self.stderr
+            );
+            self
+        }
+
+        /// The single line carrying `rule` and every fragment in `needles`.
+        /// Same-line, never `contains` over the whole output: the report names
+        /// the same file on several lines (`A09`, `A12`, `R04`…), so a
+        /// whole-output `contains(rule) && contains(name)` can pass with the
+        /// rule silent.
+        fn line_with(&self, rule: &str, needles: &[&str]) -> &str {
+            let hit: Vec<&str> = self
+                .stdout
+                .lines()
+                .filter(|l| l.contains(rule) && needles.iter().all(|n| l.contains(n)))
+                .collect();
+            assert_eq!(
+                hit.len(),
+                1,
+                "expected exactly one {rule} line carrying {needles:?}, got {}:\n{}",
+                hit.len(),
+                self.stdout
+            );
+            hit[0]
+        }
+
+        fn has_no_line_with(&self, rule: &str, needles: &[&str]) -> &Self {
+            let hit: Vec<&str> = self
+                .stdout
+                .lines()
+                .filter(|l| l.contains(rule) && needles.iter().all(|n| l.contains(n)))
+                .collect();
+            assert!(
+                hit.is_empty(),
+                "expected no {rule} line carrying {needles:?}, got {hit:?}:\n{}",
+                self.stdout
+            );
+            self
+        }
+    }
+
+    /// The whole point of the feature: skills live in the user's library, not
+    /// in repositories. Measured on three real projects — zero local skills
+    /// against 48 installed globally — which is why `R01` never fired before
+    /// this flag existed.
+    #[test]
+    fn global_finds_the_installed_skills_a_project_scope_cannot_see() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/skills/native-heavy/SKILL.md",
+            &heavy_skill("native-heavy"),
+        );
+        s.write(
+            "home/.config/armadai/skills/installed-heavy/SKILL.md",
+            &heavy_skill("installed-heavy"),
+        );
+        // A project that is detectable, so its own run produces a report.
+        s.write(
+            "work/.claude/agents/dev.md",
+            "---\nname: dev\ndescription: Develops\ntools: Read\n---\nShort.",
+        );
+
+        let global = s.run(&["--global"]);
+        global.ran();
+        global.line_with("R01", &["native-heavy"]);
+        global.line_with("R01", &["installed-heavy"]);
+
+        let project = s.run(&[]);
+        project.ran();
+        project
+            .has_no_line_with("R01", &["native-heavy"])
+            .has_no_line_with("R01", &["installed-heavy"]);
+    }
+
+    /// The separation has to hold in both directions: a repository's own
+    /// skills are the project's business and must not leak into the global
+    /// report, or `--global` would just be "audit everything".
+    #[test]
+    fn a_project_skill_stays_out_of_the_global_report() {
+        let s = Sandbox::new();
+        s.write(
+            "work/.claude/skills/repo-heavy/SKILL.md",
+            &heavy_skill("repo-heavy"),
+        );
+        // A global skill, so `--global` has something to report and the
+        // absence below is silence from the rule, not from the command.
+        s.write(
+            "home/.claude/skills/mine-heavy/SKILL.md",
+            &heavy_skill("mine-heavy"),
+        );
+
+        let project = s.run(&[]);
+        project.ran().line_with("R01", &["repo-heavy"]);
+
+        let global = s.run(&["--global"]);
+        global.ran().line_with("R01", &["mine-heavy"]);
+        global.has_no_line_with("R01", &["repo-heavy"]);
+    }
+
+    /// `U01`-`U04` correlate declarations against *one project's* transcripts,
+    /// so they are the single family the global registry drops. Proven with
+    /// transcripts that demonstrably fire them in project scope from the same
+    /// working directory — otherwise this would only prove that no transcript
+    /// was found.
+    #[test]
+    fn global_never_measures_observed_usage() {
+        let s = Sandbox::new();
+        s.write(
+            "work/.claude/agents/ghost.md",
+            "---\nname: ghost\ndescription: never invoked\n---\nBody",
+        );
+        s.write(
+            "home/.claude/skills/mine-heavy/SKILL.md",
+            &heavy_skill("mine-heavy"),
+        );
+        // The binary runs with `current_dir(work)` and resolves its root from
+        // `current_dir()`, which on macOS returns the `/private/var/...` form
+        // of a tempdir's `/var/...` path. The transcript's `cwd` is what the
+        // discovery pass matches on, so it has to be the same form.
+        let cwd = std::fs::canonicalize(s.work())
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        s.write(
+            "transcripts/session/s1.jsonl",
+            &format!(
+                "{{\"type\":\"assistant\",\"timestamp\":\"2026-08-01T00:00:00Z\",\
+                 \"isSidechain\":false,\"uuid\":\"u1\",\"cwd\":\"{cwd}\",\"message\":{{\
+                 \"model\":\"m\",\"content\":[{{\"type\":\"tool_use\",\"id\":\"t1\",\
+                 \"name\":\"Agent\",\"input\":{{\"subagent_type\":\"general-purpose\",\
+                 \"description\":\"work\"}}}}],\"usage\":{{\"input_tokens\":1,\
+                 \"output_tokens\":1}}}}}}\n"
+            ),
+        );
+
+        let project = s.run(&[]);
+        project.ran();
+        assert!(
+            project.stdout.contains("Observed usage"),
+            "the fixture must fire the usage pass in project scope:\n{}",
+            project.stdout
+        );
+        project.line_with("U01", &["ghost"]);
+        project.line_with("U02", &["general-purpose"]);
+
+        let global = s.run(&["--global"]);
+        global.ran().line_with("R01", &["mine-heavy"]);
+        assert!(
+            !global.stdout.contains("Observed usage"),
+            "the global library belongs to no project: no transcript correlation:\n{}",
+            global.stdout
+        );
+        global
+            .has_no_line_with("U01", &["ghost"])
+            .has_no_line_with("U02", &["general-purpose"]);
+    }
+
+    /// The synced catalogue is other people's assets, and it is what skewed
+    /// `R01`'s original calibration (407 of 461 files). Excluding it is a
+    /// correctness fix, so it gets a black-box guard: a decoy heavy skill in
+    /// the catalogue against a control heavy skill in the installed set.
+    #[test]
+    fn global_never_reads_the_synced_catalogue() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.config/armadai/skills/mine-heavy/SKILL.md",
+            &heavy_skill("mine-heavy"),
+        );
+        s.write(
+            "home/.config/armadai/registry/borrowed-heavy/SKILL.md",
+            &heavy_skill("borrowed-heavy"),
+        );
+        s.write(
+            "home/.config/armadai/registry/repo/skills/deep-borrowed/SKILL.md",
+            &heavy_skill("deep-borrowed"),
+        );
+        s.write(
+            "home/.config/armadai/starters/pack/skills/starter-heavy/SKILL.md",
+            &heavy_skill("starter-heavy"),
+        );
+
+        let out = s.run(&["--global"]);
+        out.ran().line_with("R01", &["mine-heavy"]);
+        out.has_no_line_with("R01", &["borrowed-heavy"])
+            .has_no_line_with("R01", &["deep-borrowed"])
+            .has_no_line_with("R01", &["starter-heavy"]);
+        assert!(
+            out.stdout.contains("Not read:") && out.stdout.contains("armadai/registry"),
+            "the exclusion must be stated in the report:\n{}",
+            out.stdout
+        );
+    }
+
+    /// `~/.config/armadai/agents` holds ArmadAI-format agents, not native
+    /// Claude Code frontmatter. Measured on a real 77-agent library, reading
+    /// them through this reverse pass yields 77 `A01` criticals and a non-zero
+    /// exit on a healthy library. They are skipped — and *named*, so the
+    /// report never reads as "you have no agents".
+    #[test]
+    fn global_names_the_armadai_agent_library_it_skips() {
+        let s = Sandbox::new();
+        for name in ["agent-builder", "dev-lead", "qa"] {
+            s.write(
+                &format!("home/.config/armadai/agents/{name}.md"),
+                "# Name\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nHi.",
+            );
+        }
+        s.write(
+            "home/.claude/skills/mine/SKILL.md",
+            "---\nname: mine\ndescription: d\n---\nB.",
+        );
+
+        let out = s.run(&["--global"]);
+        out.ran();
+        assert!(
+            out.success,
+            "an ArmadAI-format library is not a critical finding:\n{}\n{}",
+            out.stdout, out.stderr
+        );
+        let line = out.line_with("Not read:", &["armadai/agents", "3 file(s)"]);
+        assert!(
+            line.contains("native Claude Code"),
+            "the note must say why, got: {line}"
+        );
+        out.has_no_line_with("A01", &["agent-builder"]);
+    }
+
+    /// A report file that does not say which scope it covers is a trap: the
+    /// two carry identical rule codes over different assets.
+    #[test]
+    fn a_global_report_file_says_so() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/skills/mine/SKILL.md",
+            "---\nname: mine\ndescription: d\n---\nB.",
+        );
+
+        let out = s.run(&["--global", "--report", "g.md"]);
+        out.ran();
+        let md = std::fs::read_to_string(s.work().join("g.md")).unwrap();
+        assert!(
+            md.starts_with("# armadai audit (global)"),
+            "the report must name its scope:\n{md}"
+        );
+    }
+
+    /// `--global` and a path are contradictory: one says "this repository",
+    /// the other "no repository at all". Refused by the parser rather than
+    /// silently resolved in favour of one of them.
+    #[test]
+    fn global_and_an_explicit_path_are_mutually_exclusive() {
+        let s = Sandbox::new();
+        let out = s.run(&["--global", "/tmp"]);
+        assert!(!out.success, "expected a parse error:\n{}", out.stdout);
+        assert!(
+            out.stderr.contains("cannot be used with"),
+            "expected clap's conflict message, got:\n{}",
+            out.stderr
+        );
+    }
+
+    /// The exit code must still mean what it means: a broken global asset is
+    /// a critical finding, and the command fails on it.
+    #[test]
+    fn a_critical_finding_in_the_global_library_still_fails_the_command() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/skills/broken/SKILL.md",
+            "---\nname: broken\ndescription: has a bad : unquoted value\n---\nBody",
+        );
+
+        let out = s.run(&["--global"]);
+        out.ran().line_with("A01", &["broken"]);
+        assert!(
+            !out.success,
+            "a critical finding must still exit non-zero:\n{}",
+            out.stdout
+        );
+    }
+
+    /// `--propose` in global scope has no project root to write into, and
+    /// writing into `$HOME` unasked would be rude. It writes where the user
+    /// stands.
+    #[test]
+    fn global_propose_writes_into_the_working_directory_not_home() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/agents/reviewer.md",
+            "---\nname: reviewer\ndescription: Reviews code\ntools: Read\n---\nYou review code.",
+        );
+        s.write(
+            "home/.claude/skills/mine/SKILL.md",
+            "---\nname: mine\ndescription: d\n---\nB.",
+        );
+
+        let out = s.run(&["--global", "--propose"]);
+        out.ran();
+        assert!(
+            s.work().join(".armadai-proposal/pack.yaml").is_file(),
+            "the proposal belongs in the working directory:\n{}\n{}",
+            out.stdout,
+            out.stderr
+        );
+        assert!(
+            !s.home().join(".armadai-proposal").exists(),
+            "nothing may be written into $HOME"
+        );
+    }
+
+    /// An empty library is not an error, and must not be reported as a
+    /// project path the user never named.
+    #[test]
+    fn an_empty_global_library_is_reported_as_such() {
+        let s = Sandbox::new();
+        let out = s.run(&["--global"]);
+        assert!(out.success, "{}\n{}", out.stdout, out.stderr);
+        assert!(
+            out.stdout
+                .contains("No native agentic configuration detected in your global library"),
+            "got:\n{}",
+            out.stdout
+        );
+    }
+
+    /// Guard on the isolation itself: with `HOME` pointed at an empty
+    /// sandbox, the run must find nothing. A green suite whose sandbox leaked
+    /// into the developer's real `~/.claude` would prove nothing at all — and
+    /// this is the assertion that fails if `HOME` ever stops being honoured.
+    #[test]
+    fn the_sandbox_home_is_what_the_global_scope_reads() {
+        let s = Sandbox::new();
+        let out = s.run(&["--global"]);
+        assert!(
+            !out.stdout.contains("R01") && !out.stdout.contains("R04"),
+            "the real home library must be unreachable from a sandboxed run:\n{}",
+            out.stdout
+        );
+        assert!(!Path::new(&s.home().join(".claude")).exists());
+    }
+}

--- a/docs/superpowers/specs/2026-08-26-audit-scopes-design.md
+++ b/docs/superpowers/specs/2026-08-26-audit-scopes-design.md
@@ -113,3 +113,44 @@ looking where the fleet lives.
   that boundary than a project one, so if this is ever revisited it belongs here, not in the
   project scope.
 - Any automatic rewriting. The audit reports.
+
+## Measured corrections, found while implementing (2026-08-26)
+
+The three decisions above held. Four factual claims inside them did not — each measured on the
+same machine the spec was measured on, through the real binary where the binary can answer.
+
+1. **`~/.config/armadai/agents` cannot be read by this reverse pass.** The design above lists it
+   as a global surface ("**77 entries here**") and applies the `assets` family to it. All 77 files
+   are ArmadAI-format (H1 + `## Metadata` + `## System Prompt`); **none** carries YAML
+   frontmatter. Measured by pointing the shipped binary at them
+   (`ln -s ~/.config/armadai/agents probe/.claude/agents && armadai audit probe`):
+   `77 critical, 2 warning(s), 0 info` / `A01×77` — every file flagged "missing YAML
+   frontmatter", and a non-zero exit on a healthy library. So `--global` reads
+   `~/.claude/agents` and *names* `~/.config/armadai/agents` as skipped, with its file count.
+   Reading it properly needs an ArmadAI-format reverse importer, which is separate work: even
+   with one, `A02` would fire on all 77, because the ArmadAI agent format has no `description`
+   field at all.
+
+2. **"Recalibrating to 2456 would flag roughly 5 skills instead of 1" is false.** Measured over
+   the installed corpus: 2456 flags **1**, exactly as 4000 does. Only 4 skills exceed 2456 and
+   3 of them already carry a `references/`. This *strengthens* the decision to keep 4000 — the
+   threshold is not the binding constraint on this corpus, the `references/` condition is — but
+   the reason given was not the real one.
+
+3. **The `references/` split-rate argument does not survive the corpus fix.** It is inherited
+   from #386 (`52%` of skills above the p90 carry a `references/` against `32%` below), and that
+   was measured on the same 88%-catalogue corpus this spec disqualifies. Re-measured on the
+   auditable 48: **75%** above the p90 versus **77%** at or below — no contrast at all, on 4
+   samples and 44. The two-condition rule is still right, for a definitional reason (a skill
+   with `references/` has already used the mechanism the suggestion recommends), and the
+   statistical claim has been removed from both the rule and the wiki.
+
+4. **The corpus is 48, not 47.** `~/.config/armadai/skills` now holds 41 directories, one of
+   which has no `SKILL.md` (hence `min=0`, not `min=2`). `p90=2456` is unchanged and the
+   reported rate is unchanged at 2%, which is the point: the figure is robust to that drift and
+   the exact `n` is not load-bearing.
+
+One limit worth recording rather than fixing here: `R04` counts the instructions file as it sits
+on disk and does not follow Claude Code's `@file` imports. On this machine `~/.claude/CLAUDE.md`
+is 59 tokens and `@`-imports a 241-token file, so the global weight figure is a floor. That is a
+pre-existing `R04` limit, not one the scope split introduced.

--- a/docs/superpowers/specs/2026-08-26-audit-scopes-design.md
+++ b/docs/superpowers/specs/2026-08-26-audit-scopes-design.md
@@ -1,0 +1,115 @@
+# Audit scopes: project vs global — design
+
+**Issue:** #389 · **Date:** 2026-08-26 · **Status:** design, awaiting approval
+
+## Problem
+
+`armadai audit` is project-scoped: `import_surfaces(root)` reads the repo's `.claude/agents/`,
+`.claude/skills/` and `CLAUDE.md`. Skills do not live in repos.
+
+Measured on three real projects on this machine — armadai, refonte-front, ci-engine — all three
+have **zero** local skills, against **47** installed globally (`~/.claude/skills` = 7,
+`~/.config/armadai/skills` = 40). So `R01`, delivered by #386, **never fires in real use**. It
+measures a location nobody populates.
+
+Worse, its threshold was calibrated on a corpus that is 88% out of scope:
+
+| source of the 460 calibration files | count |
+|---|---|
+| `~/.config/armadai/registry` (synced catalogue) | **407 (88%)** |
+| installed skills | 47 |
+| starters | 6 |
+
+The catalogue is other people's skills. Nobody should audit those, and they should never have
+set a threshold.
+
+## Design
+
+Two scopes, because they answer different questions, have different owners, and admit
+different rules.
+
+**Project scope** (today's behaviour, unchanged default) — what *this repo* declares. It is what
+a team shares and a reviewer reads.
+
+**Global scope** (`armadai audit --global`) — what *this user* carries into every session:
+`~/.claude/skills`, `~/.config/armadai/skills`, `~/.claude/agents`,
+`~/.config/armadai/agents` (**77 entries here**), and `~/.claude/CLAUDE.md`, which exists and
+is currently unreachable.
+
+`--global` rather than a new `doctor` command: the flag already exists on `list`, `tui` and
+`web`, so this is the repo's own convention. No new surface to learn.
+
+### The catalogue is excluded from both
+
+`~/.config/armadai/registry` is a synced catalogue. Flagging it would be pure noise, and it is
+what skewed the calibration. Excluding it is not an optimisation, it is a correctness fix.
+
+### Which rules apply to which scope
+
+Measured by what each family actually reads:
+
+| family | reads | project | global |
+|---|---|---|---|
+| `assets` (A01 A02 A05 A08 A09 A12) | agents, skills | yes | **yes** |
+| `collisions` (C01–C05) | agents, skills, instructions | yes | **yes** |
+| `models` (A03 A04) | — | yes | **yes** |
+| `references` (A10 A11) | agents, instructions | yes | **yes** |
+| `similarity` (A06 A07) | agents | yes | **yes** |
+| `rightsizing` (R01 R02 R04) | skills, instructions | yes | **yes** |
+| `usage_rules` (U01–U04) | + transcripts | yes | **no** |
+
+Only `usage_rules` is genuinely project-bound: it correlates declarations against *this
+project's* Claude Code transcripts. Everything else is a property of the assets themselves and
+holds wherever they live.
+
+This is deliberately a whitelist of one exclusion rather than a per-rule opt-in: a rule that
+reads only `ctx.config` cannot tell which scope filled it, so the default must be "applies",
+with `usage` the single documented exception.
+
+### The threshold: keep 4000, change its justification
+
+The measured distribution of the 47 **installed** skills, in tokens:
+
+```
+n=47  min=2  median=628  p75=915  p90=2456  max=10087
+```
+
+So 4000 sits **above** the p90 of the corpus that will actually be audited. Recalibrating to
+2456 would flag roughly 5 skills instead of 1.
+
+**Decision: keep 4000 and stop justifying it as a quantile.** Two reasons.
+
+A quantile says "you are in the top 10% of what happens to be on this machine" — which changes
+as the corpus changes, and 47 samples is a thin base to derive precision from. A **context
+budget** says "this costs 4000 tokens the moment it triggers", which is true regardless of what
+anyone else's skills look like. The second is the useful claim, and it is the one the rule was
+always really making.
+
+And the honest reporting follows: the docs must state the rate on the auditable corpus — **1 of
+47 installed skills (2%)** — not the 4.3% derived from a corpus that is 88% catalogue. That
+4.3% figure is exactly the defect #384 existed to fix, one layer up: a documented number that
+the code does not deliver.
+
+`skill_token_threshold` stays configurable, so a user whose skills run large can lower it.
+
+## What this unlocks beyond R01
+
+Three defects we hit **by hand** this week, invisible to the tool as it stands:
+
+- Stale agent definitions — `qa-specialist.md` asserted two contradicting gaveldrop counts
+  (#388), found by an agent reading its own definition, never by the audit.
+- Skill/memory duplication — measured on the `armadai` skill: 9 of 10 lessons duplicated the
+  memory, 6163 words loaded on every invocation before #382/#383.
+- The real weight of global context, which `R04` cannot compute because it only sees the repo.
+
+It is also the only angle from which "a `/doctor` for fleets" holds: sizing a fleet means
+looking where the fleet lives.
+
+## Out of scope
+
+- Auditing the catalogue (above).
+- `R03`, the memory-duplication rule, still dropped on principle: the memory is under the
+  user's own directory and private to them. Note the tension — a *global* audit is closer to
+  that boundary than a project one, so if this is ever revisited it belongs here, not in the
+  project scope.
+- Any automatic rewriting. The audit reports.

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -25,23 +25,36 @@ Two scopes, because they answer different questions, have different owners, and 
 
 | | project scope (default) | global scope (`--global`) |
 |---|---|---|
-| reads | `<root>/.claude/agents/`, `<root>/.claude/skills/`, `<root>/CLAUDE.md` | `~/.claude/agents/`, `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.config/armadai/skills/` |
+| reads | `<root>/.claude/agents/`, `<root>/.claude/skills/`, `<root>/CLAUDE.md` | `~/.claude/agents/`, `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.config/armadai/skills/` — **not** the plugin trees, see [What neither scope reads](#what-neither-scope-reads-and-why) |
+| settings | `<root>/armadai.yaml` or `<root>/.armadai/config.yaml` | `~/.config/armadai/config.yaml` |
 | answers | what does *this repository* declare — what a team shares and a reviewer reads | what does *this user* carry into every session, wherever they work |
 | rules | every family, `U01`–`U04` included | every family **except** `U01`–`U04` |
 
 `--global` rather than a separate `doctor` command: the flag already exists on `list`, `tui` and `web`, so this is the repository's own convention rather than a new surface to learn. It cannot be combined with a path — one says "this repository", the other "no repository at all" — and the parser refuses the combination instead of silently picking one.
 
+`--global` needs `$HOME`, and **refuses** to run without it rather than falling back to the current directory: a global audit *is* "what lives under `~`", so with no `~` there is nothing to audit. The fallback that used to stand there reported the current repository's `.claude/` as the user's library, labelled `~/.claude` — a wrong answer indistinguishable from a right one.
+
 ### Why global scope exists
 
-**Skills do not live in repositories.** Measured on three real projects on one machine — `armadai`, `refonte-front`, `ci-engine` — all three declare **zero** local skills, against **48** installed globally (`~/.claude/skills` = 7, `~/.config/armadai/skills` = 41). Before `--global`, `R01` and the skill half of `R04` measured a location nobody populates: they could not fire in real use. The same holds for `~/.claude/CLAUDE.md`, which is loaded on every invocation of every project and was unreachable.
+**Skills do not live in repositories.** Measured on three real projects on one machine — `armadai`, `refonte-front`, `ci-engine` — all three declare **zero** local skills, against **48** installed globally and read by this pass (`~/.claude/skills` = 7, `~/.config/armadai/skills` = 41), plus **17 more** in installed plugins that it names but does not read (see below). Before `--global`, `R01` and the skill half of `R04` measured a location nobody populates: they could not fire in real use. The same holds for `~/.claude/CLAUDE.md`, which is loaded on every invocation of every project and was unreachable.
 
 ### What neither scope reads, and why
 
-Three exclusions, three different reasons. Each is printed as a `Not read:` line in the report — an asset pile the audit skips has to be a *stated* omission, or the report reads as "you have none".
+Five exclusions, and each is printed as a `Not read:` line in the report — an asset pile the audit skips has to be a *stated* omission, or the report reads as "you have none". The counts a global report prints are therefore a **floor**, and the `Not read:` lines are what tell you by how much.
+
+Under `~/.claude`:
+
+- **`~/.claude/plugins/cache/`** — the skills of the plugins you have **installed**. These are live in the session, exactly like `~/.claude/skills`, and this is the largest omission of the two scopes: measured on one real machine, the report announced 48 skills and ~49967 tokens of front-loaded context while this directory held **17 further `SKILL.md` worth ~39177 tokens** — the stated total 44% short of what is actually loaded — and **2 of those 17 cross `R01`**. Reading them means knowing which plugins are *enabled*, which lives in Claude Code's own `installed_plugins.json` and per-plugin manifests: a plugin-aware importer, and a separate piece of work. Until it exists, the note carries the skill count so the total is visibly a floor.
+- **`~/.claude/plugins/marketplaces/`** — the **catalogue** each plugin was installed *from*: every plugin on offer, not the ones in use. Same category as `registry/` below, and it gets its own line rather than being folded into one `~/.claude/plugins` note, because installed-versus-catalogue is exactly the distinction this pass draws under `~/.config/armadai` (`skills/` read, `registry/` excluded). It carries no count: it holds git checkouts, and counting it would mean walking their object stores.
+- **`~/.claude/plugins/data/`** gets no line at all. It is Claude Code's per-plugin *writable state* — measured on the same machine: 5 directories, 0 files, 0 `SKILL.md`. Nothing there is an agentic asset, and a note about a directory that holds none would be a lecture, not a fact.
+
+Under `~/.config/armadai`:
 
 - **`~/.config/armadai/registry/`** — a synced catalogue of *other people's* skills. Flagging them would be noise, and this directory is also what skewed `R01`'s original calibration: of the 461 `SKILL.md` files the threshold was derived from, **407 (88%)** came from here. Excluding it is a correctness fix, not an optimisation.
 - **`~/.config/armadai/starters/`** and **`~/.config/armadai/skills-registry/`** — starter packs and a second synced catalogue. Neither holds an asset that is installed, so neither is in anyone's context.
 - **`~/.config/armadai/agents/`** — ArmadAI-format agents (H1 + `## Metadata` + `## System Prompt`), not native Claude Code frontmatter. Measured on a real 77-agent library, reading them through this reverse pass produced **77 `A01` criticals** ("missing YAML frontmatter") and a non-zero exit on a perfectly healthy library. Reading them properly needs an ArmadAI-format reverse importer, which does not exist yet; until it does, the report says how many files it left alone rather than reporting zero agents.
+
+The exclusions are **structural**, not a blacklist: only `<config>/skills` is ever read, so a redirected `$ARMADAI_CONFIG_DIR` moves them with it and a skill of your own that happens to be *named* `registry` is read normally.
 
 ### Which rules apply to which scope
 
@@ -49,7 +62,9 @@ Three exclusions, three different reasons. Each is printed as a `Not read:` line
 
 This is deliberately a whitelist of one exclusion rather than a per-rule opt-in, and it is enforced in the rule *registry* rather than inside any rule: a rule that only ever sees `ctx.config` cannot tell which scope filled it, so the default has to be "applies".
 
-`--propose` and `--deep` both work in global scope. In global scope `--propose` writes its pack into the **working directory** — there is no project root to write into, and writing into `$HOME` unasked would be rude.
+`--propose` and `--deep` both work in global scope. In global scope `--propose` writes its pack into the **current directory, whatever that is** — there is no project root to write into, so the pack follows where you stand, exactly as it does in project scope. If you stand in `$HOME`, that is where it lands.
+
+`--deep` in global scope widens what leaves the machine: the excerpts it sends are your own `~/.claude/CLAUDE.md` and the prompts of your global agents — personal material rather than a repository's shared config. It is the same privacy boundary that kept `R03` out of the rule set, and the command's `--deep` warning names the scope for that reason.
 
 ## What gets checked
 
@@ -59,7 +74,7 @@ Most of the rule surface predates this page's focus and is only summarized here 
 - **`C0x` — collision rules.** Checks across declared assets: name collisions, overlapping scopes, overlapping activation surfaces, double ownership of the same module, inconsistent tool restrictions.
 - **`R0x` — context rightsizing.** Checks what gets front-loaded into context rather than what is declared: an oversized skill with no progressive disclosure, a path cited in the instructions file that no longer exists, and the total weight of the context loaded up front. Detailed below. `R01` and the skill half of `R04` only have real material to work on in **global** scope — see [Scopes](#scopes).
 - **`D0x` — optional deep pass (`--deep`).** Sends secret-redacted prompt excerpts to an installed CLI (`claude` or `gemini`) for an LLM-driven review, layered on top of the static findings.
-- **`--propose`.** Generates an installable ArmadAI pack (`.armadai-proposal/`) from the audited native configuration. In global scope it writes into the working directory rather than into `$HOME`.
+- **`--propose`.** Generates an installable ArmadAI pack (`.armadai-proposal/`) from the audited native configuration. In global scope it writes into the current directory, there being no project root to write into.
 
 The rest of this page covers the two newer halves: **context rightsizing**, rules `R01`, `R02` and `R04`, and **observed usage**, rules `U01`–`U04`.
 
@@ -89,7 +104,9 @@ Only the root instructions file is loaded unconditionally, on every invocation. 
 
 So `R01` does not say "this skill is too big". It says "this skill is big *and* has nothing at level 3" — and `armadai` already installs `references/` (`crates/armadai-core/src/skill.rs`), so the fix asks the author to use a mechanism that exists rather than invent one.
 
-One known limit of the total, in both scopes: `R04` counts the instructions file as it is on disk and does not follow Claude Code's `@file` imports. Measured on one real `~/.claude/CLAUDE.md`, that is 59 tokens counted against a 241-token `@`-imported file left out — so the figure is a floor, not the whole bill. It is a pre-existing limit, not one the global scope introduced, but the global instructions file is where it bites hardest, because that one is loaded on every invocation of every project.
+`R04`'s total is a **floor**, for two reasons, and both are stated in the report rather than hidden. In global scope, the skills of installed plugins are counted by no one: measured on one machine, `~/.claude/plugins/cache` held 17 further `SKILL.md` worth ~39177 tokens against a reported total of ~49967 — 44% short — which is why that directory gets a `Not read:` line carrying its skill count (see [What neither scope reads](#what-neither-scope-reads-and-why)).
+
+The second limit holds in both scopes: `R04` counts the instructions file as it is on disk and does not follow Claude Code's `@file` imports. Measured on one real `~/.claude/CLAUDE.md`, that is 59 tokens counted against a 241-token `@`-imported file left out — so the figure is a floor, not the whole bill. It is a pre-existing limit, not one the global scope introduced, but the global instructions file is where it bites hardest, because that one is loaded on every invocation of every project.
 
 ### Where the default threshold comes from
 
@@ -109,7 +126,7 @@ So 4000 sits *above* the p90 of what will really be audited. But recalibrating t
 
 So the honest reporting is **1 of 48 installed skills (2%)**. An earlier version of this page claimed 4.3%, derived from that 88%-catalogue corpus — a documented number the code does not deliver, which is precisely the class of defect this project has had to fix before.
 
-`skill_token_threshold` stays configurable, so a user whose skills genuinely run large can lower it.
+`skill_token_threshold` stays configurable, so a user whose skills genuinely run large can lower it — in global scope, where `R01` actually has material to work on, that means `audit.skill_token_threshold` in `~/.config/armadai/config.yaml` (see [Settings](#settings)).
 
 ### Why `references/` is the second condition
 
@@ -135,7 +152,7 @@ Limits are known, and documented rather than hidden — a rule whose blind spots
 
 ## Settings
 
-Every threshold the static rules use is tunable per project, in an optional `audit:` section of `armadai.yaml` (or `.armadai/config.yaml`; the first of the two that exists wins). A missing file, a missing section, or YAML that fails to parse all leave the defaults in place — the audit never refuses to run over its own configuration.
+Every threshold the static rules use is tunable, in an optional `audit:` section:
 
 ```yaml
 audit:
@@ -145,6 +162,17 @@ audit:
   deep_prompt_truncation: 2000   # --deep: max characters kept per excerpt sent to the LLM
   usage: true                    # scan this project's transcripts (--no-usage always wins)
 ```
+
+**The settings follow the audited surface, not the directory you typed the command in.**
+
+| scope | reads |
+|---|---|
+| project (default) | `<root>/armadai.yaml`, else `<root>/.armadai/config.yaml` — the first of the two that *exists* wins, whether or not it carries an `audit:` section |
+| global (`--global`) | `~/.config/armadai/config.yaml` — the user-level config, next to the library it configures |
+
+A global audit reads one fixed set of assets, so it has to reach one fixed verdict. Sourcing its thresholds from the working directory made that false: measured on one machine, the same global library reported **2 `R01` warnings** from a folder carrying `skill_token_threshold: 5` and **0** from a neutral one. `~/.config/armadai/config.yaml` already exists and holds the rest of the user-level configuration, so `audit:` simply joins it there.
+
+A missing file, a missing section, or YAML that fails to parse all leave the defaults in place — the audit never refuses to run over its own configuration.
 
 ## Observed usage
 

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -40,7 +40,7 @@ Two scopes, because they answer different questions, have different owners, and 
 
 ### What neither scope reads, and why
 
-Five exclusions, and each is printed as a `Not read:` line in the report — an asset pile the audit skips has to be a *stated* omission, or the report reads as "you have none". The counts a global report prints are therefore a **floor**, and the `Not read:` lines are what tell you by how much.
+Six directories are left unread. Five of them get a `Not read:` line in the report — an asset pile the audit skips has to be a *stated* omission, or the report reads as "you have none". The sixth (`plugins/data/`) gets none, because it holds no asset at all; the reason is below. So the counts a global report prints are a **floor**, and the `Not read:` lines are what tell you by how much.
 
 Under `~/.claude`:
 

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -1,11 +1,14 @@
 # Audit
 
-`armadai audit` scans a project's *native* Claude Code configuration — no ArmadAI setup required — and reports on it as an adoption funnel: is `.claude/agents/`, `.claude/skills/` and `CLAUDE.md` internally consistent, and does what they *declare* match what Claude Code actually *ran*.
+`armadai audit` scans *native* Claude Code configuration — no ArmadAI setup required — and reports on it as an adoption funnel: are the declared agents, skills and instructions internally consistent, and does what they *declare* match what Claude Code actually *ran*.
+
+It answers that question over one of two **scopes**: a project, or the library you carry into every session.
 
 ## Usage
 
 ```bash
-armadai audit [path]                 # defaults to the current directory
+armadai audit [path]                 # project scope; defaults to the current directory
+armadai audit --global               # global scope: your own library, no repository
 armadai audit --report report.md     # write the report to a file (markdown)
 armadai audit --report report.html   # ...or HTML, by extension
 armadai audit --min-severity warn    # only show findings at or above this severity
@@ -14,23 +17,55 @@ armadai audit --propose              # generate an installable ArmadAI pack
 armadai audit --deep                 # add an optional LLM-driven pass
 ```
 
-The command exits non-zero when critical findings exist, regardless of `--min-severity` (which only filters what is displayed). See `armadai audit --help` for the exact option reference.
+The command exits non-zero when critical findings exist, regardless of `--min-severity` (which only filters what is displayed) and regardless of scope. See `armadai audit --help` for the exact option reference.
+
+## Scopes
+
+Two scopes, because they answer different questions, have different owners, and admit different rules.
+
+| | project scope (default) | global scope (`--global`) |
+|---|---|---|
+| reads | `<root>/.claude/agents/`, `<root>/.claude/skills/`, `<root>/CLAUDE.md` | `~/.claude/agents/`, `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.config/armadai/skills/` |
+| answers | what does *this repository* declare — what a team shares and a reviewer reads | what does *this user* carry into every session, wherever they work |
+| rules | every family, `U01`–`U04` included | every family **except** `U01`–`U04` |
+
+`--global` rather than a separate `doctor` command: the flag already exists on `list`, `tui` and `web`, so this is the repository's own convention rather than a new surface to learn. It cannot be combined with a path — one says "this repository", the other "no repository at all" — and the parser refuses the combination instead of silently picking one.
+
+### Why global scope exists
+
+**Skills do not live in repositories.** Measured on three real projects on one machine — `armadai`, `refonte-front`, `ci-engine` — all three declare **zero** local skills, against **48** installed globally (`~/.claude/skills` = 7, `~/.config/armadai/skills` = 41). Before `--global`, `R01` and the skill half of `R04` measured a location nobody populates: they could not fire in real use. The same holds for `~/.claude/CLAUDE.md`, which is loaded on every invocation of every project and was unreachable.
+
+### What neither scope reads, and why
+
+Three exclusions, three different reasons. Each is printed as a `Not read:` line in the report — an asset pile the audit skips has to be a *stated* omission, or the report reads as "you have none".
+
+- **`~/.config/armadai/registry/`** — a synced catalogue of *other people's* skills. Flagging them would be noise, and this directory is also what skewed `R01`'s original calibration: of the 461 `SKILL.md` files the threshold was derived from, **407 (88%)** came from here. Excluding it is a correctness fix, not an optimisation.
+- **`~/.config/armadai/starters/`** and **`~/.config/armadai/skills-registry/`** — starter packs and a second synced catalogue. Neither holds an asset that is installed, so neither is in anyone's context.
+- **`~/.config/armadai/agents/`** — ArmadAI-format agents (H1 + `## Metadata` + `## System Prompt`), not native Claude Code frontmatter. Measured on a real 77-agent library, reading them through this reverse pass produced **77 `A01` criticals** ("missing YAML frontmatter") and a non-zero exit on a perfectly healthy library. Reading them properly needs an ArmadAI-format reverse importer, which does not exist yet; until it does, the report says how many files it left alone rather than reporting zero agents.
+
+### Which rules apply to which scope
+
+`U01`–`U04` are the single exclusion. They correlate declarations against *one project's* Claude Code transcripts, so they have no meaning over assets that belong to no project — and in global scope the transcript scan is skipped outright rather than run and then ignored. Every other family reads the assets themselves, and a property of an asset holds wherever the asset lives.
+
+This is deliberately a whitelist of one exclusion rather than a per-rule opt-in, and it is enforced in the rule *registry* rather than inside any rule: a rule that only ever sees `ctx.config` cannot tell which scope filled it, so the default has to be "applies".
+
+`--propose` and `--deep` both work in global scope. In global scope `--propose` writes its pack into the **working directory** — there is no project root to write into, and writing into `$HOME` unasked would be rude.
 
 ## What gets checked
 
 Most of the rule surface predates this page's focus and is only summarized here — see `armadai audit --help` and the rule codes printed in the report for the exhaustive list:
 
-- **`A0x` — static asset rules.** Checks over the declared `.claude/agents/`, `.claude/skills/` and `CLAUDE.md` in isolation: unparsable files, missing descriptive fields, deprecated or unknown models, oversized prompts, duplicated content, permissive tool access, malformed skills, broken `@agent` references, plaintext secrets.
+- **`A0x` — static asset rules.** Checks over the declared agents, skills and instructions file in isolation: unparsable files, missing descriptive fields, deprecated or unknown models, oversized prompts, duplicated content, permissive tool access, malformed skills, broken `@agent` references, plaintext secrets.
 - **`C0x` — collision rules.** Checks across declared assets: name collisions, overlapping scopes, overlapping activation surfaces, double ownership of the same module, inconsistent tool restrictions.
-- **`R0x` — context rightsizing.** Checks what the project front-loads into context rather than what it declares: an oversized skill with no progressive disclosure, a path cited in the instructions file that no longer exists, and the total weight of the context a project loads up front. Detailed below.
+- **`R0x` — context rightsizing.** Checks what gets front-loaded into context rather than what is declared: an oversized skill with no progressive disclosure, a path cited in the instructions file that no longer exists, and the total weight of the context loaded up front. Detailed below. `R01` and the skill half of `R04` only have real material to work on in **global** scope — see [Scopes](#scopes).
 - **`D0x` — optional deep pass (`--deep`).** Sends secret-redacted prompt excerpts to an installed CLI (`claude` or `gemini`) for an LLM-driven review, layered on top of the static findings.
-- **`--propose`.** Generates an installable ArmadAI pack (`.armadai-proposal/`) from the audited native configuration.
+- **`--propose`.** Generates an installable ArmadAI pack (`.armadai-proposal/`) from the audited native configuration. In global scope it writes into the working directory rather than into `$HOME`.
 
 The rest of this page covers the two newer halves: **context rightsizing**, rules `R01`, `R02` and `R04`, and **observed usage**, rules `U01`–`U04`.
 
 ## Context rightsizing
 
-The `A`, `C` and `U` families ask *is it declared?* and *does it run?*. The `R` family asks a third question none of the others does: **is it sized correctly?** — what a project spends on context before anyone has typed a prompt.
+The `A`, `C` and `U` families ask *is it declared?* and *does it run?*. The `R` family asks a third question none of the others does: **is it sized correctly?** — what gets spent on context before anyone has typed a prompt.
 
 ### Rules
 
@@ -40,7 +75,7 @@ The `A`, `C` and `U` families ask *is it declared?* and *does it run?*. The `R` 
 | `R02` | Warning | A repo path cited in backticks in the root instructions file that resolves to nothing. The counterpart of `A10`, which does the same for `@agent` mentions. |
 | `R04` | Info | The total front-loaded context — the instructions file plus every `SKILL.md` — reported without judgement, on the model of `U04`. No threshold, no suggestion. |
 
-`R03` was designed and dropped. It would have flagged a lesson duplicated between a skill and the user's personal memory; that memory lives outside the project, under the user's own directory. `armadai audit` is project-scoped and must not read it.
+`R03` was designed and dropped. It would have flagged a lesson duplicated between a skill and the user's personal memory; that memory lives under the user's own directory. It stays dropped now that a global scope exists, and the tension is worth stating rather than hiding: a global audit sits closer to that boundary than a project one, so if `R03` is ever revisited it belongs in the global scope — never in the project one.
 
 ### What "front-loaded" means, exactly
 
@@ -54,15 +89,33 @@ Only the root instructions file is loaded unconditionally, on every invocation. 
 
 So `R01` does not say "this skill is too big". It says "this skill is big *and* has nothing at level 3" — and `armadai` already installs `references/` (`crates/armadai-core/src/skill.rs`), so the fix asks the author to use a mechanism that exists rather than invent one.
 
+One known limit of the total, in both scopes: `R04` counts the instructions file as it is on disk and does not follow Claude Code's `@file` imports. Measured on one real `~/.claude/CLAUDE.md`, that is 59 tokens counted against a 241-token `@`-imported file left out — so the figure is a floor, not the whole bill. It is a pre-existing limit, not one the global scope introduced, but the global instructions file is where it bites hardest, because that one is loaded on every invocation of every project.
+
 ### Where the default threshold comes from
 
-`audit.skill_token_threshold` defaults to **4000** estimated tokens. That number is derived, not picked: 460 real `SKILL.md` files measured on one machine give `min=3 · median=746 · p75=1343 · p90=2224 · max=41795` words — and the *same corpus* measures **1.84 tokens per word** (median) under the `chars/4` estimate the audit uses everywhere. So the p90 is ≈4100 tokens; read directly in tokens rather than converted, the p90 of the same distribution is 3956. Either way the answer rounds to 4000.
+`audit.skill_token_threshold` defaults to **4000** estimated tokens, and it is a **context budget**, not a quantile: 4000 tokens is the point past which "the whole body enters context the moment this skill triggers" stops being a detail and becomes a cost worth naming. That claim is true regardless of what anyone else's skills look like, which is exactly why it is the one worth making.
 
-The rule first shipped with 3000, from assuming one token per word. The corpus says 1.84, so the converted threshold came out **36% low** — and the consequence was measurable, not theoretical: run over those same 460 skills, the 3000 default flagged **54 (11.7%)** where the p90 criterion promises ~4.6%. The criterion was right; only its conversion was wrong.
+It used to be justified as the p90 of a measured corpus, and that justification was wrong twice over.
 
-Size alone would be the wrong signal, and the same corpus says why: **52%** of the skills above p90 carry a `references/` directory against **32%** below it — large skills are *more* often split, not less. Hence two conditions rather than one. The largest skill in that corpus (41795 words, 16 references) is big and correctly structured, and must never be flagged.
+First, the corpus. The 461 `SKILL.md` files it was measured on were **88% `~/.config/armadai/registry`** — a synced catalogue of other people's skills that no scope audits (see [What neither scope reads](#what-neither-scope-reads-and-why)). A threshold for *your* skills was set by 407 files that were never yours.
 
-The intersection is deliberately narrow, and this is where the threshold is judged rather than argued. The design target was the 21 skills of 460 (4.6%) that exceed the p90 with no `references/` at all. Run through the real command over those same 460 skills, the shipped rule at the 4000 default flags **20 (4.3%)**: of the 44 skills above the threshold, 24 are already split. Target met — the right order of magnitude for a warning, neither noise nor decoration. At 3000 the same run flagged 54 (11.7%), 2.5× the promise.
+Second, the method. On the corpus that is actually auditable — the 48 skills installed on the same machine — the distribution in tokens is:
+
+```
+n=48  min=0  median=610  p75=874  p90=2456  max=10087
+```
+
+So 4000 sits *above* the p90 of what will really be audited. But recalibrating to 2456 changes nothing observable: measured over those same 48 skills, the rule flags **1 (2%)** at 4000, and **1 (2%)** at 2456 too — only 4 skills exceed 2456 and 3 of them already carry a `references/`. The threshold is not what makes `R01` narrow; the `references/` condition is. And 48 samples are far too thin a base to derive a precise threshold from in the first place.
+
+So the honest reporting is **1 of 48 installed skills (2%)**. An earlier version of this page claimed 4.3%, derived from that 88%-catalogue corpus — a documented number the code does not deliver, which is precisely the class of defect this project has had to fix before.
+
+`skill_token_threshold` stays configurable, so a user whose skills genuinely run large can lower it.
+
+### Why `references/` is the second condition
+
+Both conditions are required for a definitional reason, not a statistical one: a skill that already has a `references/` directory has used the mechanism `R01`'s own suggestion would recommend, so flagging it would be advice with no action attached. The largest skill on the measured machine (10087 tokens, split into references) is big and correctly structured, and must never be flagged.
+
+An earlier version of this page argued it statistically instead — "52% of the skills above p90 carry a `references/` against 32% below it, so large skills are *more* often split". That was the catalogue-heavy corpus again. Re-measured on the auditable 48, the contrast disappears: **75%** above the p90 have `references/` against **77%** at or below it, on 4 samples and 44 respectively. There is no signal there, and a 4-sample rate was never one. The rule stands; that argument for it does not.
 
 ### `R02`'s known blind spots
 
@@ -94,6 +147,8 @@ audit:
 ```
 
 ## Observed usage
+
+Project scope only (see [Scopes](#scopes)): `--global` never scans transcripts, so this whole section and rules `U01`-`U04` are absent from a global report.
 
 Beyond what a project declares, `armadai audit` also measures what it actually *ran*, by scanning the project's Claude Code transcripts. A project with no transcripts at all is not an error: the audit still runs to completion, simply without an "Observed usage" section and without any `U0x` finding — the same report you'd get before this feature existed.
 


### PR DESCRIPTION
Ferme #389. Spec : `docs/superpowers/specs/2026-08-26-audit-scopes-design.md` (fusionnée dans cette branche).

## Le problème mesuré

`armadai audit` ne lisait que `<root>/.claude/{agents,skills}` et `<root>/CLAUDE.md`. Les skills ne vivent pas dans les dépôts : mesuré sur trois projets réels (`armadai`, `refonte-front`, `ci-engine`), **zéro** skill locale contre **48** installées globalement. `R01` et la moitié « skills » de `R04` mesuraient donc un emplacement que personne ne remplit, et `~/.claude/CLAUDE.md` — chargé à chaque invocation de chaque projet — était inatteignable.

## Ce que fait la PR

`armadai audit --global` audite la bibliothèque de l'utilisateur : `~/.claude/{agents,skills}`, `~/.claude/CLAUDE.md`, `~/.config/armadai/skills`. Même nom de flag que sur `list`, `tui`, `web` ; incompatible avec un chemin explicite (refusé par le parseur, pas arbitré en silence).

Sortie réelle sur la machine de calibration :

```
armadai audit (global) - /Users/bl209054
  Detected: claude (~/.claude), armadai (~/.config/armadai) (0 agent(s), 48 skill(s))
  Not read: ~/.claude/plugins/cache (17 skill(s)) — installed plugin skills, in your session context; reading them needs a plugin-aware importer, so the counts above are a floor
  Not read: ~/.claude/plugins/marketplaces — catalogue of plugin marketplaces, not installed assets
  Not read: ~/.config/armadai/agents (77 file(s)) — ArmadAI-format agents; this pass reads native Claude Code frontmatter only
  Not read: ~/.config/armadai/registry — synced catalogue of other people's assets
  Not read: ~/.config/armadai/starters — starter packs, not installed assets

  Warning (3)
    R01  .claude/skills/obs-dashboard-style/SKILL.md  skill 'obs-dashboard-style' is ~8622 tokens (threshold 4000) and has no references/...
    A09  .config/armadai/skills/boulanger-quick-ref  skill 'boulanger-quick-ref': missing SKILL.md
    A09  .config/armadai/skills/my-skill/SKILL.md  skill 'my-skill': missing frontmatter, missing description
  Info (2)
    R04  .claude/CLAUDE.md  ~49967 tokens of front-loaded context...
    A12  ... non-standard frontmatter field(s) across 32 file(s): tools (32)
  Summary: 0 critical, 3 warning(s), 2 info
```

Les deux `A09` et le `R04` global étaient invisibles avant cette PR. Taux `R01` réel : **1 skill sur 48, soit 2 %** — la valeur que la doc annonce désormais.

Le scope projet est inchangé (même en-tête, aucune ligne `Not read:`, mêmes findings).

## Le point d'architecture

**Fonction d'assemblage, pas de `ReverseLinker` dédié.** Le trait est `detect(root)` / `parse(root)` : « lis ce qui est sous cette racine ». La portée globale n'a pas de racine unique — `~/.claude` et `~/.config/armadai` sont deux arbres sans parent commun, et le fichier d'instructions global est `~/.claude/CLAUDE.md` et non `~/CLAUDE.md`. Un linker global aurait donc pris un `root` qu'il ignore : un mensonge dans la signature. `audit/scope.rs` appelle à la place **les trois mêmes parseurs** (`parse_agents`, `parse_skills`, `parse_instructions`, passés en `pub(crate)`) sur des répertoires explicites. Même lecteur, mêmes findings, pas de racine factice.

Corollaire : `AuditInput` (`for_project` / `for_global` / `analyse`) devient le seul endroit où un `AuditReport` est assemblé. `--propose` et `--deep` reçoivent maintenant la config déjà importée au lieu de relire les fichiers (le chemin `--deep` faisait une **troisième** passe sur les mêmes fichiers). En portée globale, `--propose` écrit dans le **répertoire courant, quel qu'il soit** — `$HOME` compris si c'est là qu'on se trouve. L'invariant est le cwd, pas une interdiction sur `$HOME` (formulation corrigée après revue).

## Exclusion de règles

`U01`-`U04` sont la seule famille exclue, et l'exclusion est décidée **dans le registre**, pas dans les règles : une règle qui ne lit que `ctx.config` ne peut pas savoir quelle portée l'a rempli. En portée globale le scan de transcripts est purement sauté (pas exécuté puis ignoré).

## Cinq exclusions de surfaces, annoncées

Sous `~/.config/armadai` : `registry` / `skills-registry` (catalogues synchronisés — et ce qui a faussé le calage de `R01` : 407 fichiers sur 461), `starters` (packs non installés), `agents` (format ArmadAI).

Sous `~/.claude` : `plugins/cache` (skills des plugins **installés**, donc dans le contexte, mais illisibles sans importeur conscient des manifestes de plugins — la note porte le compte, pour que les totaux se lisent comme un plancher) et `plugins/marketplaces` (le **catalogue** dont les plugins proviennent, sans comptage : il contient des dépôts git). `plugins/data` n'a pas de ligne : c'est l'état inscriptible par plugin, mesuré à 5 répertoires et 0 fichier.

Chacune imprimée en `Not read:` : un tas d'assets que l'audit saute doit être une omission **dite**, sinon le rapport se lit « vous n'en avez pas ».

## Défauts de la spec, mesurés (détail dans le fichier de spec)

1. **`~/.config/armadai/agents` est illisible par cette passe.** Les 77 fichiers sont au format ArmadAI, aucun n'a de frontmatter YAML. Mesuré avec le binaire livré : `77 critical` / `A01×77`, sortie non nulle sur une bibliothèque saine. D'où le choix de la nommer plutôt que de la parser.
2. **« Recalibrer à 2456 flaggerait ~5 skills au lieu de 1 » est faux** : 2456 en flagge **1**, comme 4000. Seuls 4 skills dépassent 2456 et 3 ont déjà un `references/`. Cela *renforce* la décision de garder 4000, mais pas pour la raison donnée : le seuil n'est pas la contrainte active, la condition `references/` l'est.
3. **L'argument statistique du `references/` ne survit pas à la correction de corpus** (hérité de #386 : 52 % au-dessus du p90 contre 32 % en dessous). Re-mesuré sur les 48 auditables : **75 %** contre **77 %**, sur 4 et 44 échantillons. Aucun signal. La règle reste juste, pour une raison définitionnelle (un skill qui a déjà un `references/` a utilisé le mécanisme que la suggestion recommande) ; l'argument statistique est retiré du code et du wiki.
4. **Le corpus fait 48, pas 47** (`min=0`, pas 2). `p90=2456` et le taux de 2 % sont inchangés — c'est bien le point : la valeur est robuste à cette dérive.

## Tests

- `crates/armadai/src/audit/scope.rs` — 10 unitaires, sans toucher l'environnement (`GlobalLayout` est passé explicitement, donc pas de `env_lock()`).
- `crates/armadai/src/audit/report.rs` — 2 unitaires sur le rendu des lignes `Not read:` et sur le titre de portée en HTML (voir vague de revue ci-dessous).
- `crates/armadai/src/audit/rules/mod.rs` — 4 unitaires : registre (dont un qui fournit des `UsageFacts` **non vides** en portée globale — tester l'exclusion via `usage: None` resterait vert même en supprimant la garde) et provenance des réglages projet.
- `crates/armadai/src/cli/audit.rs` — 1 unitaire sur l'avertissement `--deep` selon la portée.
- `crates/armadai/tests/audit_scopes.rs` — **16 cas boîte-noire sur le binaire réel**, chacun différentiel (même fixture, deux portées qui doivent diverger). Cinq répertoires redirigés, `HOME` compris, plus un cas qui garde l'isolation elle-même et un cas qui tourne `HOME` **retiré**.
- 18 + 14 expériences de mutation, chacune vérifiée rouge.

## Vague de correctifs après revue indépendante (issue #389, verdict CHANGES REQUESTED)

La revue a validé le point critique — aucune régression de `--deep` / `--propose` malgré la disparition de `run_audit` (différentiel binaire identique sur stdout, `--report`, l'arbre `--propose` et le payload `--deep`). Cinq points corrigés ici, deux constats de la revue rectifiés.

**C1 (majeur) — les skills plugin n'étaient ni lues ni nommées.** `~/.claude/plugins/cache` porte 17 `SKILL.md` de plus, ~39177 tokens, contre un total annoncé de ~49967 : `R04` sous-estimait de **44 %**, et 2 des 17 franchiraient `R01`. Le correctif proposé par la revue — une entrée unique pour tout `~/.claude/plugins` — est **refusé par 4 tests** : il aurait fondu l'installé et le catalogue, la distinction même que ce chantier établit pour `~/.config/armadai`. Deux lignes séparées, chacune avec sa raison.

**C2 (modéré) — `$HOME` absent faisait auditer le dépôt courant.** Mesuré, mutation à l'appui : `--global` sans `$HOME` rapportait le skill du projet sous l'étiquette `Detected: claude (~/.claude)`. `GlobalLayout::from_env` renvoie `Option<Self>`, la CLI refuse. Le commentaire invoquait `usage::discovery::projects_root` comme précédent alors que celle-ci **refuse** (`.ok()?`, plus un `NoHomeGuard`) : corrigé.

**C3 (modéré) — 4 mutations survivaient**, dont 3 sur la promesse `Not read:` (« rendered in all three output formats », seul le terminal était gardé) et 1 sur l'ancre `root` globale. Les quatre sont maintenant rouges. Les trois assertions proposées par la revue étaient raisonnées, non mesurées ; elles ont été reformulées puis vérifiées par mutation.

**C6 (non bloquant, traité) — un audit global n'était pas reproductible** : ses seuils venaient du cwd (2 warnings `R01` depuis un dossier à `skill_token_threshold: 5`, 0 depuis un dossier neutre). La portée globale lit désormais `~/.config/armadai/config.yaml`. Vérifié sur la vraie bibliothèque : 1 finding `R01` à 4000, **10 à 500** — la promesse « `skill_token_threshold` stays configurable » devient matérielle dans la seule portée où `R01` a de la matière.

**C4 / C5 / C9 / C10 (non bloquants)** — champs de `AuditInput` privés (la construction incohérente `{ root: <projet>, scope: Global }` ne compile plus : `E0451`) ; formulation `$HOME` → « répertoire courant, quel qu'il soit » dans le wiki et le nom du test ; avertissement `--deep` qui nomme la portée (même frontière de vie privée que celle qui a écarté `R03`) ; deux continuations `\` perdues.

**C7** validé, rien touché. **C8** préexistant, rattaché à #391, non corrigé ici.

Deux constats de la revue rectifiés par la mesure :
- la revue attribuait 5 franchissements de `R01` à `plugins/cache` ; mesuré, **2 seulement** y sont (`subagent-driven-development` ~8030, `writing-skills` ~6565). Les 3 autres (`m5-onboard`, `project-artifact`, `receipts`) sont dans `plugins/marketplaces`, le catalogue — ce qui illustre exactement pourquoi les deux arbres ne doivent pas être fondus.
- `~/.claude/plugins/data` ne contient aucun asset (5 répertoires, 0 fichier) : pas de ligne, plutôt qu'une note sur un répertoire vide.

## Gate

fmt · clippy `-D warnings` en 5 modes · tests en 4 modes (1501 / 1596 / 1544 / 1628 passés, **0 échec**) · gaveldrop **13 cas · 83/83** · `cargo build --release`.

Non-régression en portée projet re-mesurée après la vague, binaire HEAD contre binaire corrigé : stdout identique, `--report` markdown identique, `--report` HTML identique, arbre `--propose` identique (8 fichiers, mêmes empreintes).

## Point laissé au mainteneur

`CLAUDE.md` décrit le module `audit/` et gagnerait une mention de `audit/scope.rs` ; je ne modifie pas ce fichier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

