### PR TITLE
fix(core): run envoie toutes les sections d'un agent, pas seulement son system prompt

### DIFF
--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -152,7 +152,93 @@ pub struct PipelineConfig {
     pub next: Vec<String>,
 }
 
+/// The optional sections [`compose_agent_prompt`] appends, each with the
+/// heading it is reintroduced under — the declaration order of an agent file.
+///
+/// Kept as one list so "which sections make up a prompt, in which order" is
+/// stated once. Adding a fifth section to [`Agent`] means adding one line
+/// here, and both `run` and `link` gain it in the same gesture.
+const OPTIONAL_SECTION_HEADINGS: [&str; 3] = ["## Instructions", "## Output Format", "## Context"];
+
+/// Compose an agent's declared sections into the single prompt body that IS
+/// "the prompt of an agent".
+///
+/// The parser splits an agent file into `system_prompt` / `instructions` /
+/// `output_format` / `context`, dropping the `##` headings on the way in.
+/// Every consumer that hands an agent to a model has to put them back
+/// together, and until #395 only the linkers did: `run` sent `system_prompt`
+/// alone, so an agent whose output rules lived in `## Output Format` obeyed
+/// them when linked into a native CLI and ignored them when run directly,
+/// with nothing saying so.
+///
+/// This is that single definition. Measured before hoisting it here: the five
+/// linkers (claude/codex/copilot/gemini/opencode) each carried their own copy
+/// of this loop and produced byte-identical bodies for the same agent
+/// (md5 `15461e18a2577665048e85fa3c5667b9` on a four-section fixture) — only
+/// the surrounding wrapper (YAML frontmatter, TOML quoting) differed, which
+/// is why the shareable part is exactly this function and not more.
+///
+/// A section present but empty still contributes its heading: that is what
+/// the linkers did before, and `run`/`link` staying byte-identical matters
+/// more than trimming a stray heading.
+///
+/// No trailing newline is appended — callers that need one normalise
+/// afterwards, as the linkers already do for the file as a whole.
+pub fn compose_agent_prompt(
+    system_prompt: &str,
+    instructions: Option<&str>,
+    output_format: Option<&str>,
+    context: Option<&str>,
+) -> String {
+    let mut out = String::from(system_prompt);
+    for (heading, body) in
+        OPTIONAL_SECTION_HEADINGS
+            .iter()
+            .zip([instructions, output_format, context])
+    {
+        let Some(body) = body else { continue };
+        // Blank line before the heading, exactly as every linker did.
+        if !out.ends_with("\n\n") {
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push('\n');
+        }
+        out.push_str(heading);
+        out.push_str("\n\n");
+        out.push_str(body);
+    }
+    out
+}
+
 impl Agent {
+    /// This agent's four sections composed into the prompt a model receives.
+    ///
+    /// The one entry point every provider-request construction site must use
+    /// — reading `self.system_prompt` directly is what issue #395 was.
+    pub fn composed_prompt(&self) -> String {
+        compose_agent_prompt(
+            &self.system_prompt,
+            self.instructions.as_deref(),
+            self.output_format.as_deref(),
+            self.context.as_deref(),
+        )
+    }
+
+    /// Replace every section with a single, already-composed prompt.
+    ///
+    /// For the callers that must append something *after* the whole prompt
+    /// (`run`'s guided mode) while the composition itself happens further
+    /// down, inside an engine: folding here and clearing the folded sections
+    /// is what keeps the engine from composing them a second time, so
+    /// [`Agent::composed_prompt`] stays idempotent across the hand-off.
+    pub fn set_composed_prompt(&mut self, prompt: String) {
+        self.system_prompt = prompt;
+        self.instructions = None;
+        self.output_format = None;
+        self.context = None;
+    }
+
     /// Load all agents from the given directory (recursively).
     pub fn load_all(agents_dir: &std::path::Path) -> anyhow::Result<Vec<Agent>> {
         let mut agents = Vec::new();
@@ -286,5 +372,85 @@ mod tests {
     fn the_two_arguments_are_not_interchangeable() {
         assert!(name_matches_reference("Dev Lead", "dev-lead"));
         assert!(!name_matches_reference("dev-lead", "Dev Lead"));
+    }
+
+    /// Order and separators, pinned byte for byte.
+    ///
+    /// `run` and `link` now share this function, so a change here moves both
+    /// at once and the wiring tests comparing them (`--test
+    /// run_sends_every_section`) would stay green through it. This is what
+    /// makes reordering the sections, or changing how they are separated, a
+    /// deliberate act rather than a silent one.
+    #[test]
+    fn the_sections_compose_in_declaration_order_with_a_blank_line_between() {
+        let composed = compose_agent_prompt("SYS", Some("INST"), Some("OUT"), Some("CTX"));
+        assert_eq!(
+            composed,
+            "SYS\n\n## Instructions\n\nINST\n\n## Output Format\n\nOUT\n\n## Context\n\nCTX"
+        );
+    }
+
+    /// An absent section contributes nothing — not an empty heading.
+    #[test]
+    fn absent_sections_are_skipped_entirely() {
+        assert_eq!(compose_agent_prompt("SYS", None, None, None), "SYS");
+        assert_eq!(
+            compose_agent_prompt("SYS", None, Some("OUT"), None),
+            "SYS\n\n## Output Format\n\nOUT"
+        );
+    }
+
+    /// A system prompt already ending in a newline must not gain a third one:
+    /// the parser trims sections inconsistently across formats, and `link`
+    /// normalised this before the composition moved here.
+    #[test]
+    fn a_trailing_newline_does_not_double_the_separator() {
+        assert_eq!(
+            compose_agent_prompt("SYS\n", Some("INST"), None, None),
+            "SYS\n\n## Instructions\n\nINST"
+        );
+        assert_eq!(
+            compose_agent_prompt("SYS\n\n", Some("INST"), None, None),
+            "SYS\n\n## Instructions\n\nINST"
+        );
+    }
+
+    /// `set_composed_prompt` must make `composed_prompt` idempotent: it is
+    /// what stops `run`'s guided mode from having its sections composed a
+    /// second time inside the engine.
+    #[test]
+    fn set_composed_prompt_makes_composition_idempotent() {
+        let mut agent = Agent {
+            name: "a".to_string(),
+            source: PathBuf::new(),
+            metadata: AgentMetadata {
+                provider: "cli".to_string(),
+                model: None,
+                command: None,
+                args: None,
+                temperature: default_temperature(),
+                max_tokens: None,
+                timeout: None,
+                tags: Vec::new(),
+                stacks: Vec::new(),
+                scope: Vec::new(),
+                model_fallback: Vec::new(),
+                cost_limit: None,
+                rate_limit: None,
+                context_window: None,
+                mode: None,
+                orchestration: None,
+                triggers: None,
+                ring_config: None,
+            },
+            system_prompt: "SYS".to_string(),
+            instructions: Some("INST".to_string()),
+            output_format: None,
+            pipeline: None,
+            context: None,
+        };
+        let once = agent.composed_prompt();
+        agent.set_composed_prompt(once.clone());
+        assert_eq!(agent.composed_prompt(), once);
     }
 }

--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -152,14 +152,6 @@ pub struct PipelineConfig {
     pub next: Vec<String>,
 }
 
-/// The optional sections [`compose_agent_prompt`] appends, each with the
-/// heading it is reintroduced under — the declaration order of an agent file.
-///
-/// Kept as one list so "which sections make up a prompt, in which order" is
-/// stated once. Adding a fifth section to [`Agent`] means adding one line
-/// here, and both `run` and `link` gain it in the same gesture.
-const OPTIONAL_SECTION_HEADINGS: [&str; 3] = ["## Instructions", "## Output Format", "## Context"];
-
 /// Compose an agent's declared sections into the single prompt body that IS
 /// "the prompt of an agent".
 ///
@@ -178,6 +170,14 @@ const OPTIONAL_SECTION_HEADINGS: [&str; 3] = ["## Instructions", "## Output Form
 /// the surrounding wrapper (YAML frontmatter, TOML quoting) differed, which
 /// is why the shareable part is exactly this function and not more.
 ///
+/// They agreed on every four-section agent, not on every input: an *empty*
+/// `## System Prompt` made codex and copilot open the body with two blank
+/// lines and the other three with none. A single definition has to pick one,
+/// and picks "no leading blank line" — see
+/// `an_empty_system_prompt_does_not_open_the_prompt_with_a_blank_line`. On
+/// the 77-agent library this repository links against, every generated file
+/// is byte-identical to what the per-linker copies produced.
+///
 /// A section present but empty still contributes its heading: that is what
 /// the linkers did before, and `run`/`link` staying byte-identical matters
 /// more than trimming a stray heading.
@@ -191,14 +191,19 @@ pub fn compose_agent_prompt(
     context: Option<&str>,
 ) -> String {
     let mut out = String::from(system_prompt);
-    for (heading, body) in
-        OPTIONAL_SECTION_HEADINGS
-            .iter()
-            .zip([instructions, output_format, context])
-    {
+    // Which sections make up a prompt, and in which order, is stated once —
+    // here. A heading cannot be added without its body: the tuple demands
+    // both, where a second array zipped against a list of headings let one
+    // be added alone and silently dropped.
+    for (heading, body) in [
+        ("## Instructions", instructions),
+        ("## Output Format", output_format),
+        ("## Context", context),
+    ] {
         let Some(body) = body else { continue };
-        // Blank line before the heading, exactly as every linker did.
-        if !out.ends_with("\n\n") {
+        // One blank line before the heading — but never open the prompt with
+        // one, which is where the five linkers disagreed (see above).
+        if !out.is_empty() && !out.ends_with("\n\n") {
             if !out.ends_with('\n') {
                 out.push('\n');
             }
@@ -418,6 +423,10 @@ mod tests {
     /// `set_composed_prompt` must make `composed_prompt` idempotent: it is
     /// what stops `run`'s guided mode from having its sections composed a
     /// second time inside the engine.
+    ///
+    /// The fixture carries all three optional sections deliberately. With
+    /// only `instructions` set it exercised one of the three fields the
+    /// method has to clear, and clearing just that one kept it green.
     #[test]
     fn set_composed_prompt_makes_composition_idempotent() {
         let mut agent = Agent {
@@ -445,12 +454,35 @@ mod tests {
             },
             system_prompt: "SYS".to_string(),
             instructions: Some("INST".to_string()),
-            output_format: None,
+            output_format: Some("OUT".to_string()),
             pipeline: None,
-            context: None,
+            context: Some("CTX".to_string()),
         };
         let once = agent.composed_prompt();
         agent.set_composed_prompt(once.clone());
         assert_eq!(agent.composed_prompt(), once);
+    }
+
+    /// An agent may declare `## System Prompt` and leave its body empty — the
+    /// parser accepts it. The five linkers disagreed on that input: codex and
+    /// copilot opened the composed body with two blank lines, claude, gemini
+    /// and opencode with none. Folding them into one definition forces a
+    /// choice, and this pins it: no leading blank line, because a prompt that
+    /// opens on whitespace spends the model's first tokens on nothing.
+    ///
+    /// Nothing else pins it. No agent in the 77-agent library exercises an
+    /// empty system prompt, so both forms passed the whole suite — which is
+    /// precisely why the chosen one has to be stated here rather than left to
+    /// whichever linker's copy happened to be hoisted.
+    #[test]
+    fn an_empty_system_prompt_does_not_open_the_prompt_with_a_blank_line() {
+        assert_eq!(
+            compose_agent_prompt("", Some("INST"), None, None),
+            "## Instructions\n\nINST"
+        );
+        assert_eq!(
+            compose_agent_prompt("", None, Some("OUT"), Some("CTX")),
+            "## Output Format\n\nOUT\n\n## Context\n\nCTX"
+        );
     }
 }

--- a/crates/armadai-core/src/orchestration/es/blackboard.rs
+++ b/crates/armadai-core/src/orchestration/es/blackboard.rs
@@ -647,7 +647,8 @@ impl EffectRunner for BlackboardEffectRunner {
 
         let request = CompletionRequest {
             model,
-            system_prompt: agent_def.system_prompt.clone(),
+            // Every declared section, not just `## System Prompt` (#395).
+            system_prompt: agent_def.composed_prompt(),
             messages: vec![ChatMessage {
                 role: "user".to_string(),
                 content: prompt,

--- a/crates/armadai-core/src/orchestration/es/direct.rs
+++ b/crates/armadai-core/src/orchestration/es/direct.rs
@@ -226,7 +226,8 @@ impl EffectRunner for DirectEffectRunner {
 
         let request = CompletionRequest {
             model,
-            system_prompt: agent_def.system_prompt.clone(),
+            // Every declared section, not just `## System Prompt` (#395).
+            system_prompt: agent_def.composed_prompt(),
             messages: vec![ChatMessage {
                 role: "user".to_string(),
                 content: input.to_string(),

--- a/crates/armadai-core/src/orchestration/es/hierarchical.rs
+++ b/crates/armadai-core/src/orchestration/es/hierarchical.rs
@@ -1325,22 +1325,26 @@ impl HierarchicalEffectRunner {
             .collect()
     }
 
-    /// Build the enriched system prompt for `agent_name`: its own
-    /// `system_prompt`, plus the orchestration-protocol block from
-    /// `context_injection::build_orchestration_prompt` when one applies
+    /// Build the enriched system prompt for `agent_name`: its whole composed
+    /// prompt (every declared section, per `Agent::composed_prompt` — #395,
+    /// not just `## System Prompt`), plus the orchestration-protocol block
+    /// from `context_injection::build_orchestration_prompt` when one applies
     /// (hierarchical pattern enabled, per `self.config`). Falls back to a
     /// generic default if `agent_name` isn't in `self.agents` — should not
     /// happen once the caller (`run_invoke`) has already resolved the agent,
     /// but keeps this helper total.
+    ///
+    /// The protocol block goes *after* the agent's own sections: it describes
+    /// how to answer, and must be the last word on it.
     fn enriched_system_prompt(&self, agent_name: &str) -> String {
         let base = self
             .agents
             .get(agent_name)
-            .map(|a| a.system_prompt.as_str())
-            .unwrap_or("You are a helpful assistant.");
+            .map(|a| a.composed_prompt())
+            .unwrap_or_else(|| "You are a helpful assistant.".to_string());
         match build_orchestration_prompt(agent_name, &self.config, &self.agents_info()) {
             Some(block) => format!("{base}{block}"),
-            None => base.to_string(),
+            None => base,
         }
     }
 }

--- a/crates/armadai-core/src/orchestration/es/ring.rs
+++ b/crates/armadai-core/src/orchestration/es/ring.rs
@@ -838,7 +838,8 @@ impl EffectRunner for RingEffectRunner {
                 let prompt = self.build_circulate_prompt(input, lap, state);
                 let request = CompletionRequest {
                     model,
-                    system_prompt: agent_def.system_prompt.clone(),
+                    // Every declared section, not just `## System Prompt` (#395).
+                    system_prompt: agent_def.composed_prompt(),
                     messages: vec![ChatMessage {
                         role: "user".to_string(),
                         content: prompt,
@@ -901,7 +902,8 @@ impl EffectRunner for RingEffectRunner {
                 let prompt = self.build_vote_prompt(input, state);
                 let request = CompletionRequest {
                     model,
-                    system_prompt: agent_def.system_prompt.clone(),
+                    // Every declared section, not just `## System Prompt` (#395).
+                    system_prompt: agent_def.composed_prompt(),
                     messages: vec![ChatMessage {
                         role: "user".to_string(),
                         content: prompt,

--- a/crates/armadai/src/audit/reverse/armadai.rs
+++ b/crates/armadai/src/audit/reverse/armadai.rs
@@ -149,21 +149,14 @@ fn imported(path: &Path, agent: &Agent) -> ImportedAgent {
 /// Measured after the fix, on the same 77 agents: the rules read 3.01x more
 /// text (16205 -> 48778 estimated tokens), and `A06` goes from 0 to 2 real
 /// duplication clusters — the number predicted here before the fix landed.
+///
+/// Delegates to `Agent::composed_prompt` (#395): this was a seventh private
+/// copy of that loop — subtly divergent, since it pushed a raw `\n\n` where
+/// the linkers normalise, so a section already ending in a newline gained a
+/// third one here and nowhere else. The audit must read exactly the text a
+/// model gets, which is now one function away rather than a re-derivation.
 fn prompt_text(agent: &Agent) -> String {
-    let mut out = agent.system_prompt.clone();
-    for (heading, section) in [
-        ("## Instructions", &agent.instructions),
-        ("## Output Format", &agent.output_format),
-        ("## Context", &agent.context),
-    ] {
-        if let Some(body) = section {
-            out.push_str("\n\n");
-            out.push_str(heading);
-            out.push_str("\n\n");
-            out.push_str(body);
-        }
-    }
-    out
+    agent.composed_prompt()
 }
 
 #[cfg(test)]

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -1226,10 +1226,15 @@ async fn run_single_agent(
         .or(project_defaults.and_then(|d| d.mode))
         .unwrap_or_default();
 
+    // Every declared section, not just `## System Prompt` (#395) — composed
+    // through the one core definition `link` also uses. The guided-mode
+    // instruction is appended *after* the whole prompt, so it stays the last
+    // word on how to answer.
+    let composed = agent.composed_prompt();
     let system_prompt = if effective_mode == AgentMode::Guided {
-        format!("{}{GUIDED_MODE_INSTRUCTION}", agent.system_prompt)
+        format!("{composed}{GUIDED_MODE_INSTRUCTION}")
     } else {
-        agent.system_prompt.clone()
+        composed
     };
 
     // 5. Build request
@@ -1677,7 +1682,12 @@ async fn run_single_agent_es(
         .or(project_defaults.and_then(|d| d.mode))
         .unwrap_or_default();
     if effective_mode == AgentMode::Guided {
-        agent.system_prompt = format!("{}{GUIDED_MODE_INSTRUCTION}", agent.system_prompt);
+        // The engine composes the sections itself (#395), so fold them here
+        // and append the guided instruction after the lot — same order as the
+        // legacy path above. `set_composed_prompt` clears the folded sections
+        // so the engine cannot compose them twice.
+        let guided = format!("{}{GUIDED_MODE_INSTRUCTION}", agent.composed_prompt());
+        agent.set_composed_prompt(guided);
     }
 
     // 5-7. Drive the event-sourced engine (model routing, request building,

--- a/crates/armadai/src/linker/claude.rs
+++ b/crates/armadai/src/linker/claude.rs
@@ -63,28 +63,7 @@ fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
     content.push_str("---\n\n");
 
     // System prompt (main content)
-    content.push_str(&agent.system_prompt);
-
-    // Instructions section
-    if let Some(ref instructions) = agent.instructions {
-        ensure_blank_line(&mut content);
-        content.push_str("## Instructions\n\n");
-        content.push_str(instructions);
-    }
-
-    // Output format section
-    if let Some(ref output_format) = agent.output_format {
-        ensure_blank_line(&mut content);
-        content.push_str("## Output Format\n\n");
-        content.push_str(output_format);
-    }
-
-    // Context section
-    if let Some(ref context) = agent.context {
-        ensure_blank_line(&mut content);
-        content.push_str("## Context\n\n");
-        content.push_str(context);
-    }
+    content.push_str(&agent.composed_prompt());
 
     // Ensure trailing newline
     if !content.ends_with('\n') {

--- a/crates/armadai/src/linker/codex.rs
+++ b/crates/armadai/src/linker/codex.rs
@@ -53,27 +53,9 @@ fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
 
     let model = agent.model.as_deref().unwrap_or("o3-mini");
 
-    // Build developer_instructions from all sections
-    let mut instructions = String::new();
-    instructions.push_str(&agent.system_prompt);
-
-    if let Some(ref inst) = agent.instructions {
-        ensure_blank_line(&mut instructions);
-        instructions.push_str("## Instructions\n\n");
-        instructions.push_str(inst);
-    }
-
-    if let Some(ref output_format) = agent.output_format {
-        ensure_blank_line(&mut instructions);
-        instructions.push_str("## Output Format\n\n");
-        instructions.push_str(output_format);
-    }
-
-    if let Some(ref context) = agent.context {
-        ensure_blank_line(&mut instructions);
-        instructions.push_str("## Context\n\n");
-        instructions.push_str(context);
-    }
+    // developer_instructions carries the agent's whole prompt — the four
+    // sections composed exactly as every other target composes them.
+    let instructions = agent.composed_prompt();
 
     let mut content = String::new();
     content.push_str(&format!("model = \"{model}\"\n"));

--- a/crates/armadai/src/linker/copilot.rs
+++ b/crates/armadai/src/linker/copilot.rs
@@ -47,28 +47,7 @@ fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
     }
 
     // System prompt
-    content.push_str(&agent.system_prompt);
-
-    // Instructions section
-    if let Some(ref instructions) = agent.instructions {
-        ensure_blank_line(&mut content);
-        content.push_str("## Instructions\n\n");
-        content.push_str(instructions);
-    }
-
-    // Output format section
-    if let Some(ref output_format) = agent.output_format {
-        ensure_blank_line(&mut content);
-        content.push_str("## Output Format\n\n");
-        content.push_str(output_format);
-    }
-
-    // Context section
-    if let Some(ref context) = agent.context {
-        ensure_blank_line(&mut content);
-        content.push_str("## Context\n\n");
-        content.push_str(context);
-    }
+    content.push_str(&agent.composed_prompt());
 
     // Ensure trailing newline
     if !content.ends_with('\n') {

--- a/crates/armadai/src/linker/gemini.rs
+++ b/crates/armadai/src/linker/gemini.rs
@@ -75,25 +75,7 @@ fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
     content.push_str("---\n\n");
 
     // Body: system prompt
-    content.push_str(&agent.system_prompt);
-
-    if let Some(ref instructions) = agent.instructions {
-        ensure_blank_line(&mut content);
-        content.push_str("## Instructions\n\n");
-        content.push_str(instructions);
-    }
-
-    if let Some(ref output_format) = agent.output_format {
-        ensure_blank_line(&mut content);
-        content.push_str("## Output Format\n\n");
-        content.push_str(output_format);
-    }
-
-    if let Some(ref context) = agent.context {
-        ensure_blank_line(&mut content);
-        content.push_str("## Context\n\n");
-        content.push_str(context);
-    }
+    content.push_str(&agent.composed_prompt());
 
     if !content.ends_with('\n') {
         content.push('\n');

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -158,6 +158,25 @@ impl From<&Agent> for LinkAgent {
     }
 }
 
+impl LinkAgent {
+    /// This agent's sections composed into one prompt body, through the same
+    /// core definition `run` uses (`armadai_core::agent::compose_agent_prompt`).
+    ///
+    /// The five linkers each carried their own copy of this loop until #395,
+    /// and `run` carried none — which is how the same agent came to behave
+    /// differently depending on the path that executed it. Sharing the
+    /// composition is what makes "same order, same separators" a fact rather
+    /// than a convention.
+    pub fn composed_prompt(&self) -> String {
+        armadai_core::agent::compose_agent_prompt(
+            &self.system_prompt,
+            self.instructions.as_deref(),
+            self.output_format.as_deref(),
+            self.context.as_deref(),
+        )
+    }
+}
+
 /// Protocol block appended to linked config files for ArmadAI shell parsing.
 pub fn armadai_protocol_block() -> &'static str {
     r"

--- a/crates/armadai/src/linker/opencode.rs
+++ b/crates/armadai/src/linker/opencode.rs
@@ -71,25 +71,7 @@ fn generate_agent_file(agent: &LinkAgent) -> OutputFile {
     content.push_str("---\n\n");
 
     // Body: system prompt
-    content.push_str(&agent.system_prompt);
-
-    if let Some(ref instructions) = agent.instructions {
-        ensure_blank_line(&mut content);
-        content.push_str("## Instructions\n\n");
-        content.push_str(instructions);
-    }
-
-    if let Some(ref output_format) = agent.output_format {
-        ensure_blank_line(&mut content);
-        content.push_str("## Output Format\n\n");
-        content.push_str(output_format);
-    }
-
-    if let Some(ref context) = agent.context {
-        ensure_blank_line(&mut content);
-        content.push_str("## Context\n\n");
-        content.push_str(context);
-    }
+    content.push_str(&agent.composed_prompt());
 
     if !content.ends_with('\n') {
         content.push('\n');

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -2027,6 +2027,58 @@ mod tests {
         }
     }
 
+    /// #395: the shell relay is a fifth consumer of "the prompt of an
+    /// agent", and it too used to forward `system_prompt` alone. Measured
+    /// through `step_from_agent`, which is the only thing the relay ever
+    /// sees.
+    #[test]
+    fn a_relayed_step_carries_every_declared_section() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+        std::fs::write(
+            dir.path().join("agents/shell-pipeline-fixture-sections.md"),
+            concat!(
+                "# shell-pipeline-fixture-sections\n\n",
+                "## Metadata\n- provider: cli\n- command: echo\n\n",
+                "## System Prompt\nSYS body.\n\n",
+                "## Instructions\nINST body.\n\n",
+                "## Output Format\nOUT body.\n\n",
+                "## Context\nCTX body.\n",
+            ),
+        )
+        .unwrap();
+        let config = armadai_core::project::ProjectConfig::default();
+        let agent =
+            match lookup_agent_in_config(&config, dir.path(), "shell-pipeline-fixture-sections") {
+                AgentLookup::Loaded { agent, .. } => *agent,
+                AgentLookup::Failed(reason) => panic!("fixture must load, got: {reason}"),
+            };
+
+        let StepPlan::Relay { system_prompt, .. } =
+            step_from_agent("shell-pipeline-fixture-sections", &agent)
+        else {
+            panic!("a cli-backed agent must be relayable");
+        };
+        // Byte for byte against the core composition — the same string
+        // `run` and `link` build, not merely a superset containing the
+        // bodies somewhere.
+        assert_eq!(system_prompt, agent.composed_prompt());
+        for needle in [
+            "SYS body.",
+            "## Instructions",
+            "INST body.",
+            "## Output Format",
+            "OUT body.",
+            "## Context",
+            "CTX body.",
+        ] {
+            assert!(
+                system_prompt.contains(needle),
+                "{needle:?} never reached the relayed step:\n{system_prompt}"
+            );
+        }
+    }
+
     #[test]
     fn a_cli_backed_agent_relays_the_command_it_names_not_the_literal_word_cli() {
         // `provider: cli` says "spawn what `command:` names" — the shape the

--- a/crates/armadai/src/shell/app.rs
+++ b/crates/armadai/src/shell/app.rs
@@ -1253,7 +1253,8 @@ fn step_from_agent(agent_name: &str, agent: &Agent) -> StepPlan {
     StepPlan::Relay {
         cmd,
         args,
-        system_prompt: agent.system_prompt.clone(),
+        // Every declared section, not just `## System Prompt` (#395).
+        system_prompt: agent.composed_prompt(),
         label,
     }
 }

--- a/crates/armadai/tests/run_sends_every_section.rs
+++ b/crates/armadai/tests/run_sends_every_section.rs
@@ -1,0 +1,451 @@
+//! Black-box regressions for #395: an agent declares up to four sections
+//! (`## System Prompt`, `## Instructions`, `## Output Format`, `## Context`)
+//! and `armadai link` writes all four into every native config it generates,
+//! while `armadai run` used to hand the provider `agent.system_prompt` and
+//! nothing else. The same agent therefore behaved differently depending on
+//! which path executed it, and nothing said so.
+//!
+//! These are wiring tests on purpose. A unit test on the composition function
+//! proves the string that function builds; it cannot prove that string is what
+//! a provider receives. Each test below runs the real binary against a
+//! `provider: cli` agent whose command appends the exact argument it was
+//! handed to a capture log — hermetic, no key, no network — so the log *is*
+//! the prompt that was sent, whatever the engine later does with the reply.
+//! (Reading it back off stdout would not do: the orchestrated engines parse
+//! the reply and only surface the fragment they extracted from it.)
+//!
+//! Measured on `master` before the fix, on every path below: only
+//! `SYSPROMPT_MARKER_*` ever reached the provider; the three other sections
+//! never did.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use std::path::{Path, PathBuf};
+
+    /// Separates two captured invocations in the log. A token nothing the
+    /// product emits could produce.
+    const CAPTURE_SEP: &str = "\n<<<ARMADAI_PROMPT_CAPTURE>>>\n";
+
+    /// Isolate `~/.config/armadai` per project: `link`/`run` register the
+    /// project and scan the global agent library, which on a developer machine
+    /// holds real agents that would shadow the fixture.
+    fn isolated_config(dir: &Path) -> PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(&config).unwrap();
+        config
+    }
+
+    /// A four-section agent whose markers are tokens nothing else in the repo
+    /// produces, so an assertion on one cannot be satisfied by boilerplate a
+    /// linker or an engine emits anyway.
+    ///
+    /// `sh <script> <input>`: the CLI provider appends the composed input as
+    /// the last argument, so `$1` inside the script is verbatim what the
+    /// provider sent. Invoked via `sh <path>` rather than as an executable so
+    /// no chmod is needed.
+    fn four_section_agent(name: &str, script: &Path) -> String {
+        let up = marker_suffix(name);
+        format!(
+            "# {name}\n\n\
+             ## Metadata\n\
+             - provider: cli\n\
+             - command: sh\n\
+             - args: [{script}]\n\n\
+             ## System Prompt\n\n\
+             SYSPROMPT_MARKER_{up} is the system prompt body.\n\n\
+             ## Instructions\n\n\
+             INSTRUCTIONS_MARKER_{up} is the instructions body.\n\n\
+             ## Output Format\n\n\
+             OUTPUTFORMAT_MARKER_{up} is the output format body.\n\n\
+             ## Context\n\n\
+             CONTEXT_MARKER_{up} is the context body.\n",
+            script = script.display()
+        )
+    }
+
+    fn marker_suffix(name: &str) -> String {
+        name.to_uppercase().replace('-', "_")
+    }
+
+    /// Every marker of `name`'s four sections, in declaration order.
+    fn markers(name: &str) -> [String; 4] {
+        let up = marker_suffix(name);
+        [
+            format!("SYSPROMPT_MARKER_{up}"),
+            format!("INSTRUCTIONS_MARKER_{up}"),
+            format!("OUTPUTFORMAT_MARKER_{up}"),
+            format!("CONTEXT_MARKER_{up}"),
+        ]
+    }
+
+    /// A temp project holding `names`, each a four-section agent whose
+    /// provider command records what it was sent into `capture_log()`.
+    struct Fixture {
+        dir: tempfile::TempDir,
+    }
+
+    impl Fixture {
+        /// `fail_first`: the probe exits non-zero on its very first invocation
+        /// and behaves normally afterwards — the only way to leave a run in
+        /// the `Running` state `--resume` requires.
+        fn new(names: &[&str], fail_first: bool) -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path().join("project");
+            std::fs::create_dir_all(root.join("agents")).unwrap();
+            std::fs::create_dir_all(root.join(".armadai")).unwrap();
+
+            let log = dir.path().join("sent.log");
+            let armed = dir.path().join("armed");
+            // Records what it was sent, then answers a fixed harmless string.
+            // It must NOT echo the prompt back: the hierarchical coordinator's
+            // enriched prompt contains the literal `@agent-name:` delegation
+            // syntax, and an echo would be parsed as a delegation to an agent
+            // by that name, failing the run before the test can measure it.
+            let capture = format!(
+                "printf '%s{sep}' \"$1\" >> '{log}'\nprintf 'PROBE_REPLY'\n",
+                sep = CAPTURE_SEP.escape_default(),
+                log = log.display(),
+            );
+            let script_body = if fail_first {
+                format!(
+                    "if [ -f '{armed}' ]; then\n{capture}else\n  : > '{armed}'\n  exit 1\nfi\n",
+                    armed = armed.display(),
+                )
+            } else {
+                capture
+            };
+            let script = root.join("probe.sh");
+            std::fs::write(&script, script_body).unwrap();
+
+            let mut config = String::from("agents:\n");
+            for name in names {
+                std::fs::write(
+                    root.join(format!("agents/{name}.md")),
+                    four_section_agent(name, &script),
+                )
+                .unwrap();
+                config.push_str(&format!("  - path: agents/{name}.md\n"));
+            }
+            std::fs::write(root.join(".armadai/config.yaml"), config).unwrap();
+            Self { dir }
+        }
+
+        fn root(&self) -> PathBuf {
+            self.dir.path().join("project")
+        }
+
+        /// Append `yaml` to the project config (an `orchestration:` block, to
+        /// reach the patterns `--orchestrate` cannot name).
+        fn append_config(&self, yaml: &str) {
+            let path = self.root().join(".armadai/config.yaml");
+            let mut content = std::fs::read_to_string(&path).unwrap();
+            content.push_str(yaml);
+            std::fs::write(&path, content).unwrap();
+        }
+
+        /// `armadai <args>` in the project, isolated from the developer's
+        /// config AND data dirs.
+        ///
+        /// `run` records into SQLite, and `db.rs`'s `#[cfg(test)]` guard does
+        /// not protect a *spawned* binary: without `XDG_DATA_HOME` the test
+        /// writes into the real `~/.local/share/armadai/armadai.sqlite`,
+        /// prompt in clear (measured during #392 — the `runs` table grew by
+        /// one row).
+        fn armadai(&self, args: &[&str]) -> std::process::Output {
+            let mut cmd = Command::cargo_bin("armadai").unwrap();
+            cmd.current_dir(self.root())
+                .env("ARMADAI_CONFIG_DIR", isolated_config(self.dir.path()))
+                .env("XDG_DATA_HOME", self.dir.path().join("data"))
+                .args(args);
+            cmd.output().unwrap()
+        }
+
+        /// Every prompt the CLI provider was handed, in call order.
+        ///
+        /// `CliProvider::compose_input` wraps the system prompt as
+        /// `<system>\n{prompt}\n</system>\n\n{message}`, so what sits between
+        /// the tags is byte-for-byte what the run handed the provider.
+        fn sent_prompts(&self) -> Vec<String> {
+            let log = std::fs::read_to_string(self.dir.path().join("sent.log")).unwrap_or_default();
+            log.split(CAPTURE_SEP)
+                .filter(|r| !r.trim().is_empty())
+                .filter_map(|record| {
+                    let after = record.strip_prefix("<system>\n")?;
+                    let end = after.find("\n</system>")?;
+                    Some(after[..end].to_string())
+                })
+                .collect()
+        }
+
+        /// Everything the provider was sent, concatenated — for "did this
+        /// marker ever reach a model" assertions.
+        fn all_sent(&self) -> String {
+            self.sent_prompts().join("\n")
+        }
+    }
+
+    fn assert_success(output: &std::process::Output, what: &str) {
+        assert!(
+            output.status.success(),
+            "{what} failed: {}\n--- stdout ---\n{}",
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    /// Assert that EVERY prompt the provider received carries all four
+    /// sections of whichever agent it belongs to, and that each agent in
+    /// `agents` was invoked at least once.
+    ///
+    /// Per call, not over the concatenation of all calls: measured, an
+    /// assertion on the concatenation stays green when only one of an
+    /// engine's two `CompletionRequest` sites is fixed (reverting the ring's
+    /// circulate site alone, its vote site alone kept the markers present).
+    /// That is the exact failure mode #376 cost a whole review.
+    fn assert_every_call_carries_every_section(fx: &Fixture, agents: &[&str], what: &str) {
+        let sent = fx.sent_prompts();
+        assert!(
+            !sent.is_empty(),
+            "{what}: the probe recorded no provider call at all — the test's own \
+             mechanism is broken, not the product."
+        );
+        let mut called: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for (i, prompt) in sent.iter().enumerate() {
+            let owner = agents
+                .iter()
+                .copied()
+                .find(|a| prompt.contains(markers(a)[0].as_str()))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{what}: call #{i} carries none of {agents:?}'s system prompts — \
+                         the fixture and the assertion disagree.\n--- sent ---\n{prompt}"
+                    )
+                });
+            called.insert(owner);
+            for marker in markers(owner) {
+                let hits = prompt.matches(marker.as_str()).count();
+                assert_eq!(
+                    hits, 1,
+                    "{what}: call #{i} (agent {owner}) carries {marker} {hits}x, expected \
+                     exactly once — 0 means the section was never sent, >1 means it was \
+                     composed twice.\n--- sent ---\n{prompt}"
+                );
+            }
+            for heading in ["## Instructions", "## Output Format", "## Context"] {
+                assert!(
+                    prompt.contains(heading),
+                    "{what}: call #{i} (agent {owner}) lost {heading:?} — the bodies \
+                     alone, concatenated, lose the structure they rely on.\n\
+                     --- sent ---\n{prompt}"
+                );
+            }
+        }
+        for agent in agents {
+            assert!(
+                called.contains(agent),
+                "{what}: {agent} was never invoked, so nothing was measured about it \
+                 ({} call(s) recorded)",
+                sent.len()
+            );
+        }
+    }
+
+    /// The plain single-agent path: `armadai run <agent> <input>`.
+    #[test]
+    fn run_sends_every_section_to_the_provider() {
+        let fx = Fixture::new(&["solo"], false);
+        assert_success(&fx.armadai(&["run", "solo", "TASK", "--headless"]), "run");
+        assert_every_call_carries_every_section(&fx, &["solo"], "run");
+    }
+
+    /// `run` and `link` must compose the sections *identically* — same order,
+    /// same separators — otherwise one inconsistency is traded for another,
+    /// harder to see. Compared byte for byte on the same agent: the prompt
+    /// `run` sent, against the body `link --target claude` wrote.
+    #[test]
+    fn run_and_link_compose_the_sections_identically() {
+        let fx = Fixture::new(&["twin"], false);
+        assert_success(&fx.armadai(&["run", "twin", "TASK", "--headless"]), "run");
+        let sent = fx.sent_prompts();
+        assert_eq!(sent.len(), 1, "expected exactly one provider call");
+
+        assert_success(
+            &fx.armadai(&["link", "--target", "claude", "--force"]),
+            "link",
+        );
+        let linked = std::fs::read_to_string(fx.root().join(".claude/agents/twin.md")).unwrap();
+        // Drop the leading YAML frontmatter; what follows is the composed body.
+        let body = linked
+            .strip_prefix("---\n")
+            .and_then(|rest| rest.split_once("\n---\n\n"))
+            .map(|(_, body)| body.to_string())
+            .unwrap_or_else(|| panic!("no YAML frontmatter in the linked file:\n{linked}"));
+
+        assert_eq!(
+            sent[0].trim_end(),
+            body.trim_end(),
+            "`run` and `link` disagree on how an agent's sections compose.\n\
+             --- run sent ---\n{}\n--- link wrote ---\n{body}",
+            sent[0]
+        );
+    }
+
+    /// Guided mode appends a clarifying-questions instruction to the prompt.
+    /// It must land *after* every section, on both paths that implement it
+    /// (the single-agent ES dispatch and the legacy `--pipe` loop), and it
+    /// must not cause a section to be composed twice.
+    #[test]
+    fn guided_mode_appends_its_instruction_after_every_section() {
+        for (extra, invoked) in [
+            (Vec::new(), vec!["guided"]),
+            (vec!["--pipe", "tail"], vec!["guided", "tail"]),
+        ] {
+            let fx = Fixture::new(&["guided", "tail"], false);
+            let path = fx.root().join("agents/guided.md");
+            let agent = std::fs::read_to_string(&path)
+                .unwrap()
+                .replace("- provider: cli", "- provider: cli\n- mode: guided");
+            std::fs::write(&path, agent).unwrap();
+
+            let mut args = vec!["run", "guided", "TASK"];
+            args.extend_from_slice(&extra);
+            args.push("--headless");
+            let what = format!("guided run {extra:?}");
+            assert_success(&fx.armadai(&args), &what);
+            assert_every_call_carries_every_section(&fx, &invoked, &what);
+
+            let sent = fx.sent_prompts();
+            let guided = sent
+                .iter()
+                .find(|p| p.contains("CONTEXT_MARKER_GUIDED"))
+                .unwrap_or_else(|| panic!("{what}: the guided agent was never invoked"));
+            let needle = "Before providing your full response";
+            let instruction = guided
+                .find(needle)
+                .unwrap_or_else(|| panic!("{what}: guided instruction missing:\n{guided}"));
+            let context = guided.find("CONTEXT_MARKER_GUIDED").unwrap();
+            assert!(
+                instruction > context,
+                "{what}: the guided instruction must come after the last section, \
+                 not be buried mid-prompt.\n--- sent ---\n{guided}"
+            );
+        }
+    }
+
+    /// `--pipe` runs on the legacy sequential loop — a different function from
+    /// the single-agent path, which builds its own `CompletionRequest`.
+    #[test]
+    fn pipe_sends_every_section_for_every_link() {
+        let fx = Fixture::new(&["first", "second"], false);
+        assert_success(
+            &fx.armadai(&["run", "first", "TASK", "--pipe", "second", "--headless"]),
+            "run --pipe",
+        );
+        assert_every_call_carries_every_section(&fx, &["first", "second"], "run --pipe");
+    }
+
+    /// `--orchestrate` dispatches to the blackboard and ring engines, each of
+    /// which builds its own `CompletionRequest` (ring builds two).
+    #[test]
+    fn orchestrate_sends_every_section_to_the_provider() {
+        for pattern in ["blackboard", "ring"] {
+            let fx = Fixture::new(&["alpha", "beta"], false);
+            assert_success(
+                &fx.armadai(&[
+                    "run",
+                    "alpha",
+                    "TASK",
+                    "--pipe",
+                    "beta",
+                    "--orchestrate",
+                    pattern,
+                    "--headless",
+                    "--no-tui",
+                ]),
+                &format!("run --orchestrate {pattern}"),
+            );
+            assert_every_call_carries_every_section(
+                &fx,
+                &["alpha", "beta"],
+                &format!("--orchestrate {pattern}"),
+            );
+        }
+    }
+
+    /// The hierarchical engine is reachable only through the project's
+    /// `orchestration:` block (`--orchestrate` accepts blackboard/ring only),
+    /// and it is the one engine that *enriches* the system prompt with an
+    /// orchestration protocol — the four sections must survive that too.
+    #[test]
+    fn hierarchical_sends_every_section_to_the_coordinator() {
+        let fx = Fixture::new(&["lead", "worker"], false);
+        fx.append_config(
+            "orchestration:\n  \
+               enabled: true\n  \
+               pattern: hierarchical\n  \
+               coordinator: lead\n  \
+               teams:\n    \
+                 - name: t1\n      \
+                   agents: [worker]\n",
+        );
+        assert_success(
+            &fx.armadai(&["run", "lead", "TASK", "--headless", "--no-tui"]),
+            "hierarchical run",
+        );
+        // Only the coordinator is invoked: the probe answers a fixed string
+        // with no `@`, so nothing is delegated to `worker`.
+        assert_every_call_carries_every_section(&fx, &["lead"], "hierarchical");
+        let sent = fx.all_sent();
+        // The enrichment must still be there — the fix must add sections, not
+        // replace the orchestration protocol with them.
+        assert!(
+            sent.contains("## Orchestration Protocol"),
+            "hierarchical: the orchestration protocol enrichment was lost.\n\
+             --- sent ---\n{sent}"
+        );
+        // …and after them: the protocol describes how to answer, so it must be
+        // the last word, not buried between two of the agent's own sections.
+        assert!(
+            sent.find("## Orchestration Protocol") > sent.find("CONTEXT_MARKER_LEAD"),
+            "hierarchical: the orchestration protocol must come after the agent's \
+             own sections.\n--- sent ---\n{sent}"
+        );
+    }
+
+    /// `--resume` reloads the roster from disk and re-enters the same effect
+    /// runners. It is a distinct entry point (`execute_resume`/`resume_run`),
+    /// so it is measured, not assumed.
+    #[cfg(feature = "storage")]
+    #[test]
+    fn resume_sends_every_section_to_the_provider() {
+        let fx = Fixture::new(&["solo"], true);
+
+        // First run: the probe exits 1, leaving the run `Running` — the only
+        // state `--resume` accepts.
+        let first = fx.armadai(&["run", "solo", "TASK", "--headless", "--json"]);
+        assert!(
+            !first.status.success(),
+            "the fail-first probe was expected to fail the first run"
+        );
+        let stdout = String::from_utf8_lossy(&first.stdout);
+        let run_id = stdout
+            .lines()
+            .filter(|l| l.contains("\"t\":\"run_start\""))
+            .find_map(|l| {
+                let after = l.split_once("\"run_id\":\"")?.1;
+                Some(after.split_once('"')?.0.to_string())
+            })
+            .unwrap_or_else(|| panic!("no run_start event in:\n{stdout}"));
+        assert!(
+            fx.sent_prompts().is_empty(),
+            "the failed first call must not have recorded a prompt"
+        );
+
+        assert_success(
+            &fx.armadai(&["run", "--resume", &run_id, "--headless", "--json"]),
+            "run --resume",
+        );
+        assert_every_call_carries_every_section(&fx, &["solo"], "run --resume");
+    }
+}

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -145,11 +145,28 @@ heading and separated by a blank line:
 An absent section contributes nothing at all — no empty heading.
 
 `armadai run` (including `--pipe`, `--orchestrate` and `--resume`), `armadai
-shell` and `armadai link` all compose the prompt this same way, from one
-definition in the core (`armadai_core::agent::compose_agent_prompt`). Before
-issue #395 was fixed, `run` sent `## System Prompt` alone, so an agent that
-put its output rules in `## Output Format` obeyed them once linked into a
-native CLI and ignored them when run directly.
+shell` and `armadai link`'s per-agent files all compose the prompt this same
+way, from one definition in the core
+(`armadai_core::agent::compose_agent_prompt`). Before issue #395 was fixed,
+`run` sent `## System Prompt` alone, so an agent that put its output rules in
+`## Output Format` obeyed them once linked into a native CLI and ignored them
+when run directly.
+
+Two things still fall outside that sentence:
+
+- **The coordinator's root instructions file.** `armadai link --coordinator
+  <name>` also writes `CLAUDE.md` (and its equivalent per target), and that
+  file is *not* composed this way: it carries the system prompt and the
+  `## Instructions` body — the body alone, without its heading — and drops
+  `## Output Format` and `## Context` entirely. Put anything a coordinator
+  must obey in its system prompt until issue #409 is fixed.
+- **`##` headings the parser does not know.** The parser keys sections by
+  their exact heading, case-insensitively, and knows eight: `Metadata`,
+  `System Prompt`, `Instructions`, `Output Format`, `Pipeline`, `Context`,
+  `Triggers`, `Ring Config`. Any other `##` is dropped in silence, in every
+  consumer, `link` included — nothing warns, the content simply never
+  reaches a model. Put prose under one of the eight, or demote its heading
+  to `###` so it stays inside the section above it.
 
 `## Metadata`, `## Pipeline`, `## Triggers` and `## Ring Config` are
 configuration, not prompt text: they are parsed into fields and never sent.

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -120,6 +120,40 @@ Key-value pairs configuring the agent's technical behavior.
 | `context_window` | int | No | — | Context window size override |
 | `orchestration` | string | No | — | Orchestration pattern: `blackboard`, `ring` |
 
+### What reaches the model
+
+`## System Prompt`, `## Instructions`, `## Output Format` and `## Context` are
+**all** sent to the model, in that order, each reintroduced under its own `##`
+heading and separated by a blank line:
+
+```
+<System Prompt body>
+
+## Instructions
+
+<Instructions body>
+
+## Output Format
+
+<Output Format body>
+
+## Context
+
+<Context body>
+```
+
+An absent section contributes nothing at all — no empty heading.
+
+`armadai run` (including `--pipe`, `--orchestrate` and `--resume`), `armadai
+shell` and `armadai link` all compose the prompt this same way, from one
+definition in the core (`armadai_core::agent::compose_agent_prompt`). Before
+issue #395 was fixed, `run` sent `## System Prompt` alone, so an agent that
+put its output rules in `## Output Format` obeyed them once linked into a
+native CLI and ignored them when run directly.
+
+`## Metadata`, `## Pipeline`, `## Triggers` and `## Ring Config` are
+configuration, not prompt text: they are parsed into fields and never sent.
+
 ### System Prompt (required)
 
 The system prompt sent to the model. This defines the agent's identity, role, and behavioral boundaries.


### PR DESCRIPTION
Ferme #395.

## Le défaut

Un agent ArmadAI déclare jusqu'à quatre sections — `## System Prompt`,
`## Instructions`, `## Output Format`, `## Context`. **`armadai link` les
transmettait toutes ; `armadai run` n'envoyait que `system_prompt`.** Le même
agent se comportait donc différemment selon le chemin, et rien ne le disait.

## Où assembler : dans le cœur, et voici la mesure qui tranche

L'issue laissait le choix entre « `run` réutilise la composition de `link` » et
« l'assemblage remonte dans le cœur ». J'ai pris la seconde, après avoir mesuré
ce que produisent réellement les cinq linkers pour **le même agent à quatre
sections** — parce que l'argument contraire (« chaque linker a son format,
donc le partageable est plus étroit qu'il n'y paraît ») est plausible et
méritait d'être testé plutôt que supposé.

Fichier par agent généré pour un agent à quatre sections, corps extrait après
retrait de l'enveloppe propre à la cible :

| cible | fichier | md5 du corps |
|---|---|---|
| claude | `.claude/agents/four.md` | `15461e18a2577665048e85fa3c5667b9` |
| codex | `.codex/agents/four.toml` | `15461e18a2577665048e85fa3c5667b9` |
| copilot | `.github/agents/four.agent.md` | `15461e18a2577665048e85fa3c5667b9` |
| gemini | `.gemini/agents/four.md` | `15461e18a2577665048e85fa3c5667b9` |
| opencode | `.opencode/agents/four.md` | `15461e18a2577665048e85fa3c5667b9` |

**Les cinq corps sont octet pour octet identiques** (154 octets). Ce qui diffère
n'est que l'enveloppe : frontmatter YAML (champs différents), quoting TOML,
ligne de description dupliquée chez copilot. Le partageable est donc exactement
« le prompt d'un agent » — ni plus, ni moins — et il tenait en cinq copies
privées du même `for`.

D'où : `armadai_core::agent::compose_agent_prompt` (+ `Agent::composed_prompt`),
une seule définition, appelée par les cinq linkers via `LinkAgent` et par tous
les chemins d'exécution. **Vérifié : la sortie de `link` est inchangée octet
pour octet** par cette PR (les 8 fichiers générés des 5 cibles, `diff -q`).

Corollaire non prévu : il y avait une **septième** copie, dans
`audit/reverse/armadai.rs::prompt_text`, et elle divergeait — elle poussait un
`\n\n` brut là où les linkers normalisent, donc une section finissant déjà par
un saut de ligne en gagnait un troisième là et nulle part ailleurs. Elle
délègue désormais aussi.

## Les sept sites, chacun mesuré

Le brief rappelait #376 (cinq sites de résolution de modèle, un seul corrigé).

| chemin | site | test qui le protège |
|---|---|---|
| `run <agent>` | `es/direct.rs` | `run_sends_every_section_to_the_provider` |
| `--orchestrate blackboard` | `es/blackboard.rs` | `orchestrate_sends_every_section_to_the_provider` |
| `--orchestrate ring` | `es/ring.rs` (**2 sites** : circulate + vote) | idem |
| hiérarchique (config projet) | `es/hierarchical.rs::enriched_system_prompt` | `hierarchical_sends_every_section_to_the_coordinator` |
| `--pipe` | `cli/run.rs::run_single_agent` (boucle séquentielle héritée) | `pipe_sends_every_section_for_every_link` |
| `armadai shell` | `shell/app.rs::step_from_agent` | `a_relayed_step_carries_every_declared_section` |
| `--resume` | réentre dans les mêmes effect runners | `resume_sends_every_section_to_the_provider` |

`--resume` **mesuré, pas supposé** : sonde qui échoue à son premier appel (le
run reste `Running`, seul état que `--resume` accepte), puis `--resume` sur le
`run_id`. Avant le correctif, la sonde ne recevait que `SYSPROMPT_MARKER_SOLO`.

`--replay` n'appelle aucun provider (rejeu du log) : rien à corriger.

Le relais `armadai shell` est hors du périmètre de l'issue mais porte le même
défaut ; corrigé, et le test a été ajouté séparément parce que les tests
existants sur `StepPlan::Relay` n'utilisent que des agents à une section et
restaient verts dans les deux cas.

## Ordre et séparateurs, identiques des deux côtés

`run_and_link_compose_the_sections_identically` compare **octet pour octet** ce
que `run` a envoyé au provider et ce que `link --target claude` a écrit, pour
le même agent. Comme les deux passent désormais par la même fonction, un
`assert_eq!` unitaire dans le cœur épingle en plus l'ordre et les séparateurs
exacts, sinon un réordonnancement bougerait les deux côtés à la fois sans
qu'aucun test ne bronche.

## Le coût, chiffré

Sur la bibliothèque réelle `~/.config/armadai/agents` (77 fichiers, 76 parsés,
`my-agent.md` rejeté par le parseur — pas de `## Metadata`) :

```
octets de prompt avant = 160 387
octets de prompt après = 196 936
delta                  = +36 549  (+22,8 %)
agents dont le prompt grossit : 60 / 76
plus gros contributeur : agent-builder.md, +1 302 octets
sections présentes : Instructions 60, Output Format 44, Context 0
```

C'est la correction attendue, et c'est un changement de facturation : tout
agent utilisant plus d'une section envoie désormais davantage.

## Mode guidé

L'instruction de mode guidé reste **après** tout le prompt, sur les deux
chemins qui l'implémentent. Sur le chemin ES (où la composition a lieu dans le
moteur), `Agent::set_composed_prompt` replie les sections en amont et efface
les champs repliés, pour que le moteur ne puisse pas les composer deux fois.

## Méthode : 15 mutations, chacune vérifiée rouge

| # | mutation | résultat |
|---|---|---|
| M1 | `direct.rs` revient à `system_prompt` seul | 3 rouges (run, run-vs-link, resume) |
| M2 | `blackboard.rs` idem | orchestrate rouge |
| M3b | ring : **seul** le site *circulate* revient en arrière | orchestrate rouge |
| M3c | ring : **seul** le site *vote* revient en arrière | orchestrate rouge |
| M4 | `enriched_system_prompt` idem | hierarchical rouge |
| M5 | boucle héritée (`--pipe`) idem | pipe + guided rouges |
| M6 | le linker claude compose avec son propre séparateur | run-vs-link rouge |
| M7 | le mode guidé cesse d'effacer les sections repliées | guided rouge (composées 2x) |
| M8 | l'instruction guidée passe avant la composition | guided rouge (ordre) |
| M9 | `compose_agent_prompt` n'émet plus les titres `##` | 6 rouges |
| M10 | ordre des sections inversé | test unitaire d'ordre rouge |
| M11 | une section absente émet quand même son titre | 3 unitaires rouges |
| M12 | normalisation du séparateur supprimée | unitaire rouge |
| M14 | l'audit revient à `system_prompt` seul | test d'audit existant rouge |
| M15 | le relais shell revient à `system_prompt` seul | test shell rouge |

**Une mutation a invalidé une première version d'un test** : M3b (ne corriger
qu'un des deux sites de `ring`) laissait le test `--orchestrate` **vert**, car
il assertait sur la concaténation de tous les appels. L'assertion a été
resserrée en invariant **par appel** — c'est exactement le mode de défaillance
#376. Elle est rouge depuis.

## Base réelle intacte

Un test qui lance `run` écrit dans SQLite et le garde `#[cfg(test)]` de `db.rs`
ne protège pas un binaire *spawné*. `ARMADAI_CONFIG_DIR` **et** `XDG_DATA_HOME`
sont redirigés. Vérifié après tout le gate : `~/.local/share/armadai/armadai.sqlite`
md5 `330e0993c7cd72c21755152406ceb748` **avant et après**, `runs` = 0, zéro
marqueur de cette PR dans `execution_events`.

## Ce que j'ai trouvé de faux, ou d'incomplet

1. **L'issue dit « `link` transmet les quatre sections ». C'est vrai des
   fichiers par agent, faux du fichier de contexte racine du coordinateur.**
   Mesuré sur les cinq cibles avec `link --coordinator lead` : `.claude/CLAUDE.md`,
   `.codex/AGENTS.md`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`
   et `.opencode/instructions.md` ne portent que `System Prompt` + `Instructions`
   — et `Instructions` **sans son titre `## Instructions`**. `Output Format` et
   `Context` du coordinateur sont perdus, sur les cinq cibles.
   **Non corrigé ici, délibérément** : le réparer changerait la sortie de `link`
   pour tout projet ayant un coordinateur (deux sections en plus, un titre en
   plus), ce qui est un changement visible qui mérite sa propre issue et son
   propre chiffrage. C'est la seule copie de la composition que cette PR laisse
   diverger, et c'est dit.

2. **Pollution antérieure de la vraie base.** `execution_events` contient
   **7 runs / 14 événements** datés du 2026-08-27 20:57 → 21:24 portant en clair
   le prompt de la sonde de #392 (`RUN_DEEP_PROMPT_MARKER`, agent `probe`). La
   table `runs` a été nettoyée, le log d'événements non — le nettoyage a été
   partiel. Je n'ai pas touché à la base de l'utilisateur.

## Gate

- `cargo fmt --all -- --check` : OK
- clippy `-D warnings` dans les **5** modes : OK
- tests dans les **4** modes : OK
- gaveldrop : **13 cases · 13 passed · 0 failed · score 83/83**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
