### PR TITLE
fix(providers): codex, copilot et opencode exécutables par armadai run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ armadai tui
 ### Key Features
 
 - **Markdown-based agents** — one `.md` file = one agent. Human-readable, git-friendly.
-- **Multi-provider** — unified tool names (`claude`, `gemini`, `gpt`, `aider`) auto-detect CLI vs API; explicit API/CLI/proxy modes also supported
+- **Multi-provider** — unified tool names (`claude`, `gemini`, `codex`, `copilot`, `opencode`, `gpt`, `aider`) auto-detect CLI vs API; explicit API/CLI/proxy modes also supported
 - **Multi-pattern orchestration** — Direct (single-shot), Blackboard (parallel shared-state), Ring (sequential consensus), Hierarchical (coordinator → leads → agents)
 - **Pipeline mode** — chain agents sequentially (output A becomes input B)
 - **TUI & Web dashboards** — agent library management with browser, detail view, history, costs, and command palette

--- a/crates/armadai-core/skills/armadai-agent-authoring/references/format.md
+++ b/crates/armadai-core/skills/armadai-agent-authoring/references/format.md
@@ -47,7 +47,7 @@ Instead of hardcoding model names, use `latest:*` placeholders that resolve to t
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `provider` | string | **yes** | — | Provider backend: `anthropic`, `openai`, `google`, `gemini`, `cli`, `proxy`, `aider` |
+| `provider` | string | **yes** | — | Provider backend: an API (`anthropic`, `openai`, `google`, `proxy`), a unified tool name (`claude`, `gemini`, `codex`, `copilot`, `opencode`, `gpt`, `aider`), or `cli` for any other binary |
 | `model` | string | for API providers | — | Model identifier or `latest:*` placeholder (e.g., `latest:pro`, `latest:fast`) |
 | `command` | string | for `cli` provider | — | CLI command to execute |
 | `args` | string[] | no | — | Arguments for CLI command: `[--flag, value]` |

--- a/crates/armadai-core/starters/armadai-authoring/agents/agent-builder.md
+++ b/crates/armadai-core/starters/armadai-authoring/agents/agent-builder.md
@@ -27,9 +27,9 @@ An ArmadAI agent file is a Markdown document with these required sections:
 
 ### Metadata Fields
 Required:
-- `provider:` — Unified tool name (`claude`, `gemini`, `gpt`, `aider`) OR explicit API (`anthropic`, `openai`, `google`) OR explicit CLI (`cli` + `command:` field).
+- `provider:` — Unified tool name (`claude`, `gemini`, `codex`, `copilot`, `opencode`, `gpt`, `aider`) OR explicit API (`anthropic`, `openai`, `google`, `proxy`) OR explicit CLI (`cli` + `command:` field).
 
-  Unified names auto-detect: if the CLI tool is installed on the user's system, it is used; otherwise ArmadAI falls back to the API. **Prefer unified names** — it's the most portable choice.
+  Unified names auto-detect: if the CLI tool is installed on the user's system, it is used; otherwise ArmadAI falls back to the API. `codex`, `copilot` and `opencode` are CLI-only — they have no API fallback, and ArmadAI says so when their binary is missing. **Prefer unified names** — it's the most portable choice.
 
   Don't use legacy syntax like `cli claude` — it is NOT supported. Use `provider: claude` instead.
 

--- a/crates/armadai-providers/src/factory.rs
+++ b/crates/armadai-providers/src/factory.rs
@@ -3,23 +3,30 @@ use armadai_core::agent::Agent;
 use armadai_core::provider::Provider;
 
 /// Known tool definitions for unified provider names.
-/// Each entry maps a user-friendly name to its CLI command and API backend.
+/// Each entry maps a user-friendly name to its CLI command and, when one
+/// exists, the API backend to fall back to.
 struct ToolDef {
     /// CLI command name (e.g. "claude", "gemini")
     cli_command: &'static str,
-    /// Default CLI args for this tool
+    /// Default CLI args for this tool, used only when the CLI has no JSON
+    /// mode (`json_runner::supports_json`) and the agent declares no `args:`.
     cli_args: &'static [&'static str],
-    /// Corresponding API provider name (e.g. "anthropic")
-    api_backend: &'static str,
-    /// Environment variable for API key.
-    // Populated for every entry but never read anywhere today (API key
-    // resolution goes through `get_api_key` with the env var name inlined
-    // per-provider in `api/*.rs`). Previously silent under the bin's blanket
-    // `#[allow(dead_code)] mod providers;`; scoped here rather than adding an
-    // allow at the crate root (OH7 #252 Lot 4, pure refactor, no behavior
-    // change).
-    #[allow(dead_code)]
-    api_key_env: &'static str,
+    /// API provider to fall back to when the CLI is not installed, or `None`
+    /// for a CLI-only tool.
+    ///
+    /// `Option` rather than a required string because three of these tools
+    /// (`codex`, `copilot`, `opencode`) have no API ArmadAI can reach with an
+    /// agent's plain-text exchange: their vendors expose the agent behind the
+    /// CLI itself. Naming an arbitrary backend for them would turn "the
+    /// binary is missing" into "no API key found for openai", which sends the
+    /// user looking for the wrong thing (issue #369).
+    ///
+    /// The struct previously also carried an `api_key_env` field, never read
+    /// anywhere and silenced with `#[allow(dead_code)]`: API keys are
+    /// resolved by `get_api_key` with the variable name inlined per provider
+    /// in `create_api_provider`. Widening it to `Option` alongside this field
+    /// would have added three more never-read `None`s, so it was dropped.
+    api_backend: Option<&'static str>,
 }
 
 const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
@@ -28,8 +35,7 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
         ToolDef {
             cli_command: "claude",
             cli_args: &["-p", "--output-format", "text"],
-            api_backend: "anthropic",
-            api_key_env: "ANTHROPIC_API_KEY",
+            api_backend: Some("anthropic"),
         },
     ),
     (
@@ -37,8 +43,7 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
         ToolDef {
             cli_command: "gemini",
             cli_args: &["-p"],
-            api_backend: "google",
-            api_key_env: "GOOGLE_API_KEY",
+            api_backend: Some("google"),
         },
     ),
     (
@@ -46,8 +51,7 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
         ToolDef {
             cli_command: "gpt",
             cli_args: &[],
-            api_backend: "openai",
-            api_key_env: "OPENAI_API_KEY",
+            api_backend: Some("openai"),
         },
     ),
     (
@@ -55,8 +59,37 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
         ToolDef {
             cli_command: "aider",
             cli_args: &["--message"],
-            api_backend: "openai",
-            api_key_env: "OPENAI_API_KEY",
+            api_backend: Some("openai"),
+        },
+    ),
+    // CLI-only from here on: `armadai link` already writes a native config
+    // for each of these, and `armadai shell` already relays them in JSON
+    // mode, but `armadai run` used to refuse them as unknown (issue #369).
+    // Their `cli_args` are the non-interactive form each tool needs; in
+    // practice `create_unified_provider` uses `json_runner::json_mode_args`
+    // for all three, since they do speak JSON.
+    (
+        "codex",
+        ToolDef {
+            cli_command: "codex",
+            cli_args: &["exec"],
+            api_backend: None,
+        },
+    ),
+    (
+        "copilot",
+        ToolDef {
+            cli_command: "copilot",
+            cli_args: &["-p"],
+            api_backend: None,
+        },
+    ),
+    (
+        "opencode",
+        ToolDef {
+            cli_command: "opencode",
+            cli_args: &["run"],
+            api_backend: None,
         },
     ),
 ];
@@ -106,6 +139,22 @@ const KNOWN_TOOLS: &[(&str, ToolDef)] = &[
 /// closing it.
 pub const DEFAULT_TIMEOUT_SECS: u64 = 300;
 
+/// Providers served over HTTP rather than by spawning a command.
+pub const API_PROVIDER_NAMES: &[&str] = &["anthropic", "openai", "google", "proxy"];
+
+/// The unified tool names `KNOWN_TOOLS` declares, in declaration order.
+pub fn known_tool_names() -> Vec<&'static str> {
+    KNOWN_TOOLS.iter().map(|(name, _)| *name).collect()
+}
+
+/// Every value `provider:` accepts.
+pub fn accepted_provider_names() -> Vec<&'static str> {
+    let mut names = vec!["cli"];
+    names.extend_from_slice(API_PROVIDER_NAMES);
+    names.extend(known_tool_names());
+    names
+}
+
 fn find_tool(name: &str) -> Option<&'static ToolDef> {
     KNOWN_TOOLS
         .iter()
@@ -117,13 +166,11 @@ fn find_tool(name: &str) -> Option<&'static ToolDef> {
 /// Returns the backend directly for explicit API providers.
 /// e.g. "claude" → "anthropic", "gemini" → "google", "anthropic" → "anthropic"
 pub fn api_backend_for_tool(name: &str) -> Option<&'static str> {
-    match name {
-        "anthropic" => Some("anthropic"),
-        "openai" => Some("openai"),
-        "google" => Some("google"),
-        "proxy" => Some("proxy"),
-        _ => find_tool(name).map(|t| t.api_backend),
-    }
+    API_PROVIDER_NAMES
+        .iter()
+        .find(|n| **n == name)
+        .copied()
+        .or_else(|| find_tool(name).and_then(|t| t.api_backend))
 }
 
 /// Check if a CLI command is available on the system.
@@ -140,10 +187,10 @@ fn cli_available(command: &str) -> bool {
 ///
 /// Provider resolution order:
 /// 1. `provider: cli` — explicit CLI mode, requires `command` field
-/// 2. `provider: anthropic|openai|google` — explicit API mode
-/// 3. `provider: claude|gemini|gpt|aider` — unified name, auto-detects:
+/// 2. A name from [`API_PROVIDER_NAMES`] — explicit API mode
+/// 3. A unified tool name from [`known_tool_names`] — auto-detects:
 ///    a. If the CLI tool is installed → use CLI provider
-///    b. Otherwise → fall back to API provider
+///    b. Otherwise → its API backend, or a report of the missing binary
 pub fn create_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
     let provider = agent.metadata.provider.as_str();
 
@@ -152,33 +199,46 @@ pub fn create_provider(agent: &Agent) -> anyhow::Result<Box<dyn Provider>> {
         "cli" => create_cli_provider(agent)?,
 
         // Explicit API providers
-        "anthropic" | "openai" | "google" | "proxy" => create_api_provider(provider, agent)?,
+        p if API_PROVIDER_NAMES.contains(&p) => create_api_provider(p, agent)?,
 
         // Unified tool names — auto-detect CLI vs API
-        _ => {
-            if let Some(tool) = find_tool(provider) {
-                create_unified_provider(provider, tool, agent)?
-            } else {
-                anyhow::bail!(
-                    "Unknown provider: '{provider}'. \
-                     Known providers: cli, anthropic, openai, google, claude, gemini, gpt, aider"
-                )
-            }
-        }
+        _ => match find_tool(provider) {
+            Some(tool) => create_unified_provider(provider, tool, agent)?,
+            None => anyhow::bail!("{}", unknown_provider_message(provider)),
+        },
     };
     Ok(wrap_rate_limited(agent, inner))
+}
+
+/// What to answer for a `provider:` value nothing recognises.
+///
+/// The list is derived from the inventories `create_provider` actually
+/// branches on, not typed out: the hand-written version drifted, advertising
+/// neither `proxy` (accepted since the gateway provider landed) nor `codex`,
+/// `copilot`, `opencode`.
+///
+/// It also names the generic escape hatch. `provider: cli` runs *any*
+/// binary, which is what a user with an unlisted tool needs to hear —
+/// listing only the known names left them believing the tool was
+/// unsupported.
+fn unknown_provider_message(provider: &str) -> String {
+    format!(
+        "Unknown provider: '{provider}'. Known providers: {}. \
+         Any other command-line tool can still be run as an agent with \
+         `provider: cli` plus `command: <binary>` (and `args:` if it needs \
+         flags to answer non-interactively).",
+        accepted_provider_names().join(", ")
+    )
 }
 
 /// Map an agent's `provider` string to the `config.rate_limits` key, or `None`
 /// for providers with no per-account API quota (pure CLI).
 fn rate_limit_key(provider: &str) -> Option<String> {
-    match provider {
-        "anthropic" | "openai" | "google" | "proxy" => Some(provider.to_string()),
-        "claude" => Some("anthropic".to_string()),
-        "gemini" => Some("google".to_string()),
-        "gpt" => Some("openai".to_string()),
-        _ => None, // "cli", unknown, or unified-resolving-to-cli
-    }
+    // The unified-name -> backend mapping already lives in `ToolDef`; a
+    // second copy here is how `codex` would silently acquire an OpenAI quota
+    // it never spends. `None` for "cli", for an unknown name, and for a
+    // CLI-only tool — none of them consume a per-account API quota.
+    api_backend_for_tool(provider).map(str::to_string)
 }
 
 /// Wrap `inner` with the shared per-provider limiter (from `config.rate_limits`)
@@ -243,12 +303,21 @@ fn create_unified_provider(
             args,
             timeout,
         )))
-    } else {
+    } else if let Some(backend) = tool.api_backend {
         tracing::info!(
-            "Provider '{name}': CLI '{command}' not found, falling back to API ({})",
-            tool.api_backend
+            "Provider '{name}': CLI '{command}' not found, falling back to API ({backend})"
         );
-        create_api_provider(tool.api_backend, agent)
+        create_api_provider(backend, agent)
+    } else {
+        // No API to fall back to. Say which binary was looked for and how to
+        // point at it — an arbitrary backend here would answer a missing
+        // binary with "no API key found", which is the wrong hunt.
+        anyhow::bail!(
+            "Provider '{name}' runs the `{command}` CLI, which was not found on PATH, \
+             and it has no API backend to fall back to. Install it, or point this \
+             agent at the executable with `command: /full/path/to/{}`.",
+            tool.cli_command
+        )
     }
 }
 
@@ -388,6 +457,41 @@ fn get_api_key(env_var: &str, provider_name: &str) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use armadai_core::agent::AgentMetadata;
+
+    /// An agent carrying nothing but the two fields provider resolution
+    /// reads: `provider:` and (optionally) `command:`.
+    fn agent_with(provider: &str, command: Option<&str>) -> Agent {
+        Agent {
+            name: "t".into(),
+            source: std::path::PathBuf::from("t.md"),
+            metadata: AgentMetadata {
+                provider: provider.into(),
+                model: None,
+                command: command.map(str::to_string),
+                args: None,
+                temperature: 0.7,
+                max_tokens: None,
+                timeout: None,
+                tags: vec![],
+                stacks: vec![],
+                scope: vec![],
+                model_fallback: vec![],
+                cost_limit: None,
+                rate_limit: None,
+                context_window: None,
+                mode: None,
+                orchestration: None,
+                triggers: None,
+                ring_config: None,
+            },
+            system_prompt: String::new(),
+            instructions: None,
+            output_format: None,
+            pipeline: None,
+            context: None,
+        }
+    }
 
     #[test]
     fn find_known_tools() {
@@ -396,6 +500,152 @@ mod tests {
         assert!(find_tool("gpt").is_some());
         assert!(find_tool("aider").is_some());
         assert!(find_tool("unknown").is_none());
+    }
+
+    /// The three CLIs `armadai link` already writes a config for and the
+    /// shell already relays in JSON mode were absent from `KNOWN_TOOLS`, so
+    /// `armadai run` answered `Unknown provider: 'codex'` (issue #369).
+    ///
+    /// `command: echo` pins the CLI branch without depending on whether the
+    /// real tool happens to be installed on the machine running the suite.
+    #[test]
+    fn the_cli_only_tools_are_providers_run_accepts() {
+        for tool in ["codex", "copilot", "opencode"] {
+            let provider = create_provider(&agent_with(tool, Some("echo")))
+                .unwrap_or_else(|e| panic!("provider '{tool}' must build: {e}"));
+            assert_eq!(
+                provider.metadata().name,
+                "cli:echo",
+                "provider '{tool}' must resolve to the CLI branch"
+            );
+        }
+    }
+
+    /// Their canonical argv is the one `json_runner` already carries — the
+    /// whole reason `provider: cli` + `command: codex` is not an equivalent
+    /// workaround, since that path passes no flags at all and `codex` with a
+    /// bare positional opens its interactive UI.
+    #[test]
+    fn a_cli_only_tool_gets_its_canonical_json_argv() {
+        for (tool, expected) in [
+            ("codex", vec!["exec", "--json"]),
+            ("copilot", vec!["--output-format", "json", "-p"]),
+            ("opencode", vec!["run", "--format", "json"]),
+        ] {
+            let def = find_tool(tool).unwrap_or_else(|| panic!("{tool} must be a known tool"));
+            assert_eq!(
+                crate::json_runner::json_mode_args(def.cli_command),
+                expected,
+                "{tool} must be spawned with the argv the shell relay already uses"
+            );
+        }
+    }
+
+    /// A CLI-only tool has no API equivalent ArmadAI can reach. With the
+    /// binary missing the answer must name the binary and say so — not
+    /// dead-end in an API fallback that can only fail on a missing key.
+    #[test]
+    fn a_missing_cli_only_binary_is_reported_as_such() {
+        let missing = "this_command_does_not_exist_xyz";
+        assert!(!cli_available(missing));
+
+        for tool in ["codex", "copilot", "opencode"] {
+            let err = match create_provider(&agent_with(tool, Some(missing))) {
+                Ok(_) => panic!("'{tool}' built a provider with no binary present"),
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                err.contains(missing),
+                "must name the binary looked for: {err}"
+            );
+            assert!(
+                err.contains("command:"),
+                "must say how to point at the binary: {err}"
+            );
+            assert!(
+                !err.contains("Unknown provider"),
+                "'{tool}' is a known provider: {err}"
+            );
+            assert!(
+                !err.contains("API_KEY"),
+                "'{tool}' has no API fallback, so no key is the answer: {err}"
+            );
+        }
+    }
+
+    /// The list `create_provider` advertises must be the list it accepts.
+    ///
+    /// Held as a literal on purpose: deriving the expectation from
+    /// `accepted_provider_names()` would make the test agree with any drift
+    /// of that function, which is the defect (`proxy` was accepted by
+    /// `create_provider` and missing from the message for as long as the
+    /// message was a hand-typed string).
+    #[test]
+    fn the_advertised_provider_names_are_exactly_the_accepted_ones() {
+        let expected = [
+            "cli",
+            "anthropic",
+            "openai",
+            "google",
+            "proxy",
+            "claude",
+            "gemini",
+            "gpt",
+            "aider",
+            "codex",
+            "copilot",
+            "opencode",
+        ];
+        let mut advertised = accepted_provider_names();
+        advertised.sort_unstable();
+        let mut want = expected.to_vec();
+        want.sort_unstable();
+        assert_eq!(advertised, want);
+
+        let message = match create_provider(&agent_with("nope-not-a-provider", None)) {
+            Ok(_) => panic!("a bogus provider name must be refused"),
+            Err(e) => e.to_string(),
+        };
+        for name in expected {
+            assert!(
+                message.contains(name),
+                "the refusal must advertise '{name}': {message}"
+            );
+        }
+    }
+
+    /// Every advertised name must reach its own branch: none of them may
+    /// come back as `Unknown provider`. The API ones legitimately fail on a
+    /// missing key here; that is a different, actionable answer.
+    #[test]
+    fn no_advertised_provider_name_falls_through_to_unknown() {
+        for name in accepted_provider_names() {
+            if let Err(e) = create_provider(&agent_with(name, Some("echo"))) {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains("Unknown provider"),
+                    "'{name}' is advertised but not accepted: {msg}"
+                );
+            }
+        }
+    }
+
+    /// The refusal must teach the escape hatch: any binary at all is
+    /// runnable through `provider: cli`, which the old message never said.
+    #[test]
+    fn the_refusal_teaches_the_generic_cli_escape_hatch() {
+        let message = match create_provider(&agent_with("some-other-tool", None)) {
+            Ok(_) => panic!("a bogus provider name must be refused"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            message.contains("provider: cli"),
+            "must name the escape hatch: {message}"
+        );
+        assert!(
+            message.contains("command:"),
+            "must name the field it needs: {message}"
+        );
     }
 
     #[test]
@@ -418,6 +668,13 @@ mod tests {
         // pure CLI: no per-provider quota key
         assert_eq!(rate_limit_key("cli"), None);
         assert_eq!(rate_limit_key("unknown-tool"), None);
+        // CLI-only tools bill through their own subscription, not through an
+        // ArmadAI-held API key: giving them a backend would also give them a
+        // shared quota bucket they never draw on.
+        for tool in ["codex", "copilot", "opencode"] {
+            assert_eq!(rate_limit_key(tool), None, "{tool}");
+            assert_eq!(api_backend_for_tool(tool), None, "{tool}");
+        }
     }
 
     /// `wrap_rate_limited` with an agent-level `rate_limit` throttles even
@@ -535,7 +792,6 @@ mod tests {
     #[cfg(feature = "api")]
     mod api_wiring {
         use super::*;
-        use armadai_core::agent::AgentMetadata;
         use armadai_core::test_support::IsolatedConfigDir;
 
         /// Redirect the config dir (so no real `providers.yaml`/secrets are
@@ -552,38 +808,6 @@ mod tests {
                 .fold(IsolatedConfigDir::enter(), |scope, (name, value)| {
                     scope.with_var(name, *value)
                 })
-        }
-
-        fn agent_with(provider: &str, command: Option<&str>) -> Agent {
-            Agent {
-                name: "t".into(),
-                source: std::path::PathBuf::from("t.md"),
-                metadata: AgentMetadata {
-                    provider: provider.into(),
-                    model: None,
-                    command: command.map(str::to_string),
-                    args: None,
-                    temperature: 0.7,
-                    max_tokens: None,
-                    timeout: None,
-                    tags: vec![],
-                    stacks: vec![],
-                    scope: vec![],
-                    model_fallback: vec![],
-                    cost_limit: None,
-                    rate_limit: None,
-                    context_window: None,
-                    mode: None,
-                    orchestration: None,
-                    triggers: None,
-                    ring_config: None,
-                },
-                system_prompt: String::new(),
-                instructions: None,
-                output_format: None,
-                pipeline: None,
-                context: None,
-            }
         }
 
         #[test]

--- a/crates/armadai-providers/src/json_runner.rs
+++ b/crates/armadai-providers/src/json_runner.rs
@@ -26,58 +26,92 @@ pub struct CliResponse {
     pub from_json: bool,
 }
 
+/// One CLI this module knows how to drive in JSON mode.
+///
+/// A single table rather than one `match` per accessor: `supports_json`
+/// gates how a stream is *parsed* while `json_mode_args` decides how the
+/// process is *spawned*, and two independent matches can silently disagree
+/// — a CLI spawned in JSON mode but parsed as text, or the reverse.
+struct JsonCli {
+    /// Command name, as it appears on `PATH` and in `command:`.
+    name: &'static str,
+    /// Flags that make the CLI answer in one JSON document.
+    output_flags: &'static [&'static str],
+    /// Full leading argv for streaming JSONL mode. The caller appends the
+    /// prompt as the last argument, so any flag that *takes* the prompt as
+    /// its value (`-p`) must come last here.
+    mode_args: &'static [&'static str],
+}
+
+const JSON_CLIS: &[JsonCli] = &[
+    JsonCli {
+        name: "claude",
+        output_flags: &["--output-format", "json"],
+        mode_args: &["-p", "--output-format", "stream-json", "--verbose"],
+    },
+    // NOTE: For Gemini, -p must be followed immediately by the prompt value,
+    // so -o comes BEFORE -p.
+    JsonCli {
+        name: "gemini",
+        output_flags: &["-o", "json"],
+        mode_args: &["-o", "stream-json", "-p"],
+    },
+    // `codex` with a bare positional forwards to its interactive UI; `exec`
+    // is the non-interactive subcommand.
+    JsonCli {
+        name: "codex",
+        output_flags: &["--json"],
+        mode_args: &["exec", "--json"],
+    },
+    // Copilot: -p takes a value, so put other flags before -p.
+    JsonCli {
+        name: "copilot",
+        output_flags: &["--output-format", "json"],
+        mode_args: &["--output-format", "json", "-p"],
+    },
+    // `opencode` with a bare positional reads it as a *project path*, not a
+    // prompt; `run` is the non-interactive subcommand.
+    JsonCli {
+        name: "opencode",
+        output_flags: &["--format", "json"],
+        mode_args: &["run", "--format", "json"],
+    },
+];
+
+/// Aider speaks no JSON: it is driven in text mode and its stdout is parsed
+/// as prose. Kept out of [`JSON_CLIS`] on purpose — being in that table is
+/// exactly what `supports_json` means.
+const AIDER_TEXT_MODE_ARGS: &[&str] = &["--yes", "--message"];
+
+fn json_cli(name: &str) -> Option<&'static JsonCli> {
+    JSON_CLIS.iter().find(|c| c.name == name)
+}
+
+/// Every CLI this module can drive in JSON mode.
+pub fn json_capable_clis() -> Vec<&'static str> {
+    JSON_CLIS.iter().map(|c| c.name).collect()
+}
+
 /// Get the JSON output flags for a provider.
 /// Returns None if the provider doesn't support JSON output.
 pub fn json_output_flags(provider: &str) -> Option<Vec<String>> {
-    match provider {
-        "claude" => Some(vec!["--output-format".to_string(), "json".to_string()]),
-        "gemini" => Some(vec!["-o".to_string(), "json".to_string()]),
-        "codex" => Some(vec!["--json".to_string()]),
-        "copilot" => Some(vec!["--output-format".to_string(), "json".to_string()]),
-        "opencode" => Some(vec!["--format".to_string(), "json".to_string()]),
-        // Aider and unknown CLIs: no JSON support
-        _ => None,
-    }
+    json_cli(provider).map(|c| c.output_flags.iter().map(|s| (*s).to_string()).collect())
 }
 
 /// Get the base CLI args for a provider in stream-JSON mode.
 /// Uses stream-json when available for real-time JSONL event streaming.
 pub fn json_mode_args(provider: &str) -> Vec<String> {
-    match provider {
-        "claude" => vec![
-            "-p".to_string(),
-            "--output-format".to_string(),
-            "stream-json".to_string(),
-            "--verbose".to_string(),
-        ],
-        // NOTE: For Gemini, -p must be followed immediately by the prompt value.
-        // The prompt is appended as the last arg by the caller, so we put -o BEFORE -p.
-        "gemini" => vec![
-            "-o".to_string(),
-            "stream-json".to_string(),
-            "-p".to_string(),
-        ],
-        "codex" => vec!["exec".to_string(), "--json".to_string()],
-        // Copilot: -p takes a value, so put other flags before -p
-        "copilot" => vec![
-            "--output-format".to_string(),
-            "json".to_string(),
-            "-p".to_string(),
-        ],
-        "opencode" => vec![
-            "run".to_string(),
-            "--format".to_string(),
-            "json".to_string(),
-        ],
-        // Aider: text mode fallback
-        "aider" => vec!["--yes".to_string(), "--message".to_string()],
-        _ => vec![],
-    }
+    let args: &[&str] = match json_cli(provider) {
+        Some(cli) => cli.mode_args,
+        None if provider == "aider" => AIDER_TEXT_MODE_ARGS,
+        None => &[],
+    };
+    args.iter().map(|s| (*s).to_string()).collect()
 }
 
 /// Check if a provider supports JSON output.
 pub fn supports_json(provider: &str) -> bool {
-    json_output_flags(provider).is_some()
+    json_cli(provider).is_some()
 }
 
 /// Extract the visible text from a CLI's raw JSONL stdout.
@@ -758,6 +792,31 @@ mod tests {
         assert_eq!(resp.content, "Just some text response");
         assert!(resp.tokens_in.is_none());
         assert!(!resp.from_json);
+    }
+
+    /// `json_capable_clis` is the inventory the rest of the workspace reads
+    /// to know which CLIs speak JSON; it must not disagree with the two
+    /// accessors built on the same table.
+    #[test]
+    fn the_json_inventory_agrees_with_both_accessors() {
+        let clis = json_capable_clis();
+        assert!(!clis.is_empty());
+        for name in &clis {
+            assert!(supports_json(name), "{name} listed but not supported");
+            assert!(
+                json_output_flags(name).is_some_and(|f| !f.is_empty()),
+                "{name} listed with no output flags"
+            );
+            assert!(
+                !json_mode_args(name).is_empty(),
+                "{name} listed with no stream-mode argv"
+            );
+        }
+        // Aider is driven in text mode: it has argv but no JSON support, so
+        // it must stay out of the inventory.
+        assert!(!clis.contains(&"aider"));
+        assert!(!json_mode_args("aider").is_empty());
+        assert!(!supports_json("aider"));
     }
 
     #[test]

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -120,8 +120,8 @@ pub async fn execute(
         .or_else(|| config.link.as_ref().and_then(|l| l.target.clone()))
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "No link target specified. Use --target or set link.target in armadai.yaml.\n\
-                 Supported targets: claude, codex, copilot, gemini, opencode"
+                "No link target specified. Use --target or set link.target in armadai.yaml.\n{}",
+                crate::linker::supported_targets_sentence()
             )
         })?;
 

--- a/crates/armadai/src/cli/new.rs
+++ b/crates/armadai/src/cli/new.rs
@@ -145,23 +145,12 @@ async fn interactive_create() -> anyhow::Result<()> {
     };
 
     // 3. Provider
-    let providers = [
-        "claude",
-        "gemini",
-        "gpt",
-        "aider",
-        "anthropic",
-        "openai",
-        "google",
-        "cli",
-        "proxy",
-    ];
     let provider_idx = Select::new()
         .with_prompt("Provider")
-        .items(providers)
+        .items(WIZARD_PROVIDER_CHOICES)
         .default(0)
         .interact()?;
-    let provider = providers[provider_idx];
+    let provider = WIZARD_PROVIDER_CHOICES[provider_idx];
 
     // 4. Model (filtered by provider)
     let model = prompt_model(provider).await?;
@@ -316,6 +305,30 @@ async fn interactive_create() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// The `provider:` values `armadai new -i` offers.
+///
+/// This is the same set `providers::factory::create_provider` accepts, and a
+/// test pins that: a name missing here is a provider the wizard cannot author
+/// an agent for, which is how `codex`, `copilot` and `opencode` stayed
+/// unreachable from the wizard after they became runnable (issue #369).
+///
+/// Order is UX, not inventory: the CLI-backed tools first (`claude` is the
+/// default), then the explicit API providers, then the generic escape hatch.
+pub(crate) const WIZARD_PROVIDER_CHOICES: &[&str] = &[
+    "claude",
+    "gemini",
+    "codex",
+    "copilot",
+    "opencode",
+    "gpt",
+    "aider",
+    "anthropic",
+    "openai",
+    "google",
+    "proxy",
+    "cli",
+];
 
 /// Prompt for model based on provider.
 /// Tries models.dev registry first (with cache), falls back to providers.yaml.

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -77,8 +77,8 @@ pub async fn execute(
         .or_else(|| config.link.as_ref().and_then(|l| l.target.clone()))
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "No link target specified. Use --target or set link.target in armadai.yaml.\n\
-                 Supported targets: claude, codex, copilot, gemini, opencode"
+                "No link target specified. Use --target or set link.target in armadai.yaml.\n{}",
+                crate::linker::supported_targets_sentence()
             )
         })?;
 

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -81,6 +81,27 @@ pub trait Linker: Send + Sync {
     ) -> Vec<OutputFile>;
 }
 
+/// Every target `create_linker` can build, as a comma-separated list for an
+/// error message.
+///
+/// Derived from `LinkTarget` rather than typed out. Three separate messages
+/// (`create_linker`, `link`, `unlink`) each carried their own copy of the
+/// five names — the same shape as the `Unknown provider` message that had
+/// silently stopped advertising `proxy` (issue #369). A target added to the
+/// enum now reaches all three at once.
+pub fn supported_target_names() -> Vec<&'static str> {
+    use clap::ValueEnum;
+    LinkTarget::value_variants()
+        .iter()
+        .map(|t| t.as_str())
+        .collect()
+}
+
+/// The sentence every "no/unknown target" message ends with.
+pub fn supported_targets_sentence() -> String {
+    format!("Supported targets: {}", supported_target_names().join(", "))
+}
+
 /// Create a linker for the given target name.
 pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
     match target {
@@ -90,7 +111,8 @@ pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
         "gemini" => Ok(Box::new(GeminiLinker)),
         "opencode" => Ok(Box::new(OpencodeLinker)),
         _ => anyhow::bail!(
-            "Unknown link target: '{target}'. Supported targets: claude, codex, copilot, gemini, opencode"
+            "Unknown link target: '{target}'. {}",
+            supported_targets_sentence()
         ),
     }
 }
@@ -302,6 +324,28 @@ mod tests {
                 sorted(crate::cli::new::WIZARD_PROVIDER_CHOICES.to_vec()),
                 sorted(accepted_provider_names())
             );
+        }
+
+        /// The names the "unknown target" messages advertise must be the
+        /// names `create_linker` can actually build.
+        ///
+        /// `link` and `unlink` print the same sentence from the same helper,
+        /// so this covers all three sites; before, each carried its own copy
+        /// of the five names.
+        #[test]
+        fn every_advertised_link_target_can_actually_be_built() {
+            for name in supported_target_names() {
+                let linker = create_linker(name)
+                    .unwrap_or_else(|e| panic!("target '{name}' is advertised but: {e}"));
+                assert_eq!(linker.name(), name);
+            }
+            let err = match create_linker("kilocode") {
+                Ok(_) => panic!("an unknown target must be refused"),
+                Err(e) => e.to_string(),
+            };
+            for name in supported_target_names() {
+                assert!(err.contains(name), "refusal must advertise '{name}': {err}");
+            }
         }
 
         /// And a fifth: the model-resolution preview shown in the TUI's agent

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -160,6 +160,167 @@ mod tests {
     use super::*;
     use armadai_core::agent::AgentMetadata;
 
+    /// The three provider inventories, checked against each other.
+    ///
+    /// They live in three crates and drifted apart unnoticed until a user hit
+    /// it (issue #369): `armadai link --target codex` wrote a config, the
+    /// shell relayed `codex` in JSON, and `armadai run` answered
+    /// `Unknown provider: 'codex'`. A comment saying "keep these in sync"
+    /// is what was there before; this is the same statement, executable.
+    mod provider_inventories {
+        use super::*;
+        use armadai_core::test_support::IsolatedConfigDir;
+        use armadai_providers::factory::{accepted_provider_names, create_provider};
+        use armadai_providers::json_runner::json_capable_clis;
+        use clap::ValueEnum;
+
+        /// An agent whose `provider:` is under test and whose `command:`
+        /// exists everywhere, so the CLI branch is reached regardless of
+        /// which tools happen to be installed on the machine.
+        fn agent_with_provider(provider: &str) -> Agent {
+            Agent {
+                name: "inventory-probe".into(),
+                source: std::path::PathBuf::from("probe.md"),
+                metadata: AgentMetadata {
+                    provider: provider.into(),
+                    model: None,
+                    command: Some("echo".into()),
+                    args: None,
+                    temperature: 0.7,
+                    max_tokens: None,
+                    timeout: None,
+                    tags: vec![],
+                    stacks: vec![],
+                    scope: vec![],
+                    model_fallback: vec![],
+                    cost_limit: None,
+                    rate_limit: None,
+                    context_window: None,
+                    mode: None,
+                    orchestration: None,
+                    triggers: None,
+                    ring_config: None,
+                },
+                system_prompt: String::new(),
+                instructions: None,
+                output_format: None,
+                pipeline: None,
+                context: None,
+            }
+        }
+
+        fn sorted(mut v: Vec<&str>) -> Vec<&str> {
+            v.sort_unstable();
+            v
+        }
+
+        /// Inventory 1 (`linker::LinkTarget`) vs inventory 2
+        /// (`factory::KNOWN_TOOLS`): writing a native config for a CLI is
+        /// worth nothing if `armadai run` then refuses the same name.
+        ///
+        /// `value_variants()` comes from the `ValueEnum` derive, so a target
+        /// added to the enum is in this loop without anyone remembering to
+        /// add it.
+        #[test]
+        fn every_link_target_is_a_provider_run_can_execute() {
+            // `create_provider` reads the user config for rate limits; keep
+            // it off the developer's real one.
+            let _cfg = IsolatedConfigDir::enter();
+            for target in LinkTarget::value_variants() {
+                let name = target.as_str();
+                let provider = create_provider(&agent_with_provider(name)).unwrap_or_else(|e| {
+                    panic!(
+                        "`armadai link --target {name}` writes a config for a CLI that \
+                         `armadai run` refuses: {e}"
+                    )
+                });
+                assert_eq!(
+                    provider.metadata().name,
+                    "cli:echo",
+                    "link target '{name}' must resolve to the CLI branch"
+                );
+            }
+        }
+
+        /// Inventory 3 (`json_runner`, the shell relay) vs inventory 2: a CLI
+        /// the shell can drive in JSON must be a name `armadai run` accepts,
+        /// or the same agent works in `armadai shell` and fails in
+        /// `armadai run`.
+        #[test]
+        fn every_json_relayable_cli_is_a_provider_run_can_execute() {
+            let _cfg = IsolatedConfigDir::enter();
+            for name in json_capable_clis() {
+                let provider = create_provider(&agent_with_provider(name)).unwrap_or_else(|e| {
+                    panic!("the shell relays '{name}' in JSON but `armadai run` refuses it: {e}")
+                });
+                assert_eq!(provider.metadata().name, "cli:echo", "'{name}'");
+            }
+        }
+
+        /// Inventory 1 vs inventory 3, both directions. These two sets being
+        /// equal is not a coincidence: a linker exists to configure a CLI
+        /// ArmadAI will then drive, and the shell drives it in JSON.
+        #[test]
+        fn the_link_targets_and_the_json_relayable_clis_are_the_same_set() {
+            let targets = sorted(
+                LinkTarget::value_variants()
+                    .iter()
+                    .map(|t| t.as_str())
+                    .collect(),
+            );
+            assert_eq!(targets, sorted(json_capable_clis()));
+        }
+
+        /// The remaining gap, pinned so widening it is a decision.
+        ///
+        /// `gpt` and `aider` are runnable but have no linker: neither writes
+        /// an ArmadAI-shaped agent config, so there is nothing to generate.
+        /// That is legitimate — unlike the codex/copilot/opencode gap, which
+        /// was not.
+        #[test]
+        fn the_only_runnable_tools_without_a_link_target_are_gpt_and_aider() {
+            let targets: Vec<&str> = LinkTarget::value_variants()
+                .iter()
+                .map(|t| t.as_str())
+                .collect();
+            let api_or_generic = ["cli", "anthropic", "openai", "google", "proxy"];
+            let orphans = sorted(
+                accepted_provider_names()
+                    .into_iter()
+                    .filter(|n| !targets.contains(n) && !api_or_generic.contains(n))
+                    .collect(),
+            );
+            assert_eq!(orphans, vec!["aider", "gpt"]);
+        }
+
+        /// The `armadai new -i` wizard is a fourth inventory: a provider the
+        /// wizard does not offer is one no interactive author can produce an
+        /// agent for, even though `run` accepts it.
+        #[test]
+        fn the_new_wizard_offers_exactly_the_providers_run_accepts() {
+            assert_eq!(
+                sorted(crate::cli::new::WIZARD_PROVIDER_CHOICES.to_vec()),
+                sorted(accepted_provider_names())
+            );
+        }
+
+        /// And a fifth: the model-resolution preview shown in the TUI's agent
+        /// detail view must cover every target `link` can write, or it shows
+        /// the user a preview of something other than what will happen.
+        #[test]
+        fn the_model_resolution_preview_covers_every_link_target() {
+            let previewed: Vec<&str> = model_resolution::preview_model_resolution(Some("m"))
+                .into_iter()
+                .map(|(target, _)| target)
+                .collect();
+            let targets: Vec<&str> = LinkTarget::value_variants()
+                .iter()
+                .map(|t| t.as_str())
+                .collect();
+            assert_eq!(sorted(previewed), sorted(targets));
+        }
+    }
+
     #[test]
     fn test_slugify_simple() {
         assert_eq!(slugify("Code Reviewer"), "code-reviewer");

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -346,6 +346,24 @@ mod tests {
             for name in supported_target_names() {
                 assert!(err.contains(name), "refusal must advertise '{name}': {err}");
             }
+
+            // And the converse. The loops above only prove advertised is a
+            // subset of buildable; *under*-advertising is the exact defect this
+            // derivation exists to prevent — `proxy` had silently dropped out
+            // of the provider message the same way. Measured before this
+            // existed: filtering `gemini` out of `supported_target_names()`
+            // left 746 tests green. This half iterates the enum, not the
+            // helper, so the helper cannot vouch for itself.
+            use clap::ValueEnum;
+            let sentence = supported_targets_sentence();
+            for target in LinkTarget::value_variants() {
+                let name = target.as_str();
+                assert!(
+                    supported_target_names().contains(&name),
+                    "link target '{name}' exists but is not advertised"
+                );
+                assert!(sentence.contains(name), "'{name}' missing from: {sentence}");
+            }
         }
 
         /// And a fifth: the model-resolution preview shown in the TUI's agent
@@ -567,7 +585,10 @@ mod tests {
     /// Run against **every** target, not just claude: a divergence that only
     /// shows in the codex projection is still a divergence.
     fn assert_projections_equal_across_targets(declared: &Agent, written: &Agent) {
-        for target in ["claude", "codex", "copilot", "gemini", "opencode"] {
+        for target in {
+            use clap::ValueEnum;
+            LinkTarget::value_variants().iter().map(|t| t.as_str())
+        } {
             let linker = create_linker(target).unwrap();
             let a = linker.generate(&[LinkAgent::from(declared)], None, &[]);
             let b = linker.generate(&[LinkAgent::from(written)], None, &[]);

--- a/crates/armadai/src/linker/model_resolution.rs
+++ b/crates/armadai/src/linker/model_resolution.rs
@@ -121,11 +121,14 @@ pub fn resolve_latest_placeholders(agents: &mut [LinkAgent]) {
 /// Returns a list of (target_name, resolved_model) tuples showing what model
 /// would be used when linking to each target.
 pub fn preview_model_resolution(agent_model: Option<&str>) -> Vec<(&'static str, String)> {
+    use clap::ValueEnum;
     let tier = agent_model.and_then(parse_latest_placeholder);
-    let targets = ["claude", "codex", "gemini", "copilot", "opencode"];
-    targets
+    // Derived from the enum rather than restated: a preview that silently
+    // omits a link target is a UI that lies about what `link` will do.
+    super::LinkTarget::value_variants()
         .iter()
-        .map(|&target| {
+        .map(|t| t.as_str())
+        .map(|target| {
             let resolved = match classify_target(target) {
                 TargetKind::LlmEditor { provider } => {
                     resolve_model_for_tier(provider, tier.unwrap_or(ModelTier::Pro))

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1176,7 +1176,10 @@ fn resolve_project_agent_from(start: &std::path::Path, name: &str) -> AgentLooku
 /// list of relayable names: the relay spawns whatever `command:` names, so a
 /// project is free to point a step at a CLI neither `json_runner` nor
 /// `factory` has heard of, and an allow-list would silently refuse those.
-const API_ONLY_PROVIDERS: [&str; 4] = ["anthropic", "openai", "google", "proxy"];
+///
+/// Read from `factory` rather than restated: a private copy here is one more
+/// provider inventory to keep in step with the others (issue #369).
+const API_ONLY_PROVIDERS: &[&str] = armadai_providers::factory::API_PROVIDER_NAMES;
 
 /// What this session can do with a loaded agent — data, not a spawn attempt.
 ///

--- a/docs/wiki/migration-v0-to-v1.md
+++ b/docs/wiki/migration-v0-to-v1.md
@@ -157,8 +157,9 @@ arguments.
 ```
 
 See [`docs/wiki/providers.md`](providers.md) for the complete list of
-unified names (`claude`, `gemini`, `gpt`, `aider`) and their CLI/API
-mapping.
+unified names and their CLI/API mapping. It has grown since this migration
+was written: `codex`, `copilot` and `opencode` are unified names too, and
+they are CLI-only (no API fallback).
 
 ### Migration steps
 

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -6,12 +6,54 @@ ArmadAI supports three types of providers for executing agents — **API** (dire
 
 Use a tool name directly as the provider. ArmadAI auto-detects whether the CLI tool is installed and falls back to the API if not.
 
-| Provider | CLI tool | API fallback | Default CLI args |
+| Provider | Command `armadai run` spawns | API fallback when the CLI is missing | `armadai link --target` |
 |---|---|---|---|
-| `claude` | `claude` | Anthropic API | `-p --output-format text` |
-| `gemini` | `gemini` | Google API | `-p` |
-| `gpt` | `gpt` | OpenAI API | (none) |
-| `aider` | `aider` | OpenAI API | `--message` |
+| `claude` | `claude -p --output-format stream-json --verbose` | Anthropic API | yes |
+| `gemini` | `gemini -o stream-json -p` | Google API | yes |
+| `codex` | `codex exec --json` | none — CLI only | yes |
+| `copilot` | `copilot --output-format json -p` | none — CLI only | yes |
+| `opencode` | `opencode run --format json` | none — CLI only | yes |
+| `gpt` | `gpt` | OpenAI API | no |
+| `aider` | `aider --message` | OpenAI API | no |
+
+The prompt is always appended as the last argument, which is why any flag that
+*takes* the prompt as its value (`-p`) comes last.
+
+### Runnable and linkable are two different things
+
+They are easy to confuse, and confusing them is what produced
+[#369](https://github.com/Dr0drigues/armadai/issues/369):
+
+- **runnable** — `armadai run` accepts the name in an agent's `provider:` and
+  spawns (or calls) something for it. That is the first column above.
+- **linkable** — `armadai link --target <name>` generates that tool's *own*
+  native config from your ArmadAI agents, so the tool sees them as its own
+  sub-agents. That is the last column.
+
+Every link target is runnable. The reverse does not hold: `gpt` and `aider`
+run but have no linker, because neither has an ArmadAI-shaped agent config to
+generate.
+
+### CLI-only providers
+
+`codex`, `copilot` and `opencode` are **CLI-only**: their vendors expose the
+agent behind the command-line tool, not behind an API an ArmadAI agent's
+plain-text exchange could call. When the binary is not on `PATH`, ArmadAI says
+so instead of falling back to an unrelated API:
+
+```
+Error: Provider 'codex' runs the `codex` CLI, which was not found on PATH, and
+it has no API backend to fall back to. Install it, or point this agent at the
+executable with `command: /full/path/to/codex`.
+```
+
+### Any other tool
+
+A provider name only has to be known for ArmadAI to supply defaults. Any other
+command-line tool runs through `provider: cli` (see [CLI
+Provider](#cli-provider)), which spawns exactly what `command:` and `args:`
+say and nothing else — so a tool that needs a subcommand or a flag to answer
+non-interactively needs that flag written out in `args:`.
 
 ### Example
 
@@ -176,7 +218,14 @@ eventually.
 - timeout: 60
 ```
 
-> **Note:** For standard tools (claude, gemini, gpt, aider), prefer using the unified tool name (`provider: claude`) instead of `provider: cli` + `command: claude`. The unified names auto-detect CLI availability and provide sensible defaults.
+> **Note:** For the tools listed under [Unified Tool Names](#unified-tool-names-recommended)
+> — claude, gemini, codex, copilot, opencode, gpt, aider — prefer the unified
+> name (`provider: codex`) over `provider: cli` + `command: codex`. They are not
+> equivalent: the unified name auto-detects CLI availability, falls back to the
+> API where one exists, and supplies the tool's non-interactive argv, whereas
+> `provider: cli` with no `args:` passes the prompt alone — and `codex` with a
+> bare positional opens its interactive UI, while `opencode` reads it as a
+> project path.
 
 ## OpenAI-compatible servers
 


### PR DESCRIPTION
Ferme #369.

## Le défaut

`armadai link --target codex` écrivait sa config, `armadai shell` savait relayer `codex` en JSON — et `armadai run` sur un agent `provider: codex` répondait `Unknown provider`. Idem `copilot` et `opencode` : trois CLI utilisables par deux surfaces sur trois.

## Le choix de design, et pourquoi

L'issue proposait deux voies. J'ai pris la **1** (`api_backend: Option`, les trois en CLI-only), pas la 2 (pansement sur le message), et la mesure tranche :

en donnant à `codex` un `api_backend: Some("openai")` arbitraire, binaire absent, `armadai run` répond

```
No API key found for 'openai'. Set OPENAI_API_KEY or add to config/providers.secret.yaml
```

L'utilisateur part chercher une clé pour un outil qui n'en veut pas. Avec `Option`, il lit :

```
Provider 'codex' runs the `codex` CLI, which was not found on PATH, and it has no
API backend to fall back to. Install it, or point this agent at the executable with
`command: /full/path/to/codex`.
```

Deuxième raison, mesurée aussi : le contournement `provider: cli` + `command: codex` que l'issue dit « fonctionne aujourd'hui » **ne fonctionne pas** sans `args:`. Cette voie ne passe aucun flag — argv observé = le prompt seul — et `codex [PROMPT]` sans sous-commande bascule sur son UI interactive (`codex --help` : « If no subcommand is specified, options will be forwarded to the interactive CLI »), tandis qu'`opencode [project]` lit le positionnel comme un *chemin de projet*. La valeur ajoutée n'est donc pas seulement « plus de `bail!` », c'est l'argv canonique que `json_mode_args` portait déjà.

`api_key_env` est **supprimé** plutôt qu'élargi : jamais lu nulle part (résolution par `get_api_key`, nom de variable inliné par provider), l'élargir en `Option` n'aurait ajouté que trois `None` morts de plus.

## Le message enseigne

Ancien : `Known providers: cli, anthropic, openai, google, claude, gemini, gpt, aider`. Il omettait déjà **`proxy`**, accepté par `create_provider` depuis l'arrivée de la passerelle — la liste écrite à la main avait dérivé toute seule. Elle est maintenant dérivée de `accepted_provider_names()`, et elle dit l'échappatoire générique :

```
Unknown provider: 'kilocode'. Known providers: cli, anthropic, openai, google, proxy,
claude, gemini, gpt, aider, codex, copilot, opencode. Any other command-line tool can
still be run as an agent with `provider: cli` plus `command: <binary>` (and `args:` if
it needs flags to answer non-interactively).
```

## Les inventaires : il y en avait cinq, pas trois

L'issue en compte trois. En cherchant, j'en ai trouvé **cinq** qui se contredisaient, plus quatre copies internes des mêmes faits :

| Inventaire | Avant | Après |
|---|---|---|
| `factory::KNOWN_TOOLS` | claude, gemini, gpt, aider | + codex, copilot, opencode |
| `json_runner` (relais shell) | claude, gemini, codex, copilot, opencode | inchangé, mais **énumérable** (`json_capable_clis()`) |
| `linker::LinkTarget` | claude, codex, copilot, gemini, opencode | inchangé |
| `cli::new` (assistant `new -i`) | 9 noms sur 12 | les 12, dans une constante épinglée |
| `model_resolution::preview` | les 5 cibles réécrites à la main | dérivé de `LinkTarget` |
| `rate_limit_key` | recopiait nom→backend | dérivé de `ToolDef` |
| `shell::app::API_ONLY_PROVIDERS` | recopiait les 4 API | lit `factory::API_PROVIDER_NAMES` |
| `create_linker` / `link` / `unlink` | **3 copies** de « Supported targets: … » | `supported_targets_sentence()` |
| ressources embarquées (`format.md`, starter `armadai-authoring`) | listes périmées — `format.md` omettait `claude` **et** `gpt` tout en listant `gemini` et `aider` | alignées, mention CLI-only |

Les trois derniers messages de cibles étaient exactement la classe de défaut que la correction du `Unknown provider` venait de fermer, une couche au-dessus — les laisser aurait été fermer la classe et remettre le piège à côté.

**Sept tests** énoncent maintenant les relations, en parcourant `LinkTarget::value_variants()` et `json_capable_clis()` plutôt qu'en les réécrivant. Le seul écart restant est nommé explicitement : `gpt` et `aider` sont exécutables sans être linkables, ce qui est légitime — contrairement à celui des trois autres.

## Mutations (chaque test cassé, rouge observé, restauré)

| # | Mutation | Rouge |
|---|---|---|
| M1 | `codex` retiré de `KNOWN_TOOLS` | 6 tests, 2 crates |
| M2 | argv `codex` privé de `exec` | `a_cli_only_tool_gets_its_canonical_json_argv` |
| M3 | `codex` reçoit `api_backend: Some("openai")` | message = `No API key found for 'openai'` + `rate_limit_key` |
| M4 | `proxy` retiré d'`API_PROVIDER_NAMES` | 3 tests, dont un préexistant |
| M5 | un nom non accepté ajouté à la liste annoncée | `no_advertised_provider_name_falls_through_to_unknown` |
| M6 | phrase d'échappatoire retirée du refus | `the_refusal_teaches_the_generic_cli_escape_hatch` |
| M7 | `aider` entre dans `JSON_CLIS` | 4 tests, dont 3 préexistants |
| M8 | outil exécutable ajouté sans linker | `the_only_runnable_tools_without_a_link_target_…` |
| M9 | le relais connaît un CLI que la factory ignore | 2 tests d'inventaire |
| M10 | l'assistant cesse d'offrir copilot/opencode | `the_new_wizard_offers_exactly_…` |
| M11 | l'aperçu perd la cible `opencode` | 2 tests, dont un préexistant |
| M12 | `create_linker` ne construit plus `opencode` qu'il annonce | `every_advertised_link_target_can_actually_be_built` |

M12 donne la sortie qui résume la classe : `Unknown link target: 'opencode'. Supported targets: claude, codex, copilot, gemini, opencode`.

## Vérifié au binaire réel

- CLI présent : argv `<exec> <--json>`, `<--output-format> <json> <-p>`, `<run> <--format> <json>`.
- CLI absent : le message CLI-only ci-dessus, pour les trois.
- `unlink` sans cible, et `link.target` inconnu dans le fichier : la phrase dérivée s'affiche bien.
- Repli API d'`aider` (demandé hors issue) : **fonctionne**, mesuré contre un serveur OpenAI local — `POST /v1/chat/completions`, `model: gpt-4o-mini`, réponse rendue. #374 tient.

## Doc

Deux ressources **embarquées** que lit un agent d'authoring portaient elles aussi leur copie périmée : la table de `armadai-agent-authoring/references/format.md` omettait `claude` et `gpt` tout en listant `gemini` et `aider`, et le starter `armadai-authoring` en était resté aux quatre noms d'avant #369, sans `proxy`.

`docs/wiki/providers.md` distingue **linkable** et **exécutable** en deux colonnes, et corrige la colonne des arguments : elle documentait `ToolDef.cli_args`, morte pour tout CLI qui parle JSON — `claude` reçoit en réalité `-p --output-format stream-json --verbose`, `gemini` `-o stream-json -p`.

## Deux défauts adjacents trouvés, **non corrigés** ici

1. **`gpt` entre en collision avec `/usr/sbin/gpt` sur macOS** (l'outil de table de partition GUID). `cli_available("gpt")` est donc vrai sur tout macOS, le repli API est court-circuité, et `armadai run` répond `gpt: unknown command: <system>…`. Corriger demande de trancher si un vrai CLI LLM nommé `gpt` existe — décision produit, pas correction de bug.
2. **`provider: aider` sur `run` omet `--yes`** là où le relais shell le passe : aider bloque sur sa confirmation (`Warning: Input is not a terminal`). Aligner change la posture d'auto-confirmation des éditions de fichiers — décision produit également.

## Gate

Rebasée sur `master` (#393). fmt OK · clippy `-D warnings` dans les **5** modes · tests dans les **4** modes · gaveldrop **13 cases · 83/83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
