### PR TITLE
fix(run): résoudre les alias de palier et rendre --dry-run réellement sec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "gaveldrop-conformance",
  "gaveldrop-fake",
  "include_dir",
+ "libc",
  "portable-pty",
  "pulldown-cmark",
  "ratatui",

--- a/crates/armadai-core/src/model_resolution.rs
+++ b/crates/armadai-core/src/model_resolution.rs
@@ -63,6 +63,47 @@ pub fn classify_model_tier(id: &str, provider: &str) -> Option<ModelTier> {
     }
 }
 
+/// Parse a **static** `latest` tier placeholder into its tier.
+///
+/// Syntax: `latest` (defaults to Pro), `latest:fast`/`latest:low`,
+/// `latest:pro`/`latest:medium`, `latest:max`/`latest:high`.
+///
+/// Returns `None` for a concrete model id — and, deliberately, for
+/// `latest:auto`: that placeholder's tier is not knowable statically. It
+/// depends on the run's own input and is resolved per call by
+/// [`crate::routing::route`], which is why every caller here treats it
+/// separately rather than folding it into this table.
+///
+/// Lives in core (rather than beside the linker, which was its only user
+/// until #376) because the run path needs the exact same table: a tier
+/// placeholder that `armadai link` resolves but `armadai run` sends
+/// verbatim to the provider is the defect #376 closed, and two tables would
+/// have let that divergence come back.
+pub fn parse_latest_placeholder(model: &str) -> Option<ModelTier> {
+    match model.trim() {
+        "latest" | "latest:pro" | "latest:medium" => Some(ModelTier::Pro),
+        "latest:fast" | "latest:low" => Some(ModelTier::Fast),
+        "latest:max" | "latest:high" => Some(ModelTier::Max),
+        _ => None,
+    }
+}
+
+/// Resolve a static `latest:*` tier placeholder into a concrete model id for
+/// `provider`.
+///
+/// Returns `None` when `model` is not a static placeholder — a concrete
+/// model id, or `latest:auto` — so a caller can keep its own handling for
+/// those two cases (`.unwrap_or(raw_model)` for the former, the router for
+/// the latter).
+///
+/// This is the last gate before a model string reaches a provider: every
+/// site that builds a `CompletionRequest` from an agent's declared model
+/// goes through it, so no `latest:*` placeholder other than `latest:auto`
+/// can be sent over the wire as a model name (#376).
+pub fn resolve_tier_placeholder(model: &str, provider: &str) -> Option<String> {
+    parse_latest_placeholder(model).map(|tier| resolve_model_for_tier(provider, tier))
+}
+
 /// Hardcoded fallback model for a given provider and tier.
 ///
 /// Used when the model registry cache is unavailable.
@@ -194,6 +235,57 @@ mod tests {
             "gpt-4o-mini"
         );
         assert_eq!(fallback_model_for_tier("openai", ModelTier::Max), "o3-pro");
+    }
+
+    // ── `latest:*` placeholders ──────────────────────────────────
+
+    #[test]
+    fn test_parse_latest_placeholder() {
+        assert_eq!(parse_latest_placeholder("latest"), Some(ModelTier::Pro));
+        assert_eq!(
+            parse_latest_placeholder("latest:fast"),
+            Some(ModelTier::Fast)
+        );
+        assert_eq!(parse_latest_placeholder("latest:pro"), Some(ModelTier::Pro));
+        assert_eq!(parse_latest_placeholder("latest:max"), Some(ModelTier::Max));
+        assert_eq!(parse_latest_placeholder("claude-sonnet-4-5-20250929"), None);
+        assert_eq!(parse_latest_placeholder("gemini-2.5-pro"), None);
+        assert_eq!(parse_latest_placeholder(""), None);
+    }
+
+    // `latest:auto` is NOT a static placeholder: its tier depends on the
+    // run's input, so it must fall through to the caller's router rather
+    // than silently resolving to Pro here.
+    #[test]
+    fn latest_auto_is_not_a_static_placeholder() {
+        assert_eq!(parse_latest_placeholder("latest:auto"), None);
+        assert_eq!(
+            resolve_tier_placeholder("latest:auto", "test-only-uncached-provider"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_tier_placeholder_maps_each_tier_and_passes_concrete_ids_through() {
+        // Uncached provider name so the hardcoded `fallback_model_for_tier`
+        // table is the deterministic answer, whatever the machine's
+        // models.dev cache holds.
+        let prov = "test-only-uncached-provider";
+        assert_eq!(
+            resolve_tier_placeholder("latest:fast", prov).as_deref(),
+            Some(fallback_model_for_tier(prov, ModelTier::Fast))
+        );
+        assert_eq!(
+            resolve_tier_placeholder("latest", prov).as_deref(),
+            Some(fallback_model_for_tier(prov, ModelTier::Pro))
+        );
+        assert_eq!(
+            resolve_tier_placeholder("latest:max", prov).as_deref(),
+            Some(fallback_model_for_tier(prov, ModelTier::Max))
+        );
+        // A concrete id is not a placeholder: `None` tells the caller to
+        // keep the string it already has.
+        assert_eq!(resolve_tier_placeholder("gpt-4o-mini", prov), None);
     }
 
     // ── Model tier classification ────────────────────────────────

--- a/crates/armadai-core/src/model_resolution.rs
+++ b/crates/armadai-core/src/model_resolution.rs
@@ -88,20 +88,76 @@ pub fn parse_latest_placeholder(model: &str) -> Option<ModelTier> {
     }
 }
 
+/// The model catalog whose ids name `provider`'s models, or `None` when
+/// nothing here knows.
+///
+/// An agent's `provider:` is a *tool* name (`gemini`, `aider`, `claude`, …)
+/// while the models.dev catalog — and [`fallback_model_for_tier`] — are
+/// keyed by *vendor* (`google`, `openai`, `anthropic`). Handing the tool
+/// name straight to either lookup misses the cache and then falls through
+/// the vendor table's catch-all, which answers with an **Anthropic** model:
+/// `provider: gemini` + `model: latest:pro` used to send
+/// `claude-sonnet-4-5-20250929` to `generativelanguage.googleapis.com`
+/// (#398 review, F1). `armadai shell` already carried this table privately
+/// (`shell::config::shell_provider_to_linker`), which is exactly how two
+/// subcommands of one binary came to disagree on one agent file.
+///
+/// Deliberately NOT `armadai_providers::factory::api_backend_for_tool`,
+/// which answers a different question — "if this CLI is missing, which API
+/// can I call instead?". `codex` has no such backend (issue #369) yet its
+/// models are named by OpenAI, so the two mappings differ on purpose. (Core
+/// could not depend on `armadai-providers` anyway: the dependency runs the
+/// other way.)
+///
+/// `None` — for `cli`, `proxy`, `copilot`, `opencode` and anything unknown
+/// — means "no vendor catalog names these models", not "use Anthropic's".
+/// See [`resolve_tier_placeholder`] for what callers do with it.
+pub fn model_catalog_provider(provider: &str) -> Option<&'static str> {
+    match provider {
+        "anthropic" | "claude" => Some("anthropic"),
+        "google" | "gemini" => Some("google"),
+        "openai" | "gpt" | "aider" | "codex" => Some("openai"),
+        _ => None,
+    }
+}
+
 /// Resolve a static `latest:*` tier placeholder into a concrete model id for
 /// `provider`.
 ///
-/// Returns `None` when `model` is not a static placeholder — a concrete
+/// Returns `None` when the string is not a static placeholder — a concrete
 /// model id, or `latest:auto` — so a caller can keep its own handling for
 /// those two cases (`.unwrap_or(raw_model)` for the former, the router for
 /// the latter).
 ///
-/// This is the last gate before a model string reaches a provider: every
-/// site that builds a `CompletionRequest` from an agent's declared model
-/// goes through it, so no `latest:*` placeholder other than `latest:auto`
-/// can be sent over the wire as a model name (#376).
+/// Also returns `None` when [`model_catalog_provider`] does not name a
+/// vendor for `provider`. That covers `provider: cli` and the CLI-only tools
+/// (whose relay ignores `request.model` outright) and `provider: proxy`,
+/// where the placeholder is the more useful string of the two: a gateway
+/// administrator can route `latest:max` through a house alias, whereas a
+/// concrete `claude-opus-4-6` picked here is a vendor this side of the wire
+/// chose on its own, with no opt-out (#398 review, F1).
+///
+/// For every provider that *does* name a vendor, this is the last gate
+/// before a model string reaches the wire: every site that builds a
+/// `CompletionRequest` from an agent's declared model goes through it, so no
+/// `latest:*` placeholder other than `latest:auto` can be sent to an API as
+/// a model name (#376).
 pub fn resolve_tier_placeholder(model: &str, provider: &str) -> Option<String> {
-    parse_latest_placeholder(model).map(|tier| resolve_model_for_tier(provider, tier))
+    let catalog = model_catalog_provider(provider)?;
+    parse_latest_placeholder(model).map(|tier| resolve_model_for_tier(catalog, tier))
+}
+
+/// Resolve `tier` to a concrete model id for `provider`, naming its vendor
+/// catalog first.
+///
+/// The counterpart of [`resolve_tier_placeholder`] for `latest:auto`, whose
+/// tier the router picks per call: there is no placeholder left to pass
+/// through by then, so an unnamed vendor keeps the old behaviour (the
+/// provider name is handed to the catalog lookup as-is, which misses and
+/// lands on [`fallback_model_for_tier`]'s catch-all) rather than answering
+/// `None`.
+pub fn resolve_routed_tier(provider: &str, tier: ModelTier) -> String {
+    resolve_model_for_tier(model_catalog_provider(provider).unwrap_or(provider), tier)
 }
 
 /// Hardcoded fallback model for a given provider and tier.

--- a/crates/armadai-core/src/model_resolution.rs
+++ b/crates/armadai-core/src/model_resolution.rs
@@ -315,18 +315,18 @@ mod tests {
     #[test]
     fn latest_auto_is_not_a_static_placeholder() {
         assert_eq!(parse_latest_placeholder("latest:auto"), None);
-        assert_eq!(
-            resolve_tier_placeholder("latest:auto", "test-only-uncached-provider"),
-            None
-        );
+        // A named vendor, so the `None` can only come from the parse — not
+        // from `model_catalog_provider` declining to name one.
+        assert_eq!(resolve_tier_placeholder("latest:auto", "anthropic"), None);
     }
 
     #[test]
     fn resolve_tier_placeholder_maps_each_tier_and_passes_concrete_ids_through() {
-        // Uncached provider name so the hardcoded `fallback_model_for_tier`
-        // table is the deterministic answer, whatever the machine's
-        // models.dev cache holds.
-        let prov = "test-only-uncached-provider";
+        // Hermetic: an empty `ARMADAI_CONFIG_DIR` means no models.dev cache
+        // is reachable, so `fallback_model_for_tier`'s hardcoded table is
+        // the deterministic answer whatever the machine holds.
+        let _iso = crate::test_support::IsolatedConfigDir::enter();
+        let prov = "anthropic";
         assert_eq!(
             resolve_tier_placeholder("latest:fast", prov).as_deref(),
             Some(fallback_model_for_tier(prov, ModelTier::Fast))
@@ -342,6 +342,77 @@ mod tests {
         // A concrete id is not a placeholder: `None` tells the caller to
         // keep the string it already has.
         assert_eq!(resolve_tier_placeholder("gpt-4o-mini", prov), None);
+    }
+
+    // ── Which vendor names a provider's models (#398 review, F1) ─────
+
+    /// The defect this closes, measured at the real binary before the fix:
+    /// an agent declaring `provider: gemini` + `model: latest:pro` sent
+    /// `POST /v1beta/models/claude-sonnet-4-5-20250929:generateContent` to
+    /// Google. The tool name missed the vendor-keyed lookup and fell through
+    /// `fallback_model_for_tier`'s catch-all, which answers with Anthropic.
+    #[test]
+    fn a_tool_name_resolves_against_its_own_vendor_not_anthropic() {
+        let _iso = crate::test_support::IsolatedConfigDir::enter();
+        for (tool, vendor) in [
+            ("gemini", "google"),
+            ("claude", "anthropic"),
+            ("aider", "openai"),
+            ("codex", "openai"),
+            ("gpt", "openai"),
+        ] {
+            for tier in [ModelTier::Fast, ModelTier::Pro, ModelTier::Max] {
+                let placeholder = match tier {
+                    ModelTier::Fast => "latest:fast",
+                    ModelTier::Pro => "latest:pro",
+                    ModelTier::Max => "latest:max",
+                };
+                assert_eq!(
+                    resolve_tier_placeholder(placeholder, tool).as_deref(),
+                    Some(fallback_model_for_tier(vendor, tier)),
+                    "{tool} + {placeholder} must resolve against {vendor}"
+                );
+                assert_eq!(
+                    resolve_routed_tier(tool, tier),
+                    fallback_model_for_tier(vendor, tier),
+                    "{tool} + routed {tier:?} must resolve against {vendor}"
+                );
+            }
+        }
+    }
+
+    /// A provider no vendor names keeps its placeholder rather than being
+    /// handed a model some other vendor sells. `cli` and the CLI-only tools
+    /// ignore `request.model` outright; a `proxy` gateway can route
+    /// `latest:max` through a house alias, which a concrete
+    /// `claude-opus-4-6` chosen here would silently override.
+    #[test]
+    fn a_provider_with_no_named_vendor_keeps_the_placeholder() {
+        let _iso = crate::test_support::IsolatedConfigDir::enter();
+        for prov in ["cli", "proxy", "copilot", "opencode", "some-local-thing"] {
+            assert_eq!(model_catalog_provider(prov), None, "{prov}");
+            for placeholder in ["latest", "latest:fast", "latest:pro", "latest:max"] {
+                assert_eq!(
+                    resolve_tier_placeholder(placeholder, prov),
+                    None,
+                    "{prov} + {placeholder} must be left to the caller"
+                );
+            }
+        }
+    }
+
+    /// `latest:auto` has no placeholder left to pass through once the router
+    /// has named a tier, so `resolve_routed_tier` always answers — including
+    /// for a provider with no named vendor, where it keeps the pre-existing
+    /// catch-all rather than leaking `latest:auto` to a server.
+    #[test]
+    fn a_routed_tier_always_answers_even_with_no_named_vendor() {
+        let _iso = crate::test_support::IsolatedConfigDir::enter();
+        for prov in ["cli", "proxy", "some-local-thing"] {
+            let got = resolve_routed_tier(prov, ModelTier::Pro);
+            assert!(!got.contains("latest"), "{prov} got {got}");
+            assert_eq!(got, fallback_model_for_tier(prov, ModelTier::Pro));
+        }
     }
 
     // ── Model tier classification ────────────────────────────────

--- a/crates/armadai-core/src/orchestration/es/blackboard.rs
+++ b/crates/armadai-core/src/orchestration/es/blackboard.rs
@@ -23,7 +23,7 @@ use super::state::{BoardEntryRec, ExecutionState};
 use crate::agent::Agent;
 #[cfg(test)]
 use crate::model_resolution::fallback_model_for_tier;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
+use crate::model_resolution::{ModelTier, resolve_routed_tier, resolve_tier_placeholder};
 use crate::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
 use crate::orchestration::llm_agents::{BOARD_ACTION_INSTRUCTIONS, parse_board_action};
 use crate::provider::{ChatMessage, CompletionRequest, Provider};
@@ -634,7 +634,7 @@ impl EffectRunner for BlackboardEffectRunner {
                     ModelTier::Pro
                 }
             };
-            resolve_model_for_tier(&agent_def.metadata.provider, tier)
+            resolve_routed_tier(&agent_def.metadata.provider, tier)
         } else {
             // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
             // `latest:pro`, `latest:max`, …) has a tier that is known

--- a/crates/armadai-core/src/orchestration/es/blackboard.rs
+++ b/crates/armadai-core/src/orchestration/es/blackboard.rs
@@ -23,7 +23,7 @@ use super::state::{BoardEntryRec, ExecutionState};
 use crate::agent::Agent;
 #[cfg(test)]
 use crate::model_resolution::fallback_model_for_tier;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
 use crate::orchestration::blackboard::{BlackboardConfig, EntryKind, entry_kind_name};
 use crate::orchestration::llm_agents::{BOARD_ACTION_INSTRUCTIONS, parse_board_action};
 use crate::provider::{ChatMessage, CompletionRequest, Provider};
@@ -636,7 +636,13 @@ impl EffectRunner for BlackboardEffectRunner {
             };
             resolve_model_for_tier(&agent_def.metadata.provider, tier)
         } else {
-            raw_model
+            // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
+            // `latest:pro`, `latest:max`, …) has a tier that is known
+            // statically, so it is resolved right here — the last gate
+            // before the string becomes a provider's model name. Until #376
+            // this branch passed them through verbatim, and an API provider
+            // was asked for a model literally called `latest:pro`.
+            resolve_tier_placeholder(&raw_model, &agent_def.metadata.provider).unwrap_or(raw_model)
         };
 
         let request = CompletionRequest {
@@ -1783,6 +1789,38 @@ mod tests {
                 }
                 other => panic!("expected a degraded BoardEntryAdded, got {other:?}"),
             }
+        }
+
+        // A STATIC tier placeholder resolves to a concrete model too
+        // (#376). No `ModelRouted` is involved — its tier is known from the
+        // string alone — so the folded state below records no routing at
+        // all, exactly as on the real path. Uncached provider name for the
+        // same hermeticity reason as the `latest:auto` test below.
+        #[tokio::test]
+        async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+            let mut agent = test_agent("a", "latest:fast");
+            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), agent);
+            let capturing = Arc::new(CapturingProvider::new(
+                "ACTION:FINDING\nCONFIDENCE:0.5\nCONTENT:noted",
+            ));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), capturing.clone() as Arc<dyn Provider>);
+            let runner =
+                BlackboardEffectRunner::new(agents, providers, BlackboardConfig::default());
+
+            let state = fold(&[
+                board_run_started(&["a"]),
+                ExecutionEvent::RoundStarted { round: 0 },
+            ]);
+            runner.run_invoke("a", "task", &state, 1).await.unwrap();
+
+            let expected =
+                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Fast).to_string();
+            let sent = capturing.requests();
+            assert_eq!(sent[0].model, expected);
+            assert_ne!(sent[0].model, "latest:fast");
         }
 
         // `"latest:auto"` is resolved the same way as

--- a/crates/armadai-core/src/orchestration/es/blackboard.rs
+++ b/crates/armadai-core/src/orchestration/es/blackboard.rs
@@ -1798,8 +1798,16 @@ mod tests {
         // same hermeticity reason as the `latest:auto` test below.
         #[tokio::test]
         async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+            // Hermetic against the machine's models.dev cache. The `latest:auto`
+            // test above gets that for free from a provider name no catalog
+            // knows; a STATIC placeholder cannot use the same trick, because a
+            // provider with no named vendor is precisely the case
+            // `resolve_tier_placeholder` leaves alone (#398 review, F1). So the
+            // vendor is real and the cache is emptied instead.
+            let _iso = crate::test_support::IsolatedConfigDir::enter();
+
             let mut agent = test_agent("a", "latest:fast");
-            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            agent.metadata.provider = "anthropic".to_string();
             let mut agents = BTreeMap::new();
             agents.insert("a".to_string(), agent);
             let capturing = Arc::new(CapturingProvider::new(
@@ -1816,8 +1824,7 @@ mod tests {
             ]);
             runner.run_invoke("a", "task", &state, 1).await.unwrap();
 
-            let expected =
-                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Fast).to_string();
+            let expected = fallback_model_for_tier("anthropic", ModelTier::Fast).to_string();
             let sent = capturing.requests();
             assert_eq!(sent[0].model, expected);
             assert_ne!(sent[0].model, "latest:fast");

--- a/crates/armadai-core/src/orchestration/es/bridge.rs
+++ b/crates/armadai-core/src/orchestration/es/bridge.rs
@@ -72,10 +72,26 @@ pub fn roster_from_agents(agents: &BTreeMap<String, Agent>) -> BTreeMap<String, 
 ///   `agent`/`input`, so the metadata is threaded in from the run's roster via
 ///   `agent_meta`. **Model choice**: `agent_meta` carries the agent's
 ///   *configured* model (`agent.metadata.model`), matching what the legacy
-///   `AgentStart` emitted — NOT the effectively-resolved model when the agent
-///   uses `latest:auto` (resolved later, per turn). The resolved tier is
-///   already carried separately by `Route`/`ModelRouted`, so `AgentStart`
-///   deliberately keeps the configured value for start/end symmetry.
+///   `AgentStart` emitted — NOT the effectively-resolved model. For
+///   `latest:auto` that is defensible: the resolved tier is carried
+///   separately by `Route`/`ModelRouted`, so a consumer can still reconstruct
+///   what ran, and `AgentStart` keeps the configured value for start/end
+///   symmetry.
+///
+///   **That argument does not extend to the static tiers.** Since #376
+///   `latest`/`latest:fast`/`latest:pro`/`latest:max` are resolved before the
+///   call too, but their tier is known from the string alone, so **no**
+///   `ModelRouted` (and no `Route`) event is emitted for them — measured, and
+///   asserted by `run_invoke_resolves_static_latest_tier_to_concrete_model`
+///   in each effect runner, which drives a state with no routing recorded at
+///   all. The consequence, also measured at the binary: an agent on
+///   `model: latest:pro` produces `agent_start{model:"latest:pro"}` and
+///   nothing else, so the concrete id actually billed appears in **no** event
+///   of the `--json` stream — nor on stderr, where the `[name] model=…`
+///   summary lives only in `run_single_agent`, i.e. on `--pipe` alone. The
+///   convention is kept here (changing it is an event-schema decision, not a
+///   side effect of a model-resolution fix) but it is a gap, not a
+///   consequence of the `Route`/`ModelRouted` argument above.
 /// - `Completed` → `[]` (not `Result`): `RunEvent::Result` also needs
 ///   aggregate `tin`/`tout`/`cost`/`agents` totals that only `ExecutionState`
 ///   has (via [`to_orchestration_result`]). Building the terminal `Result`

--- a/crates/armadai-core/src/orchestration/es/direct.rs
+++ b/crates/armadai-core/src/orchestration/es/direct.rs
@@ -27,7 +27,7 @@ use super::event::ExecutionEvent;
 use super::log::EventLog;
 use super::state::ExecutionState;
 use crate::agent::Agent;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
+use crate::model_resolution::{ModelTier, resolve_routed_tier, resolve_tier_placeholder};
 use crate::provider::{ChatMessage, CompletionRequest, Provider};
 use crate::routing::{RoutingRules, route};
 
@@ -213,7 +213,7 @@ impl EffectRunner for DirectEffectRunner {
                     ModelTier::Pro
                 }
             };
-            resolve_model_for_tier(&agent_def.metadata.provider, tier)
+            resolve_routed_tier(&agent_def.metadata.provider, tier)
         } else {
             // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
             // `latest:pro`, `latest:max`, …) has a tier that is known

--- a/crates/armadai-core/src/orchestration/es/direct.rs
+++ b/crates/armadai-core/src/orchestration/es/direct.rs
@@ -27,7 +27,7 @@ use super::event::ExecutionEvent;
 use super::log::EventLog;
 use super::state::ExecutionState;
 use crate::agent::Agent;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
 use crate::provider::{ChatMessage, CompletionRequest, Provider};
 use crate::routing::{RoutingRules, route};
 
@@ -215,7 +215,13 @@ impl EffectRunner for DirectEffectRunner {
             };
             resolve_model_for_tier(&agent_def.metadata.provider, tier)
         } else {
-            raw_model
+            // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
+            // `latest:pro`, `latest:max`, …) has a tier that is known
+            // statically, so it is resolved right here — the last gate
+            // before the string becomes a provider's model name. Until #376
+            // this branch passed them through verbatim, and an API provider
+            // was asked for a model literally called `latest:pro`.
+            resolve_tier_placeholder(&raw_model, &agent_def.metadata.provider).unwrap_or(raw_model)
         };
 
         let request = CompletionRequest {
@@ -740,6 +746,36 @@ mod tests {
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0].model, expected);
         assert_ne!(sent[0].model, "latest:auto");
+    }
+
+    // A STATIC tier placeholder (`latest:pro` here, but equally `latest`,
+    // `latest:fast`, `latest:max`) must be resolved to a concrete model too
+    // (#376). Unlike `latest:auto` it needs no `ModelRouted` event — its
+    // tier is known from the string alone — so this drives `run_invoke`
+    // against a bare `ExecutionState` with no routing recorded at all, which
+    // is exactly the state a static placeholder produces on the real path.
+    //
+    // Uncached provider name for the same hermeticity reason as the
+    // `latest:auto` test above.
+    #[tokio::test]
+    async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+        let mut agent = test_agent("solo", "latest:pro");
+        agent.metadata.provider = "test-only-uncached-provider".to_string();
+        let mut agents = BTreeMap::new();
+        agents.insert("solo".to_string(), agent);
+        let capturing = Arc::new(CapturingProvider::new("resp"));
+        let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+        providers.insert("solo".to_string(), capturing.clone() as Arc<dyn Provider>);
+        let runner = DirectEffectRunner::new(agents, providers);
+
+        let state = ExecutionState::default();
+        runner.run_invoke("solo", "go", &state, 1).await.unwrap();
+
+        let expected =
+            fallback_model_for_tier("test-only-uncached-provider", ModelTier::Pro).to_string();
+        let sent = capturing.requests();
+        assert_eq!(sent[0].model, expected);
+        assert_ne!(sent[0].model, "latest:pro");
     }
 
     #[tokio::test]

--- a/crates/armadai-core/src/orchestration/es/direct.rs
+++ b/crates/armadai-core/src/orchestration/es/direct.rs
@@ -759,8 +759,16 @@ mod tests {
     // `latest:auto` test above.
     #[tokio::test]
     async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+        // Hermetic against the machine's models.dev cache. The `latest:auto`
+        // test above gets that for free from a provider name no catalog
+        // knows; a STATIC placeholder cannot use the same trick, because a
+        // provider with no named vendor is precisely the case
+        // `resolve_tier_placeholder` leaves alone (#398 review, F1). So the
+        // vendor is real and the cache is emptied instead.
+        let _iso = crate::test_support::IsolatedConfigDir::enter();
+
         let mut agent = test_agent("solo", "latest:pro");
-        agent.metadata.provider = "test-only-uncached-provider".to_string();
+        agent.metadata.provider = "anthropic".to_string();
         let mut agents = BTreeMap::new();
         agents.insert("solo".to_string(), agent);
         let capturing = Arc::new(CapturingProvider::new("resp"));
@@ -771,8 +779,7 @@ mod tests {
         let state = ExecutionState::default();
         runner.run_invoke("solo", "go", &state, 1).await.unwrap();
 
-        let expected =
-            fallback_model_for_tier("test-only-uncached-provider", ModelTier::Pro).to_string();
+        let expected = fallback_model_for_tier("anthropic", ModelTier::Pro).to_string();
         let sent = capturing.requests();
         assert_eq!(sent[0].model, expected);
         assert_ne!(sent[0].model, "latest:pro");

--- a/crates/armadai-core/src/orchestration/es/hierarchical.rs
+++ b/crates/armadai-core/src/orchestration/es/hierarchical.rs
@@ -25,7 +25,7 @@ use super::state::ExecutionState;
 use crate::agent::Agent;
 #[cfg(test)]
 use crate::model_resolution::fallback_model_for_tier;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
+use crate::model_resolution::{ModelTier, resolve_routed_tier, resolve_tier_placeholder};
 use crate::orchestration::blackboard::BlackboardConfig;
 use crate::orchestration::context_injection::{AgentInfo, build_orchestration_prompt};
 use crate::orchestration::protocol::{DelegationAction, extract_narrative, parse_delegations};
@@ -1437,7 +1437,7 @@ impl EffectRunner for HierarchicalEffectRunner {
                     ModelTier::Pro
                 }
             };
-            resolve_model_for_tier(&agent_def.metadata.provider, tier)
+            resolve_routed_tier(&agent_def.metadata.provider, tier)
         } else {
             // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
             // `latest:pro`, `latest:max`, …) has a tier that is known

--- a/crates/armadai-core/src/orchestration/es/hierarchical.rs
+++ b/crates/armadai-core/src/orchestration/es/hierarchical.rs
@@ -3321,8 +3321,16 @@ mod tests {
         // hermeticity reason as the `latest:auto` test below.
         #[tokio::test]
         async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+            // Hermetic against the machine's models.dev cache. The `latest:auto`
+            // test above gets that for free from a provider name no catalog
+            // knows; a STATIC placeholder cannot use the same trick, because a
+            // provider with no named vendor is precisely the case
+            // `resolve_tier_placeholder` leaves alone (#398 review, F1). So the
+            // vendor is real and the cache is emptied instead.
+            let _iso = crate::test_support::IsolatedConfigDir::enter();
+
             let mut agent = test_agent("a", "latest:max");
-            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            agent.metadata.provider = "anthropic".to_string();
             let mut agents = BTreeMap::new();
             agents.insert("a".to_string(), agent);
             let capturing = Arc::new(CapturingProvider::new("resp"));
@@ -3334,8 +3342,7 @@ mod tests {
             let state = fold(&[run_started(&["a"], "go")]);
             let event = runner.run_invoke("a", "go", &state, 1).await.unwrap();
 
-            let expected =
-                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Max).to_string();
+            let expected = fallback_model_for_tier("anthropic", ModelTier::Max).to_string();
             let sent = capturing.requests();
             assert_eq!(sent[0].model, expected);
             assert_ne!(sent[0].model, "latest:max");

--- a/crates/armadai-core/src/orchestration/es/hierarchical.rs
+++ b/crates/armadai-core/src/orchestration/es/hierarchical.rs
@@ -25,7 +25,7 @@ use super::state::ExecutionState;
 use crate::agent::Agent;
 #[cfg(test)]
 use crate::model_resolution::fallback_model_for_tier;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
 use crate::orchestration::blackboard::BlackboardConfig;
 use crate::orchestration::context_injection::{AgentInfo, build_orchestration_prompt};
 use crate::orchestration::protocol::{DelegationAction, extract_narrative, parse_delegations};
@@ -1407,9 +1407,8 @@ impl EffectRunner for HierarchicalEffectRunner {
         // `crate::model_resolution::resolve_model_for_tier` — this
         // is the only place in the event-sourced hierarchical engine that
         // does so, keeping the pure `Decider` free of that effectful lookup.
-        // Every other model string (a concrete id, or another `latest:*`
-        // placeholder such as `latest:pro`) is sent as-is, unchanged from
-        // before.
+        // Every other `latest:*` placeholder resolves in the `else`
+        // branch below (#376); a concrete model id is sent as-is.
         let raw_model = agent_def
             .metadata
             .model
@@ -1440,7 +1439,13 @@ impl EffectRunner for HierarchicalEffectRunner {
             };
             resolve_model_for_tier(&agent_def.metadata.provider, tier)
         } else {
-            raw_model
+            // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
+            // `latest:pro`, `latest:max`, …) has a tier that is known
+            // statically, so it is resolved right here — the last gate
+            // before the string becomes a provider's model name. Until #376
+            // this branch passed them through verbatim, and an API provider
+            // was asked for a model literally called `latest:pro`.
+            resolve_tier_placeholder(&raw_model, &agent_def.metadata.provider).unwrap_or(raw_model)
         };
 
         let request = CompletionRequest {
@@ -3279,11 +3284,13 @@ mod tests {
             assert!(sent[0].system_prompt.contains("core-specialist"));
         }
 
-        // Model is passed through as-is when it isn't the exact
-        // `"latest:auto"` placeholder — a concrete model, or any other
-        // `latest:*` placeholder (e.g. `latest:pro`), reaches the provider
-        // unchanged. `"latest:auto"` itself is special-cased — covered by
-        // `run_invoke_resolves_latest_auto_to_concrete_model` below.
+        // A CONCRETE model id is passed through as-is. The `latest:*`
+        // placeholders are not: `latest:auto` routes per turn
+        // (`run_invoke_resolves_latest_auto_to_concrete_model`) and the
+        // static tiers resolve from the string alone
+        // (`run_invoke_resolves_static_latest_tier_to_concrete_model`).
+        // Until #376 this test pinned `latest:pro` here and asserted the
+        // provider received that literal string — it was pinning the defect.
         //
         // Also asserts `temperature`/`max_tokens` from the agent's metadata
         // reach the `CompletionRequest` unchanged (`test_agent` sets
@@ -3291,7 +3298,7 @@ mod tests {
         #[tokio::test]
         async fn run_invoke_passes_agent_model_through_verbatim() {
             let mut agents = BTreeMap::new();
-            agents.insert("a".to_string(), test_agent("a", "latest:pro"));
+            agents.insert("a".to_string(), test_agent("a", "some-concrete-model-id"));
             let capturing = Arc::new(CapturingProvider::new("resp"));
             let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
             providers.insert("a".to_string(), capturing.clone() as Arc<dyn Provider>);
@@ -3302,9 +3309,40 @@ mod tests {
             runner.run_invoke("a", "go", &state, 1).await.unwrap();
 
             let sent = capturing.requests();
-            assert_eq!(sent[0].model, "latest:pro");
+            assert_eq!(sent[0].model, "some-concrete-model-id");
             assert_eq!(sent[0].temperature, 0.5);
             assert_eq!(sent[0].max_tokens, Some(256));
+        }
+
+        // A STATIC tier placeholder resolves to a concrete model too (#376),
+        // with no `ModelRouted` event needed — its tier is known from the
+        // string alone, so the state carries no routing at all here, exactly
+        // as on the real path. Uncached provider name for the same
+        // hermeticity reason as the `latest:auto` test below.
+        #[tokio::test]
+        async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+            let mut agent = test_agent("a", "latest:max");
+            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), agent);
+            let capturing = Arc::new(CapturingProvider::new("resp"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), capturing.clone() as Arc<dyn Provider>);
+            let runner =
+                HierarchicalEffectRunner::new(agents, providers, OrchestrationConfig::default());
+
+            let state = fold(&[run_started(&["a"], "go")]);
+            let event = runner.run_invoke("a", "go", &state, 1).await.unwrap();
+
+            let expected =
+                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Max).to_string();
+            let sent = capturing.requests();
+            assert_eq!(sent[0].model, expected);
+            assert_ne!(sent[0].model, "latest:max");
+            match event {
+                ExecutionEvent::AgentObserved { model, .. } => assert_eq!(model, expected),
+                other => panic!("expected AgentObserved, got {other:?}"),
+            }
         }
 
         // `"latest:auto"` is the one placeholder the effect runner resolves

--- a/crates/armadai-core/src/orchestration/es/ring.rs
+++ b/crates/armadai-core/src/orchestration/es/ring.rs
@@ -28,7 +28,7 @@ use super::state::{ExecutionState, RunStatus, VoteRec};
 use crate::agent::Agent;
 #[cfg(test)]
 use crate::model_resolution::fallback_model_for_tier;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier};
+use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
 use crate::orchestration::llm_agents::{
     RING_ACTION_INSTRUCTIONS, parse_ring_action, parse_vote_confidence,
 };
@@ -818,7 +818,13 @@ impl EffectRunner for RingEffectRunner {
             };
             resolve_model_for_tier(&agent_def.metadata.provider, tier)
         } else {
-            raw_model
+            // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
+            // `latest:pro`, `latest:max`, …) has a tier that is known
+            // statically, so it is resolved right here — the last gate
+            // before the string becomes a provider's model name. Until #376
+            // this branch passed them through verbatim, and an API provider
+            // was asked for a model literally called `latest:pro`.
+            resolve_tier_placeholder(&raw_model, &agent_def.metadata.provider).unwrap_or(raw_model)
         };
 
         match ring_phase(state, &self.config) {
@@ -2133,6 +2139,34 @@ mod tests {
                 msg.contains("provider") && msg.contains("'a'"),
                 "expected a distinctive missing-provider message, got: {msg}"
             );
+        }
+
+        // A STATIC tier placeholder resolves to a concrete model too
+        // (#376). No `ModelRouted` is involved — its tier is known from the
+        // string alone — so the folded state below records no routing at
+        // all, exactly as on the real path. Uncached provider name for the
+        // same hermeticity reason as the `latest:auto` test below.
+        #[tokio::test]
+        async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+            let mut agent = test_agent("a", "latest");
+            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            let mut agents = BTreeMap::new();
+            agents.insert("a".to_string(), agent);
+            let capturing = Arc::new(CapturingProvider::new("ACTION: PROPOSE\nCONTENT: x"));
+            let mut providers: BTreeMap<String, Arc<dyn Provider>> = BTreeMap::new();
+            providers.insert("a".to_string(), capturing.clone() as Arc<dyn Provider>);
+            let runner =
+                RingEffectRunner::new(agents, providers, RingConfig::default(), BTreeMap::new());
+
+            let state = fold(&[run_started(&["a"]), E::LapStarted { lap: 0 }]);
+            runner.run_invoke("a", "task", &state, 1).await.unwrap();
+
+            // The bare `latest` placeholder means the Pro tier.
+            let expected =
+                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Pro).to_string();
+            let sent = capturing.requests();
+            assert_eq!(sent[0].model, expected);
+            assert_ne!(sent[0].model, "latest");
         }
 
         // `"latest:auto"` resolves to a concrete model via `state.routed_tiers`,

--- a/crates/armadai-core/src/orchestration/es/ring.rs
+++ b/crates/armadai-core/src/orchestration/es/ring.rs
@@ -28,7 +28,7 @@ use super::state::{ExecutionState, RunStatus, VoteRec};
 use crate::agent::Agent;
 #[cfg(test)]
 use crate::model_resolution::fallback_model_for_tier;
-use crate::model_resolution::{ModelTier, resolve_model_for_tier, resolve_tier_placeholder};
+use crate::model_resolution::{ModelTier, resolve_routed_tier, resolve_tier_placeholder};
 use crate::orchestration::llm_agents::{
     RING_ACTION_INSTRUCTIONS, parse_ring_action, parse_vote_confidence,
 };
@@ -816,7 +816,7 @@ impl EffectRunner for RingEffectRunner {
                     ModelTier::Pro
                 }
             };
-            resolve_model_for_tier(&agent_def.metadata.provider, tier)
+            resolve_routed_tier(&agent_def.metadata.provider, tier)
         } else {
             // Every OTHER `latest:*` placeholder (`latest`, `latest:fast`,
             // `latest:pro`, `latest:max`, …) has a tier that is known

--- a/crates/armadai-core/src/orchestration/es/ring.rs
+++ b/crates/armadai-core/src/orchestration/es/ring.rs
@@ -2148,8 +2148,16 @@ mod tests {
         // same hermeticity reason as the `latest:auto` test below.
         #[tokio::test]
         async fn run_invoke_resolves_static_latest_tier_to_concrete_model() {
+            // Hermetic against the machine's models.dev cache. The `latest:auto`
+            // test above gets that for free from a provider name no catalog
+            // knows; a STATIC placeholder cannot use the same trick, because a
+            // provider with no named vendor is precisely the case
+            // `resolve_tier_placeholder` leaves alone (#398 review, F1). So the
+            // vendor is real and the cache is emptied instead.
+            let _iso = crate::test_support::IsolatedConfigDir::enter();
+
             let mut agent = test_agent("a", "latest");
-            agent.metadata.provider = "test-only-uncached-provider".to_string();
+            agent.metadata.provider = "anthropic".to_string();
             let mut agents = BTreeMap::new();
             agents.insert("a".to_string(), agent);
             let capturing = Arc::new(CapturingProvider::new("ACTION: PROPOSE\nCONTENT: x"));
@@ -2162,8 +2170,7 @@ mod tests {
             runner.run_invoke("a", "task", &state, 1).await.unwrap();
 
             // The bare `latest` placeholder means the Pro tier.
-            let expected =
-                fallback_model_for_tier("test-only-uncached-provider", ModelTier::Pro).to_string();
+            let expected = fallback_model_for_tier("anthropic", ModelTier::Pro).to_string();
             let sent = capturing.requests();
             assert_eq!(sent[0].model, expected);
             assert_ne!(sent[0].model, "latest");

--- a/crates/armadai-core/src/provider.rs
+++ b/crates/armadai-core/src/provider.rs
@@ -53,4 +53,23 @@ pub trait Provider: Send + Sync {
 
     /// Return provider metadata.
     fn metadata(&self) -> ProviderMetadata;
+
+    /// Whether [`CompletionRequest::model`] actually selects the model this
+    /// provider answers with.
+    ///
+    /// `true` for everything that speaks an HTTP API: the field is the model
+    /// name in the request body or URL. `false` for a provider that relays a
+    /// command-line tool, which owns its own model choice — `CliProvider`
+    /// spawns the binary and never passes the field on, and reports back the
+    /// command name (or whatever the tool's own JSON says it used).
+    ///
+    /// Only a preview needs to ask. `armadai run --dry-run` was answering
+    /// "which model will I pay for" with the agent's resolved model id for
+    /// every agent, including CLI-relayed ones where that id is never sent
+    /// and never billed (#398 review, F2) — and a CLI-relayed agent is
+    /// ArmadAI's reference configuration. Defaulted to `true` so an API
+    /// provider states nothing, and the one exception is where it belongs.
+    fn honors_request_model(&self) -> bool {
+        true
+    }
 }

--- a/crates/armadai-providers/src/cli.rs
+++ b/crates/armadai-providers/src/cli.rs
@@ -501,6 +501,13 @@ impl Provider for CliProvider {
             supports_streaming: true,
         }
     }
+
+    /// `false`: `complete`/`stream` build the command from `self.command`
+    /// and `self.args` and hand the composed prompt to it — `request.model`
+    /// is read nowhere in this file. The tool picks its own model.
+    fn honors_request_model(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/armadai-providers/src/rate_limiter.rs
+++ b/crates/armadai-providers/src/rate_limiter.rs
@@ -152,6 +152,13 @@ impl Provider for RateLimitedProvider {
     fn metadata(&self) -> ProviderMetadata {
         self.inner.metadata()
     }
+
+    /// Delegated, like `metadata`: this decorator only throttles, and every
+    /// provider `create_provider` builds is wrapped in one — a default `true`
+    /// here would hide `CliProvider`'s `false` from every caller.
+    fn honors_request_model(&self) -> bool {
+        self.inner.honors_request_model()
+    }
 }
 
 static PROVIDER_LIMITERS: OnceLock<Mutex<HashMap<String, Arc<RateLimiter>>>> = OnceLock::new();

--- a/crates/armadai/Cargo.toml
+++ b/crates/armadai/Cargo.toml
@@ -102,3 +102,9 @@ gaveldrop = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.1
 gaveldrop-fake = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.16" }
 gaveldrop-conformance = { git = "https://github.com/Dr0drigues/gaveldrop.git", tag = "v0.1.16" }
 tempfile = { workspace = true }
+# `openpty` only, for the one test that must give the binary a real terminal
+# (`run_dry_run_spends_nothing.rs`) — the `--dry-run` guard on the live
+# Workroom is unobservable without one. Already in the tree transitively
+# (crossterm), so this adds no crate to the dependency graph.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/crates/armadai/src/cli/mod.rs
+++ b/crates/armadai/src/cli/mod.rs
@@ -99,7 +99,10 @@ pub enum Command {
         /// C8: select agents whose tags/stacks intersect these (comma-separated)
         #[arg(long, value_name = "TAGS", value_delimiter = ',')]
         tags: Option<Vec<String>>,
-        /// C8: resolve and print the agent selection without executing (0 tokens)
+        /// Resolve agents, providers and models and print what would run,
+        /// without calling any provider (0 tokens). Refuses whatever the real
+        /// run refuses, with the same exit code. Works on every path: a single
+        /// agent, --pipe, --orchestrate and --resume.
         #[arg(long)]
         dry_run: bool,
         /// Disable the live orchestration TUI (force plain headless output)

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -1122,7 +1122,18 @@ async fn run_single_agent(
         });
         armadai_core::model_resolution::resolve_model_for_tier(&agent.metadata.provider, tier)
     } else {
-        raw_model
+        // The static tier placeholders (`latest`, `latest:fast`,
+        // `latest:pro`, `latest:max`) resolve here — this is the last gate
+        // before the string becomes a provider's model name on the ONLY
+        // path that does not go through an event-sourced effect runner
+        // (`--pipe`'s sequential loop). Until #376 they were passed through
+        // verbatim and an API provider was asked for a model literally
+        // called `latest:pro`.
+        armadai_core::model_resolution::resolve_tier_placeholder(
+            &raw_model,
+            &agent.metadata.provider,
+        )
+        .unwrap_or(raw_model)
     };
 
     let request = CompletionRequest {
@@ -1150,6 +1161,17 @@ async fn run_single_agent(
             let mut last_err = err;
             let mut fallback_resp = None;
             for fallback_model in &agent.metadata.model_fallback {
+                // A fallback entry is a model string like any other, so it
+                // gets the same tier resolution as the primary one (#376) —
+                // all the more so since `resolve_model_deprecations` above
+                // can itself rewrite a deprecated id INTO `latest:pro` (see
+                // `model_aliases`), which would otherwise reach the provider
+                // verbatim on the retry.
+                let fallback_model = armadai_core::model_resolution::resolve_tier_placeholder(
+                    fallback_model,
+                    &agent.metadata.provider,
+                )
+                .unwrap_or_else(|| fallback_model.clone());
                 let w = crate::cli::style::warn();
                 anstream::eprintln!(
                     "{w}[{agent_name}] Model unavailable, falling back to {fallback_model}...{w:#}"

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -527,23 +527,11 @@ async fn resume_run(
             names.join(", ")
         );
         for name in &names {
-            let mut meta = agents_map[name].metadata.clone();
-            armadai_core::model_aliases::resolve_model_deprecations(
-                &mut meta.model,
-                &mut meta.model_fallback,
+            let (prov, model) = preview_provider_and_model(
+                &agents_map[name].metadata,
+                providers_map[name].as_ref(),
             );
-            let model = match meta.model.as_deref() {
-                None => "(none declared)".to_string(),
-                Some("latest:auto") => "latest:auto (tier chosen per call)".to_string(),
-                Some(m) => {
-                    armadai_core::model_resolution::resolve_tier_placeholder(m, &meta.provider)
-                        .unwrap_or_else(|| m.to_string())
-                }
-            };
-            eprintln!(
-                "[dry-run]   {name} — provider={}, model={model}",
-                meta.provider
-            );
+            eprintln!("[dry-run]   {name} — provider={prov}, model={model}");
         }
         eprintln!(
             "[dry-run] the remaining steps are decided by the engine as it runs, \
@@ -1147,13 +1135,8 @@ fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<
 /// one per line on **stdout** when not emitting JSON — so a script consuming
 /// either preview reads the same thing on stdout.
 ///
-/// The model shown is the one the run would send, not the one written in the
-/// agent file: deprecated aliases are resolved (`model_aliases`) and so are
-/// the static tier placeholders (#376). `latest:auto` is the one that cannot
-/// be previewed — its tier is chosen from each link's own input, which for
-/// every link but the first is the previous link's output, i.e. exactly what
-/// a dry run refuses to compute — so it is reported as such rather than
-/// guessed.
+/// What the provider/model column says, and why it is not just a copy of the
+/// agent file, is [`preview_provider_and_model`]'s job.
 fn report_dry_run_chain(chain: &[String], links: &[ChainLink], json: bool) {
     let n = chain.len();
     eprintln!(
@@ -1161,21 +1144,11 @@ fn report_dry_run_chain(chain: &[String], links: &[ChainLink], json: bool) {
         chain.join(", ")
     );
     for (i, (name, link)) in chain.iter().zip(links).enumerate() {
-        let mut meta = link.agent.metadata.clone();
-        armadai_core::model_aliases::resolve_model_deprecations(
-            &mut meta.model,
-            &mut meta.model_fallback,
-        );
-        let model = match meta.model.as_deref() {
-            None => "(none declared)".to_string(),
-            Some("latest:auto") => "latest:auto (tier chosen per call)".to_string(),
-            Some(m) => armadai_core::model_resolution::resolve_tier_placeholder(m, &meta.provider)
-                .unwrap_or_else(|| m.to_string()),
-        };
+        let (prov, model) =
+            preview_provider_and_model(&link.agent.metadata, link.provider.as_ref());
         eprintln!(
-            "[dry-run]   {}/{n} {name} — provider={}, model={model}",
-            i + 1,
-            meta.provider
+            "[dry-run]   {}/{n} {name} — provider={prov}, model={model}",
+            i + 1
         );
         if let Some(w) = &link.warning {
             let s = crate::cli::style::warn();
@@ -1392,6 +1365,53 @@ async fn run_single_agent(
     record_run(&metrics, input, &response.content, project);
 
     Ok((response.content, metrics))
+}
+
+/// What a `--dry-run` preview should say an agent's run would use, as
+/// `("<provider>", "<model>")`.
+///
+/// The single answer to "how does a declared model become the effective
+/// one", for all three previews (`--pipe`/single, `--resume`,
+/// `--orchestrate`). It was written out three times, word for word, which is
+/// how a preview could be right on one path and wrong on another.
+///
+/// Two things the agent file alone does not say:
+///
+/// - **Deprecated aliases and static tier placeholders resolve** the way the
+///   run resolves them (`model_aliases`, then `resolve_tier_placeholder` —
+///   #376), so the preview names the string that would actually be sent.
+///   `latest:auto` is the one that cannot be previewed: its tier is chosen
+///   from each call's own input, which is exactly what a dry run declines to
+///   compute, so it is reported as such rather than guessed.
+/// - **A provider that ignores `request.model`** gets told so. `CliProvider`
+///   spawns the tool and never passes the field on; previewing a resolved
+///   `claude-sonnet-4-5-20250929` for a `provider: cli` agent answered "which
+///   model will I pay for" with an id that is never sent and never billed
+///   (#398 review, F2) — and CLI-relayed agents are ArmadAI's reference
+///   configuration. Hence the built provider, not just the metadata:
+///   `create_provider` is what decides between an API client and a relay
+///   (`provider: claude` becomes either, depending on the binary being on
+///   PATH), so nothing read off the agent file could tell the two apart.
+fn preview_provider_and_model(
+    meta: &armadai_core::agent::AgentMetadata,
+    provider: &dyn armadai_core::provider::Provider,
+) -> (String, String) {
+    if !provider.honors_request_model() {
+        return (
+            meta.provider.clone(),
+            format!("(not sent — {} chooses)", provider.metadata().name),
+        );
+    }
+    let mut model = meta.model.clone();
+    let mut fallbacks = meta.model_fallback.clone();
+    armadai_core::model_aliases::resolve_model_deprecations(&mut model, &mut fallbacks);
+    let model = match model.as_deref() {
+        None => "(none declared)".to_string(),
+        Some("latest:auto") => "latest:auto (tier chosen per call)".to_string(),
+        Some(m) => armadai_core::model_resolution::resolve_tier_placeholder(m, &meta.provider)
+            .unwrap_or_else(|| m.to_string()),
+    };
+    (meta.provider.clone(), model)
 }
 
 /// Result of driving the event-sourced `direct` engine for one agent
@@ -2169,6 +2189,26 @@ async fn run_orchestrated_inner(
             effective_names.len(),
             effective_names.join(", ")
         );
+        // Provider and model per agent, like the sequential preview. The
+        // roster alone was all this printed, while `--dry-run`'s help
+        // promised "agents, providers and models … on every path" — the
+        // orchestrated paths made two words of that false (#398 review, F3).
+        // `agents`/`providers` are aligned with `effective_names` in both
+        // branches above: the C8 selection reassigns all three together, and
+        // when it does not run they are the untouched load-loop order.
+        for ((name, agent), provider) in effective_names
+            .iter()
+            .zip(agents.iter())
+            .zip(providers.iter())
+        {
+            let (prov, model) = preview_provider_and_model(&agent.metadata, provider.as_ref());
+            eprintln!("[dry-run]   {name} — provider={prov}, model={model}");
+        }
+        eprintln!(
+            "[dry-run] which agent speaks when, and how often, is decided by the \
+             engine as it runs, so it cannot be listed without executing it"
+        );
+        eprintln!("[dry-run] no provider was called; nothing was recorded or billed");
         if !json {
             println!("{}", effective_names.join("\n"));
         }

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -53,7 +53,7 @@ pub async fn execute(
         return execute_replay(&run_id, json, quiet, headless).await;
     }
     if let Some(run_id) = resume {
-        return execute_resume(&run_id, json, quiet, headless, max_content, no_tui).await;
+        return execute_resume(&run_id, json, quiet, headless, max_content, no_tui, dry_run).await;
     }
     let agent_name =
         agent_name.expect("clap ArgGroup guarantees agent is present when resume/replay are not");
@@ -245,10 +245,14 @@ async fn execute_resume(
     headless: bool,
     max_content: Option<usize>,
     no_tui: bool,
+    // `--dry-run` was silently dropped here until #378: the flag never
+    // reached this entry point at all, so `armadai run --resume <id>
+    // --dry-run` resumed for real and billed every remaining step.
+    dry_run: bool,
 ) -> anyhow::Result<()> {
     #[cfg(not(feature = "storage"))]
     {
-        let _ = (run_id, json, quiet, headless, max_content, no_tui);
+        let _ = (run_id, json, quiet, headless, max_content, no_tui, dry_run);
         anyhow::bail!("--resume requires the 'storage' feature (event log persistence)")
     }
 
@@ -279,6 +283,7 @@ async fn execute_resume(
             && !json
             && !quiet
             && !no_tui
+            && !dry_run
             && std::io::IsTerminal::is_terminal(&std::io::stdout());
 
         #[cfg(feature = "tui")]
@@ -294,7 +299,16 @@ async fn execute_resume(
                     // `false, false` for json/quiet: guaranteed by the
                     // `use_tui` gate above (mirrors `execute`'s own TUI
                     // closure, which hardcodes the same for `run_inner`).
-                    resume_run(&run_id_owned, &sink, false, false, max_content, false).await
+                    resume_run(
+                        &run_id_owned,
+                        &sink,
+                        false,
+                        false,
+                        max_content,
+                        false,
+                        false,
+                    )
+                    .await
                 },
                 None,
                 explicit_pattern,
@@ -319,7 +333,7 @@ async fn execute_resume(
         // `human_output` here means "not the TUI's alternate screen", not
         // "not machine output" (see `run_orchestrated_inner`'s identical
         // convention).
-        let result = resume_run(run_id, &sink, json, quiet, max_content, true).await;
+        let result = resume_run(run_id, &sink, json, quiet, max_content, true, dry_run).await;
 
         if let Err(e) = result {
             if headless {
@@ -362,6 +376,7 @@ async fn resume_run(
     quiet: bool,
     max_content: Option<usize>,
     human_output: bool,
+    dry_run: bool,
 ) -> anyhow::Result<()> {
     use crate::es_log::SqliteLog;
     use armadai_core::orchestration::es::bridge::synthetic_run_start;
@@ -488,6 +503,57 @@ async fn resume_run(
         let provider = create_provider(&agent)?;
         providers_map.insert(name.clone(), Arc::from(provider));
         agents_map.insert(name.clone(), agent);
+    }
+
+    // `--dry-run` (#378): everything a resume can check without spending is
+    // done by this point — the run exists, it is resumable, and the whole
+    // roster has been reloaded from the current project with each agent's
+    // provider actually built. Report it and stop before the engine gets a
+    // chance to dispatch anything.
+    if dry_run {
+        // `state.agents` — the roster exactly as the run recorded it in its
+        // own `RunStarted` — not `agents_map.keys()`, which is a
+        // `BTreeMap`'s alphabetical order. For `ring` the recorded order IS
+        // the circulation order (`run_ring_es` stores `agent_order`
+        // verbatim), so sorting it would preview an execution that is not
+        // the one that would happen. (`hierarchical` records its roster
+        // alphabetically already, from `agents.keys()`, and carries its
+        // coordinator separately — reading the record is right there too,
+        // it just changes nothing.)
+        let names: Vec<String> = state.agents.clone();
+        eprintln!(
+            "[dry-run] resume {run_id} — pattern '{pattern}', {} agent(s) reloaded: {}",
+            names.len(),
+            names.join(", ")
+        );
+        for name in &names {
+            let mut meta = agents_map[name].metadata.clone();
+            armadai_core::model_aliases::resolve_model_deprecations(
+                &mut meta.model,
+                &mut meta.model_fallback,
+            );
+            let model = match meta.model.as_deref() {
+                None => "(none declared)".to_string(),
+                Some("latest:auto") => "latest:auto (tier chosen per call)".to_string(),
+                Some(m) => {
+                    armadai_core::model_resolution::resolve_tier_placeholder(m, &meta.provider)
+                        .unwrap_or_else(|| m.to_string())
+                }
+            };
+            eprintln!(
+                "[dry-run]   {name} — provider={}, model={model}",
+                meta.provider
+            );
+        }
+        eprintln!(
+            "[dry-run] the remaining steps are decided by the engine as it runs, \
+             so they cannot be listed without executing them"
+        );
+        eprintln!("[dry-run] no provider was called; nothing was recorded or billed");
+        if !json {
+            println!("{}", names.join("\n"));
+        }
+        return Ok(());
     }
 
     let filtered_sink = quiet_max_content_sink(sink, quiet, max_content);
@@ -756,6 +822,27 @@ async fn run_inner(
         anstream::println!("{m}run {run_id}{m:#}");
     }
 
+    // `--dry-run` on the sequential path (#378). Placed AFTER the whole
+    // chain has been resolved — agent *and* provider, via the same
+    // [`load_chain`] pre-pass #366 gave the real run — and BEFORE the
+    // single-agent branch below, so it covers `armadai run <a>` as well as
+    // `--pipe`: the flag's own help text promises "0 tokens" without
+    // qualification, and until #378 that promise held only under
+    // `--orchestrate`. Everything else emitted `agent_start`/`agent_end`/
+    // `result` for every link, i.e. made and paid for every provider call
+    // the command claimed it would not make.
+    //
+    // Refusing exactly like the real pass is the point (#348's lesson from
+    // `unlink --dry-run`): a preview that cannot fail pre-checks nothing.
+    // Routing through `load_chain` is what buys that — an unresolvable
+    // agent, or one whose provider cannot be built, exits non-zero here
+    // with the same message and the same code the real run would give.
+    if dry_run {
+        let links = load_chain(&resolution, &chain)?;
+        report_dry_run_chain(&chain, &links, json);
+        return Ok(());
+    }
+
     // Single-agent direct execution (OH1 Lot 5, T5a): switched onto the
     // event-sourced `direct` engine (`run_direct_es`), wrapped in a
     // `SinkProjectingLog` so `AgentStart`/`AgentEnd`/`Route` observability
@@ -1013,12 +1100,28 @@ fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<
         .iter()
         .enumerate()
         .map(|(i, name)| {
-            let position = format!("chain link {}/{} ('{name}')", i + 1, chain.len());
-            let (agent, warning) = load_agent_reporting_warning(resolution, name).map_err(|e| {
-                anyhow::anyhow!("{position} could not be resolved, so no agent was run: {e:#}")
-            })?;
-            let provider = create_provider(&agent).map_err(|e| {
-                anyhow::anyhow!("{position} has no usable provider, so no agent was run: {e:#}")
+            // The positional prefix exists so a failure on one of SEVERAL
+            // names on the command line says which one. With a single name
+            // there is nothing to count, and the prefix would make
+            // `armadai run <x> --dry-run` — which routes through here too
+            // since #378 — refuse in different words than the real
+            // single-agent pass it is previewing. So: no name to
+            // disambiguate, no prefix, and the resolver's own error is
+            // returned untouched.
+            let position = (chain.len() > 1)
+                .then(|| format!("chain link {}/{} ('{name}')", i + 1, chain.len()));
+            let (agent, warning) =
+                load_agent_reporting_warning(resolution, name).map_err(|e| match &position {
+                    Some(p) => {
+                        anyhow::anyhow!("{p} could not be resolved, so no agent was run: {e:#}")
+                    }
+                    None => e,
+                })?;
+            let provider = create_provider(&agent).map_err(|e| match &position {
+                Some(p) => {
+                    anyhow::anyhow!("{p} has no usable provider, so no agent was run: {e:#}")
+                }
+                None => e,
             })?;
             let warning = warning.and_then(|w| match w {
                 armadai_core::agent_source::LoadWarning::DeclarationsUnreadable(m) => {
@@ -1033,6 +1136,56 @@ fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<
             })
         })
         .collect()
+}
+
+/// Render a `--dry-run` preview of an already-resolved sequential chain: the
+/// links in execution order, each with the provider that would be used and
+/// the model string that would actually be sent.
+///
+/// Mirrors the orchestrated preview's shape (`run_orchestrated_inner`): a
+/// `[dry-run] …` summary plus the details on **stderr**, and the agent names
+/// one per line on **stdout** when not emitting JSON — so a script consuming
+/// either preview reads the same thing on stdout.
+///
+/// The model shown is the one the run would send, not the one written in the
+/// agent file: deprecated aliases are resolved (`model_aliases`) and so are
+/// the static tier placeholders (#376). `latest:auto` is the one that cannot
+/// be previewed — its tier is chosen from each link's own input, which for
+/// every link but the first is the previous link's output, i.e. exactly what
+/// a dry run refuses to compute — so it is reported as such rather than
+/// guessed.
+fn report_dry_run_chain(chain: &[String], links: &[ChainLink], json: bool) {
+    let n = chain.len();
+    eprintln!(
+        "[dry-run] sequential chain ({n} agent(s)): {}",
+        chain.join(", ")
+    );
+    for (i, (name, link)) in chain.iter().zip(links).enumerate() {
+        let mut meta = link.agent.metadata.clone();
+        armadai_core::model_aliases::resolve_model_deprecations(
+            &mut meta.model,
+            &mut meta.model_fallback,
+        );
+        let model = match meta.model.as_deref() {
+            None => "(none declared)".to_string(),
+            Some("latest:auto") => "latest:auto (tier chosen per call)".to_string(),
+            Some(m) => armadai_core::model_resolution::resolve_tier_placeholder(m, &meta.provider)
+                .unwrap_or_else(|| m.to_string()),
+        };
+        eprintln!(
+            "[dry-run]   {}/{n} {name} — provider={}, model={model}",
+            i + 1,
+            meta.provider
+        );
+        if let Some(w) = &link.warning {
+            let s = crate::cli::style::warn();
+            anstream::eprintln!("{s}[dry-run]   warn: {w}{s:#}");
+        }
+    }
+    eprintln!("[dry-run] no provider was called; nothing was recorded or billed");
+    if !json {
+        println!("{}", chain.join("\n"));
+    }
 }
 
 /// Execute a single agent with given input and configuration. Parameters represent

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -1273,7 +1273,7 @@ async fn run_single_agent(
             tier: format!("{tier:?}"),
             reason: format!("{reason:?}"),
         });
-        armadai_core::model_resolution::resolve_model_for_tier(&agent.metadata.provider, tier)
+        armadai_core::model_resolution::resolve_routed_tier(&agent.metadata.provider, tier)
     } else {
         // The static tier placeholders (`latest`, `latest:fast`,
         // `latest:pro`, `latest:max`) resolve here — this is the last gate

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -75,12 +75,13 @@ pub async fn execute(
     // or config-driven auto-detect), only when nothing else demands
     // plain/machine output, and only when attached to a real terminal. Falls
     // through to the unchanged headless path otherwise.
-    let use_tui = (orchestrate.is_some() || config_orchestrated)
-        && !json
-        && !quiet
-        && !no_tui
-        && !dry_run
-        && std::io::IsTerminal::is_terminal(&std::io::stdout());
+    let use_tui = use_live_workroom(
+        orchestrate.is_some() || config_orchestrated,
+        json,
+        quiet,
+        no_tui,
+        dry_run,
+    );
 
     #[cfg(feature = "tui")]
     if use_tui {
@@ -279,12 +280,13 @@ async fn execute_resume(
             anyhow::bail!("run {run_id} is not resumable (status: {:?})", peek.status);
         }
 
-        let use_tui = is_orchestrated_pattern(&peek.pattern)
-            && !json
-            && !quiet
-            && !no_tui
-            && !dry_run
-            && std::io::IsTerminal::is_terminal(&std::io::stdout());
+        let use_tui = use_live_workroom(
+            is_orchestrated_pattern(&peek.pattern),
+            json,
+            quiet,
+            no_tui,
+            dry_run,
+        );
 
         #[cfg(feature = "tui")]
         if use_tui {
@@ -2022,6 +2024,33 @@ async fn run_orchestrated(
 /// provider/model (via [`agent_meta_from_roster`]) and real per-turn content.
 /// Only `--pipe`/legacy sequential runs (`run_single_agent`) still emit their
 /// own inline `AgentStart`/`AgentEnd`; those paths never reach this fn.
+/// Whether a run should take over the terminal with the live Workroom TUI.
+///
+/// One decision, two call sites (`execute` and `execute_resume`), each of
+/// which used to spell out the same five-term conjunction.
+///
+/// `!dry_run` is the term with no other guard behind it. The Workroom drives
+/// its own event loop until the run it is watching produces a terminal
+/// event; a `--dry-run` produces none, because by design it never dispatches
+/// anything — so on a real terminal the preview would enter the alternate
+/// screen and **stay there indefinitely**, showing an empty roster. Measured
+/// under a PTY (`a_dry_run_on_a_terminal_prints_a_preview_and_exits`): with
+/// the term removed the process never exits.
+fn use_live_workroom(
+    orchestrated: bool,
+    json: bool,
+    quiet: bool,
+    no_tui: bool,
+    dry_run: bool,
+) -> bool {
+    orchestrated
+        && !json
+        && !quiet
+        && !no_tui
+        && !dry_run
+        && std::io::IsTerminal::is_terminal(&std::io::stdout())
+}
+
 /// Style for a terminal orchestration status line: `Completed` reads as
 /// success, anything else (`Halted`, or the in-flight `Running` default,
 /// which should not appear at a terminal print site) as a warning — factual,
@@ -3045,14 +3074,6 @@ mod tests {
             4
         );
         assert_eq!(exit_code_for(&anyhow::anyhow!("boom")), 1);
-    }
-
-    #[test]
-    fn latest_auto_is_the_only_routed_value() {
-        // concrete + latest:pro must NOT be treated as auto
-        assert_ne!("claude-3", "latest:auto");
-        assert_ne!("latest:pro", "latest:auto");
-        // routing only triggers on the exact "latest:auto" string (guard documented)
     }
 
     #[test]

--- a/crates/armadai/src/linker/model_resolution.rs
+++ b/crates/armadai/src/linker/model_resolution.rs
@@ -24,18 +24,10 @@ pub fn classify_target(target: &str) -> TargetKind {
 
 /// Parse a `latest` placeholder into a tier.
 ///
-/// Returns `Some(tier)` if the model string is a `latest` placeholder,
-/// `None` if it is a concrete model name.
-///
-/// Syntax: `latest` (defaults to Pro), `latest:fast`, `latest:pro`, `latest:max`.
-pub fn parse_latest_placeholder(model: &str) -> Option<ModelTier> {
-    match model.trim() {
-        "latest" | "latest:pro" | "latest:medium" => Some(ModelTier::Pro),
-        "latest:fast" | "latest:low" => Some(ModelTier::Fast),
-        "latest:max" | "latest:high" => Some(ModelTier::Max),
-        _ => None,
-    }
-}
+/// Re-exported from core, where it moved in #376 so the `armadai run` path
+/// resolves the exact same tier table this linker does — an alias that
+/// `link` honours and `run` sends verbatim to the provider was that issue.
+pub use armadai_core::model_resolution::parse_latest_placeholder;
 
 /// Check whether a model string is a `latest:*` placeholder.
 pub fn is_latest_placeholder(model: &str) -> bool {
@@ -356,20 +348,6 @@ mod tests {
     }
 
     // ── Latest placeholder parsing ───────────────────────────────
-
-    #[test]
-    fn test_parse_latest_placeholder() {
-        assert_eq!(parse_latest_placeholder("latest"), Some(ModelTier::Pro));
-        assert_eq!(
-            parse_latest_placeholder("latest:fast"),
-            Some(ModelTier::Fast)
-        );
-        assert_eq!(parse_latest_placeholder("latest:pro"), Some(ModelTier::Pro));
-        assert_eq!(parse_latest_placeholder("latest:max"), Some(ModelTier::Max));
-        assert_eq!(parse_latest_placeholder("claude-sonnet-4-5-20250929"), None);
-        assert_eq!(parse_latest_placeholder("gemini-2.5-pro"), None);
-        assert_eq!(parse_latest_placeholder(""), None);
-    }
 
     #[test]
     fn test_is_latest_placeholder() {

--- a/crates/armadai/src/linker/model_resolution.rs
+++ b/crates/armadai/src/linker/model_resolution.rs
@@ -412,6 +412,39 @@ mod tests {
         assert!(agents[3].model.as_ref().unwrap().contains("sonnet"));
     }
 
+    /// An agent's `provider:` may be a *tool* name, which the vendor-keyed
+    /// catalog does not know: `link` wrote a Claude model id into a native
+    /// config for a `provider: gemini` agent (#398 review, F1).
+    ///
+    /// Hermetic for the same reason `test_preview_resolution_with_latest`
+    /// is: with no models.dev cache reachable, resolution is the hardcoded
+    /// fallback table and the expectation is derived from it rather than
+    /// restated.
+    #[test]
+    fn resolve_latest_placeholders_uses_each_agents_own_vendor() {
+        let _iso = armadai_core::test_support::IsolatedConfigDir::enter();
+        let mut agents = vec![
+            make_agent_with_provider("A", Some("latest:pro"), Some("gemini")),
+            make_agent_with_provider("B", Some("latest:fast"), Some("aider")),
+            make_agent_with_provider("C", Some("latest:max"), Some("claude")),
+        ];
+
+        resolve_latest_placeholders(&mut agents);
+
+        for (agent, vendor, tier) in [
+            (&agents[0], "google", ModelTier::Pro),
+            (&agents[1], "openai", ModelTier::Fast),
+            (&agents[2], "anthropic", ModelTier::Max),
+        ] {
+            assert_eq!(
+                agent.model.as_deref(),
+                Some(fallback_model_for_tier(vendor, tier)),
+                "{} should resolve against {vendor}",
+                agent.name
+            );
+        }
+    }
+
     #[test]
     fn test_preview_resolution_fallbacks() {
         // Without cache, preview should return fallback models for LLM editors

--- a/crates/armadai/src/linker/model_resolution.rs
+++ b/crates/armadai/src/linker/model_resolution.rs
@@ -1,5 +1,7 @@
 use super::LinkAgent;
-use armadai_core::model_resolution::{ModelTier, fallback_model_for_tier, resolve_model_for_tier};
+use armadai_core::model_resolution::{
+    ModelTier, fallback_model_for_tier, resolve_model_for_tier, resolve_routed_tier,
+};
 
 /// Classification of link targets.
 pub enum TargetKind {
@@ -102,8 +104,14 @@ pub fn resolve_latest_placeholders(agents: &mut [LinkAgent]) {
         if let Some(ref model) = agent.model
             && let Some(tier) = parse_latest_placeholder(model)
         {
+            // `resolve_routed_tier`, not `resolve_model_for_tier`: the value
+            // here is an agent's own `provider:` — a *tool* name (`gemini`,
+            // `aider`, …), which the vendor-keyed catalog does not know. Fed
+            // in raw it missed the cache and fell through to the Anthropic
+            // catch-all, so a `provider: gemini` agent was written into a
+            // native config with a Claude model id (#398 review, F1).
             let provider = agent.provider.as_deref().unwrap_or("anthropic");
-            agent.model = Some(resolve_model_for_tier(provider, tier));
+            agent.model = Some(resolve_routed_tier(provider, tier));
         }
     }
 }

--- a/crates/armadai/src/shell/config.rs
+++ b/crates/armadai/src/shell/config.rs
@@ -6,35 +6,33 @@
 //! reach into `crate::linker` and so cannot live in core.
 
 use crate::linker::model_resolution::parse_latest_placeholder;
-use armadai_core::model_resolution::{ModelTier, fallback_model_for_tier, resolve_model_for_tier};
+use armadai_core::model_resolution::{
+    ModelTier, fallback_model_for_tier, model_catalog_provider, resolve_routed_tier,
+};
 pub use armadai_core::project::{PipelineStep, ShellConfig, ShellProviderEntry};
 
 // ── Model resolution for shell providers ────────────────────────
 
-/// Map a shell provider name to the linker provider identifier.
-fn shell_provider_to_linker(provider: &str) -> &str {
-    match provider {
-        "gemini" => "google",
-        "claude" => "anthropic",
-        "aider" | "codex" => "openai",
-        _ => "anthropic",
-    }
-}
-
 /// Resolve a model string (which may be a `latest:*` placeholder) for a shell provider.
+///
+/// The tool-name → vendor-catalog mapping this used to carry privately
+/// (`shell_provider_to_linker`) now lives in
+/// [`armadai_core::model_resolution::model_catalog_provider`], shared with
+/// `armadai run` and `armadai link`. It was the only correct copy of it in
+/// the tree, which is how `armadai shell` and `armadai run` came to resolve
+/// the same agent file's `latest:pro` to two different vendors' models
+/// (#398 review, F1).
 pub fn resolve_shell_model(provider: &str, model: &str) -> String {
-    let linker_provider = shell_provider_to_linker(provider);
-    if let Some(tier) = parse_latest_placeholder(model) {
-        resolve_model_for_tier(linker_provider, tier)
-    } else {
-        model.to_string()
+    match parse_latest_placeholder(model) {
+        Some(tier) => resolve_routed_tier(provider, tier),
+        None => model.to_string(),
     }
 }
 
 /// Get the default model for a provider (Pro tier).
 pub fn default_model_for_provider(provider: &str) -> String {
-    let linker_provider = shell_provider_to_linker(provider);
-    fallback_model_for_tier(linker_provider, ModelTier::Pro).to_string()
+    let catalog = model_catalog_provider(provider).unwrap_or(provider);
+    fallback_model_for_tier(catalog, ModelTier::Pro).to_string()
 }
 
 /// Build CLI model flags for a provider, if the CLI supports it.

--- a/crates/armadai/src/shell/config.rs
+++ b/crates/armadai/src/shell/config.rs
@@ -102,6 +102,32 @@ mod tests {
         assert_eq!(high, max);
     }
 
+    /// `armadai shell` and `armadai run` must resolve one agent file's
+    /// placeholder to one model.
+    ///
+    /// They did not: shell carried the tool → vendor table (privately) and
+    /// run did not, so `provider: gemini` + `latest:pro` gave
+    /// `gemini-2.5-pro` under `shell` and `claude-sonnet-4-5-20250929` under
+    /// `run` (#398 review, F1). Both now read
+    /// `model_catalog_provider`; this pins the two together so a future
+    /// second table cannot re-open the gap silently.
+    #[test]
+    fn shell_and_run_resolve_a_placeholder_to_the_same_model() {
+        let _iso = armadai_core::test_support::IsolatedConfigDir::enter();
+        for provider in ["claude", "gemini", "aider", "codex", "gpt", "anthropic"] {
+            for placeholder in ["latest", "latest:fast", "latest:pro", "latest:max"] {
+                let via_run =
+                    armadai_core::model_resolution::resolve_tier_placeholder(placeholder, provider)
+                        .unwrap_or_else(|| panic!("{provider} should name a vendor"));
+                assert_eq!(
+                    resolve_shell_model(provider, placeholder),
+                    via_run,
+                    "{provider} + {placeholder}: shell and run disagree"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_model_cli_args_claude() {
         let args = model_cli_args("claude", "claude-sonnet-4-5");

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -1,0 +1,476 @@
+//! Black-box regressions for `armadai run --dry-run` on the paths that are
+//! not `--orchestrate` (#378).
+//!
+//! `dry_run` was read in exactly one place, `run_orchestrated_inner`. The
+//! sequential chain never consulted it: `armadai run <a> <task> --pipe b,c
+//! --dry-run` emitted a full `agent_start`/`agent_end`/`result` per link,
+//! which means every provider call was made and billed — on a command whose
+//! own help text promises "0 tokens". The single-agent path had the same
+//! hole, and `--resume` never received the flag at all.
+//!
+//! **What these tests assert is the ABSENCE of a call**, not the exit code:
+//! a `--dry-run` that returns 0 while spending money is precisely the bug.
+//! Every agent here is `provider: cli` with `command: echo`, so a real run
+//! is hermetic (no key, no network, no fake-provider feature) and visibly
+//! emits `agent_start` per link — which is exactly the event that must not
+//! appear.
+//!
+//! They spawn the real binary because the defect is in the wiring of
+//! `cli::run`'s entry points, one per roster construction; a unit test on
+//! any single function would stay green while another entry point kept
+//! spending.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+
+/// A project with `agents/<name>.md` for each `(name, metadata)` pair, plus
+/// an isolated config dir and data dir.
+///
+/// Both redirections matter: without `ARMADAI_CONFIG_DIR` the agent
+/// shadowing check scans the developer's real global library, and without
+/// `XDG_DATA_HOME` a run that *does* execute writes into the developer's
+/// real SQLite database — the `#[cfg(test)]` guard in `db.rs` does not
+/// protect a spawned binary (#267). Both matter more than usual here, since
+/// half of these tests exist to prove a run did *not* happen.
+struct Sandbox {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+    config: PathBuf,
+    data: PathBuf,
+}
+
+/// The `## Metadata` body of an agent that runs hermetically: `echo` returns
+/// the composed prompt verbatim, so a link that ran is unmistakable.
+const ECHO: &str = "- provider: cli\n- command: echo\n";
+
+impl Sandbox {
+    fn new(agents: &[(&str, &str)]) -> Self {
+        Self::with_config(agents, "")
+    }
+
+    /// [`Sandbox::new`] plus extra top-level `armadai.yaml` keys (an
+    /// `orchestration:` block, say).
+    fn with_config(agents: &[(&str, &str)], extra_yaml: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+
+        let list: String = agents
+            .iter()
+            .map(|(name, _)| format!("  - name: {name}\n"))
+            .collect();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            format!("agents:\n{list}{extra_yaml}"),
+        )
+        .unwrap();
+        for (name, metadata) in agents {
+            write_agent(&root, name, metadata);
+        }
+
+        let config = dir.path().join("config");
+        let data = dir.path().join("data");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        Self {
+            _dir: dir,
+            root,
+            config,
+            data,
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&self.root)
+            .env("ARMADAI_CONFIG_DIR", &self.config)
+            .env("XDG_DATA_HOME", &self.data)
+            .env("NO_COLOR", "1")
+            .args(args);
+        Output(cmd.output().unwrap())
+    }
+}
+
+fn write_agent(root: &Path, name: &str, metadata: &str) {
+    std::fs::write(
+        root.join("agents").join(format!("{name}.md")),
+        format!("# {name}\n\n## Metadata\n{metadata}\n## System Prompt\nMARKER-{name}\n"),
+    )
+    .unwrap();
+}
+
+struct Output(std::process::Output);
+
+impl Output {
+    fn stdout(&self) -> String {
+        String::from_utf8_lossy(&self.0.stdout).into_owned()
+    }
+    fn stderr(&self) -> String {
+        String::from_utf8_lossy(&self.0.stderr).into_owned()
+    }
+    fn succeeded(&self) -> bool {
+        self.0.status.success()
+    }
+    /// The `agent` of every event of kind `t` on stdout, in emission order.
+    fn events(&self, t: &str) -> Vec<String> {
+        self.stdout()
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .filter(|v| v["t"] == t)
+            .map(|v| v["agent"].as_str().unwrap_or("").to_string())
+            .collect()
+    }
+}
+
+/// The single assertion these tests are about: not one provider call was
+/// made. `agent_start` is emitted immediately before the call on every path
+/// (`run_single_agent`'s inline emission, and the ES bridge's
+/// `AgentInvoked → agent_start` projection), so its absence is the proof.
+fn assert_nothing_ran(out: &Output) {
+    assert_eq!(
+        out.events("agent_start"),
+        Vec::<String>::new(),
+        "--dry-run called a provider; stdout was:\n{}",
+        out.stdout()
+    );
+    assert_eq!(
+        out.events("agent_end"),
+        Vec::<String>::new(),
+        "--dry-run produced agent output; stdout was:\n{}",
+        out.stdout()
+    );
+}
+
+// ── The preview spends nothing ───────────────────────────────────────
+
+#[test]
+fn a_pipe_chain_dry_run_calls_no_provider_and_lists_the_links_in_order() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO), ("gamma", ECHO)]);
+
+    let out = sb.run(&[
+        "run",
+        "alpha",
+        "hello",
+        "--pipe",
+        "beta",
+        "gamma",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+    assert_nothing_ran(&out);
+
+    // The preview still has to say what *would* run, in order.
+    let err = out.stderr();
+    let positions: Vec<usize> = ["1/3 alpha", "2/3 beta", "3/3 gamma"]
+        .iter()
+        .map(|s| {
+            err.find(s)
+                .unwrap_or_else(|| panic!("missing {s} in:\n{err}"))
+        })
+        .collect();
+    assert!(
+        positions.windows(2).all(|w| w[0] < w[1]),
+        "links previewed out of execution order:\n{err}"
+    );
+}
+
+/// The single-agent invocation is the same defect: `--dry-run` has no
+/// `--pipe`/`--orchestrate` qualifier in its help text, and this path ran
+/// the agent too.
+#[test]
+fn a_single_agent_dry_run_calls_no_provider() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+
+    let out = sb.run(&["run", "alpha", "hello", "--dry-run", "--json"]);
+
+    assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+    assert_nothing_ran(&out);
+    assert!(
+        out.stderr().contains("1/1 alpha"),
+        "the preview did not name the agent:\n{}",
+        out.stderr()
+    );
+}
+
+// ── The preview refuses what the real pass refuses ───────────────────
+
+/// #348's lesson from `unlink --dry-run`: a preview that always succeeds
+/// pre-checks nothing. An unresolvable link must fail the dry run with the
+/// same non-zero exit the real run gives — and still call nothing.
+#[test]
+fn a_dry_run_with_an_unresolvable_link_exits_non_zero_like_the_real_pass() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+
+    let dry = sb.run(&[
+        "run",
+        "alpha",
+        "hello",
+        "--pipe",
+        "nope",
+        "--dry-run",
+        "--json",
+    ]);
+    let real = sb.run(&["run", "alpha", "hello", "--pipe", "nope", "--json"]);
+
+    assert!(!dry.succeeded(), "dry-run accepted a missing link");
+    assert!(!real.succeeded(), "the real run accepted a missing link");
+    assert_nothing_ran(&dry);
+    assert_eq!(
+        dry.0.status.code(),
+        real.0.status.code(),
+        "dry-run and the real pass disagree on the exit code"
+    );
+}
+
+/// The provider is built by the same pre-pass, so a link whose provider
+/// cannot be constructed is refused before anything runs — on the preview
+/// exactly as on the real pass, word for word.
+#[test]
+fn a_dry_run_with_an_unbuildable_provider_refuses_exactly_like_the_real_pass() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("bad", "- provider: gtp\n- model: x\n")]);
+
+    let dry = sb.run(&[
+        "run",
+        "alpha",
+        "hello",
+        "--pipe",
+        "bad",
+        "--dry-run",
+        "--json",
+    ]);
+    let real = sb.run(&["run", "alpha", "hello", "--pipe", "bad", "--json"]);
+
+    assert!(!dry.succeeded(), "dry-run accepted an unbuildable provider");
+    assert_nothing_ran(&dry);
+
+    let msg = |o: &Output| {
+        o.stdout()
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .find(|v| v["t"] == "error")
+            .and_then(|v| v["msg"].as_str().map(str::to_string))
+            .unwrap_or_default()
+    };
+    assert!(
+        msg(&dry).contains("has no usable provider"),
+        "unexpected dry-run error: {}",
+        msg(&dry)
+    );
+    assert_eq!(msg(&dry), msg(&real), "the preview refuses in other words");
+}
+
+/// A single agent gets the *unprefixed* message the real single-agent pass
+/// produces: routing the preview through the chain pre-pass must not make
+/// `armadai run <x> --dry-run` talk about "chain link 1/1" when there is no
+/// chain and nothing to count.
+#[test]
+fn a_single_agent_dry_run_refuses_in_the_same_words_as_the_real_pass() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+
+    let dry = sb.run(&["run", "nope", "hello", "--dry-run", "--json"]);
+    let real = sb.run(&["run", "nope", "hello", "--json"]);
+
+    let msg = |o: &Output| {
+        o.stdout()
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .find(|v| v["t"] == "error")
+            .and_then(|v| v["msg"].as_str().map(str::to_string))
+            .unwrap_or_default()
+    };
+    assert!(!dry.succeeded());
+    assert_eq!(dry.0.status.code(), real.0.status.code());
+    assert!(!msg(&dry).is_empty(), "no error event on the dry run");
+    assert_eq!(msg(&dry), msg(&real));
+    assert!(
+        !msg(&dry).contains("chain link"),
+        "a one-agent run was described as a chain link: {}",
+        msg(&dry)
+    );
+}
+
+// ── --resume ─────────────────────────────────────────────────────────
+
+/// `--resume` has its own roster construction, and until #378 it never even
+/// received `dry_run` — `armadai run --resume <id> --dry-run` resumed for
+/// real. The preview must call nothing AND leave the run resumable, since a
+/// dry run that consumed the resume point would be worse than the bug.
+#[cfg(feature = "storage")]
+#[test]
+fn a_resume_dry_run_calls_no_provider_and_leaves_the_run_resumable() {
+    let sb = Sandbox::new(&[(
+        "alpha",
+        "- provider: cli\n- command: /nonexistent-armadai-cmd\n",
+    )]);
+
+    // A run whose provider cannot execute dies mid-flight, leaving the
+    // event log in `Running` — i.e. resumable.
+    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
+    assert!(!setup.succeeded(), "the setup run was supposed to fail");
+    let run_id = setup
+        .stdout()
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["t"] == "run_start")
+        .and_then(|v| v["run_id"].as_str().map(str::to_string))
+        .expect("no run_start to take a run id from");
+
+    write_agent(&sb.root, "alpha", ECHO);
+
+    let dry = sb.run(&[
+        "run",
+        "--resume",
+        &run_id,
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(dry.succeeded(), "resume dry-run failed: {}", dry.stderr());
+    assert_nothing_ran(&dry);
+    assert!(
+        dry.stderr().contains("alpha"),
+        "the preview did not name the reloaded roster:\n{}",
+        dry.stderr()
+    );
+
+    // Still resumable: the preview appended nothing to the log.
+    let real = sb.run(&["run", "--resume", &run_id, "--json", "--no-tui"]);
+    assert!(real.succeeded(), "resume failed: {}", real.stderr());
+    assert_eq!(real.events("agent_start"), vec!["alpha".to_string()]);
+}
+
+/// Same refusal, same exit code: an unknown run id is rejected by the
+/// preview exactly as by a real resume.
+#[cfg(feature = "storage")]
+#[test]
+fn a_resume_dry_run_of_an_unknown_id_exits_non_zero() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+
+    let dry = sb.run(&[
+        "run",
+        "--resume",
+        "no-such-run",
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    let real = sb.run(&["run", "--resume", "no-such-run", "--json", "--no-tui"]);
+
+    assert!(!dry.succeeded(), "dry-run accepted an unknown run id");
+    assert_eq!(dry.0.status.code(), real.0.status.code());
+    assert_nothing_ran(&dry);
+}
+
+/// The resume preview must list the roster in the order the run recorded,
+/// not sorted. For `ring` that order IS the circulation order
+/// (`run_ring_es` stores `agent_order` in its `RunStarted`), so an
+/// alphabetical listing would describe a run that would not happen. The
+/// three names are chosen so run order (`zeta, mid, alpha`) is the exact
+/// reverse of alphabetical order — nothing but reading the recorded roster
+/// can produce it.
+///
+/// Interrupting a run is the only way to get a resumable multi-agent one:
+/// `ring` deliberately swallows provider failures (it records a `pass` and
+/// keeps circulating), so a broken command completes the run instead of
+/// leaving it `Running`. The interruption is driven by the run's OWN output
+/// rather than by a timer — the process is killed the moment its first
+/// `agent_start` reaches stdout, which is after `RunStarted` is persisted
+/// and before the first provider call returns. No wall-clock assumption,
+/// so nothing here can flake under load.
+#[cfg(feature = "storage")]
+#[test]
+fn a_resume_dry_run_lists_the_roster_in_run_order_not_sorted() {
+    use std::io::BufRead;
+
+    let sb = Sandbox::new(&[]);
+
+    // A command that blocks, so the run can be caught mid-flight. Written as
+    // a script rather than passed as `args:` so nothing depends on how a
+    // multi-word argument survives metadata parsing.
+    let blocker = sb.root.join("blocker.sh");
+    std::fs::write(&blocker, "#!/bin/sh\nsleep 10\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&blocker, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let names = ["zeta", "mid", "alpha"];
+    let list: String = names.iter().map(|n| format!("  - name: {n}\n")).collect();
+    std::fs::write(sb.root.join("armadai.yaml"), format!("agents:\n{list}")).unwrap();
+    for n in names {
+        write_agent(
+            &sb.root,
+            n,
+            &format!("- provider: cli\n- command: {}\n", blocker.display()),
+        );
+    }
+
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("armadai"))
+        .current_dir(&sb.root)
+        .env("ARMADAI_CONFIG_DIR", &sb.config)
+        .env("XDG_DATA_HOME", &sb.data)
+        .env("NO_COLOR", "1")
+        .args([
+            "run",
+            "zeta",
+            "hello",
+            "--pipe",
+            "mid",
+            "alpha",
+            "--orchestrate",
+            "ring",
+            "--json",
+            "--no-tui",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut reader = std::io::BufReader::new(child.stdout.take().unwrap());
+    let mut run_id = None;
+    let mut line = String::new();
+    while reader.read_line(&mut line).unwrap() > 0 {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+            if v["t"] == "run_start" {
+                run_id = v["run_id"].as_str().map(str::to_string);
+            }
+            if v["t"] == "agent_start" {
+                break;
+            }
+        }
+        line.clear();
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    let run_id = run_id.expect("the interrupted run never announced a run id");
+
+    // Make the roster runnable again, so nothing but the preview's own
+    // ordering can be what this test observes.
+    for n in names {
+        write_agent(&sb.root, n, ECHO);
+    }
+
+    let dry = sb.run(&[
+        "run",
+        "--resume",
+        &run_id,
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(dry.succeeded(), "resume dry-run failed: {}", dry.stderr());
+    assert_nothing_ran(&dry);
+
+    let err = dry.stderr();
+    let at = |n: &str| {
+        err.find(&format!("[dry-run]   {n} —"))
+            .unwrap_or_else(|| panic!("{n} missing from the preview:\n{err}"))
+    };
+    assert!(
+        at("zeta") < at("mid") && at("mid") < at("alpha"),
+        "roster previewed sorted instead of in the order the run recorded:\n{err}"
+    );
+}

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -605,3 +605,123 @@ fn an_orchestrated_preview_names_each_agents_provider_and_model() {
         );
     }
 }
+
+// ── The preview must not enter the live Workroom (#398 review) ───────
+
+/// `--dry-run` on a **real terminal**.
+///
+/// Everything above runs with stdout on a pipe, where `IsTerminal` is false
+/// and the live Workroom is out of reach whatever the flags say. That makes
+/// the `&& !dry_run` term in [`use_live_workroom`](../src/cli/run.rs)
+/// invisible to the whole suite: remove it and every test stays green.
+///
+/// What it guards is not cosmetic. The Workroom drives its own event loop
+/// until the run produces a terminal event, and a dry run produces none — it
+/// never dispatches anything. On a terminal, without the term, the preview
+/// enters the alternate screen and stays there: the process does not exit.
+///
+/// So this test gives the binary an actual TTY (`openpty`, no fork — the
+/// child simply gets the slave side as its stdio) and asserts it *finishes*,
+/// having printed the preview. The timeout is the assertion: a hang is the
+/// failure mode, and a hang is what a plain `output()` would turn into a
+/// stuck test run rather than a red one.
+#[cfg(unix)]
+#[test]
+fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
+    use std::io::Read;
+    use std::os::fd::{FromRawFd, OwnedFd};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+
+    let (master, slave) = {
+        let (mut m, mut s) = (0, 0);
+        // SAFETY: `openpty` writes two fresh fds through the out-params and
+        // returns 0 on success; all other args are the documented "defaults"
+        // null pointers.
+        let rc = unsafe {
+            libc::openpty(
+                &mut m,
+                &mut s,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+        // SAFETY: both fds are owned by this process and handed over exactly
+        // once each.
+        unsafe { (OwnedFd::from_raw_fd(m), OwnedFd::from_raw_fd(s)) }
+    };
+
+    let mut cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin("armadai"));
+    cmd.current_dir(&sb.root)
+        .env("ARMADAI_CONFIG_DIR", &sb.config)
+        .env("XDG_DATA_HOME", &sb.data)
+        .env("NO_COLOR", "1")
+        .args([
+            "run",
+            "alpha",
+            "hello",
+            "--pipe",
+            "beta",
+            "--orchestrate",
+            "ring",
+            "--dry-run",
+        ])
+        .stdin(std::process::Stdio::from(slave.try_clone().unwrap()))
+        .stdout(std::process::Stdio::from(slave.try_clone().unwrap()))
+        .stderr(std::process::Stdio::from(slave.try_clone().unwrap()));
+    let mut child = cmd.spawn().expect("spawn armadai on a pty");
+    // The parent must not keep the slave open, or the master never sees EOF.
+    drop(slave);
+
+    // Drain the master continuously: a pty buffer is a few KB, and a child
+    // blocked on a full one would look exactly like the hang under test.
+    let seen: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    std::thread::spawn(move || {
+        let mut f = std::fs::File::from(master);
+        let mut buf = [0u8; 4096];
+        // Linux reports EIO (not EOF) once the last slave closes; any error
+        // is the end as far as this drain is concerned.
+        while let Ok(n) = f.read(&mut buf) {
+            if n == 0 {
+                break;
+            }
+            sink.lock().unwrap().extend_from_slice(&buf[..n]);
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        match child.try_wait().unwrap() {
+            Some(st) => break st,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!(
+                    "--dry-run never returned on a terminal — it entered the live \
+                     Workroom, which waits for a run that will never dispatch. \
+                     Output so far:\n{}",
+                    String::from_utf8_lossy(&seen.lock().unwrap())
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    };
+    // Let the drain thread pick up whatever was still in the pty buffer.
+    std::thread::sleep(Duration::from_millis(100));
+    let out = String::from_utf8_lossy(&seen.lock().unwrap()).into_owned();
+
+    assert!(status.success(), "--dry-run on a terminal failed:\n{out}");
+    assert!(
+        out.contains("[dry-run] pattern 'ring'"),
+        "expected the plain preview on a terminal, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\u{1b}[?1049h"),
+        "--dry-run entered the alternate screen (the live Workroom):\n{out}"
+    );
+}

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -81,12 +81,22 @@ impl Sandbox {
     }
 
     fn run(&self, args: &[&str]) -> Output {
+        self.run_env(args, &[])
+    }
+
+    /// [`Sandbox::run`] plus extra environment variables — an API key, for a
+    /// test whose agent is on an HTTP provider (`create_provider` builds it
+    /// even on the preview, and refuses without one).
+    fn run_env(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
         let mut cmd = Command::cargo_bin("armadai").unwrap();
         cmd.current_dir(&self.root)
             .env("ARMADAI_CONFIG_DIR", &self.config)
             .env("XDG_DATA_HOME", &self.data)
             .env("NO_COLOR", "1")
             .args(args);
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
         Output(cmd.output().unwrap())
     }
 }
@@ -473,4 +483,125 @@ fn a_resume_dry_run_lists_the_roster_in_run_order_not_sorted() {
         at("zeta") < at("mid") && at("mid") < at("alpha"),
         "roster previewed sorted instead of in the order the run recorded:\n{err}"
     );
+}
+
+// ── What the preview says the run would use (#398 review, F2/F3) ─────
+
+/// The preview line for a link, e.g. `1/2 alpha — provider=…, model=…`.
+fn preview_line(out: &Output, name: &str) -> String {
+    out.stderr()
+        .lines()
+        .find(|l| l.contains(&format!(" {name} — ")))
+        .unwrap_or_else(|| panic!("no preview line for {name}:\n{}", out.stderr()))
+        .to_string()
+}
+
+/// Just the `model=…` half of a preview line. The provider half can legally
+/// contain a vendor's name (`provider: claude`), so a naive substring check
+/// over the whole line would answer about the wrong column.
+fn previewed_model(out: &Output, name: &str) -> String {
+    let line = preview_line(out, name);
+    let at = line
+        .find("model=")
+        .unwrap_or_else(|| panic!("no model column in: {line}"));
+    line[at + "model=".len()..].to_string()
+}
+
+/// A CLI-relayed agent's declared model is never sent: `CliProvider` spawns
+/// the command and reads `request.model` nowhere, reporting the command name
+/// back instead. The preview used to resolve the placeholder anyway and
+/// announce an Anthropic id — the most misleading possible answer to "which
+/// model will I pay for", on ArmadAI's own reference configuration.
+///
+/// The real run is executed straight after, so the two are compared rather
+/// than the preview being asserted against a hardcoded expectation. It is a
+/// `--pipe` run because `run_single_agent`'s `[name] model=…` summary is the
+/// only place ArmadAI prints the model a run actually used, and `--pipe` is
+/// the only path that reaches it.
+#[test]
+fn the_preview_does_not_name_a_model_a_cli_relay_would_ignore() {
+    // `provider: claude` + `command: echo`: a unified tool name whose CLI is
+    // present, so `create_provider` builds a relay — while the metadata
+    // still names a vendor, so the model column has something concrete to
+    // get wrong. This is the residual case: for `provider: cli` the tier no
+    // longer resolves at all (no vendor is named), but a unified name does
+    // name one, and the run still never sends it.
+    let sb = Sandbox::new(&[
+        (
+            "alpha",
+            "- provider: claude\n- command: echo\n- model: latest:pro\n",
+        ),
+        ("beta", ECHO),
+    ]);
+
+    let dry = sb.run(&["run", "alpha", "hello", "--pipe", "beta", "--dry-run"]);
+    assert!(dry.succeeded(), "dry-run failed: {}", dry.stderr());
+    let previewed = previewed_model(&dry, "alpha");
+    assert!(
+        !previewed.contains("claude-"),
+        "the preview named a model the CLI relay never sends: model={previewed}"
+    );
+    assert!(
+        previewed.contains("echo"),
+        "the preview should name the relay that actually chooses: model={previewed}"
+    );
+
+    let real = sb.run(&["run", "alpha", "hello", "--pipe", "beta"]);
+    assert!(real.succeeded(), "run failed: {}", real.stderr());
+    assert!(
+        real.stderr().contains("model=echo"),
+        "expected the relay to report its own command as the model:\n{}",
+        real.stderr()
+    );
+}
+
+/// An API-backed agent still gets its resolved id — the guard above must not
+/// have turned the model column into a blanket "unknown".
+#[cfg(feature = "providers-api")]
+#[test]
+fn the_preview_names_the_resolved_model_for_an_api_agent() {
+    let sb = Sandbox::new(&[("alpha", "- provider: anthropic\n- model: latest:pro\n")]);
+
+    let dry = sb.run_env(
+        &["run", "alpha", "hello", "--dry-run"],
+        &[("ANTHROPIC_API_KEY", "sk-not-a-real-key")],
+    );
+    assert!(dry.succeeded(), "dry-run failed: {}", dry.stderr());
+    assert_nothing_ran(&dry);
+    let previewed = previewed_model(&dry, "alpha");
+    assert!(
+        previewed.starts_with("claude-") && !previewed.contains("latest:pro"),
+        "expected the resolved Anthropic id, got: model={previewed}"
+    );
+}
+
+/// `--dry-run`'s help promises "agents, providers and models … on every
+/// path". The orchestrated preview printed the roster and nothing else, so
+/// two of those words were false on two paths out of four (#398 review, F3).
+#[test]
+fn an_orchestrated_preview_names_each_agents_provider_and_model() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+
+    let dry = sb.run(&[
+        "run",
+        "alpha",
+        "hello",
+        "--pipe",
+        "beta",
+        "--orchestrate",
+        "ring",
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(dry.succeeded(), "dry-run failed: {}", dry.stderr());
+    assert_nothing_ran(&dry);
+
+    for name in ["alpha", "beta"] {
+        let line = preview_line(&dry, name);
+        assert!(
+            line.contains("provider=cli") && line.contains("model="),
+            "orchestrated preview should name provider and model for {name}: {line}"
+        );
+    }
 }

--- a/crates/armadai/tests/run_latest_tier_models.rs
+++ b/crates/armadai/tests/run_latest_tier_models.rs
@@ -48,6 +48,14 @@ struct FakeApi {
 
 impl FakeApi {
     fn start() -> Self {
+        Self::rejecting(&[])
+    }
+
+    /// Same server, except every request naming a model in `rejected` is
+    /// answered with the 404 an API returns for a model it does not serve —
+    /// the trigger for the `model_fallback` retry path.
+    fn rejecting(rejected: &[&str]) -> Self {
+        let rejected: Vec<String> = rejected.iter().map(|s| (*s).to_string()).collect();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let models: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -86,15 +94,30 @@ impl FakeApi {
                     .unwrap_or_else(|| "<unparseable>".to_string());
                 sink.lock().unwrap().push(model.clone());
 
-                let payload = serde_json::json!({
-                    "content": [{"type": "text", "text": "ok"}],
-                    "model": model,
-                    "usage": {"input_tokens": 1, "output_tokens": 1},
-                })
-                .to_string();
+                let (status, payload) = if rejected.contains(&model) {
+                    (
+                        "404 Not Found",
+                        serde_json::json!({
+                            "type": "error",
+                            "error": {"type": "not_found_error",
+                                      "message": format!("model: {model} not found")},
+                        })
+                        .to_string(),
+                    )
+                } else {
+                    (
+                        "200 OK",
+                        serde_json::json!({
+                            "content": [{"type": "text", "text": "ok"}],
+                            "model": model,
+                            "usage": {"input_tokens": 1, "output_tokens": 1},
+                        })
+                        .to_string(),
+                    )
+                };
                 let _ = write!(
                     stream,
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\
                      Content-Length: {}\r\nConnection: close\r\n\r\n{payload}",
                     payload.len()
                 );
@@ -170,18 +193,122 @@ impl Sandbox {
             .args(args);
         cmd.output().unwrap()
     }
+
+    /// Same, pointed at a Gemini-shaped server instead, and with a PATH that
+    /// holds no `gemini` binary — so `provider: gemini` takes the API
+    /// fallback (`create_unified_provider`) rather than relaying a CLI that
+    /// would ignore the model entirely. `/usr/bin:/bin` still carries
+    /// `which`, which is what the availability probe shells out to.
+    fn run_gemini(&self, api: &FakeGoogleApi, args: &[&str]) -> std::process::Output {
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&self.root)
+            .env("ARMADAI_CONFIG_DIR", &self.config)
+            .env("XDG_DATA_HOME", &self.data)
+            .env("PATH", "/usr/bin:/bin")
+            .env("GOOGLE_BASE_URL", api.base_url())
+            .env("GOOGLE_API_KEY", "not-a-real-key")
+            .env("NO_COLOR", "1")
+            .args(args);
+        cmd.output().unwrap()
+    }
+}
+
+// ── Scripted Gemini-shaped server ────────────────────────────────────
+
+/// Google names the model in the **URL**
+/// (`/v1beta/models/<model>:generateContent`), not the body — which is how
+/// the F1 defect was legible at a glance: a Claude id in a Google path.
+struct FakeGoogleApi {
+    port: u16,
+    paths: Arc<Mutex<Vec<String>>>,
+}
+
+impl FakeGoogleApi {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let paths: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&paths);
+
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+                    continue;
+                }
+                let mut len = 0usize;
+                loop {
+                    let mut line = String::new();
+                    if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                        break;
+                    }
+                    if line == "\r\n" || line == "\n" {
+                        break;
+                    }
+                    if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                        len = v.trim().parse().unwrap_or(0);
+                    }
+                }
+                let mut body = vec![0u8; len];
+                if reader.read_exact(&mut body).is_err() {
+                    continue;
+                }
+                let path = request_line
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or("<no path>")
+                    .to_string();
+                sink.lock().unwrap().push(path);
+
+                let payload = serde_json::json!({
+                    "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
+                    "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1},
+                })
+                .to_string();
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+                    payload.len()
+                );
+                let _ = stream.flush();
+            }
+        });
+
+        Self { port, paths }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}/v1beta", self.port)
+    }
+
+    /// Every request path the binary asked for, in request order.
+    fn paths_seen(&self) -> Vec<String> {
+        self.paths.lock().unwrap().clone()
+    }
 }
 
 /// An agent on the HTTP Anthropic provider — the path that takes the model
 /// string literally.
 fn write_api_agent(root: &Path, name: &str, model: &str) {
+    write_agent(
+        root,
+        name,
+        &format!("- provider: anthropic\n- model: {model}\n"),
+    );
+}
+
+/// An agent with arbitrary `## Metadata` lines.
+fn write_agent(root: &Path, name: &str, metadata: &str) {
     std::fs::write(
         root.join("agents").join(format!("{name}.md")),
         format!(
             "# {name}\n\n\
              ## Metadata\n\
-             - provider: anthropic\n\
-             - model: {model}\n\n\
+             {metadata}\n\
              ## System Prompt\n\
              You are {name}.\n"
         ),
@@ -324,4 +451,123 @@ fn a_resumed_run_resolves_the_reloaded_rosters_tier() {
     let seen = api.models_seen();
     assert_no_placeholder_reached_the_wire(&seen);
     assert_eq!(seen, vec![expected(ModelTier::Max)]);
+}
+
+// ── The vendor a tier resolves against (#398 review, F1) ─────────────
+
+/// An agent's `provider:` is a *tool* name; the model catalog is keyed by
+/// *vendor*. Handing the tool name to the catalog missed it and fell through
+/// to a table whose catch-all answers with Anthropic, so this exact fixture
+/// — `provider: gemini`, `model: latest:pro`, no `gemini` binary on PATH —
+/// sent `POST /v1beta/models/claude-sonnet-4-5-20250929:generateContent` to
+/// Google.
+///
+/// The assertion is on the URL because that is where the answer is
+/// unambiguous: a Claude id inside a `generativelanguage` path cannot be
+/// read as anything but the wrong vendor.
+#[test]
+fn a_tools_tier_resolves_against_its_own_vendor_not_anthropic() {
+    let api = FakeGoogleApi::start();
+    let sb = Sandbox::new(&[("alpha", "unused")]);
+    write_agent(
+        &sb.root,
+        "alpha",
+        "- provider: gemini\n- model: latest:pro\n",
+    );
+
+    let out = sb.run_gemini(&api, &["run", "alpha", "hello", "--json"]);
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let seen = api.paths_seen();
+    assert!(
+        !seen.is_empty(),
+        "the binary never called the provider — the test proves nothing"
+    );
+    let want = fallback_model_for_tier("google", ModelTier::Pro);
+    for path in &seen {
+        assert!(
+            path.contains(want),
+            "expected the Google catalog's Pro model ({want}) in the request path, got: {seen:?}"
+        );
+        assert!(
+            !path.contains("claude"),
+            "an Anthropic model id reached a Google endpoint: {seen:?}"
+        );
+    }
+}
+
+/// `latest:auto` had the same defect one line above the one #376 fixed: the
+/// router names a tier, and the tier was resolved against the raw tool name
+/// too. Measured before the fix, this fixture sent
+/// `.../models/claude-haiku-4-5-20251001:generateContent` to Google.
+#[test]
+fn a_routed_tier_resolves_against_its_own_vendor_too() {
+    let api = FakeGoogleApi::start();
+    let sb = Sandbox::new(&[("alpha", "unused")]);
+    write_agent(
+        &sb.root,
+        "alpha",
+        "- provider: gemini\n- model: latest:auto\n",
+    );
+
+    let out = sb.run_gemini(&api, &["run", "alpha", "hello", "--json"]);
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let seen = api.paths_seen();
+    assert!(
+        !seen.is_empty(),
+        "the binary never called the provider — the test proves nothing"
+    );
+    for path in &seen {
+        assert!(
+            path.contains("gemini-"),
+            "expected a Google model id in the request path, got: {seen:?}"
+        );
+        assert!(
+            !path.contains("claude"),
+            "an Anthropic model id reached a Google endpoint: {seen:?}"
+        );
+    }
+}
+
+// ── model_fallback entries get the same resolution (#398 review, F4) ──
+
+/// A `model_fallback:` entry is a model string like any other, so the retry
+/// that uses it resolves its tier too. Nothing covered this: deleting the
+/// resolution at that site left the whole suite green.
+///
+/// The server rejects the primary model with the 404 an API returns for a
+/// model it does not serve, which is what arms the fallback loop; the
+/// fallback is a placeholder, and the assertion is that the *second* request
+/// named a concrete id and not `latest:fast`.
+#[test]
+fn a_model_fallback_entry_resolves_its_tier_before_the_retry() {
+    let api = FakeApi::rejecting(&["definitely-not-a-model"]);
+    let sb = Sandbox::new(&[("alpha", "unused")]);
+    write_agent(
+        &sb.root,
+        "alpha",
+        "- provider: anthropic\n\
+         - model: definitely-not-a-model\n\
+         - model_fallback: [latest:fast]\n",
+    );
+
+    let out = sb.run(
+        &api,
+        &["run", "alpha", "hello", "--pipe", "alpha", "--json"],
+    );
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let seen = api.models_seen();
+    assert_no_placeholder_reached_the_wire(&seen);
+    assert_eq!(
+        seen,
+        vec![
+            "definitely-not-a-model".to_string(),
+            expected(ModelTier::Fast),
+            "definitely-not-a-model".to_string(),
+            expected(ModelTier::Fast),
+        ],
+        "each link should try its declared model, then its resolved fallback"
+    );
 }

--- a/crates/armadai/tests/run_latest_tier_models.rs
+++ b/crates/armadai/tests/run_latest_tier_models.rs
@@ -1,0 +1,327 @@
+//! Black-box regressions for the static tier placeholders (`latest`,
+//! `latest:fast`, `latest:pro`, `latest:max`) on the `armadai run` path
+//! (#376).
+//!
+//! Only `latest:auto` used to be resolved. The other four went to the
+//! provider **verbatim, as a model name** — a 400 "model not found" against
+//! a real API, or silently wrong routing on a permissive gateway — while
+//! `armadai link` resolved them correctly, so the same string appeared to
+//! work on one command and not the other.
+//!
+//! These are wire-level tests on purpose. The defect is not observable from
+//! any of ArmadAI's own output: `agent_start` reports the agent's *declared*
+//! model (`latest:pro`, by design, exactly as it does for `latest:auto`),
+//! and the CLI provider ignores `request.model` entirely. The only place the
+//! bug exists is in the bytes sent to the server, so the test reads the
+//! bytes: a scripted HTTP server on `127.0.0.1:0` records the `model` field
+//! of every request body the real `armadai` binary sends it, with
+//! `ANTHROPIC_BASE_URL` pointed at it. No key, no network, no fake-provider
+//! feature.
+//!
+//! Spawning the real binary is also what makes these *wiring* tests: the fix
+//! spans one CLI loop (`--pipe`) and four event-sourced effect runners, each
+//! with its own roster construction. A unit test per runner (there is one,
+//! next to each runner) cannot show that every CLI entry point actually
+//! reaches the fixed code.
+
+#![cfg(feature = "providers-api")]
+
+use armadai_core::model_resolution::{ModelTier, fallback_model_for_tier};
+use assert_cmd::Command;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+// ── Scripted Anthropic-shaped server ─────────────────────────────────
+
+/// A minimal HTTP/1.1 server that answers every `POST /v1/messages` with a
+/// well-formed Anthropic completion and records the `model` field of the
+/// request body.
+///
+/// The response echoes the model it was asked for, so a failure message
+/// shows what the binary actually sent rather than just that it differed.
+struct FakeApi {
+    port: u16,
+    models: Arc<Mutex<Vec<String>>>,
+}
+
+impl FakeApi {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let models: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&models);
+
+        // Detached: the test process owns the whole listener's lifetime and
+        // exits when the test binary does. Each connection is served inline
+        // (the client is a single sequential run), then closed.
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+                // Headers, then exactly `Content-Length` body bytes.
+                let mut len = 0usize;
+                loop {
+                    let mut line = String::new();
+                    if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                        break;
+                    }
+                    if line == "\r\n" || line == "\n" {
+                        break;
+                    }
+                    if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                        len = v.trim().parse().unwrap_or(0);
+                    }
+                }
+                let mut body = vec![0u8; len];
+                if reader.read_exact(&mut body).is_err() {
+                    continue;
+                }
+
+                let model = serde_json::from_slice::<serde_json::Value>(&body)
+                    .ok()
+                    .and_then(|v| v["model"].as_str().map(str::to_string))
+                    .unwrap_or_else(|| "<unparseable>".to_string());
+                sink.lock().unwrap().push(model.clone());
+
+                let payload = serde_json::json!({
+                    "content": [{"type": "text", "text": "ok"}],
+                    "model": model,
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                })
+                .to_string();
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+                    payload.len()
+                );
+                let _ = stream.flush();
+            }
+        });
+
+        Self { port, models }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}/v1", self.port)
+    }
+
+    /// Every model string the binary asked for, in request order.
+    fn models_seen(&self) -> Vec<String> {
+        self.models.lock().unwrap().clone()
+    }
+}
+
+// ── Project fixture ──────────────────────────────────────────────────
+
+/// A sandbox holding the project, an isolated `ARMADAI_CONFIG_DIR` and an
+/// isolated `XDG_DATA_HOME`.
+///
+/// Both redirections matter: without the config dir the agent-shadowing
+/// check scans the developer's real global library **and**
+/// `resolve_model_for_tier` reads their real `models-cache.json` (making the
+/// expected model machine-dependent); without the data dir `record_run`
+/// writes this test's runs into the developer's real SQLite database (#267).
+struct Sandbox {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+    config: PathBuf,
+    data: PathBuf,
+}
+
+impl Sandbox {
+    fn new(agents: &[(&str, &str)]) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+
+        let list: String = agents
+            .iter()
+            .map(|(name, _)| format!("  - name: {name}\n"))
+            .collect();
+        std::fs::write(root.join("armadai.yaml"), format!("agents:\n{list}")).unwrap();
+        for (name, model) in agents {
+            write_api_agent(&root, name, model);
+        }
+
+        let config = dir.path().join("config");
+        let data = dir.path().join("data");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        Self {
+            _dir: dir,
+            root,
+            config,
+            data,
+        }
+    }
+
+    fn run(&self, api: &FakeApi, args: &[&str]) -> std::process::Output {
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&self.root)
+            .env("ARMADAI_CONFIG_DIR", &self.config)
+            .env("XDG_DATA_HOME", &self.data)
+            .env("ANTHROPIC_BASE_URL", api.base_url())
+            .env("ANTHROPIC_API_KEY", "sk-not-a-real-key")
+            .env("NO_COLOR", "1")
+            .args(args);
+        cmd.output().unwrap()
+    }
+}
+
+/// An agent on the HTTP Anthropic provider — the path that takes the model
+/// string literally.
+fn write_api_agent(root: &Path, name: &str, model: &str) {
+    std::fs::write(
+        root.join("agents").join(format!("{name}.md")),
+        format!(
+            "# {name}\n\n\
+             ## Metadata\n\
+             - provider: anthropic\n\
+             - model: {model}\n\n\
+             ## System Prompt\n\
+             You are {name}.\n"
+        ),
+    )
+    .unwrap();
+}
+
+/// The concrete id a tier resolves to with an empty models cache — which is
+/// what the isolated `ARMADAI_CONFIG_DIR` guarantees. Derived from the same
+/// table the production code falls back to, rather than hardcoded here, so
+/// bumping a default model does not turn this into a red test about nothing.
+fn expected(tier: ModelTier) -> String {
+    fallback_model_for_tier("anthropic", tier).to_string()
+}
+
+fn assert_no_placeholder_reached_the_wire(seen: &[String]) {
+    assert!(
+        !seen.is_empty(),
+        "the binary never called the provider — the test proves nothing"
+    );
+    for m in seen {
+        assert!(
+            !m.contains("latest"),
+            "a `latest:*` placeholder reached the provider as a model name: {seen:?}"
+        );
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+/// Single agent — the `direct` event-sourced runner.
+#[test]
+fn single_agent_resolves_a_static_tier_placeholder_before_calling_the_provider() {
+    let api = FakeApi::start();
+    let sb = Sandbox::new(&[("alpha", "latest:pro")]);
+
+    let out = sb.run(&api, &["run", "alpha", "hello", "--json"]);
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let seen = api.models_seen();
+    assert_no_placeholder_reached_the_wire(&seen);
+    assert_eq!(seen, vec![expected(ModelTier::Pro)]);
+}
+
+/// `--pipe` — the sequential loop, the one path that is not event-sourced.
+/// Two links on two different tiers, so a fix that resolved a single shared
+/// model for the whole chain would show up here.
+#[test]
+fn a_pipe_chain_resolves_each_links_own_tier() {
+    let api = FakeApi::start();
+    let sb = Sandbox::new(&[("alpha", "latest:pro"), ("beta", "latest:fast")]);
+
+    let out = sb.run(&api, &["run", "alpha", "hello", "--pipe", "beta", "--json"]);
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let seen = api.models_seen();
+    assert_no_placeholder_reached_the_wire(&seen);
+    assert_eq!(
+        seen,
+        vec![expected(ModelTier::Pro), expected(ModelTier::Fast)]
+    );
+}
+
+/// `--orchestrate` — the orchestrated roster (built by `run_orchestrated`,
+/// dispatched through the `ring` effect runner). `ring` circulates then
+/// votes, so each agent is called several times; the assertion is on the
+/// distinct set, not the count.
+#[test]
+fn an_orchestrated_roster_resolves_every_members_tier() {
+    let api = FakeApi::start();
+    let sb = Sandbox::new(&[("alpha", "latest:pro"), ("beta", "latest:max")]);
+
+    let out = sb.run(
+        &api,
+        &[
+            "run",
+            "alpha",
+            "hello",
+            "--pipe",
+            "beta",
+            "--orchestrate",
+            "ring",
+            "--json",
+        ],
+    );
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let seen = api.models_seen();
+    assert_no_placeholder_reached_the_wire(&seen);
+    let mut distinct: Vec<String> = seen.clone();
+    distinct.sort();
+    distinct.dedup();
+    let mut want = vec![expected(ModelTier::Pro), expected(ModelTier::Max)];
+    want.sort();
+    assert_eq!(distinct, want);
+}
+
+/// `--resume` rebuilds its own roster from the project on disk, so it is a
+/// third construction site and needs its own proof.
+///
+/// The resumable run is created the cheap way: an agent whose `command:`
+/// does not exist makes the `direct` effect runner propagate the error, and
+/// the process dies leaving the log in `Running`. The agent is then rewritten
+/// onto the API provider with a tier placeholder, which is what `--resume`
+/// reloads.
+#[cfg(feature = "storage")]
+#[test]
+fn a_resumed_run_resolves_the_reloaded_rosters_tier() {
+    let api = FakeApi::start();
+    let sb = Sandbox::new(&[("alpha", "latest:pro")]);
+
+    std::fs::write(
+        sb.root.join("agents/alpha.md"),
+        "# alpha\n\n## Metadata\n- provider: cli\n- command: /nonexistent-armadai-command\n\n\
+         ## System Prompt\nYou are alpha.\n",
+    )
+    .unwrap();
+
+    let out = sb.run(&api, &["run", "alpha", "hello", "--json"]);
+    assert!(
+        !out.status.success(),
+        "the setup run was supposed to fail, leaving a resumable run: {out:?}"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let run_id = stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["t"] == "run_start")
+        .and_then(|v| v["run_id"].as_str().map(str::to_string))
+        .expect("no run_start event to take a run id from");
+    assert!(
+        api.models_seen().is_empty(),
+        "the setup run must not have reached the API at all"
+    );
+
+    write_api_agent(&sb.root, "alpha", "latest:max");
+    let out = sb.run(&api, &["run", "--resume", &run_id, "--json", "--no-tui"]);
+    assert!(out.status.success(), "resume failed: {out:?}");
+
+    let seen = api.models_seen();
+    assert_no_placeholder_reached_the_wire(&seen);
+    assert_eq!(seen, vec![expected(ModelTier::Max)]);
+}

--- a/crates/armadai/tests/run_latest_tier_models.rs
+++ b/crates/armadai/tests/run_latest_tier_models.rs
@@ -9,14 +9,21 @@
 //! work on one command and not the other.
 //!
 //! These are wire-level tests on purpose. The defect is not observable from
-//! any of ArmadAI's own output: `agent_start` reports the agent's *declared*
-//! model (`latest:pro`, by design, exactly as it does for `latest:auto`),
-//! and the CLI provider ignores `request.model` entirely. The only place the
-//! bug exists is in the bytes sent to the server, so the test reads the
-//! bytes: a scripted HTTP server on `127.0.0.1:0` records the `model` field
-//! of every request body the real `armadai` binary sends it, with
-//! `ANTHROPIC_BASE_URL` pointed at it. No key, no network, no fake-provider
-//! feature.
+//! any of ArmadAI's own output, and that is a measurement rather than a
+//! design claim: `agent_start` reports the agent's *declared* model
+//! (`latest:pro`), and for a static tier there is no `Route`/`ModelRouted`
+//! event carrying the resolved one either — unlike `latest:auto`, whose
+//! resolved tier the stream does carry. The stderr summary that does print a
+//! concrete id (`[name] model=…`) lives only in `run_single_agent`, i.e. on
+//! `--pipe` and nowhere else. So on three of the four run paths nothing
+//! ArmadAI emits names the model that was billed (see `es::bridge`'s
+//! `execution_event_to_run_events` doc for the open gap).
+//!
+//! The only place the bug exists is therefore in the bytes sent to the
+//! server, so the test reads the bytes: a scripted HTTP server on
+//! `127.0.0.1:0` records the `model` field of every request body the real
+//! `armadai` binary sends it, with `ANTHROPIC_BASE_URL` pointed at it. No
+//! key, no network, no fake-provider feature.
 //!
 //! Spawning the real binary is also what makes these *wiring* tests: the fix
 //! spans one CLI loop (`--pipe`) and four event-sourced effect runners, each
@@ -570,4 +577,43 @@ fn a_model_fallback_entry_resolves_its_tier_before_the_retry() {
         ],
         "each link should try its declared model, then its resolved fallback"
     );
+}
+
+// ── Which placeholder is routed per call (#398 review, F5) ───────────
+
+/// `run_single_agent`'s guard is `raw_model == "latest:auto"`, exactly: a
+/// static tier is resolved from the string alone and must NOT be handed to
+/// the router.
+///
+/// This replaces a unit test that compared two string literals to each other
+/// (`assert_ne!("latest:pro", "latest:auto")`) — true at compile time, and
+/// exercising no line of production code. It had also become half wrong:
+/// `latest:pro` *is* resolved now, just not routed.
+///
+/// The observable difference is the `route` event, so that is what is
+/// asserted — together with both models reaching the wire concrete, so a
+/// guard widened to `starts_with("latest")` cannot pass by resolving
+/// everything through the router instead.
+#[test]
+fn only_latest_auto_is_routed_per_call() {
+    let api = FakeApi::start();
+    let sb = Sandbox::new(&[("alpha", "latest:pro"), ("beta", "latest:auto")]);
+
+    let out = sb.run(&api, &["run", "alpha", "hello", "--pipe", "beta", "--json"]);
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let routed: Vec<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(|v| v["t"] == "route")
+        .map(|v| v["agent"].as_str().unwrap_or("").to_string())
+        .collect();
+    assert_eq!(
+        routed,
+        vec!["beta".to_string()],
+        "only the `latest:auto` link should be routed per call; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    assert_no_placeholder_reached_the_wire(&api.models_seen());
 }

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -209,6 +209,25 @@ What stays where it was is *running*. A link that resolves and builds fine and t
 its call still fails part-way through the chain, and the earlier links' calls are already spent —
 that is inherent to running them.
 
+`--dry-run` stops right after this pass. It prints the links in execution order with the provider
+and the model each would use, and calls nothing:
+
+```
+[dry-run] sequential chain (3 agent(s)): reader, summariser, reviewer
+[dry-run]   1/3 reader — provider=cli, model=(none declared)
+[dry-run]   2/3 summariser — provider=anthropic, model=claude-sonnet-4-5-20250929
+[dry-run]   3/3 reviewer — provider=anthropic, model=latest:auto (tier chosen per call)
+[dry-run] no provider was called; nothing was recorded or billed
+```
+
+Because it is the same pass, the preview **refuses whatever the real run refuses**, with the same
+message and the same non-zero exit — an unresolvable link, a colliding name, a provider that
+cannot be built. A preview that cannot fail would pre-check nothing. This holds for a single agent
+(`armadai run <name> --dry-run`) and for `--resume` too, which previews the roster it reloaded and
+leaves the run resumable. `latest:auto` is the one thing a dry run cannot resolve: its tier is
+chosen from each link's own input, and for every link but the first that input is the previous
+link's output — precisely what a dry run declines to compute.
+
 ## Long compositions still get audited
 
 Composing several fragments is easy to do without noticing how long the result got. `armadai

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -214,17 +214,23 @@ and the model each would use, and calls nothing:
 
 ```
 [dry-run] sequential chain (3 agent(s)): reader, summariser, reviewer
-[dry-run]   1/3 reader — provider=cli, model=(none declared)
+[dry-run]   1/3 reader — provider=cli, model=(not sent — cli:jq chooses)
 [dry-run]   2/3 summariser — provider=anthropic, model=claude-sonnet-4-5-20250929
 [dry-run]   3/3 reviewer — provider=anthropic, model=latest:auto (tier chosen per call)
 [dry-run] no provider was called; nothing was recorded or billed
 ```
 
+The model column is the string the run would really send, not the one written in the agent
+file: deprecated aliases and tier placeholders are already resolved. An agent relayed by a
+command-line tool is the exception — the relay never receives `model`, it picks its own — so the
+preview says so rather than naming an id that would never be asked for.
+
 Because it is the same pass, the preview **refuses whatever the real run refuses**, with the same
 message and the same non-zero exit — an unresolvable link, a colliding name, a provider that
 cannot be built. A preview that cannot fail would pre-check nothing. This holds for a single agent
-(`armadai run <name> --dry-run`) and for `--resume` too, which previews the roster it reloaded and
-leaves the run resumable. `latest:auto` is the one thing a dry run cannot resolve: its tier is
+(`armadai run <name> --dry-run`), for `--orchestrate` (which previews provider and model per
+roster member, then says plainly that who speaks when is the engine's to decide), and for
+`--resume` too, which previews the roster it reloaded and leaves the run resumable. `latest:auto` is the one thing a dry run cannot resolve: its tier is
 chosen from each link's own input, and for every link but the first that input is the previous
 link's output — precisely what a dry run declines to compute.
 

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -100,16 +100,23 @@ When using `armadai new -i` (interactive wizard), the model selection step fetch
 
 Direct HTTP calls to LLM APIs. Use these when you want explicit API control.
 
-> **Write a concrete model id for an API provider.** The tier placeholders
-> `latest:fast` / `latest:pro` / `latest:max` are resolved when ArmadAI
-> *generates a native CLI config* (`armadai link`) and by `armadai shell` — not
-> on the `armadai run` path, where only `latest:auto` is resolved (by the
-> router). A literal `latest:pro` on `provider: anthropic|openai|google|proxy`
-> — or on a unified name (`claude`, `gpt`, …) that has fallen back to the API
-> because its CLI is not installed — is sent to the server verbatim as the
-> model name, and the server rejects it. Measured on the current code, not a
-> hypothetical. Keeping `latest:pro` in an agent you link into a native CLI
-> config is fine and intended; it is the API path that takes it literally.
+> **Tier placeholders work on every path.** `latest` / `latest:fast` /
+> `latest:pro` / `latest:max` are resolved to a concrete model id everywhere
+> a model is needed: when ArmadAI *generates a native CLI config*
+> (`armadai link`), in `armadai shell`, and on the `armadai run` path — for a
+> single agent, for a `--pipe` chain, for `--orchestrate`, and for `--resume`
+> alike. The resolution uses the agent's own provider and the cached
+> [models.dev](https://models.dev) catalog, falling back to a built-in table
+> when the cache is absent, so no `latest:*` string is ever sent to a server
+> as a model name.
+>
+> `latest:auto` is the one placeholder resolved *per call* rather than up
+> front: its tier is chosen from the run's own input by the router
+> (configured under `routing:` in `armadai.yaml`).
+>
+> This was not always true — until #376 the `run` path sent the static tiers
+> verbatim, so a placeholder that worked under `armadai link` produced a
+> "model not found" under `armadai run`.
 
 ### Anthropic
 

--- a/docs/wiki/providers.md
+++ b/docs/wiki/providers.md
@@ -105,10 +105,22 @@ Direct HTTP calls to LLM APIs. Use these when you want explicit API control.
 > a model is needed: when ArmadAI *generates a native CLI config*
 > (`armadai link`), in `armadai shell`, and on the `armadai run` path — for a
 > single agent, for a `--pipe` chain, for `--orchestrate`, and for `--resume`
-> alike. The resolution uses the agent's own provider and the cached
-> [models.dev](https://models.dev) catalog, falling back to a built-in table
-> when the cache is absent, so no `latest:*` string is ever sent to a server
-> as a model name.
+> alike.
+>
+> **Which vendor's catalog is read** comes from the agent's own `provider:`,
+> mapped to the vendor that names its models: `gemini` → Google, `claude` →
+> Anthropic, `gpt`/`aider`/`codex` → OpenAI. The concrete id is then the best
+> match for the tier in the cached [models.dev](https://models.dev) catalog,
+> or a built-in table when the cache is absent. All three commands read the
+> same mapping — until #398 `shell` was the only one that had it, and `run`
+> resolved a `provider: gemini` agent's `latest:pro` to a *Claude* model.
+>
+> A provider with no vendor of its own — `provider: cli`, the CLI-only tools
+> (`copilot`, `opencode`), and `provider: proxy` — keeps the placeholder
+> instead. For a relayed CLI the model is not sent at all (the tool picks its
+> own), and for a gateway the placeholder is the more useful string: an
+> administrator can route `latest:max` through a house alias, which a
+> concrete id chosen here would override with no way to opt out.
 >
 > `latest:auto` is the one placeholder resolved *per call* rather than up
 > front: its tier is chosen from the run's own input by the router


### PR DESCRIPTION
Deux défauts qui vivent dans la même zone de `crates/armadai/src/cli/run.rs`, d'où le regroupement — **un commit par sujet**, chacun autonome. Rebasée sur `master` (#393 et #397 inclus).

Six commits : les deux d'origine (#376, #378), puis la vague issue de la **revue indépendante** — trois bloquants, chacun mesuré avant et après.

## #376 — les alias de palier partaient littéralement au provider

Seul `latest:auto` était résolu sur le chemin `run`. `latest`, `latest:fast`, `latest:pro` et `latest:max` partaient **tels quels comme nom de modèle** vers l'API. Trompeur, parce que `armadai link` les résout : le même alias marchait pour une commande et se faisait rejeter par l'autre.

**Mesuré au binaire réel** contre un serveur HTTP scripté local, avant correctif :

| chemin | modèles reçus par l'API |
|---|---|
| agent seul | `latest:pro` |
| `--pipe alpha,beta` | `latest:pro`, `latest:fast` |
| `--orchestrate ring` | `latest:pro`, `latest:fast` (×4) |
| `--orchestrate blackboard` | `latest:pro`, `latest:fast` |
| hierarchical (via config projet) | `latest:max` |
| `--resume` | `latest:pro` |

La résolution se fait au **dernier verrou avant que la chaîne ne devienne un nom de modèle pour un provider** : les quatre effect runners event-sourcés et `run_single_agent`, la boucle séquentielle de `--pipe`, seul chemin non event-sourcé. **Aucun chemin n'était couvert par un autre** — les six ont été mesurés séparément, et chaque site reste indépendant sous mutation.

## #378 — `--dry-run` exécutait et facturait ce qu'il prétendait prévisualiser

`dry_run` n'était lu qu'à un seul endroit, `run_orchestrated_inner`. Mesuré au binaire réel :

- `run alpha hello --pipe beta,gamma --dry-run --json` → **3 `agent_start`**, 3 `agent_end`, 1 `result`, exit 0. Les trois appels provider ont bien eu lieu.
- `run alpha hello --dry-run --json` (agent seul) → **1 `agent_start`**. Même trou, non signalé dans l'issue.
- `run --resume <id> --dry-run` → **le run reprend pour de vrai**.

Après correctif : **zéro `agent_start`** sur les trois. L'aperçu s'appuie sur la pré-passe de #373/#366, donc il **refuse ce que refuse la passe réelle**, au même message et au même code de sortie (leçon de #348 : un aperçu qui ne peut pas échouer ne pré-contrôle rien).

---

# Vague de correctifs — revue indépendante

## F1 (bloquant) — un modèle Anthropic partait à Google

Un `provider:` d'agent est un nom d'**outil** (`gemini`, `aider`, `claude`) ; le cache models.dev et `fallback_model_for_tier` sont indexés par **vendeur** (`google`, `openai`, `anthropic`). Le nom d'outil était passé brut aux deux : il ratait le cache, puis tombait dans le catch-all de la table, qui répond **Anthropic**.

**Mesuré**, agent `provider: gemini` + `model: latest:pro`, serveur scripté :

```
avant : POST /v1beta/models/claude-sonnet-4-5-20250929:generateContent?key=g-x
après : POST /v1beta/models/gemini-2.5-pro:generateContent?key=g-x
```

`latest:auto` avait **le même défaut** (préexistant, hors #376) : `gemini` + `latest:auto` → `claude-haiku-4-5-20251001` sur l'URL Google. Corrigé dans le même geste, mesuré séparément.

Le remède proposé par la revue (déplacer la table de `shell::config` dans le cœur) est adopté, avec une différence assumée. `model_catalog_provider` renvoie **`Option`**, pas un catch-all :

- vendeur nommé → le palier est résolu (`gemini`→google, `aider|codex|gpt`→openai, `claude`→anthropic) ;
- **pas de vendeur nommé** (`cli`, `proxy`, `copilot`, `opencode`) → `resolve_tier_placeholder` renvoie `None` et l'appelant garde sa chaîne.

C'est ce qui répond au cas passerelle que la revue signalait : un `provider: proxy` recevait `claude-opus-4-6` sans opt-out, il reçoit de nouveau `latest:max` — qu'un administrateur peut router par un alias maison. **Mesuré** : `proxy/latest:max -> MODEL latest:max`. Pour un relais CLI le modèle n'est de toute façon jamais envoyé.

`latest:auto` n'a pas de forme verbatim une fois le routeur passé, d'où `resolve_routed_tier`, qui répond toujours.

`shell::config` perd sa table privée, `linker::resolve_latest_placeholders` cesse de nourrir le catalogue avec un nom d'outil : `run`, `shell` et `link` résolvent le même fichier d'agent de la même façon, et un test épingle la parité.

**Mutations** — table catch-all rétablie → seul `a_provider_with_no_named_vendor_keeps_the_placeholder` rougit ; arms de noms d'outils supprimées → seuls les deux tests filaires `gemini` rougissent (`left: None / right: Some("gemini-2.5-flash")`, puis `claude-haiku-4-5-20251001` dans le chemin Google) ; `resolve_routed_tier` privé du mapping → le test cœur rougit ; `shell` ressuscitant sa table privée → le test de parité rougit (`gpt + latest: shell and run disagree`) ; `link` repassant au nom brut → `A should resolve against google`.

## F2 (bloquant) — l'aperçu annonçait un modèle que le provider ignore

`CliProvider` ne lit `request.model` nulle part : il lance la commande et rapporte le nom de la commande. L'aperçu résolvait quand même le modèle déclaré.

**Mesuré** :

```
avant  APERÇU : 1/2 alpha — provider=claude, model=claude-sonnet-4-5-20250929
       RÉEL   : [alpha] model=echo tokens=0/0 cost=$0.000000
après  APERÇU : 1/2 alpha — provider=claude, model=(not sent — cli:echo chooses)
```

Le joint est `Provider::honors_request_model` (défaut `true`, `false` sur `CliProvider`, délégué par `RateLimitedProvider`). C'est le provider **construit** qui sait : `provider: claude` devient un client API ou un relais selon la présence du binaire sur le `PATH`, donc rien de lisible dans le fichier d'agent ne distingue les deux.

Nuance mesurée : après F1, un `provider: cli` ne résout plus de palier du tout (aucun vendeur nommé), donc le cas résiduel est `provider: <nom unifié>` + `command:` — un nom unifié nomme bien un vendeur, et le run n'envoie toujours rien. C'est la fixture du test.

**Mutation** — garde supprimée → `the_preview_does_not_name_a_model_a_cli_relay_would_ignore` rougit seule (`model=latest:pro` au lieu du relais).

## F3 (bloquant) — l'aide était fausse sur 2 chemins sur 4

`--dry-run` promet « Resolve agents, **providers and models** … Works on **every path** ». `--orchestrate ring --dry-run` et le chemin hierarchical n'affichaient que le roster.

**Tranché : c'est l'aperçu qui se met à niveau, pas l'aide qui recule.** L'aide décrit ce que l'utilisateur a besoin de savoir avant de payer, et `run_orchestrated_inner` a déjà les agents *et* les providers construits en main. L'aperçu orchestré liste maintenant provider et modèle par agent, comme l'aperçu séquentiel, puis dit explicitement que qui parle quand relève du moteur :

```
[dry-run] pattern 'ring' — no routing (full roster) (2 agent(s)): alpha, beta
[dry-run]   alpha — provider=gemini, model=gemini-2.5-pro
[dry-run]   beta — provider=anthropic, model=latest:auto (tier chosen per call)
[dry-run] which agent speaks when, and how often, is decided by the engine as it runs, …
[dry-run] no provider was called; nothing was recorded or billed
```

**Mutation** — boucle par agent supprimée → `an_orchestrated_preview_names_each_agents_provider_and_model` rougit seule (`no preview line for alpha`).

## Points légers

- **F4** — la résolution de palier des `model_fallback` avait **couverture zéro**. Couverte au fil, le serveur scripté rejetant le modèle primaire par un 404 pour que le retry ait lieu. Mutation (résolution supprimée) → `["definitely-not-a-model", "latest:fast", …]` atteint le provider, un seul test rougit.
- **F5** — `latest_auto_is_the_only_routed_value` comparait deux littéraux (`assert_ne!("latest:pro", "latest:auto")`) : vrai à la compilation, zéro ligne de production exercée. Remplacé par un test boîte noire sur l'événement `route`. Mutation (garde élargie à `starts_with("latest")`) → rouge.
- **Garde-fou TUI `&& !dry_run`** — nécessaire et non testé : toute la suite tourne stdout sur un tube, où `IsTerminal` est faux et la Workroom hors d'atteinte quels que soient les flags. Un vrai TTY (`openpty`, sans fork — le fils reçoit simplement le côté esclave comme stdio) le rend observable. **Mutation : le processus ne rend jamais la main** (`test result: FAILED … finished in 30.02s`, un seul test rouge). `libc` rejoint les dev-dependencies pour ce seul appel ; il était déjà dans l'arbre via crossterm.
- **Duplication** — les trois aperçus partageaient une copie mot pour mot de « modèle déclaré → modèle effectif » ; ils partagent maintenant `preview_provider_and_model`. Le booléen du garde-fou TUI, écrit deux fois, devient `use_live_workroom`.
- **La justification de `agent_start.model` était fausse.** `bridge.rs` argumente que la valeur configurée suffit « since the resolved tier is already carried by `Route`/`ModelRouted` » — or **aucun `ModelRouted` n'est émis pour un palier statique**. Mesuré : un agent sur `latest:pro` produit `agent_start{model:"latest:pro"}` et rien d'autre, donc l'id réellement facturé n'apparaît dans **aucun** événement du flux `--json` ; et la ligne stderr qui le nommerait ne vit que dans `run_single_agent`, donc sur `--pipe` seul. Trois chemins sur quatre ne disent rien. La convention est conservée (la changer est une décision de schéma d'événements) mais documentée comme un **manque**, plus comme une conséquence d'un argument qui ne s'applique pas → issue #407.
- `docs/wiki/providers.md` affirmait « The resolution uses the agent's own provider and the cached models.dev catalog » — c'était exactement le mécanisme qui échouait. Réécrit.

## Tests

`crates/armadai/tests/run_latest_tier_models.rs` (7 cas) et `run_dry_run_spends_nothing.rs` (9 cas), tous sur le **binaire réel** : les deux correctifs sont du câblage réparti sur des constructions de roster distinctes. Plus 4 unitaires cœur (un par effect runner), la table de paliers, la parité `shell`/`run`, et `link`.

Les quatre unitaires de palier statique utilisaient un nom de provider volontairement inconnu du cache pour l'hermétisme ; c'est précisément le cas que F1 laisse désormais intact, donc ils nomment un vrai vendeur et vident le cache par `IsolatedConfigDir`. **Ré-mesuré après ce changement** : rétablir le `else` verbatim d'un runner rougit son test et aucun autre, quatre fois de suite.

**Chaque test ajouté ou modifié a été passé en mutation, rouge vérifié, restauré.**

## Gate

`fmt --check` OK · clippy `-D warnings` **5/5 modes** · tests **4/4 modes** (1566 / 1669 / 1612 / 1705 passés, 0 échec) · **gaveldrop 13 cases · 83/83** · `build --release` OK.

Base SQLite réelle **intacte** : md5 identique avant/après (`330e0993c7cd72c21755152406ceb748`, 320 Ko).

## Suivi ouvert, pas traité ici

- #403 — `--dry-run` peut réécrire des fichiers (`projects.json` mesuré ; `apply_findings` sur TTY).
- #404 — la sélection dans le cache est un `max()` alphabétique : `openai` + `latest:fast` → `o4-mini` (mesuré sur cache semé), `google` + Max ≡ Pro.
- #405 — le flux `--json` d'un dry-run n'a pas d'événement terminal (`run_start` puis rien, mesuré sur les deux chemins).
- #406 — cinq copies de la *branche* de résolution (la table est partagée, la branche non).
- #407 — le modèle facturé n'apparaît dans aucun événement sur 3 chemins sur 4.

La revue signalait aussi un `CLAUDE.md` décrivant `proxy.rs` comme un `todo!()`. **Mesuré absent** de `CLAUDE.md` sur `master` : la carte des modules a été retirée par #382 (« rightsize CLAUDE.md — drop the deductible map »), et #386 a livré la règle `R02` qui existe pour attraper ce genre de dérive — son propre doc-comment cite ce cas. Pas d'issue ouverte.

Closes #376
Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)
