### PR TITLE
fix(link): honorer et signaler link.coordinator (#371, #375)

### DIFF
--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -146,6 +146,51 @@ pub fn name_matches_reference(agent_name: &str, reference: &str) -> bool {
         || slugify(agent_name).eq_ignore_ascii_case(reference)
 }
 
+/// The project-config key that names the linker's coordinator. Spelled
+/// once, here, so the three surfaces that report on it (`link`, `unlink`,
+/// `validate`) cannot drift into naming three different keys — and so a
+/// user reading any of them is sent to the field that actually exists.
+pub const LINK_COORDINATOR_KEY: &str = "link.coordinator";
+
+/// What to tell the user when a configured coordinator reference
+/// designates no agent of the roster (issue #371).
+///
+/// The failure is silent by construction: [`name_matches_reference`]
+/// simply finds nothing, so `link` writes no root instructions file and
+/// `unlink` looks for none. Nothing is left on disk — the defect is
+/// symmetric, unlike #341 — so this message is the *only* observable, and
+/// every command that resolves the reference emits this one text rather
+/// than its own.
+///
+/// It names the H1-title namespace on purpose. `link.coordinator` is
+/// matched against an agent's title (or that title's slug), never against
+/// the key used in `agents:` or in `orchestration.coordinator`, which are
+/// a separate namespace (`docs/wiki/link.md`); a message that sent the
+/// user to the roster key would have them correct the wrong field. Listing
+/// the titles actually available is what turns "no match" into something
+/// they can act on without opening every `.md`.
+///
+/// `origin` is the field the reference came from — [`LINK_COORDINATOR_KEY`]
+/// for the config, `--coordinator` for the CLI flag that overrides it.
+pub fn coordinator_no_match_message(
+    origin: &str,
+    reference: &str,
+    roster_titles: &[String],
+) -> String {
+    let titles = if roster_titles.is_empty() {
+        "(none)".to_string()
+    } else {
+        roster_titles.join(", ")
+    };
+    format!(
+        "{origin} '{reference}' matches no agent — no root instructions file \
+         (.claude/CLAUDE.md and its equivalents) is written or removed for it.\n\
+         It is matched against an agent's H1 title, or that title's slug — not the \
+         `agents:` key, which is a separate namespace.\n\
+         Titles in this roster: {titles}."
+    )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipelineConfig {
     /// Agents to chain after this one

--- a/crates/armadai-core/src/agent.rs
+++ b/crates/armadai-core/src/agent.rs
@@ -147,20 +147,32 @@ pub fn name_matches_reference(agent_name: &str, reference: &str) -> bool {
 }
 
 /// The project-config key that names the linker's coordinator. Spelled
-/// once, here, so the three surfaces that report on it (`link`, `unlink`,
-/// `validate`) cannot drift into naming three different keys — and so a
-/// user reading any of them is sent to the field that actually exists.
+/// once, here, so the four surfaces that report on it (`link`, `unlink`,
+/// the shell's setup wizard, `validate`) cannot drift into naming four
+/// different keys — and so a user reading any of them is sent to the
+/// field that actually exists.
 pub const LINK_COORDINATOR_KEY: &str = "link.coordinator";
 
-/// What to tell the user when a configured coordinator reference
-/// designates no agent of the roster (issue #371).
+/// Does `reference` designate an agent of `roster_titles`, and if not,
+/// what should the user be told (issue #371)?
 ///
-/// The failure is silent by construction: [`name_matches_reference`]
-/// simply finds nothing, so `link` writes no root instructions file and
-/// `unlink` looks for none. Nothing is left on disk — the defect is
-/// symmetric, unlike #341 — so this message is the *only* observable, and
-/// every command that resolves the reference emits this one text rather
-/// than its own.
+/// **This is a statement about the configuration, not about an
+/// invocation.** `link.coordinator` either names an agent the project
+/// declares or it does not; that answer cannot depend on which subset of
+/// the roster a given command happens to be writing. Computing it as a
+/// side effect of the resolver — "did *this* call find the agent?" — is
+/// what made `armadai link --agents Worker` announce that a perfectly
+/// correct `coordinator: dev-lead` matched nothing, on the very same
+/// project where `armadai validate` reported no warning at all. So every
+/// caller passes the **declared** roster here, and passes whatever roster
+/// it is actually writing to the resolver, separately.
+///
+/// The failure this reports is silent by construction:
+/// [`name_matches_reference`] simply finds nothing, so `link` writes no
+/// root instructions file and `unlink` looks for none. Nothing is left on
+/// disk — the defect is symmetric, unlike #341 — so this message is the
+/// *only* observable, and every command emits this one text rather than
+/// its own.
 ///
 /// It names the H1-title namespace on purpose. `link.coordinator` is
 /// matched against an agent's title (or that title's slug), never against
@@ -172,11 +184,30 @@ pub const LINK_COORDINATOR_KEY: &str = "link.coordinator";
 ///
 /// `origin` is the field the reference came from — [`LINK_COORDINATOR_KEY`]
 /// for the config, `--coordinator` for the CLI flag that overrides it.
-pub fn coordinator_no_match_message(
+pub fn coordinator_no_match_warning(
     origin: &str,
     reference: &str,
     roster_titles: &[String],
-) -> String {
+) -> Option<String> {
+    if roster_titles
+        .iter()
+        .any(|title| name_matches_reference(title, reference))
+    {
+        return None;
+    }
+    Some(coordinator_no_match_message(
+        origin,
+        reference,
+        roster_titles,
+    ))
+}
+
+/// The wording of [`coordinator_no_match_warning`]'s report, kept private
+/// on purpose: a caller holding the formatter without the predicate is
+/// exactly how the "did this call resolve it?" coupling got written in the
+/// first place. There is no way to emit this text without first having
+/// asked the question against a roster.
+fn coordinator_no_match_message(origin: &str, reference: &str, roster_titles: &[String]) -> String {
     let titles = if roster_titles.is_empty() {
         "(none)".to_string()
     } else {

--- a/crates/armadai-core/src/pack_validation.rs
+++ b/crates/armadai-core/src/pack_validation.rs
@@ -358,32 +358,59 @@ pub fn validate_project_config(project_root: &Path) -> Vec<ValidationIssue> {
     //   a pure config lookup; this one needs every agent file to load, so
     //   its answer depends on what resolves on this machine. Reporting is
     //   worth it; failing a build on a check that can degrade is not.
-    // - **Skipped when the roster is incomplete.** If any agent failed to
-    //   load (an unresolvable ref, an unparseable `.md`, a library that
-    //   isn't there), the titles we have are not the titles `link` would
-    //   see, and "matches nothing" would be a guess. Those failures are
-    //   already reported on their own terms elsewhere.
+    // - **It refuses to answer when the roster is incomplete.** If any
+    //   agent failed to load (an unresolvable ref, an unparseable `.md`, a
+    //   library that isn't there), the titles we have are not the titles
+    //   `link` would see, and "matches nothing" would be a guess.
+    //
+    //   That second restriction used to be justified here by "those
+    //   failures are already reported on their own terms elsewhere" —
+    //   which is false *inside `validate`*, and measured so: on a project
+    //   whose `agents:` names a `ghost` no file backs and whose
+    //   `coordinator: dev-led` is a typo, `validate` answered
+    //   `0 error(s), 0 warning(s)` / "Validation passed" while `link`
+    //   printed both warnings. `validate` has no rule that reports an
+    //   unresolvable agent ref at all, so standing down silently left the
+    //   user with a green report over two real defects. It now says it
+    //   stood down, and names what stopped it — the load failures reach
+    //   the user through this warning or not at all.
     if let Some(reference) = config.link.as_ref().and_then(|l| l.coordinator.as_deref()) {
+        let location = format!(
+            "{}:{}",
+            config_path.file_name().unwrap().to_string_lossy(),
+            super::agent::LINK_COORDINATOR_KEY
+        );
         let fragments = super::agent_source::project_fragments(project_root);
         let (roster, load_warnings) =
             super::agent_source::load_all_agents(&config, project_root, &fragments);
-        if load_warnings.is_empty()
-            && !roster.is_empty()
-            && !roster
-                .iter()
-                .any(|a| super::agent::name_matches_reference(&a.name, reference))
-        {
+        if load_warnings.is_empty() {
+            // Note there is no `!roster.is_empty()` guard: a project that
+            // declares no agent at all and still configures a coordinator
+            // is a configuration that cannot be satisfied, and the report
+            // lists `(none)` as the titles available. `link` refuses such a
+            // project outright ("No agents declared in project config"), so
+            // `validate` is the only surface that can say anything here.
             let titles: Vec<String> = roster.iter().map(|a| a.name.clone()).collect();
+            if let Some(message) = super::agent::coordinator_no_match_warning(
+                super::agent::LINK_COORDINATOR_KEY,
+                reference,
+                &titles,
+            ) {
+                issues.push(ValidationIssue::warning(location, message));
+            }
+        } else {
+            let causes: Vec<&str> = load_warnings.iter().map(|w| w.message()).collect();
             issues.push(ValidationIssue::warning(
+                location,
                 format!(
-                    "{}:{}",
-                    config_path.file_name().unwrap().to_string_lossy(),
-                    super::agent::LINK_COORDINATOR_KEY
-                ),
-                super::agent::coordinator_no_match_message(
+                    "{} '{}' was not checked: part of the roster failed to load, so the \
+                     titles available here are not the titles `link` would see and \
+                     \"matches no agent\" would be a guess.\n\
+                     Resolve these first, then re-run `armadai validate`:\n\
+                     - {}",
                     super::agent::LINK_COORDINATOR_KEY,
                     reference,
-                    &titles,
+                    causes.join("\n- ")
                 ),
             ));
         }

--- a/crates/armadai-core/src/pack_validation.rs
+++ b/crates/armadai-core/src/pack_validation.rs
@@ -342,6 +342,53 @@ pub fn validate_project_config(project_root: &Path) -> Vec<ValidationIssue> {
         }
     }
 
+    // R7: Validate `link.coordinator` (issue #371). Deliberately NOT
+    // checked against `agent_names` above: that set holds the *config
+    // keys* (`agents:` entries, declaration names), while
+    // `link.coordinator` is matched against each agent's **H1 title** or
+    // that title's slug — a separate namespace, and the very split that
+    // made #341 possible. Checking it against the keys would report a
+    // working config as broken and vice versa, so the roster is loaded
+    // for its titles and compared with the one criterion `link` and
+    // `unlink` both use.
+    //
+    // Two deliberate restrictions:
+    //
+    // - **Warning, not error.** R2's `orchestration.coordinator` check is
+    //   a pure config lookup; this one needs every agent file to load, so
+    //   its answer depends on what resolves on this machine. Reporting is
+    //   worth it; failing a build on a check that can degrade is not.
+    // - **Skipped when the roster is incomplete.** If any agent failed to
+    //   load (an unresolvable ref, an unparseable `.md`, a library that
+    //   isn't there), the titles we have are not the titles `link` would
+    //   see, and "matches nothing" would be a guess. Those failures are
+    //   already reported on their own terms elsewhere.
+    if let Some(reference) = config.link.as_ref().and_then(|l| l.coordinator.as_deref()) {
+        let fragments = super::agent_source::project_fragments(project_root);
+        let (roster, load_warnings) =
+            super::agent_source::load_all_agents(&config, project_root, &fragments);
+        if load_warnings.is_empty()
+            && !roster.is_empty()
+            && !roster
+                .iter()
+                .any(|a| super::agent::name_matches_reference(&a.name, reference))
+        {
+            let titles: Vec<String> = roster.iter().map(|a| a.name.clone()).collect();
+            issues.push(ValidationIssue::warning(
+                format!(
+                    "{}:{}",
+                    config_path.file_name().unwrap().to_string_lossy(),
+                    super::agent::LINK_COORDINATOR_KEY
+                ),
+                super::agent::coordinator_no_match_message(
+                    super::agent::LINK_COORDINATOR_KEY,
+                    reference,
+                    &titles,
+                ),
+            ));
+        }
+    }
+
     // R6: Validate agent Triggers sections
     for agent_ref in &config.agents {
         if let Ok(agent_path) = super::project::resolve_agent(agent_ref, project_root) {

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -104,15 +104,26 @@ pub async fn execute(
         );
     }
 
-    // 3b. Extract coordinator if configured (CLI flag takes priority over config)
-    let coordinator_name =
-        coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
-    let mut coordinator = coordinator_name.and_then(|name| {
-        let idx = link_agents
-            .iter()
-            .position(|a| crate::linker::name_matches_reference(&a.name, &name))?;
-        Some(link_agents.remove(idx))
-    });
+    // 3b. Extract coordinator if configured (CLI flag takes priority over
+    // config), through the one resolver `unlink` and the shell wizard also
+    // use. A reference that matches nothing is reported rather than
+    // silently ignored (issue #371): the link stays valid — it is the
+    // configuration that is not what the user meant — but until this
+    // warning existed, `link` announced success having written no root
+    // instructions file at all, and `unlink` looked for none either, so a
+    // typo left no trace anywhere.
+    let (mut coordinator, coordinator_warning) = linker::take_coordinator(
+        &mut link_agents,
+        coordinator_flag,
+        config.link.as_ref().and_then(|l| l.coordinator.clone()),
+    );
+    if let Some(message) = coordinator_warning {
+        let s = crate::cli::style::warn();
+        anstream::eprintln!(
+            "{s}  warn: {}{s:#}",
+            crate::cli::style::indent_continuation(&message, "        ")
+        );
+    }
 
     // 4. Determine target
     let target_name = target

--- a/crates/armadai/src/cli/link.rs
+++ b/crates/armadai/src/cli/link.rs
@@ -67,6 +67,23 @@ pub async fn execute(
         anyhow::bail!("No agents could be resolved. Check your project config.");
     }
 
+    // 2a-bis. Whether `link.coordinator` names an agent this project
+    // declares is a statement about the **configuration**, so it is
+    // answered here, against the roster as declared — before `--agents`
+    // narrows it below. Deriving it from the resolver instead ("did this
+    // call find the agent?") is what made `armadai link --agents Worker`
+    // report a perfectly correct `coordinator: dev-lead` as matching
+    // nothing, on a project where `armadai validate` reported no warning
+    // at all. The message is printed at step 3b, where it belongs in the
+    // output, but the question is asked here.
+    let coordinator_ref = linker::coordinator_reference(
+        coordinator_flag,
+        config.link.as_ref().and_then(|l| l.coordinator.clone()),
+    );
+    let coordinator_warning = coordinator_ref
+        .as_ref()
+        .and_then(|r| r.no_match_warning(&link_agents));
+
     // 2b. Resolve deprecated model aliases before remapping
     for agent in &mut link_agents {
         armadai_core::model_aliases::resolve_model_deprecations(
@@ -104,26 +121,31 @@ pub async fn execute(
         );
     }
 
-    // 3b. Extract coordinator if configured (CLI flag takes priority over
-    // config), through the one resolver `unlink` and the shell wizard also
-    // use. A reference that matches nothing is reported rather than
-    // silently ignored (issue #371): the link stays valid — it is the
-    // configuration that is not what the user meant — but until this
-    // warning existed, `link` announced success having written no root
-    // instructions file at all, and `unlink` looked for none either, so a
-    // typo left no trace anywhere.
-    let (mut coordinator, coordinator_warning) = linker::take_coordinator(
-        &mut link_agents,
-        coordinator_flag,
-        config.link.as_ref().and_then(|l| l.coordinator.clone()),
-    );
-    if let Some(message) = coordinator_warning {
+    // 3b. Report the configured coordinator if it names no declared agent
+    // (the question was asked at step 2a-bis, against the unfiltered
+    // roster), then extract it from the agents actually being written.
+    //
+    // Reporting matters because the failure is otherwise invisible: until
+    // this warning existed, `link` announced success having written no
+    // root instructions file at all, and `unlink` looked for none either,
+    // so a typo left no trace anywhere (issue #371). It stays a warning:
+    // the link itself is valid, it is the configuration that is not what
+    // the user meant.
+    //
+    // Extraction runs on the post-filter roster on purpose: `--agents
+    // Worker` writes exactly Worker, so no root instructions file is
+    // written for a coordinator the user did not request. That is the
+    // pinned behaviour, and it is not what the warning is about.
+    if let Some(message) = &coordinator_warning {
         let s = crate::cli::style::warn();
         anstream::eprintln!(
             "{s}  warn: {}{s:#}",
-            crate::cli::style::indent_continuation(&message, "        ")
+            crate::cli::style::indent_continuation(message, "        ")
         );
     }
+    let mut coordinator = coordinator_ref
+        .as_ref()
+        .and_then(|r| r.take_from(&mut link_agents));
 
     // 4. Determine target
     let target_name = target

--- a/crates/armadai/src/cli/style.rs
+++ b/crates/armadai/src/cli/style.rs
@@ -105,4 +105,41 @@ mod tests {
             "expected no ANSI codes when forced off"
         );
     }
+
+    /// [`indent_continuation`]'s whole contract, asserted verbatim on a
+    /// multi-line input.
+    ///
+    /// It had none: this function shipped with every one of its call
+    /// sites checked by `contains` on single-line fragments, so turning it
+    /// into the identity function left all 28 test targets green — the
+    /// entire presentation of a three-line warning was unfalsifiable. Both
+    /// live indent widths are pinned here (`link`/`unlink`/wizard align
+    /// their continuations under a `  warn: ` prefix, `validate` under its
+    /// own `WARN  ` one), plus the two edges that decide whether the
+    /// function is doing anything at all.
+    #[test]
+    fn indent_continuation_indents_every_line_but_the_first() {
+        let message = "first line.\nsecond line.\nthird line.";
+
+        assert_eq!(
+            indent_continuation(message, "        "),
+            "first line.\n        second line.\n        third line.",
+            "the `  warn: ` alignment used by link, unlink and the shell wizard"
+        );
+        assert_eq!(
+            indent_continuation(message, "  "),
+            "first line.\n  second line.\n  third line.",
+            "the `WARN  ` alignment used by validate"
+        );
+        assert_eq!(
+            indent_continuation("only one line.", "        "),
+            "only one line.",
+            "a single-line message must come out untouched — no trailing indent"
+        );
+        assert_eq!(
+            indent_continuation("a\n\nb", "  "),
+            "a\n  \n  b",
+            "a blank line is a line: it gets the indent too, so the block stays one block"
+        );
+    }
 }

--- a/crates/armadai/src/cli/style.rs
+++ b/crates/armadai/src/cli/style.rs
@@ -9,6 +9,15 @@
 
 use anstyle::{AnsiColor, Color, RgbColor, Style};
 
+/// Indent a multi-line message's continuation lines by `indent`, so they
+/// read as part of the same sentence rather than as unrelated output.
+/// Shared by every surface that prints one — `link`, `unlink` and the
+/// shell's setup wizard align theirs under the `  warn: ` prefix,
+/// `validate` under its own `WARN  location:` one.
+pub(crate) fn indent_continuation(message: &str, indent: &str) -> String {
+    message.replace('\n', &format!("\n{indent}"))
+}
+
 // Design-system accents (assets/terminal-palette.json).
 // `#[allow(dead_code)]` on the remaining unwired items below: CLI-1 wired
 // `cli/run.rs`, CLI-2 (this lot) wires the discovery/read commands (`err()`

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -833,6 +833,20 @@ async fn unlink_via_fallback(
         anyhow::bail!("No agents could be resolved. Check your project config.");
     }
 
+    // Whether `link.coordinator` names an agent this project declares is a
+    // statement about the configuration, so — exactly as in `link`'s step
+    // 2a-bis — it is answered here, against the roster as declared, before
+    // `--agents` narrows it below. Asking it after the filter had `unlink
+    // --agents Worker` report a correct `coordinator: dev-lead` as
+    // matching nothing.
+    let coordinator_ref = linker::coordinator_reference(
+        coordinator_flag,
+        config.link.as_ref().and_then(|l| l.coordinator.clone()),
+    );
+    let coordinator_warning = coordinator_ref
+        .as_ref()
+        .and_then(|r| r.no_match_warning(&link_agents));
+
     // Resolve deprecated model aliases — `link` does this before
     // generating, so the content guard below must reproduce it too, or
     // every agent still using a since-renamed model would never match.
@@ -852,30 +866,28 @@ async fn unlink_via_fallback(
         }
     }
 
-    // Extract coordinator if configured (CLI flag takes priority over
-    // config), through `linker::take_coordinator` — the same resolver
-    // `link` uses, so both match by name *or* slug and never by name
-    // alone. `link` resolves `coordinator: dev-lead` to the agent titled
-    // `Dev Lead` and writes its root context file; a narrower criterion
-    // here would not even make that file a candidate for removal, leaving
-    // it on disk with no message naming it (issue #341).
+    // Report the configured coordinator if it names no declared agent
+    // (asked above, on the unfiltered roster), then extract it from the
+    // agents actually being reclaimed — through `CoordinatorRef::take_from`,
+    // the same resolver `link` uses, so both match by name *or* slug and
+    // never by name alone. `link` resolves `coordinator: dev-lead` to the
+    // agent titled `Dev Lead` and writes its root context file; a narrower
+    // criterion here would not even make that file a candidate for
+    // removal, leaving it on disk with no message naming it (issue #341).
     //
-    // The same resolver is also what reports a reference matching nothing
-    // (issue #371). Emitting that only from `link` would recreate exactly
-    // the asymmetry #341/#370 closed — one command speaking, the other
-    // silent about the same configuration.
-    let (mut coordinator, coordinator_warning) = linker::take_coordinator(
-        &mut link_agents,
-        coordinator_flag,
-        config.link.as_ref().and_then(|l| l.coordinator.clone()),
-    );
-    if let Some(message) = coordinator_warning {
+    // Reporting from `unlink` too, and not from `link` alone, is what
+    // avoids recreating the asymmetry #341/#370 closed — one command
+    // speaking, the other silent about the same configuration.
+    if let Some(message) = &coordinator_warning {
         let w = crate::cli::style::warn();
         anstream::eprintln!(
             "{w}  warn: {}{w:#}",
-            crate::cli::style::indent_continuation(&message, "        ")
+            crate::cli::style::indent_continuation(message, "        ")
         );
     }
+    let mut coordinator = coordinator_ref
+        .as_ref()
+        .and_then(|r| r.take_from(&mut link_agents));
 
     // Model resolution — mirror what `link` computes for this target, so
     // the regenerated content used by the guard below matches what `link`

--- a/crates/armadai/src/cli/unlink.rs
+++ b/crates/armadai/src/cli/unlink.rs
@@ -852,21 +852,30 @@ async fn unlink_via_fallback(
         }
     }
 
-    // Extract coordinator if configured (CLI flag takes priority over config)
-    let coordinator_name =
-        coordinator_flag.or_else(|| config.link.as_ref().and_then(|l| l.coordinator.clone()));
-    // Matched by name *or* slug, through the same
-    // `name_matches_reference` `link` uses — never by name alone. `link`
-    // resolves `coordinator: dev-lead` to the agent titled `Dev Lead` and
-    // writes its root context file; a narrower criterion here would not
-    // even make that file a candidate for removal, leaving it on disk with
-    // no message naming it (issue #341).
-    let mut coordinator = coordinator_name.and_then(|name| {
-        let idx = link_agents
-            .iter()
-            .position(|a| crate::linker::name_matches_reference(&a.name, &name))?;
-        Some(link_agents.remove(idx))
-    });
+    // Extract coordinator if configured (CLI flag takes priority over
+    // config), through `linker::take_coordinator` — the same resolver
+    // `link` uses, so both match by name *or* slug and never by name
+    // alone. `link` resolves `coordinator: dev-lead` to the agent titled
+    // `Dev Lead` and writes its root context file; a narrower criterion
+    // here would not even make that file a candidate for removal, leaving
+    // it on disk with no message naming it (issue #341).
+    //
+    // The same resolver is also what reports a reference matching nothing
+    // (issue #371). Emitting that only from `link` would recreate exactly
+    // the asymmetry #341/#370 closed — one command speaking, the other
+    // silent about the same configuration.
+    let (mut coordinator, coordinator_warning) = linker::take_coordinator(
+        &mut link_agents,
+        coordinator_flag,
+        config.link.as_ref().and_then(|l| l.coordinator.clone()),
+    );
+    if let Some(message) = coordinator_warning {
+        let w = crate::cli::style::warn();
+        anstream::eprintln!(
+            "{w}  warn: {}{w:#}",
+            crate::cli::style::indent_continuation(&message, "        ")
+        );
+    }
 
     // Model resolution — mirror what `link` computes for this target, so
     // the regenerated content used by the guard below matches what `link`

--- a/crates/armadai/src/cli/validate.rs
+++ b/crates/armadai/src/cli/validate.rs
@@ -63,7 +63,10 @@ pub async fn execute(path: Option<PathBuf>) -> anyhow::Result<()> {
             "{style}{}{style:#} {}: {}",
             prefix,
             issue.location,
-            issue.message
+            // A multi-line message (R7's `link.coordinator` report) must
+            // still read as one entry rather than as three unrelated
+            // lines.
+            crate::cli::style::indent_continuation(&issue.message, "  ")
         );
     }
 

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -126,55 +126,107 @@ pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
 /// crate has to change.
 pub use armadai_core::agent::slugify;
 
-/// Take the configured coordinator out of `link_agents`, and say so when
-/// the reference designates nobody.
+/// The coordinator a command is working from: the reference itself, and
+/// the field that supplied it.
 ///
-/// This replaced a re-export of [`armadai_core::agent::name_matches_reference`]
-/// that each caller then used to write its own three-line resolution. Two
-/// of those copies had already drifted apart once (issue #341: `link`
-/// matched by name or slug, `unlink` by name alone, and the root context
-/// file stayed on disk unnamed); a third appeared in the shell wizard.
-/// Removing the primitive they were all reaching for is what stops a
-/// fourth.
+/// This type exists to keep two questions apart that a single
+/// `take_coordinator` used to answer at once, and wrongly:
 ///
-/// The single place `link`, `unlink` and `armadai shell`'s setup wizard
-/// all resolve `link.coordinator` from — including the CLI flag's
-/// priority over the config, which used to be spelled out twice. Removing
-/// the matched agent from the roster is what turns it into the target's
-/// root instructions file instead of one more per-agent file, so a
-/// caller that skipped this would write both.
+/// - **"Does this reference name an agent the project declares?"** — a
+///   statement about the *configuration*, answered by
+///   [`Self::no_match_warning`] against the declared roster.
+/// - **"Which agent of the roster I am about to write is it?"** — the
+///   resolver's own job, answered by [`Self::take_from`] against whatever
+///   roster the command is writing.
 ///
-/// Returns the coordinator (if any) and, when a reference *was* given but
-/// matched nothing, the message to show the user — see
-/// [`armadai_core::agent::coordinator_no_match_message`] for why that case
-/// must never stay silent (issue #371). The two outcomes are deliberately
-/// distinct: no reference at all is the normal case for most projects and
-/// warrants nothing.
-pub fn take_coordinator(
-    link_agents: &mut Vec<LinkAgent>,
+/// Deriving the first from the second is what shipped
+/// `armadai link --agents Worker` printing
+/// `link.coordinator 'dev-lead' matches no agent` on a project where
+/// `dev-lead` matches `Dev Lead` perfectly — the user's own filter had
+/// removed it from the roster the resolver searched, and the message then
+/// sent them to fix an H1 title that was never wrong. `armadai validate`,
+/// which asks the first question directly, reported no warning at all on
+/// the same project: two surfaces contradicting each other over one
+/// config key.
+///
+/// The write behaviour is not the same question and does not change with
+/// it: with `--agents Worker`, `Dev Lead` is genuinely not among the
+/// agents being written, so no root instructions file is written or
+/// removed for it (pinned by
+/// `tests/link_manifest.rs::unlink_agents_filter_leaves_the_coordinator_and_unmatched_agents_alone`).
+/// Only the message was wrong.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoordinatorRef {
+    /// The field the reference came from — `link.coordinator` for the
+    /// project config, `--coordinator` for the CLI flag that overrides it.
+    /// Reported verbatim, so the user is sent to the field they actually
+    /// wrote.
+    pub origin: &'static str,
+    /// The reference as configured, before any slug folding.
+    pub reference: String,
+}
+
+/// Which coordinator reference is in force — the CLI flag when given,
+/// otherwise the project config, otherwise none.
+///
+/// One priority rule, in one place, for the three callers (`link`,
+/// `unlink`, `armadai shell`'s setup wizard) that used to spell it out
+/// themselves. `None` — no coordinator configured at all — is the normal
+/// case for most projects and warrants nothing.
+pub fn coordinator_reference(
     coordinator_flag: Option<String>,
     configured: Option<String>,
-) -> (Option<LinkAgent>, Option<String>) {
-    let (origin, reference) = match (coordinator_flag, configured) {
-        (Some(flag), _) => ("--coordinator", flag),
-        (None, Some(from_config)) => (armadai_core::agent::LINK_COORDINATOR_KEY, from_config),
-        (None, None) => return (None, None),
-    };
+) -> Option<CoordinatorRef> {
+    match (coordinator_flag, configured) {
+        (Some(flag), _) => Some(CoordinatorRef {
+            origin: "--coordinator",
+            reference: flag,
+        }),
+        (None, Some(from_config)) => Some(CoordinatorRef {
+            origin: armadai_core::agent::LINK_COORDINATOR_KEY,
+            reference: from_config,
+        }),
+        (None, None) => None,
+    }
+}
 
-    match link_agents
-        .iter()
-        .position(|a| armadai_core::agent::name_matches_reference(&a.name, &reference))
-    {
-        Some(idx) => (Some(link_agents.remove(idx)), None),
-        None => {
-            let titles: Vec<String> = link_agents.iter().map(|a| a.name.clone()).collect();
-            (
-                None,
-                Some(armadai_core::agent::coordinator_no_match_message(
-                    origin, &reference, &titles,
-                )),
-            )
-        }
+impl CoordinatorRef {
+    /// What to tell the user when this reference designates no agent of
+    /// `declared_roster` (issue #371), or `None` when it designates one.
+    ///
+    /// `declared_roster` must be the project's roster as loaded, **never**
+    /// a `--agents`-filtered subset — see this type's own doc. The
+    /// wording, and the decision of whether there is anything to say at
+    /// all, both live in
+    /// [`armadai_core::agent::coordinator_no_match_warning`], which
+    /// `validate`'s R7 calls directly: one question, one answer, four
+    /// surfaces.
+    pub fn no_match_warning(&self, declared_roster: &[LinkAgent]) -> Option<String> {
+        let titles: Vec<String> = declared_roster.iter().map(|a| a.name.clone()).collect();
+        armadai_core::agent::coordinator_no_match_warning(self.origin, &self.reference, &titles)
+    }
+
+    /// Take the agent this reference designates out of `link_agents`.
+    ///
+    /// Removing it from the roster is what turns it into the target's root
+    /// instructions file instead of one more per-agent file, so a caller
+    /// that skipped this would write both. Matching goes through
+    /// [`armadai_core::agent::name_matches_reference`] — by title *or* by
+    /// that title's slug. This replaced a re-export of that primitive on
+    /// which each caller wrote its own three-line resolution: two of those
+    /// copies had already drifted apart once (issue #341: `link` matched
+    /// by name or slug, `unlink` by name alone, and the root context file
+    /// stayed on disk unnamed), and a third appeared in the shell wizard.
+    ///
+    /// Returning `None` here is **not** a defect to report: a roster that
+    /// legitimately excludes the coordinator (a `--agents` filter that
+    /// does not name it) reaches this exact branch. Reporting is
+    /// [`Self::no_match_warning`]'s job, on the declared roster.
+    pub fn take_from(&self, link_agents: &mut Vec<LinkAgent>) -> Option<LinkAgent> {
+        let idx = link_agents
+            .iter()
+            .position(|a| armadai_core::agent::name_matches_reference(&a.name, &self.reference))?;
+        Some(link_agents.remove(idx))
     }
 }
 
@@ -247,11 +299,11 @@ mod tests {
     use super::*;
     use armadai_core::agent::AgentMetadata;
 
-    /// [`take_coordinator`]'s own branches, including the two the
-    /// black-box suite (`tests/link_coordinator_no_match.rs`) cannot
-    /// reach: the `--coordinator` flag's priority over the config, and
-    /// the origin label that flag puts in the message.
-    mod take_coordinator_tests {
+    /// [`CoordinatorRef`]'s own branches, including the two the black-box
+    /// suite (`tests/link_coordinator_no_match.rs`) cannot reach: the
+    /// `--coordinator` flag's priority over the config, and the origin
+    /// label that flag puts in the message.
+    mod coordinator_ref_tests {
         use super::*;
 
         fn roster() -> Vec<LinkAgent> {
@@ -290,11 +342,18 @@ mod tests {
         #[test]
         fn a_slug_reference_resolves_the_titled_agent_and_removes_it() {
             let mut agents = roster();
-            let (coord, warning) =
-                take_coordinator(&mut agents, None, Some("dev-lead".to_string()));
+            let coordinator = coordinator_reference(None, Some("dev-lead".to_string()))
+                .expect("a configured reference");
 
-            assert_eq!(coord.map(|c| c.name), Some("Dev Lead".to_string()));
-            assert_eq!(warning, None, "a resolved coordinator warrants no message");
+            assert_eq!(
+                coordinator.no_match_warning(&agents),
+                None,
+                "a resolved coordinator warrants no message"
+            );
+            assert_eq!(
+                coordinator.take_from(&mut agents).map(|c| c.name),
+                Some("Dev Lead".to_string())
+            );
             assert_eq!(
                 agents.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
                 vec!["Worker", "QA"],
@@ -305,31 +364,28 @@ mod tests {
         /// No reference at all is the normal case for most projects: no
         /// coordinator, and nothing to say about it.
         ///
-        /// Mutation: warning whenever the result is `None` (rather than
-        /// only when a reference was given and failed) fails this test.
+        /// Mutation: returning `Some(CoordinatorRef { .. })` for the
+        /// `(None, None)` arm fails this test.
         #[test]
         fn no_reference_at_all_is_silent() {
-            let mut agents = roster();
-            let (coord, warning) = take_coordinator(&mut agents, None, None);
-
-            assert!(coord.is_none());
-            assert_eq!(warning, None);
-            assert_eq!(agents.len(), 3, "the roster is untouched");
+            assert_eq!(coordinator_reference(None, None), None);
         }
 
         /// Issue #371: a reference that designates nobody must produce a
         /// message naming the key at fault, the H1-title namespace it is
         /// matched in, and the titles actually available.
         ///
-        /// Mutation: returning `(None, None)` here — the pre-fix
-        /// behaviour — fails every assertion below.
+        /// Mutation: having `coordinator_no_match_warning` always return
+        /// `None` — the pre-fix behaviour — fails every assertion below.
         #[test]
         fn an_unmatched_config_reference_reports_the_config_key() {
             let mut agents = roster();
-            let (coord, warning) = take_coordinator(&mut agents, None, Some("dev-led".to_string()));
+            let coordinator = coordinator_reference(None, Some("dev-led".to_string()))
+                .expect("a configured reference");
 
-            assert!(coord.is_none());
-            let message = warning.expect("an unmatched reference must be reported");
+            let message = coordinator
+                .no_match_warning(&agents)
+                .expect("an unmatched reference must be reported");
             assert!(
                 message.starts_with("link.coordinator 'dev-led' matches no agent"),
                 "must name the config key and the value: {message}"
@@ -342,6 +398,7 @@ mod tests {
                 message.contains("Titles in this roster: Worker, Dev Lead, QA."),
                 "must list what was actually available: {message}"
             );
+            assert!(coordinator.take_from(&mut agents).is_none());
             assert_eq!(agents.len(), 3, "nothing is removed when nothing matched");
         }
 
@@ -355,20 +412,79 @@ mod tests {
         #[test]
         fn the_flag_wins_over_the_config_and_names_itself() {
             let mut agents = roster();
-            let (coord, warning) = take_coordinator(
-                &mut agents,
-                Some("nobody".to_string()),
-                Some("dev-lead".to_string()),
-            );
+            let coordinator =
+                coordinator_reference(Some("nobody".to_string()), Some("dev-lead".to_string()))
+                    .expect("a configured reference");
 
             assert!(
-                coord.is_none(),
+                coordinator.take_from(&mut agents).is_none(),
                 "the flag's value is what gets resolved, and it matches nothing"
             );
-            let message = warning.expect("an unmatched flag must be reported too");
+            let message = coordinator
+                .no_match_warning(&agents)
+                .expect("an unmatched flag must be reported too");
             assert!(
                 message.starts_with("--coordinator 'nobody' matches no agent"),
                 "must name the flag, not the config key: {message}"
+            );
+        }
+
+        /// **The D1 defect, at the unit that carries it.** The two
+        /// questions must not answer each other: a roster narrowed by
+        /// `--agents` legitimately excludes the coordinator, and
+        /// `take_from` then finds nothing — but the *configuration* is
+        /// still correct, so `no_match_warning` on the declared roster
+        /// must stay silent. Deriving one from the other is what shipped
+        /// `link --agents Worker` claiming `dev-lead` matched no agent.
+        ///
+        /// Mutation: making `no_match_warning` answer against the roster
+        /// `take_from` is given (the pre-fix coupling) turns this green
+        /// assertion into a `Some(_)`.
+        #[test]
+        fn a_filtered_out_coordinator_is_a_missing_agent_not_a_broken_config() {
+            let declared = roster();
+            // What `link`'s step 3 does to the roster: `--agents Worker`.
+            let mut filtered = roster();
+            filtered.retain(|a| a.name == "Worker");
+            let coordinator = coordinator_reference(None, Some("dev-lead".to_string()))
+                .expect("a configured reference");
+
+            assert_eq!(
+                coordinator.no_match_warning(&declared),
+                None,
+                "the declared roster satisfies the reference, so there is nothing to report"
+            );
+            assert!(
+                coordinator.take_from(&mut filtered).is_none(),
+                "the filtered roster has no coordinator to hand over, and that is not a defect"
+            );
+            assert_eq!(
+                filtered.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+                vec!["Worker"],
+                "a reference that resolves to nobody here removes nobody"
+            );
+        }
+
+        /// The other half of D1: a filter must not *silence* a genuine
+        /// defect either. `dev-led` is a typo whatever `--agents` says, and
+        /// the titles listed are the declared ones — the user is told what
+        /// their project actually offers, not what this invocation kept.
+        ///
+        /// Mutation: answering against the filtered roster still warns
+        /// (the reference matches nothing there either), but lists
+        /// `Titles in this roster: Worker.` and fails the last assertion.
+        #[test]
+        fn a_filter_does_not_silence_a_genuinely_unmatched_reference() {
+            let declared = roster();
+            let coordinator = coordinator_reference(None, Some("dev-led".to_string()))
+                .expect("a configured reference");
+
+            let message = coordinator
+                .no_match_warning(&declared)
+                .expect("a typo stays a typo under any filter");
+            assert!(
+                message.contains("Titles in this roster: Worker, Dev Lead, QA."),
+                "the titles offered must be the declared ones, not the filtered ones: {message}"
             );
         }
     }

--- a/crates/armadai/src/linker/mod.rs
+++ b/crates/armadai/src/linker/mod.rs
@@ -126,11 +126,57 @@ pub fn create_linker(target: &str) -> anyhow::Result<Box<dyn Linker>> {
 /// crate has to change.
 pub use armadai_core::agent::slugify;
 
-/// Re-exported for the same reason as [`slugify`], which it is built on:
-/// resolving a configured agent reference (`link.coordinator`) against a
-/// loaded roster is one decision, and `link` and `unlink` must not each
-/// keep their own copy of it (issue #341).
-pub use armadai_core::agent::name_matches_reference;
+/// Take the configured coordinator out of `link_agents`, and say so when
+/// the reference designates nobody.
+///
+/// This replaced a re-export of [`armadai_core::agent::name_matches_reference`]
+/// that each caller then used to write its own three-line resolution. Two
+/// of those copies had already drifted apart once (issue #341: `link`
+/// matched by name or slug, `unlink` by name alone, and the root context
+/// file stayed on disk unnamed); a third appeared in the shell wizard.
+/// Removing the primitive they were all reaching for is what stops a
+/// fourth.
+///
+/// The single place `link`, `unlink` and `armadai shell`'s setup wizard
+/// all resolve `link.coordinator` from — including the CLI flag's
+/// priority over the config, which used to be spelled out twice. Removing
+/// the matched agent from the roster is what turns it into the target's
+/// root instructions file instead of one more per-agent file, so a
+/// caller that skipped this would write both.
+///
+/// Returns the coordinator (if any) and, when a reference *was* given but
+/// matched nothing, the message to show the user — see
+/// [`armadai_core::agent::coordinator_no_match_message`] for why that case
+/// must never stay silent (issue #371). The two outcomes are deliberately
+/// distinct: no reference at all is the normal case for most projects and
+/// warrants nothing.
+pub fn take_coordinator(
+    link_agents: &mut Vec<LinkAgent>,
+    coordinator_flag: Option<String>,
+    configured: Option<String>,
+) -> (Option<LinkAgent>, Option<String>) {
+    let (origin, reference) = match (coordinator_flag, configured) {
+        (Some(flag), _) => ("--coordinator", flag),
+        (None, Some(from_config)) => (armadai_core::agent::LINK_COORDINATOR_KEY, from_config),
+        (None, None) => return (None, None),
+    };
+
+    match link_agents
+        .iter()
+        .position(|a| armadai_core::agent::name_matches_reference(&a.name, &reference))
+    {
+        Some(idx) => (Some(link_agents.remove(idx)), None),
+        None => {
+            let titles: Vec<String> = link_agents.iter().map(|a| a.name.clone()).collect();
+            (
+                None,
+                Some(armadai_core::agent::coordinator_no_match_message(
+                    origin, &reference, &titles,
+                )),
+            )
+        }
+    }
+}
 
 impl From<&Agent> for LinkAgent {
     fn from(agent: &Agent) -> Self {
@@ -200,6 +246,132 @@ Follow this protocol for all responses:
 mod tests {
     use super::*;
     use armadai_core::agent::AgentMetadata;
+
+    /// [`take_coordinator`]'s own branches, including the two the
+    /// black-box suite (`tests/link_coordinator_no_match.rs`) cannot
+    /// reach: the `--coordinator` flag's priority over the config, and
+    /// the origin label that flag puts in the message.
+    mod take_coordinator_tests {
+        use super::*;
+
+        fn roster() -> Vec<LinkAgent> {
+            ["Worker", "Dev Lead", "QA"]
+                .iter()
+                .map(|name| LinkAgent {
+                    name: (*name).to_string(),
+                    system_prompt: format!("I am {name}."),
+                    instructions: None,
+                    output_format: None,
+                    context: None,
+                    description: None,
+                    tags: Vec::new(),
+                    stacks: Vec::new(),
+                    scope: Vec::new(),
+                    model: None,
+                    model_fallback: Vec::new(),
+                    temperature: 0.7,
+                    provider: None,
+                })
+                .collect()
+        }
+
+        /// The match is by title *or* slug, and the matched agent leaves
+        /// the roster — that removal is what makes it the root
+        /// instructions file instead of one more per-agent file.
+        ///
+        /// `Dev Lead` sits at index 1 on purpose: with the coordinator at
+        /// index 0 this assertion also holds under a predicate that
+        /// always matches, which is exactly the fixture defect measured
+        /// on #370.
+        ///
+        /// Mutation: replacing `name_matches_reference` with `==` (the
+        /// `Dev Lead`/`dev-lead` pair fails it) or with an always-true
+        /// closure (which takes `Worker`) fails this test.
+        #[test]
+        fn a_slug_reference_resolves_the_titled_agent_and_removes_it() {
+            let mut agents = roster();
+            let (coord, warning) =
+                take_coordinator(&mut agents, None, Some("dev-lead".to_string()));
+
+            assert_eq!(coord.map(|c| c.name), Some("Dev Lead".to_string()));
+            assert_eq!(warning, None, "a resolved coordinator warrants no message");
+            assert_eq!(
+                agents.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+                vec!["Worker", "QA"],
+                "the coordinator must leave the roster"
+            );
+        }
+
+        /// No reference at all is the normal case for most projects: no
+        /// coordinator, and nothing to say about it.
+        ///
+        /// Mutation: warning whenever the result is `None` (rather than
+        /// only when a reference was given and failed) fails this test.
+        #[test]
+        fn no_reference_at_all_is_silent() {
+            let mut agents = roster();
+            let (coord, warning) = take_coordinator(&mut agents, None, None);
+
+            assert!(coord.is_none());
+            assert_eq!(warning, None);
+            assert_eq!(agents.len(), 3, "the roster is untouched");
+        }
+
+        /// Issue #371: a reference that designates nobody must produce a
+        /// message naming the key at fault, the H1-title namespace it is
+        /// matched in, and the titles actually available.
+        ///
+        /// Mutation: returning `(None, None)` here — the pre-fix
+        /// behaviour — fails every assertion below.
+        #[test]
+        fn an_unmatched_config_reference_reports_the_config_key() {
+            let mut agents = roster();
+            let (coord, warning) = take_coordinator(&mut agents, None, Some("dev-led".to_string()));
+
+            assert!(coord.is_none());
+            let message = warning.expect("an unmatched reference must be reported");
+            assert!(
+                message.starts_with("link.coordinator 'dev-led' matches no agent"),
+                "must name the config key and the value: {message}"
+            );
+            assert!(
+                message.contains("H1 title"),
+                "must send the user to the title namespace, not the `agents:` key: {message}"
+            );
+            assert!(
+                message.contains("Titles in this roster: Worker, Dev Lead, QA."),
+                "must list what was actually available: {message}"
+            );
+            assert_eq!(agents.len(), 3, "nothing is removed when nothing matched");
+        }
+
+        /// The flag wins over the config — one priority rule, in one
+        /// place, for all three callers — and the message must then name
+        /// the flag, not the config key the user did not get wrong.
+        ///
+        /// Mutation: reversing the priority resolves `Dev Lead` (the
+        /// config value matches) and returns no warning at all, failing
+        /// both assertions.
+        #[test]
+        fn the_flag_wins_over_the_config_and_names_itself() {
+            let mut agents = roster();
+            let (coord, warning) = take_coordinator(
+                &mut agents,
+                Some("nobody".to_string()),
+                Some("dev-lead".to_string()),
+            );
+
+            assert!(
+                coord.is_none(),
+                "the flag's value is what gets resolved, and it matches nothing"
+            );
+            let message = warning.expect("an unmatched flag must be reported too");
+            assert!(
+                message.starts_with("--coordinator 'nobody' matches no agent"),
+                "must name the flag, not the config key: {message}"
+            );
+        }
+    }
 
     /// The three provider inventories, checked against each other.
     ///

--- a/crates/armadai/src/shell/wizard.rs
+++ b/crates/armadai/src/shell/wizard.rs
@@ -397,18 +397,26 @@ async fn run_link(target: &str) -> Result<()> {
 /// looking for the coordinator where `link` would have put it, left that
 /// per-agent file behind.
 ///
-/// What it still does **not** honour, each a config-driven behaviour of
-/// `link` that this function has no equivalent for (tracked as #411):
+/// What it still does **not** do that `link` does — all four measured
+/// during #375 and tracked as #411, which is an extraction rather than a
+/// fix (the shareable piece is "what `link` publishes", the way
+/// `linker::manifest::write_files` already is for "how it writes"):
 ///
 /// - **`skills:` / `prompts:`** — `link` assembles the project's skills
 ///   and prompts into the generated config; the wizard passes agents
-///   alone, so a wizard-linked project ships without them.
-/// - **`orchestration:`** — `link` validates the orchestration config and
-///   refuses on error before writing anything; the wizard writes
-///   regardless.
-/// - **the project registry** — `link` calls
-///   `project_registry::register_project`, so the project shows up in
-///   `armadai projects`; a wizard-driven link never registers it.
+///   alone. Measured on a one-agent/one-skill/one-prompt project: `link`
+///   writes 4 files, the wizard 2. A wizard-linked project therefore
+///   ships a fleet amputated of both, and nothing says so.
+/// - **`orchestration:`** — `link` validates the orchestration config
+///   (its step 1b) and refuses on error before writing anything; the
+///   wizard writes regardless. Defensible — a broken config must not lock
+///   the user out of the shell they need to fix it — but undocumented as
+///   a choice until now.
+/// - **`project_registry::register_project`** — `link`, `run` and `init`
+///   all register the project, so it shows up in `armadai projects`; a
+///   wizard-driven link never does.
+/// - **`model_updater::auto_check_and_prompt`** — same three commands run
+///   the deprecated-model check; the wizard never offers it.
 ///
 /// `warnings` is where the user-facing warnings go. In production it is
 /// `anstream::stderr()` (see [`run_link`]); tests pass a buffer, which is

--- a/crates/armadai/src/shell/wizard.rs
+++ b/crates/armadai/src/shell/wizard.rs
@@ -385,10 +385,16 @@ async fn run_link(target: &str) -> Result<()> {
 /// so the manifest write and the exists-guard come from the same place
 /// `link` gets them, rather than a third copy that could drift from both.
 ///
-/// Deliberately narrower than `link`'s own CLI surface: no coordinator, no
-/// skills/prompts, no `--agents` filter, no `--model`/interactive model
-/// prompt, no `--force` — the wizard flow never had any of those, and none
-/// of them are part of what issue #347 asks to fix.
+/// Deliberately narrower than `link`'s own CLI *flags*: no `--coordinator`
+/// override, no skills/prompts, no `--agents` filter, no
+/// `--model`/interactive model prompt, no `--force` — the wizard flow has
+/// no way to express any of those. What it does honour is the project
+/// **config**: `link.coordinator` reaches `generate` here exactly as it
+/// does in `link` (issue #375). It used to be hardcoded to `None`, so the
+/// wizard wrote a per-agent file for every agent and never the target's
+/// root instructions file — and a later manifest-less `unlink`, looking
+/// for the coordinator where `link` would have put it, left that
+/// per-agent file behind.
 async fn run_link_at(
     root: &Path,
     config: &armadai_core::project::ProjectConfig,
@@ -447,6 +453,31 @@ async fn run_link_at(
         ));
     }
 
+    // The configured coordinator, resolved against the roster through the
+    // same `name_matches_reference` `link` and `unlink` both use (issue
+    // #341/#370): `coordinator: dev-lead` designates the agent titled
+    // `Dev Lead`. Removing it from `link_agents` is what makes it the
+    // target's root instructions file instead of one more per-agent file
+    // — `link`'s own step 3b, verbatim. The wizard has no
+    // `--coordinator` flag to override the config with.
+    //
+    // The model-resolution step below runs on the coordinator too, the
+    // same way `link` and `unlink` both do. Measured: no linker
+    // serialises a coordinator's `model:` into its root instructions
+    // document today (checked in all five of claude/codex/copilot/
+    // gemini/opencode), so that arm makes no observable difference to
+    // the bytes written — it is kept aligned so a linker that starts
+    // emitting one is correct by construction rather than by accident,
+    // and so this function stays a mirror of `link` rather than a fourth
+    // variant of it.
+    let coordinator_name = config.link.as_ref().and_then(|l| l.coordinator.clone());
+    let mut coordinator = coordinator_name.and_then(|name| {
+        let idx = link_agents
+            .iter()
+            .position(|a| crate::linker::name_matches_reference(&a.name, &name))?;
+        Some(link_agents.remove(idx))
+    });
+
     // The same model resolution `link`'s own step 4b performs (issue I1 on
     // #347's review): without this, a `latest:*` placeholder reaches
     // `generate()` completely unresolved, so the wizard writes a literal
@@ -466,21 +497,37 @@ async fn run_link_at(
             #[cfg(feature = "providers-api")]
             {
                 model_resolution::remap_models_for_llm_editor(&mut link_agents, provider).await;
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_llm_editor(
+                        std::slice::from_mut(coord),
+                        provider,
+                    )
+                    .await;
+                }
             }
             #[cfg(not(feature = "providers-api"))]
             {
                 model_resolution::remap_models_for_llm_editor(&mut link_agents, provider);
+                if let Some(ref mut coord) = coordinator {
+                    model_resolution::remap_models_for_llm_editor(
+                        std::slice::from_mut(coord),
+                        provider,
+                    );
+                }
             }
         }
         TargetKind::Orchestrator => {
             model_resolution::resolve_latest_placeholders(&mut link_agents);
+            if let Some(ref mut coord) = coordinator {
+                model_resolution::resolve_latest_placeholders(std::slice::from_mut(coord));
+            }
         }
     }
 
     let linker = crate::linker::create_linker(target)?;
 
     let sources = &config.sources;
-    let files = linker.generate(&link_agents, None, sources);
+    let files = linker.generate(&link_agents, coordinator.as_ref(), sources);
 
     if files.is_empty() {
         return Err(anyhow::anyhow!("No files to generate"));
@@ -517,10 +564,17 @@ async fn run_link_at(
             let produced_by = if idx < agent_count {
                 crate::linker::manifest::ProducedBy::agent(link_agents[idx].name.clone())
             } else {
-                // No coordinator in the wizard flow — same convention
-                // `link` uses for a target that still emits a
-                // team-roster document with none configured.
-                crate::linker::manifest::ProducedBy::coordinator(target.to_string())
+                // Past the per-agent prefix: the target's root
+                // instructions document, attributed to the configured
+                // coordinator — or, for the targets that emit a
+                // team-roster document with none configured, to the
+                // target itself. `link`'s step 8, verbatim.
+                crate::linker::manifest::ProducedBy::coordinator(
+                    coordinator
+                        .as_ref()
+                        .map(|c| c.name.clone())
+                        .unwrap_or_else(|| target.to_string()),
+                )
             };
             (final_path, f.content, produced_by)
         })
@@ -672,6 +726,155 @@ mod run_link_tests {
             "# drop\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nLeave.\n",
         )
         .unwrap();
+    }
+
+    /// A project whose roster's **second** agent is the configured
+    /// `link.coordinator`, spelled as a slug (`dev-lead`) against an H1
+    /// title that is not the slug (`Dev Lead`). Both details are load
+    /// bearing:
+    ///
+    /// - **Not position 0.** A fixture with the coordinator first stays
+    ///   green under an always-true match predicate, because the agent
+    ///   picked out is the right one by accident — the exact fixture trap
+    ///   measured on #370.
+    /// - **Title ≠ reference.** `link.coordinator` is matched against the
+    ///   agent's H1 title *or that title's slug*, never against the
+    ///   `agents:` key (a separate namespace — see `docs/wiki/link.md`).
+    ///   A `Dev Lead`/`dev-lead` pair fails under a plain `==` on names
+    ///   and passes only through `name_matches_reference`.
+    fn write_coordinator_project(root: &Path) {
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: worker\n  - name: dev-lead\nlink:\n  target: claude\n  \
+             coordinator: dev-lead\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("agents/worker.md"),
+            "# Worker\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nDo the work.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("agents/dev-lead.md"),
+            "# Dev Lead\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nLead.\n",
+        )
+        .unwrap();
+    }
+
+    /// Issue #375: the wizard must honour `link.coordinator` exactly as
+    /// `link` does — the configured coordinator becomes the target's root
+    /// instructions file (`.claude/CLAUDE.md`) and gets **no** per-agent
+    /// file, because `link` removes it from the roster before generating.
+    ///
+    /// Before the fix, `run_link_at` passed a hardcoded `None` as
+    /// `generate`'s coordinator argument, so the wizard wrote a per-agent
+    /// file for every agent and never the root instructions file, whatever
+    /// the config said.
+    ///
+    /// Mutation this catches: reverting the `generate` call to
+    /// `linker.generate(&link_agents, None, sources)` (the pre-fix line)
+    /// leaves no `.claude/CLAUDE.md` and writes `.claude/agents/dev-lead.md`
+    /// instead — both assertions below fail.
+    #[tokio::test]
+    async fn wizard_link_honours_the_configured_link_coordinator() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        write_coordinator_project(&root);
+
+        let (found_root, config) = project::find_project_config_from(&root).unwrap();
+        run_link_at(&found_root, &config, "claude").await.unwrap();
+
+        assert!(
+            root.join(".claude/CLAUDE.md").is_file(),
+            "the wizard must write the coordinator's root instructions file, the way \
+             `link` does"
+        );
+        assert!(
+            !root.join(".claude/agents/dev-lead.md").exists(),
+            "the coordinator is removed from the roster before generating, so it must \
+             get no per-agent file"
+        );
+        assert!(
+            root.join(".claude/agents/worker.md").is_file(),
+            "every non-coordinator agent still gets its per-agent file"
+        );
+    }
+
+    /// Issue #375's measured symptom, end to end: what the wizard writes
+    /// must be exactly what `unlink` reclaims — including on the
+    /// **fallback** path, the one that recomputes what `link` would write
+    /// rather than reading the manifest. `.armadai/` is removed between
+    /// the two halves precisely to force that path; without that removal
+    /// the manifest answers, and this test would prove nothing about the
+    /// name-based matching it exists to pin (the trap already recorded in
+    /// `tests/unlink_content_guard.rs`).
+    ///
+    /// Measured before the fix, on the real binary:
+    ///
+    /// ```text
+    /// 1 deleted, 0 kept, 1 already absent   survivor: .claude/agents/dev-lead.md
+    /// ```
+    ///
+    /// `unlink` looked for the coordinator where `link` would have put it
+    /// (`.claude/CLAUDE.md`), did not find it, and left behind the
+    /// per-agent file the wizard had written instead.
+    ///
+    /// Mutation this catches: the same `None` revert as the test above
+    /// leaves `.claude/agents/dev-lead.md` on disk after the unlink.
+    #[tokio::test]
+    async fn wizard_link_then_unlink_without_a_manifest_leaves_nothing_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        write_coordinator_project(&root);
+
+        let _isolated = IsolatedProjectDir::enter(&root);
+
+        let (found_root, config) = project::find_project_config_from(&root).unwrap();
+        run_link_at(&found_root, &config, "claude").await.unwrap();
+
+        // Force `unlink`'s fallback path: with the manifest present it
+        // would reclaim by record, never exercising the name matching
+        // this test is about.
+        std::fs::remove_dir_all(root.join(".armadai")).unwrap();
+
+        crate::cli::unlink::execute(
+            Some(crate::linker::LinkTarget::Claude),
+            None,
+            false,
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let survivors: Vec<PathBuf> = walk_files(&root.join(".claude"));
+        assert!(
+            survivors.is_empty(),
+            "a manifest-less unlink must reclaim everything a wizard-driven link wrote; \
+             survivors: {survivors:?}"
+        );
+    }
+
+    /// Every file under `dir`, recursively — `.claude/` itself is left in
+    /// place by `unlink` by design (issue #338 case 1), so the assertion
+    /// above is about files, not the directory.
+    fn walk_files(dir: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return out;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(walk_files(&path));
+            } else {
+                out.push(path);
+            }
+        }
+        out.sort();
+        out
     }
 
     /// A wizard-driven link must write the same `.armadai/link-manifest.yaml`

--- a/crates/armadai/src/shell/wizard.rs
+++ b/crates/armadai/src/shell/wizard.rs
@@ -386,19 +386,60 @@ async fn run_link(target: &str) -> Result<()> {
 /// `link` gets them, rather than a third copy that could drift from both.
 ///
 /// Deliberately narrower than `link`'s own CLI *flags*: no `--coordinator`
-/// override, no skills/prompts, no `--agents` filter, no
-/// `--model`/interactive model prompt, no `--force` — the wizard flow has
-/// no way to express any of those. What it does honour is the project
-/// **config**: `link.coordinator` reaches `generate` here exactly as it
-/// does in `link` (issue #375). It used to be hardcoded to `None`, so the
-/// wizard wrote a per-agent file for every agent and never the target's
-/// root instructions file — and a later manifest-less `unlink`, looking
-/// for the coordinator where `link` would have put it, left that
+/// override, no `--agents` filter, no `--model`/interactive model prompt,
+/// no `--force` — the wizard flow has no way to express any of those.
+///
+/// It honours **part** of the project config, not all of it. What it does
+/// honour is `link.coordinator`, which reaches `generate` here exactly as
+/// it does in `link` (issue #375); it used to be hardcoded to `None`, so
+/// the wizard wrote a per-agent file for every agent and never the
+/// target's root instructions file — and a later manifest-less `unlink`,
+/// looking for the coordinator where `link` would have put it, left that
 /// per-agent file behind.
+///
+/// What it still does **not** honour, each a config-driven behaviour of
+/// `link` that this function has no equivalent for (tracked as #411):
+///
+/// - **`skills:` / `prompts:`** — `link` assembles the project's skills
+///   and prompts into the generated config; the wizard passes agents
+///   alone, so a wizard-linked project ships without them.
+/// - **`orchestration:`** — `link` validates the orchestration config and
+///   refuses on error before writing anything; the wizard writes
+///   regardless.
+/// - **the project registry** — `link` calls
+///   `project_registry::register_project`, so the project shows up in
+///   `armadai projects`; a wizard-driven link never registers it.
+///
+/// `warnings` is where the user-facing warnings go. In production it is
+/// `anstream::stderr()` (see [`run_link`]); tests pass a buffer, which is
+/// the only way to assert that this surface actually *prints* what the
+/// documentation says it prints — `docs/wiki/link.md` names the wizard as
+/// one of the four surfaces reporting an unmatched `link.coordinator`, and
+/// deleting the write below used to leave the whole suite green.
 async fn run_link_at(
     root: &Path,
     config: &armadai_core::project::ProjectConfig,
     target: &str,
+) -> Result<()> {
+    run_link_at_reporting(root, config, target, &mut anstream::stderr()).await
+}
+
+/// One `  warn: ` line, styled the way `link` and `unlink` style theirs
+/// (`cli::style::warn()` rather than a bare `eprintln!`) so the wizard is
+/// not the one surface printing an uncoloured warning.
+///
+/// A write failure on the warning channel is deliberately swallowed: a
+/// closed stderr must not turn a successful link into an error.
+fn emit_warning(out: &mut dyn std::io::Write, message: &str) {
+    let s = crate::cli::style::warn();
+    let _ = writeln!(out, "{s}  warn: {message}{s:#}");
+}
+
+async fn run_link_at_reporting(
+    root: &Path,
+    config: &armadai_core::project::ProjectConfig,
+    target: &str,
+    warnings_out: &mut dyn std::io::Write,
 ) -> Result<()> {
     println!("\nLinking to '{}'...", target);
 
@@ -417,7 +458,7 @@ async fn run_link_at(
     let fragments = armadai_core::agent_source::project_fragments(root);
     let (agents, warnings) = armadai_core::agent_source::load_all_agents(config, root, &fragments);
     for w in &warnings {
-        eprintln!("  warn: {}", w.message());
+        emit_warning(warnings_out, w.message());
     }
 
     let mut link_agents: Vec<crate::linker::LinkAgent> =
@@ -470,17 +511,29 @@ async fn run_link_at(
     // emitting one is correct by construction rather than by accident,
     // and so this function stays a mirror of `link` rather than a fourth
     // variant of it.
-    let (mut coordinator, coordinator_warning) = crate::linker::take_coordinator(
-        &mut link_agents,
+    //
+    // The wizard has no `--agents` filter, so the roster it asks the
+    // question on and the roster it extracts from are the same one — but
+    // it goes through the same two-step API `link` and `unlink` use, so
+    // "is this configured reference satisfiable?" stays a statement about
+    // the config on every surface rather than a by-product of whichever
+    // roster a command happens to hold.
+    let coordinator_ref = crate::linker::coordinator_reference(
         None,
         config.link.as_ref().and_then(|l| l.coordinator.clone()),
     );
-    if let Some(message) = coordinator_warning {
-        eprintln!(
-            "  warn: {}",
-            crate::cli::style::indent_continuation(&message, "        ")
+    if let Some(message) = coordinator_ref
+        .as_ref()
+        .and_then(|r| r.no_match_warning(&link_agents))
+    {
+        emit_warning(
+            warnings_out,
+            &crate::cli::style::indent_continuation(&message, "        "),
         );
     }
+    let mut coordinator = coordinator_ref
+        .as_ref()
+        .and_then(|r| r.take_from(&mut link_agents));
 
     // The same model resolution `link`'s own step 4b performs (issue I1 on
     // #347's review): without this, a `latest:*` placeholder reaches
@@ -824,8 +877,24 @@ mod run_link_tests {
     /// (`.claude/CLAUDE.md`), did not find it, and left behind the
     /// per-agent file the wizard had written instead.
     ///
-    /// Mutation this catches: the same `None` revert as the test above
-    /// leaves `.claude/agents/dev-lead.md` on disk after the unlink.
+    /// **What this catches, measured, and what it does not.** The full
+    /// pre-fix revert — no `CoordinatorRef` at all *and*
+    /// `generate(&link_agents, None, sources)` — leaves
+    /// `.claude/agents/dev-lead.md` on disk after the unlink, and this
+    /// assertion fails. Reverting the `generate` argument **alone** does
+    /// not: `take_from` still pulls `Dev Lead` out of the roster, so the
+    /// wizard writes no file for it at all, and an unlink that removes
+    /// `worker.md` leaves nothing behind. Measured: that half-revert is
+    /// **one** red test (`wizard_link_honours_the_configured_link_coordinator`),
+    /// not two.
+    ///
+    /// It also cannot catch a mutation of the shared matching criterion.
+    /// `name_matches_reference` is what *both* halves resolve through, so
+    /// breaking it moves link and unlink together: under
+    /// `name_matches_reference` → `==` this test stays **green** (measured,
+    /// 7 other tests red). What pins that criterion is the asymmetric
+    /// fixtures — a title (`Dev Lead`) that differs from its slug
+    /// (`dev-lead`) — in the *single*-sided tests.
     #[tokio::test]
     async fn wizard_link_then_unlink_without_a_manifest_leaves_nothing_behind() {
         let dir = tempfile::tempdir().unwrap();
@@ -858,6 +927,96 @@ mod run_link_tests {
             survivors.is_empty(),
             "a manifest-less unlink must reclaim everything a wizard-driven link wrote; \
              survivors: {survivors:?}"
+        );
+    }
+
+    /// The wizard is the fourth surface `docs/wiki/link.md` names as
+    /// reporting an unmatched `link.coordinator` — and it was the one that
+    /// existed only in prose. Measured on this branch's first draft:
+    /// deleting the whole warning block from `run_link_at` left **all 28
+    /// test targets green**. `link`, `unlink` and `validate` are pinned by
+    /// `tests/link_coordinator_no_match.rs`; nothing pinned this one.
+    ///
+    /// It is asserted verbatim, indentation included, for the reason the
+    /// black-box file records: turning `cli::style::indent_continuation`
+    /// into the identity function was also green everywhere, so the
+    /// eight-space continuation is only real if a test spells it.
+    ///
+    /// The seam this needs is `run_link_at_reporting`'s writer argument —
+    /// an in-process `eprintln!` cannot be captured. What that leaves
+    /// unpinned is the one-line `run_link_at` wrapper that supplies
+    /// `anstream::stderr()`; swapping it for a sink would stay green. That
+    /// is a deliberate trade: the mutation this *does* kill is the one
+    /// that was actually live.
+    #[tokio::test]
+    async fn wizard_link_reports_a_coordinator_that_matches_no_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        write_coordinator_project(&root);
+        // Break the reference the fixture writes correctly: one letter.
+        let config_path = root.join("armadai.yaml");
+        let broken = std::fs::read_to_string(&config_path)
+            .unwrap()
+            .replace("coordinator: dev-lead", "coordinator: dev-led");
+        std::fs::write(&config_path, broken).unwrap();
+
+        let (found_root, config) = project::find_project_config_from(&root).unwrap();
+        let mut warnings: Vec<u8> = Vec::new();
+        run_link_at_reporting(
+            &found_root,
+            &config,
+            "claude",
+            &mut anstream::StripStream::new(&mut warnings),
+        )
+        .await
+        .unwrap();
+
+        let reported = String::from_utf8(warnings).unwrap();
+        let expected = concat!(
+            "  warn: link.coordinator 'dev-led' matches no agent — no root instructions file ",
+            "(.claude/CLAUDE.md and its equivalents) is written or removed for it.\n",
+            "        It is matched against an agent's H1 title, or that title's slug — not the ",
+            "`agents:` key, which is a separate namespace.\n",
+            "        Titles in this roster: Worker, Dev Lead.\n",
+        );
+        assert_eq!(
+            reported, expected,
+            "the wizard must report an unmatched coordinator, in the same words and the \
+             same shape as `link` and `unlink`"
+        );
+    }
+
+    /// The wizard's own negative control: a coordinator that resolves must
+    /// leave its warning channel completely empty, or the assertion above
+    /// is satisfied by a surface that warns unconditionally.
+    ///
+    /// Mutation this catches: emitting the report whatever
+    /// `no_match_warning` answers.
+    #[tokio::test]
+    async fn wizard_link_says_nothing_when_the_coordinator_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        write_coordinator_project(&root);
+
+        let (found_root, config) = project::find_project_config_from(&root).unwrap();
+        let mut warnings: Vec<u8> = Vec::new();
+        run_link_at_reporting(
+            &found_root,
+            &config,
+            "claude",
+            &mut anstream::StripStream::new(&mut warnings),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8(warnings).unwrap(),
+            "",
+            "a resolved coordinator warrants no message at all"
+        );
+        assert!(
+            root.join(".claude/CLAUDE.md").is_file(),
+            "control: it really did resolve — silence here is not silence over a failure"
         );
     }
 

--- a/crates/armadai/src/shell/wizard.rs
+++ b/crates/armadai/src/shell/wizard.rs
@@ -470,13 +470,17 @@ async fn run_link_at(
     // emitting one is correct by construction rather than by accident,
     // and so this function stays a mirror of `link` rather than a fourth
     // variant of it.
-    let coordinator_name = config.link.as_ref().and_then(|l| l.coordinator.clone());
-    let mut coordinator = coordinator_name.and_then(|name| {
-        let idx = link_agents
-            .iter()
-            .position(|a| crate::linker::name_matches_reference(&a.name, &name))?;
-        Some(link_agents.remove(idx))
-    });
+    let (mut coordinator, coordinator_warning) = crate::linker::take_coordinator(
+        &mut link_agents,
+        None,
+        config.link.as_ref().and_then(|l| l.coordinator.clone()),
+    );
+    if let Some(message) = coordinator_warning {
+        eprintln!(
+            "  warn: {}",
+            crate::cli::style::indent_continuation(&message, "        ")
+        );
+    }
 
     // The same model resolution `link`'s own step 4b performs (issue I1 on
     // #347's review): without this, a `latest:*` placeholder reaches

--- a/crates/armadai/tests/link_coordinator_no_match.rs
+++ b/crates/armadai/tests/link_coordinator_no_match.rs
@@ -1,0 +1,358 @@
+//! Issue #371: a `link.coordinator` that matches no agent is a no-op that
+//! is **silent on both sides** — `link` simply writes no root instructions
+//! file, `unlink` looks for none, and `validate` never checked the key at
+//! all. Nothing is left on disk (the defect is symmetric, unlike #341), so
+//! the only observable is the message that was never printed.
+//!
+//! Spawns the real binary, like `link_list_gate.rs`, because what is under
+//! test is exactly what reaches a user's terminal.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+
+    /// Isolated per test directory — see `link_list_gate.rs`'s own note:
+    /// without it, `link`'s `project_registry` write lands in the
+    /// developer's real `~/.config/armadai/` and the shadowing check
+    /// scans their real global agent library.
+    fn isolated_config(dir: &std::path::Path) -> std::path::PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(&config).unwrap();
+        config
+    }
+
+    /// A two-agent project whose `link.coordinator` is spelled
+    /// `coordinator`.
+    ///
+    /// The roster is deliberately built so that a matching reference
+    /// resolves the **second** agent, not the first: a fixture with the
+    /// coordinator at position 0 stays green under an always-true match
+    /// predicate (the trap measured on #370), and the negative control
+    /// below would then prove nothing.
+    ///
+    /// The two H1 titles (`Worker`, `Dev Lead`) are also deliberately
+    /// different from their `agents:` keys in exactly one case: `dev-lead`
+    /// is the key, `Dev Lead` the title. That is the namespace split
+    /// `docs/wiki/link.md` documents, and the reason the warning must send
+    /// the user to the title rather than to the key.
+    fn project_with(coordinator: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            format!(
+                "agents:\n  - name: worker\n  - name: dev-lead\nlink:\n  target: claude\n  \
+                 coordinator: {coordinator}\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("agents/worker.md"),
+            "# Worker\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nDo the work.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("agents/dev-lead.md"),
+            "# Dev Lead\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nLead.\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// The message's own words, asserted verbatim rather than by prefix —
+    /// the lesson `link_list_gate.rs` records from a rustfmt-collapsed
+    /// continuation that shipped 14 stray spaces mid-sentence past a
+    /// prefix-only check.
+    const HEADLINE: &str = "link.coordinator 'dev-led' matches no agent";
+    const NAMESPACE_HINT: &str = "It is matched against an agent's H1 title, or that title's slug — not the `agents:` \
+         key, which is a separate namespace.";
+    const ROSTER_HINT: &str = "Titles in this roster: Worker, Dev Lead.";
+
+    fn assert_says_it_all(stream: &str, who: &str) {
+        for expected in [HEADLINE, NAMESPACE_HINT, ROSTER_HINT] {
+            assert!(
+                stream.contains(expected),
+                "{who} must report the unmatched coordinator, verbatim.\n\
+                 expected: {expected}\nin: {stream}"
+            );
+        }
+    }
+
+    /// `link` writes the per-agent files and announces success; the only
+    /// thing that can tell the user their coordinator did not resolve is
+    /// this warning. It stays a warning, not a refusal: the link itself is
+    /// valid, it is the configuration that is not what the user meant.
+    ///
+    /// Mutation this catches: dropping the warning branch from
+    /// `linker::take_coordinator` (returning `(None, None)` on no match,
+    /// the pre-fix behaviour) leaves stderr silent and every assertion in
+    /// `assert_says_it_all` fails.
+    #[test]
+    fn link_reports_a_coordinator_that_matches_no_agent() {
+        let dir = project_with("dev-led");
+        let root = dir.path().join("project");
+
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .args(["link", "--target", "claude"]);
+        let output = cmd.output().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "an unmatched coordinator is a warning, not a refusal: {stderr}"
+        );
+        assert_says_it_all(&stderr, "link");
+    }
+
+    /// The other half of the pair. Warning only in `link` would recreate
+    /// the very asymmetry #341/#370 closed, so `unlink` must say the same
+    /// thing — on the path where it actually resolves the reference
+    /// against a roster, i.e. the manifest-less fallback.
+    ///
+    /// `.armadai/` is removed between the two halves for exactly that
+    /// reason: with the manifest present, `unlink` reclaims by record and
+    /// never consults `link.coordinator` at all, so a test that skipped
+    /// the removal would prove nothing (the trap recorded in
+    /// `tests/unlink_content_guard.rs`).
+    ///
+    /// Mutation this catches: the same dropped warning branch; also,
+    /// wiring the warning into `cli::link` only leaves this test red.
+    #[test]
+    fn unlink_reports_a_coordinator_that_matches_no_agent() {
+        let dir = project_with("dev-led");
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["link", "--target", "claude"])
+            .output()
+            .unwrap();
+
+        // Force the fallback path — the only one that resolves the
+        // configured coordinator against the roster.
+        std::fs::remove_dir_all(root.join(".armadai")).unwrap();
+
+        let output = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["unlink", "--target", "claude"])
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "an unmatched coordinator is a warning, not a refusal: {stderr}"
+        );
+        assert_says_it_all(&stderr, "unlink");
+    }
+
+    /// The error is one of configuration, not of execution, so `validate`
+    /// — the command whose whole job is to find those — must report it
+    /// too. As a warning: unlike `orchestration.coordinator` (checked
+    /// against the `agents:` keys, a pure config lookup), this one needs
+    /// the roster's H1 titles, which means loading every agent file. That
+    /// makes the check dependent on what actually resolves on this
+    /// machine, and failing a build on a check that can degrade is a
+    /// worse trade than reporting it.
+    ///
+    /// Mutation this catches: removing the R7 block from
+    /// `validate_project_config` returns `0 error(s), 0 warning(s)` — the
+    /// pre-fix output — and both assertions fail.
+    #[test]
+    fn validate_reports_a_coordinator_that_matches_no_agent() {
+        let dir = project_with("dev-led");
+        let root = dir.path().join("project");
+
+        let output = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .arg("validate")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            output.status.success(),
+            "an unmatched coordinator is a warning, so validate still passes: {stdout}"
+        );
+        assert!(
+            stdout.contains("0 error(s), 1 warning(s)"),
+            "validate must count it as exactly one warning: {stdout}"
+        );
+        assert!(
+            stdout.contains("link.coordinator"),
+            "validate must name the key at fault, not just the value: {stdout}"
+        );
+        assert_says_it_all(&stdout, "validate");
+    }
+
+    /// The negative control, without which every assertion above is also
+    /// satisfied by an unconditional warning. A coordinator that *does*
+    /// resolve — here by slug, `dev-lead` against the title `Dev Lead`,
+    /// and at roster position 1 rather than 0 — must leave all three
+    /// commands silent about it.
+    ///
+    /// Mutation this catches: warning unconditionally (or matching with a
+    /// plain `==` on names, which `Dev Lead`/`dev-lead` fails) makes this
+    /// test red while the three above stay green.
+    #[test]
+    fn a_coordinator_that_resolves_is_reported_by_nobody() {
+        let dir = project_with("dev-lead");
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let link = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["link", "--target", "claude"])
+            .output()
+            .unwrap();
+        let link_err = String::from_utf8_lossy(&link.stderr);
+        assert!(
+            root.join(".claude/CLAUDE.md").is_file(),
+            "control precondition: the coordinator really did resolve"
+        );
+        assert!(
+            !link_err.contains("matches no agent"),
+            "link must stay silent when the coordinator resolves: {link_err}"
+        );
+
+        std::fs::remove_dir_all(root.join(".armadai")).unwrap();
+
+        let unlink = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["unlink", "--target", "claude"])
+            .output()
+            .unwrap();
+        let unlink_err = String::from_utf8_lossy(&unlink.stderr);
+        assert!(
+            !unlink_err.contains("matches no agent"),
+            "unlink must stay silent when the coordinator resolves: {unlink_err}"
+        );
+
+        let validate = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .arg("validate")
+            .output()
+            .unwrap();
+        let validate_out = String::from_utf8_lossy(&validate.stdout);
+        assert!(
+            validate_out.contains("0 error(s), 0 warning(s)"),
+            "validate must stay silent when the coordinator resolves: {validate_out}"
+        );
+    }
+
+    /// R7's own guard: when part of the roster failed to load, the
+    /// titles `validate` can see are not the titles `link` would see, so
+    /// "matches nothing" would be a guess. The check stands down rather
+    /// than reporting a coordinator that may well resolve on a machine
+    /// where the missing agent is present.
+    ///
+    /// Here `ghost` names an agent no file backs, so `load_all_agents`
+    /// warns and the roster is short one entry — and the coordinator
+    /// reference is `ghost` itself, i.e. the case where the incomplete
+    /// roster is exactly what would make the check wrong.
+    ///
+    /// Mutation this catches: dropping the `load_warnings.is_empty()`
+    /// guard makes `validate` report `ghost` as matching no agent, and
+    /// this test's `0 warning(s)` assertion fails.
+    #[test]
+    fn validate_stands_down_when_the_roster_did_not_fully_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: worker\n  - name: ghost\nlink:\n  target: claude\n  \
+             coordinator: ghost\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("agents/worker.md"),
+            "# Worker\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nDo the work.\n",
+        )
+        .unwrap();
+        // No agents/ghost.md — the reference does not resolve.
+
+        let output = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .arg("validate")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            stdout.contains("0 error(s), 0 warning(s)"),
+            "an incomplete roster makes the coordinator check unanswerable, so it must \
+             not answer: {stdout}"
+        );
+    }
+
+    /// A project with no `link.coordinator` at all must not be warned
+    /// about either — the setting is optional, and most projects have
+    /// none. Separate from the control above because it exercises a
+    /// different branch: `None` rather than `Some` that resolves.
+    ///
+    /// Mutation this catches: warning whenever the roster produced no
+    /// coordinator (rather than only when a reference was given and
+    /// failed) fires here, where nothing was ever configured.
+    #[test]
+    fn a_project_with_no_coordinator_is_reported_by_nobody() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join("agents")).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents:\n  - name: worker\nlink:\n  target: claude\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("agents/worker.md"),
+            "# Worker\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nDo the work.\n",
+        )
+        .unwrap();
+
+        let config = isolated_config(dir.path());
+        let link = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["link", "--target", "claude"])
+            .output()
+            .unwrap();
+        let link_err = String::from_utf8_lossy(&link.stderr);
+        assert!(
+            !link_err.contains("matches no agent"),
+            "no coordinator configured means nothing to warn about: {link_err}"
+        );
+
+        let validate = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .arg("validate")
+            .output()
+            .unwrap();
+        let validate_out = String::from_utf8_lossy(&validate.stdout);
+        assert!(
+            validate_out.contains("0 error(s), 0 warning(s)"),
+            "no coordinator configured means nothing to warn about: {validate_out}"
+        );
+    }
+}

--- a/crates/armadai/tests/link_coordinator_no_match.rs
+++ b/crates/armadai/tests/link_coordinator_no_match.rs
@@ -4,6 +4,13 @@
 //! all. Nothing is left on disk (the defect is symmetric, unlike #341), so
 //! the only observable is the message that was never printed.
 //!
+//! And its converse, measured on this branch's own first draft: the report
+//! must be a statement about the **configuration**, not a side effect of
+//! whichever roster a command happens to hold. Computed from the resolver,
+//! it fired on `link --agents Worker` for a `coordinator: dev-lead` that
+//! resolves perfectly, on the very project where `validate` reported
+//! nothing.
+//!
 //! Spawns the real binary, like `link_list_gate.rs`, because what is under
 //! test is exactly what reaches a user's terminal.
 
@@ -60,23 +67,49 @@ mod tests {
         dir
     }
 
-    /// The message's own words, asserted verbatim rather than by prefix —
-    /// the lesson `link_list_gate.rs` records from a rustfmt-collapsed
-    /// continuation that shipped 14 stray spaces mid-sentence past a
-    /// prefix-only check.
-    const HEADLINE: &str = "link.coordinator 'dev-led' matches no agent";
-    const NAMESPACE_HINT: &str = "It is matched against an agent's H1 title, or that title's slug — not the `agents:` \
-         key, which is a separate namespace.";
-    const ROSTER_HINT: &str = "Titles in this roster: Worker, Dev Lead.";
+    /// The whole entry `link` and `unlink` put on stderr, **verbatim,
+    /// three lines and their indentation included**.
+    ///
+    /// Not three `contains` fragments: that is what `link_list_gate.rs`
+    /// records as the check a rustfmt-collapsed continuation walked past,
+    /// shipping 14 stray spaces mid-sentence. Measured here on this
+    /// branch: with the three fragments checked one at a time, turning
+    /// `cli::style::indent_continuation` into the identity function left
+    /// all 28 test targets green — the entire presentation layer
+    /// (`  warn: ` + eight-space continuations) was unfalsifiable. The
+    /// indentation is part of the message, so it is part of the constant.
+    const CLI_WARNING: &str = concat!(
+        "  warn: link.coordinator 'dev-led' matches no agent — no root instructions file ",
+        "(.claude/CLAUDE.md and its equivalents) is written or removed for it.\n",
+        "        It is matched against an agent's H1 title, or that title's slug — not the ",
+        "`agents:` key, which is a separate namespace.\n",
+        "        Titles in this roster: Worker, Dev Lead.",
+    );
 
-    fn assert_says_it_all(stream: &str, who: &str) {
-        for expected in [HEADLINE, NAMESPACE_HINT, ROSTER_HINT] {
-            assert!(
-                stream.contains(expected),
-                "{who} must report the unmatched coordinator, verbatim.\n\
-                 expected: {expected}\nin: {stream}"
-            );
-        }
+    /// The same message as `validate` renders it: its own
+    /// `WARN  <file>:<key>: ` header and its own two-space continuation.
+    ///
+    /// The location is asserted here rather than through a bare
+    /// `contains("link.coordinator")`, which the *body* satisfies on its
+    /// own — the body opens with those very words. Measured: removing
+    /// `LINK_COORDINATOR_KEY` from R7's reported location left all 28 test
+    /// targets green, so the `armadai.yaml:link.coordinator:` prefix the
+    /// PR puts in its shop window was pinned by nothing.
+    const VALIDATE_WARNING: &str = concat!(
+        "WARN  armadai.yaml:link.coordinator: link.coordinator 'dev-led' matches no agent — ",
+        "no root instructions file (.claude/CLAUDE.md and its equivalents) is written or ",
+        "removed for it.\n",
+        "  It is matched against an agent's H1 title, or that title's slug — not the ",
+        "`agents:` key, which is a separate namespace.\n",
+        "  Titles in this roster: Worker, Dev Lead.",
+    );
+
+    fn assert_says_it_all(stream: &str, expected: &str, who: &str) {
+        assert!(
+            stream.contains(expected),
+            "{who} must report the unmatched coordinator, verbatim.\n\
+             expected:\n{expected}\n\nin:\n{stream}"
+        );
     }
 
     /// `link` writes the per-agent files and announces success; the only
@@ -84,10 +117,10 @@ mod tests {
     /// this warning. It stays a warning, not a refusal: the link itself is
     /// valid, it is the configuration that is not what the user meant.
     ///
-    /// Mutation this catches: dropping the warning branch from
-    /// `linker::take_coordinator` (returning `(None, None)` on no match,
-    /// the pre-fix behaviour) leaves stderr silent and every assertion in
-    /// `assert_says_it_all` fails.
+    /// Mutation this catches: having
+    /// `armadai_core::agent::coordinator_no_match_warning` always return
+    /// `None` (the pre-fix behaviour) leaves stderr silent and the
+    /// assertion fails.
     #[test]
     fn link_reports_a_coordinator_that_matches_no_agent() {
         let dir = project_with("dev-led");
@@ -104,7 +137,7 @@ mod tests {
             output.status.success(),
             "an unmatched coordinator is a warning, not a refusal: {stderr}"
         );
-        assert_says_it_all(&stderr, "link");
+        assert_says_it_all(&stderr, CLI_WARNING, "link");
     }
 
     /// The other half of the pair. Warning only in `link` would recreate
@@ -118,8 +151,8 @@ mod tests {
     /// the removal would prove nothing (the trap recorded in
     /// `tests/unlink_content_guard.rs`).
     ///
-    /// Mutation this catches: the same dropped warning branch; also,
-    /// wiring the warning into `cli::link` only leaves this test red.
+    /// Mutation this catches: the same silenced warning; also, wiring the
+    /// report into `cli::link` only leaves this test red.
     #[test]
     fn unlink_reports_a_coordinator_that_matches_no_agent() {
         let dir = project_with("dev-led");
@@ -151,7 +184,7 @@ mod tests {
             output.status.success(),
             "an unmatched coordinator is a warning, not a refusal: {stderr}"
         );
-        assert_says_it_all(&stderr, "unlink");
+        assert_says_it_all(&stderr, CLI_WARNING, "unlink");
     }
 
     /// The error is one of configuration, not of execution, so `validate`
@@ -165,7 +198,9 @@ mod tests {
     ///
     /// Mutation this catches: removing the R7 block from
     /// `validate_project_config` returns `0 error(s), 0 warning(s)` — the
-    /// pre-fix output — and both assertions fail.
+    /// pre-fix output — and both assertions fail. Removing only
+    /// `LINK_COORDINATOR_KEY` from the reported location fails the
+    /// verbatim assertion alone.
     #[test]
     fn validate_reports_a_coordinator_that_matches_no_agent() {
         let dir = project_with("dev-led");
@@ -188,11 +223,7 @@ mod tests {
             stdout.contains("0 error(s), 1 warning(s)"),
             "validate must count it as exactly one warning: {stdout}"
         );
-        assert!(
-            stdout.contains("link.coordinator"),
-            "validate must name the key at fault, not just the value: {stdout}"
-        );
-        assert_says_it_all(&stdout, "validate");
+        assert_says_it_all(&stdout, VALIDATE_WARNING, "validate");
     }
 
     /// The negative control, without which every assertion above is also
@@ -200,6 +231,14 @@ mod tests {
     /// resolve — here by slug, `dev-lead` against the title `Dev Lead`,
     /// and at roster position 1 rather than 0 — must leave all three
     /// commands silent about it.
+    ///
+    /// The three preconditions are what make this a control rather than a
+    /// coincidence. `CLAUDE.md` existing only says *a* coordinator
+    /// resolved; under a match predicate forced to `true` the coordinator
+    /// picked out is `Worker` (position 0), `CLAUDE.md` still exists, and
+    /// this test stayed **green** — measured. Naming which agent became
+    /// the root file, and which kept its per-agent file, is what closes
+    /// that hole.
     ///
     /// Mutation this catches: warning unconditionally (or matching with a
     /// plain `==` on names, which `Dev Lead`/`dev-lead` fails) makes this
@@ -221,6 +260,15 @@ mod tests {
         assert!(
             root.join(".claude/CLAUDE.md").is_file(),
             "control precondition: the coordinator really did resolve"
+        );
+        assert!(
+            root.join(".claude/agents/worker.md").is_file(),
+            "control precondition: `Worker` is a plain roster agent and keeps its own file"
+        );
+        assert!(
+            !root.join(".claude/agents/dev-lead.md").exists(),
+            "control precondition: `Dev Lead` — not `Worker` — is the one that became the \
+             root instructions file"
         );
         assert!(
             !link_err.contains("matches no agent"),
@@ -256,11 +304,124 @@ mod tests {
         );
     }
 
-    /// R7's own guard: when part of the roster failed to load, the
-    /// titles `validate` can see are not the titles `link` would see, so
-    /// "matches nothing" would be a guess. The check stands down rather
-    /// than reporting a coordinator that may well resolve on a machine
-    /// where the missing agent is present.
+    /// **The `--agents` false positive**, measured on this branch's first
+    /// draft against `master`'s silence:
+    ///
+    /// ```text
+    /// $ armadai link --target claude --agents Worker      # 14e4d25
+    ///   warn: link.coordinator 'dev-lead' matches no agent — …
+    ///         Titles in this roster: Worker.
+    /// $ armadai link --target claude --agents Worker      # master
+    ///   (silent)
+    /// ```
+    ///
+    /// Three things were wrong at once: the statement was false
+    /// (`dev-lead` matches `Dev Lead`, the user's own filter had removed
+    /// it), it sent them to correct an H1 title that was fine, and on the
+    /// same project `armadai validate` answered `0 warning(s)` — two
+    /// surfaces contradicting each other over one key. The cause was that
+    /// the report was a by-product of the resolver ("did *this* call find
+    /// it?") rather than a statement about the config.
+    ///
+    /// The **write** behaviour is unchanged and is not what this pins: no
+    /// root instructions file is written for an agent `--agents` excluded,
+    /// which `tests/link_manifest.rs` covers on the `unlink` side. Only
+    /// the message was wrong, so `.claude/CLAUDE.md` staying absent is
+    /// asserted here as the control that says so.
+    ///
+    /// Mutation this catches: asking `no_match_warning` on the filtered
+    /// roster instead of the declared one.
+    #[test]
+    fn a_filter_that_excludes_the_coordinator_reports_nothing() {
+        let dir = project_with("dev-lead");
+        let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
+
+        let link = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["link", "--target", "claude", "--agents", "Worker"])
+            .output()
+            .unwrap();
+        let link_err = String::from_utf8_lossy(&link.stderr);
+        assert!(
+            link.status.success(),
+            "a filtered link is a normal link: {link_err}"
+        );
+        assert!(
+            !link_err.contains("matches no agent"),
+            "`--agents` narrows what is written; it cannot make a correct \
+             `link.coordinator` wrong: {link_err}"
+        );
+        assert!(
+            root.join(".claude/agents/worker.md").is_file(),
+            "control: the filtered link did write the agent it was asked for"
+        );
+        assert!(
+            !root.join(".claude/CLAUDE.md").exists(),
+            "control: the coordinator was excluded from this write, so it gets no root \
+             instructions file — that behaviour is unchanged, only the message was wrong"
+        );
+
+        std::fs::remove_dir_all(root.join(".armadai")).unwrap();
+
+        let unlink = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["unlink", "--target", "claude", "--agents", "Worker"])
+            .output()
+            .unwrap();
+        let unlink_err = String::from_utf8_lossy(&unlink.stderr);
+        assert!(
+            !unlink_err.contains("matches no agent"),
+            "the same false positive was in `unlink`'s fallback: {unlink_err}"
+        );
+    }
+
+    /// The other side of the same coin, and the reason the fix is "ask the
+    /// declared roster" rather than "stay quiet whenever a filter is
+    /// active": a typo is a typo under any filter. The titles offered must
+    /// be the ones the **project** declares — telling a user their choices
+    /// are `Worker.` when `Dev Lead` exists would send them to invent an
+    /// agent they already have.
+    ///
+    /// Mutation this catches: silencing the report whenever `--agents` is
+    /// given (the shortcut remedy) leaves stderr empty; answering on the
+    /// filtered roster still warns but lists `Titles in this roster:
+    /// Worker.` and fails the verbatim assertion.
+    #[test]
+    fn a_filter_does_not_silence_a_genuinely_unmatched_coordinator() {
+        let dir = project_with("dev-led");
+        let root = dir.path().join("project");
+
+        let output = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .args(["link", "--target", "claude", "--agents", "Worker"])
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(output.status.success(), "still a warning, not a refusal");
+        assert_says_it_all(&stderr, CLI_WARNING, "link --agents");
+    }
+
+    /// R7's own guard: when part of the roster failed to load, the titles
+    /// `validate` can see are not the titles `link` would see, so "matches
+    /// nothing" would be a guess. The check stands down rather than
+    /// reporting a coordinator that may well resolve on a machine where
+    /// the missing agent is present.
+    ///
+    /// It stands down **out loud**. The guard used to be silent, justified
+    /// in a comment by "those failures are already reported on their own
+    /// terms elsewhere" — measured false inside `validate`, which has no
+    /// rule that reports an unresolvable agent ref at all: on this exact
+    /// fixture `validate` answered `0 error(s), 0 warning(s)` /
+    /// "Validation passed" while `link` printed two warnings. A green
+    /// report over two real defects is worse than either of them.
     ///
     /// Here `ghost` names an agent no file backs, so `load_all_agents`
     /// warns and the roster is short one entry — and the coordinator
@@ -268,10 +429,11 @@ mod tests {
     /// roster is exactly what would make the check wrong.
     ///
     /// Mutation this catches: dropping the `load_warnings.is_empty()`
-    /// guard makes `validate` report `ghost` as matching no agent, and
-    /// this test's `0 warning(s)` assertion fails.
+    /// guard makes `validate` report `ghost` as matching no agent, failing
+    /// the first two assertions; restoring the silent stand-down (pushing
+    /// no issue in the `else` arm) fails all three.
     #[test]
-    fn validate_stands_down_when_the_roster_did_not_fully_load() {
+    fn validate_stands_down_out_loud_when_the_roster_did_not_fully_load() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("project");
         std::fs::create_dir_all(root.join("agents")).unwrap();
@@ -297,10 +459,30 @@ mod tests {
             .unwrap();
         let stdout = String::from_utf8_lossy(&output.stdout);
 
+        // Not a bare `!contains("matches no agent")`: the stand-down text
+        // quotes that very phrase to explain what it is declining to say.
+        // What must be absent is the *claim*, which always names the key
+        // and the value.
         assert!(
-            stdout.contains("0 error(s), 0 warning(s)"),
-            "an incomplete roster makes the coordinator check unanswerable, so it must \
-             not answer: {stdout}"
+            !stdout.contains("link.coordinator 'ghost' matches no agent"),
+            "an incomplete roster makes the coordinator check unanswerable, so it must not \
+             answer it: {stdout}"
+        );
+        assert!(
+            stdout.contains("0 error(s), 1 warning(s)"),
+            "standing down is itself reported, as exactly one warning: {stdout}"
+        );
+        assert!(
+            stdout.contains(concat!(
+                "WARN  armadai.yaml:link.coordinator: link.coordinator 'ghost' was not ",
+                "checked: part of the roster failed to load",
+            )),
+            "the user must be told the check abstained, and on which key: {stdout}"
+        );
+        assert!(
+            stdout.contains("- Agent 'ghost' not found in"),
+            "and told what stopped it — `validate` has no other rule that would say so: \
+             {stdout}"
         );
     }
 
@@ -353,6 +535,48 @@ mod tests {
         assert!(
             validate_out.contains("0 error(s), 0 warning(s)"),
             "no coordinator configured means nothing to warn about: {validate_out}"
+        );
+    }
+
+    /// A project that declares no agent at all and still configures a
+    /// coordinator: the configuration cannot be satisfied by anything, and
+    /// `validate` is the only surface that can say so — `link` refuses
+    /// such a project outright ("No agents declared in project config")
+    /// before ever looking at the key.
+    ///
+    /// This is the `(none)` arm of the report, which R7's earlier
+    /// `!roster.is_empty()` guard made unreachable from every caller.
+    ///
+    /// Mutation this catches: reinstating that guard returns
+    /// `0 error(s), 0 warning(s)` and both assertions fail.
+    #[test]
+    fn validate_reports_a_coordinator_on_a_project_that_declares_no_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("armadai.yaml"),
+            "agents: []\nlink:\n  target: claude\n  coordinator: dev-lead\n",
+        )
+        .unwrap();
+
+        let output = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .arg("validate")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            stdout.contains("0 error(s), 1 warning(s)"),
+            "a coordinator no agent can satisfy is still a broken configuration: {stdout}"
+        );
+        assert!(
+            stdout.contains("Titles in this roster: (none)."),
+            "and the roster it was matched against is empty, which the report must say: \
+             {stdout}"
         );
     }
 }

--- a/crates/armadai/tests/link_coordinator_no_match.rs
+++ b/crates/armadai/tests/link_coordinator_no_match.rs
@@ -391,15 +391,25 @@ mod tests {
     /// given (the shortcut remedy) leaves stderr empty; answering on the
     /// filtered roster still warns but lists `Titles in this roster:
     /// Worker.` and fails the verbatim assertion.
+    ///
+    /// **Both surfaces, separately.** The sibling test above happens to
+    /// exercise `link` and `unlink` together, so a mutation applied to both
+    /// at once looks covered while either half alone may not be. Measured:
+    /// applying the shortcut remedy to `unlink` *only* left the whole suite
+    /// green — this half of the fix had no test at all. It does now, and the
+    /// `.armadai/` removal is what forces `unlink` down the fallback path
+    /// where `link.coordinator` is consulted; with the manifest present it
+    /// answers from the manifest and proves nothing.
     #[test]
     fn a_filter_does_not_silence_a_genuinely_unmatched_coordinator() {
         let dir = project_with("dev-led");
         let root = dir.path().join("project");
+        let config = isolated_config(dir.path());
 
         let output = Command::cargo_bin("armadai")
             .unwrap()
             .current_dir(&root)
-            .env("ARMADAI_CONFIG_DIR", isolated_config(dir.path()))
+            .env("ARMADAI_CONFIG_DIR", &config)
             .args(["link", "--target", "claude", "--agents", "Worker"])
             .output()
             .unwrap();
@@ -407,6 +417,20 @@ mod tests {
 
         assert!(output.status.success(), "still a warning, not a refusal");
         assert_says_it_all(&stderr, CLI_WARNING, "link --agents");
+
+        std::fs::remove_dir_all(root.join(".armadai")).unwrap();
+
+        let unlink = Command::cargo_bin("armadai")
+            .unwrap()
+            .current_dir(&root)
+            .env("ARMADAI_CONFIG_DIR", &config)
+            .args(["unlink", "--target", "claude", "--agents", "Worker"])
+            .output()
+            .unwrap();
+        let unlink_err = String::from_utf8_lossy(&unlink.stderr);
+
+        assert!(unlink.status.success(), "still a warning, not a refusal");
+        assert_says_it_all(&unlink_err, CLI_WARNING, "unlink --agents");
     }
 
     /// R7's own guard: when part of the roster failed to load, the titles

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -36,13 +36,21 @@ More targets (Cursor, Aider, Windsurf, Cline) may be added later.
 
 `link.coordinator` in the project config names one agent of the roster: the one whose prompt becomes the target's root instructions file (`.claude/CLAUDE.md`, `.opencode/instructions.md`, …) instead of a per-agent file. It is matched against each agent's **H1 title** — the `# Name` heading of its Markdown file — or that title's slug, case-insensitively. So `coordinator: dev-lead` resolves an agent titled `Dev Lead`, the same folding the linker uses to name files on disk.
 
-That target matters: `link.coordinator` is matched against the **title**, *not* against the key used in `agents:` or in `orchestration.coordinator`, which are a separate namespace. When the two differ — a roster entry `- name: lead` on a file titled `# Dev Lead` — `coordinator: lead` matches nothing, and nothing says so.
+That target matters: `link.coordinator` is matched against the **title**, *not* against the key used in `agents:` or in `orchestration.coordinator`, which are a separate namespace. When the two differ — a roster entry `- name: lead` on a file titled `# Dev Lead` — `coordinator: lead` matches nothing; that is reported (see below), and the field to correct is the title, not the key.
 
 `unlink` applies that identical rule whenever it has to regenerate (the no-manifest fallback below); a narrower match there would leave the root instructions file on disk as a silent orphan. Through the manifest the question never arises: `link`'s own attribution is what `unlink` reads back.
 
 The link step `armadai shell`'s setup wizard runs applies the same rule: it honours `link.coordinator` from the project config exactly as `armadai link` does, and writes the same files. (Before v1.0.0 it ignored the setting entirely, writing a per-agent file for the coordinator and no root instructions file — which a later manifest-less `unlink` then left behind.)
 
-A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none. It is also not reported, so a typo or a title/key mismatch is silent on both sides: `link` writes the per-agent files and announces success. Check that the root instructions file exists if you expected a coordinator.
+A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none. It is reported, though, on every surface that resolves it (`link`, `unlink`, the shell's setup wizard, and `armadai validate`):
+
+```text
+  warn: link.coordinator 'dev-led' matches no agent — no root instructions file (.claude/CLAUDE.md and its equivalents) is written or removed for it.
+        It is matched against an agent's H1 title, or that title's slug — not the `agents:` key, which is a separate namespace.
+        Titles in this roster: Worker, Dev Lead.
+```
+
+It stays a warning rather than a refusal: the link itself is valid, it is the configuration that is not what you meant. `armadai validate` reports the same thing as a warning too — with one restriction: if any agent of the roster failed to load, the titles it can see are not the titles `link` would see, so the check stands down instead of guessing. (Before v1.0.0 none of this was reported at all: a typo, or a title/key mismatch, was silent on both sides.)
 
 ## Examples
 

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -40,6 +40,8 @@ That target matters: `link.coordinator` is matched against the **title**, *not* 
 
 `unlink` applies that identical rule whenever it has to regenerate (the no-manifest fallback below); a narrower match there would leave the root instructions file on disk as a silent orphan. Through the manifest the question never arises: `link`'s own attribution is what `unlink` reads back.
 
+The link step `armadai shell`'s setup wizard runs applies the same rule: it honours `link.coordinator` from the project config exactly as `armadai link` does, and writes the same files. (Before v1.0.0 it ignored the setting entirely, writing a per-agent file for the coordinator and no root instructions file — which a later manifest-less `unlink` then left behind.)
+
 A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none. It is also not reported, so a typo or a title/key mismatch is silent on both sides: `link` writes the per-agent files and announces success. Check that the root instructions file exists if you expected a coordinator.
 
 ## Examples

--- a/docs/wiki/link.md
+++ b/docs/wiki/link.md
@@ -42,7 +42,7 @@ That target matters: `link.coordinator` is matched against the **title**, *not* 
 
 The link step `armadai shell`'s setup wizard runs applies the same rule: it honours `link.coordinator` from the project config exactly as `armadai link` does, and writes the same files. (Before v1.0.0 it ignored the setting entirely, writing a per-agent file for the coordinator and no root instructions file — which a later manifest-less `unlink` then left behind.)
 
-A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none. It is reported, though, on every surface that resolves it (`link`, `unlink`, the shell's setup wizard, and `armadai validate`):
+A `link.coordinator` matching no agent is not an error — the target simply gets no root instructions file, and `unlink` removes none. It is reported, though, on every surface that reads it (`link`, `unlink`, the shell's setup wizard, and `armadai validate`):
 
 ```text
   warn: link.coordinator 'dev-led' matches no agent — no root instructions file (.claude/CLAUDE.md and its equivalents) is written or removed for it.
@@ -50,7 +50,19 @@ A `link.coordinator` matching no agent is not an error — the target simply get
         Titles in this roster: Worker, Dev Lead.
 ```
 
-It stays a warning rather than a refusal: the link itself is valid, it is the configuration that is not what you meant. `armadai validate` reports the same thing as a warning too — with one restriction: if any agent of the roster failed to load, the titles it can see are not the titles `link` would see, so the check stands down instead of guessing. (Before v1.0.0 none of this was reported at all: a typo, or a title/key mismatch, was silent on both sides.)
+It stays a warning rather than a refusal: the link itself is valid, it is the configuration that is not what you meant.
+
+The question asked is always *"does this reference name an agent the project declares?"* — never *"did this particular command find it?"*. `--agents` narrows what gets written, so `armadai link --agents Worker` writes no root instructions file for a coordinator it was not asked for; but the configuration is untouched by your filter, so nothing is reported. A genuine typo is still reported under any filter, and the titles listed are the ones the project declares, not the ones the filter kept.
+
+`armadai validate` answers the same question, on the same criterion — with one restriction: if any agent of the roster failed to load, the titles it can see are not the titles `link` would see, so the check stands down instead of guessing. It says so, and lists what stopped it:
+
+```text
+WARN  armadai.yaml:link.coordinator: link.coordinator 'ghost' was not checked: part of the roster failed to load, so the titles available here are not the titles `link` would see and "matches no agent" would be a guess.
+  Resolve these first, then re-run `armadai validate`:
+  - Agent 'ghost' not found in …
+```
+
+(Before v1.0.0 none of this was reported at all: a typo, or a title/key mismatch, was silent on both sides.)
 
 ## Examples
 


### PR DESCRIPTION
Deux défauts qui portent sur le même objet, `link.coordinator`, et se répondent l'un l'autre. **Un commit par issue** (plus un troisième pour la vague de correctifs de revue).

## #375 — le wizard n'honorait jamais `link.coordinator`

`shell/wizard.rs::run_link_at` passait un `None` codé en dur comme argument coordinateur de `generate` : le wizard écrivait un fichier par agent et **jamais** le fichier d'instructions racine, quelle que soit la config.

La conséquence n'était pas seulement un fichier manquant. Un `armadai unlink` sans manifeste cherche le coordinateur là où `link` l'aurait mis, ne le trouve pas, et laisse derrière le fichier par-agent que le wizard avait écrit à la place. Mesuré sur le binaire réel, même projet, `.armadai/` supprimé avant l'unlink :

```
link    : 2 written    →  2 deleted, 0 kept, 0 already absent   survivants : aucun
wizard  : 2 written    →  1 deleted, 0 kept, 1 already absent   survivants : .claude/agents/dev-lead.md
```

Le wizard résout maintenant `link.coordinator` via le même `name_matches_reference` que `link` et `unlink` (#341/#370), le retire du roster avant génération, lui applique la même résolution de modèle, et l'attribue au manifeste — les étapes 3b/4b/8 de `link`, à l'identique. Après correction les deux exécutions sont indiscernables : `2 deleted, 0 kept, 0 already absent`.

C'est le morceau que **#347** avait laissé de côté en routant le chemin d'écriture du wizard sur `linker::manifest::write_files`.

## #371 — le no-op silencieux

`armadai validate` contrôlait `orchestration.coordinator` mais pas `link.coordinator`. Un nom mal orthographié n'appariait aucun agent et aucune commande ne le disait. Le défaut étant symétrique, rien ne restait sur disque non plus : l'utilisateur croyait avoir un coordinateur et n'en avait pas.

**Avant** (projet dont `coordinator: dev-led` aurait dû s'écrire `dev-lead`) :

```
validate: 0 error(s), 0 warning(s)
link:     Linked 2 agent(s) to 'claude': 2 written, 0 skipped, 0 unchanged.
unlink:   Unlinked 'claude': 2 deleted, 0 kept, 0 already absent.
```

**Après** — les quatre surfaces le disent, avec un seul texte partagé :

```
  warn: link.coordinator 'dev-led' matches no agent — no root instructions file (.claude/CLAUDE.md and its equivalents) is written or removed for it.
        It is matched against an agent's H1 title, or that title's slug — not the `agents:` key, which is a separate namespace.
        Titles in this roster: Worker, Dev Lead.
```

La phrase sur les espaces de noms est essentielle : `link.coordinator` s'apparie au **titre H1** de l'agent, jamais à la clé du roster `agents:` — c'est justement cette divergence qui rendait #341 possible. Un message pointant vers la clé enverrait l'utilisateur corriger le mauvais champ.

Ça reste un avertissement, pas un refus : le lien lui-même est valide, c'est la configuration qui ne dit pas ce que l'utilisateur voulait.

### Points de conception

- **La question posée est « cette référence nomme-t-elle un agent que le projet déclare ? »**, jamais « cet appel-ci l'a-t-il trouvée ? ». C'est le correctif de revue ci-dessous, et c'est ce qui fait que `link`, `unlink`, le wizard et `validate` répondent la même chose sur le même projet.
- **Les commandes ensemble.** N'avertir que dans `link` recréerait l'asymétrie que #370 vient de fermer. `link`, `unlink` et le wizard partagent un unique résolveur (`linker::CoordinatorRef`) qui porte aussi la priorité flag-sur-config, jusqu'ici écrite deux fois.
- **Le ré-export supprimé.** `linker::name_matches_reference` était la primitive tentante sur laquelle chaque appelant reconstruisait sa propre copie de trois lignes ; deux de ces copies avaient déjà divergé une fois (#341), une troisième était apparue dans le wizard. Le ré-export est supprimé : il n'y a plus de quoi en écrire une quatrième. Le formateur du message (`coordinator_no_match_message`) est passé privé pour la même raison.
- **`validate` étendu (règle R7), en `warning` et non en `error`.** Contrairement à `orchestration.coordinator` (simple lookup dans la config), cette règle a besoin que chaque fichier d'agent se charge : sa réponse dépend de ce qui résout sur la machine. Elle **s'abstient à voix haute** si le roster n'a pas chargé entièrement.

## Sortie de `armadai validate` (après)

```
WARN  armadai.yaml:link.coordinator: link.coordinator 'dev-led' matches no agent — no root instructions file (.claude/CLAUDE.md and its equivalents) is written or removed for it.
  It is matched against an agent's H1 title, or that title's slug — not the `agents:` key, which is a separate namespace.
  Titles in this roster: Worker, Dev Lead.

0 error(s), 1 warning(s)
```

Et quand le roster n'a pas chargé entièrement (R7 s'abstient) :

```
WARN  armadai.yaml:link.coordinator: link.coordinator 'ghost' was not checked: part of the roster failed to load, so the titles available here are not the titles `link` would see and "matches no agent" would be a guess.
  Resolve these first, then re-run `armadai validate`:
  - Agent 'ghost' not found in …

0 error(s), 1 warning(s)
```

⚠️ **Changement de sortie utilisateur** — validation visuelle attendue avant merge.

## Vague de correctifs de revue (commit `fix(link): answer link.coordinator against the declared roster`)

Une revue indépendante a rendu un `REQUEST_CHANGES` : quatre affirmations que rien ne pouvait faire échouer, plus une régression de sortie. Diagnostic racine retenu : l'avertissement était un **effet de bord du résolveur** (« cet appel a-t-il trouvé l'agent ? ») là où il devait être un **énoncé sur la configuration** (« cette référence apparie-t-elle un agent déclaré ? »).

**D1 — faux positif sur `--agents`, bloquant.** Sur un projet dont `link.coordinator: dev-lead` est correct :

```
$ armadai link --target claude --agents Worker      # avant
  warn: link.coordinator 'dev-lead' matches no agent — …
        Titles in this roster: Worker.
$ armadai validate                                  # même projet
  0 error(s), 0 warning(s)
```

`take_coordinator` s'exécutait après le filtre `--agents`. `linker::take_coordinator` est scindé en `coordinator_reference` → `CoordinatorRef { no_match_warning(declared_roster), take_from(roster) }` : `link`/`unlink` posent la question **avant** le filtre et font l'extraction **après**. Le comportement d'écriture ne bouge pas (`link_manifest.rs::unlink_agents_filter_leaves_the_coordinator_and_unmatched_agents_alone` toujours vert, intact). Le remède court (« se taire dès qu'un filtre est actif ») est rejeté et **mesuré comme insuffisant** : une faute de frappe reste une faute de frappe sous n'importe quel filtre, et les titres proposés doivent être ceux du projet.

**D2/D3/D4** — les trois affirmations que rien ne pouvait tuer sont maintenant épinglées : le wizard émet sur un writer (`run_link_at_reporting`), l'emplacement `armadai.yaml:link.coordinator:` de `validate` et la mise en forme des continuations (`indent_continuation`) sont assertés **verbatim et multi-lignes**, plus un test unitaire dédié pour `indent_continuation`.

**D5/D8** — R7 ne s'abstient plus en silence : le commentaire justifiait par « ces échecs sont déjà signalés ailleurs », **mesuré faux dans `validate`**, qui n'a aucune règle signalant une référence d'agent irrésoluble. La garde `!roster.is_empty()` est retirée (elle rendait l'arm `(none)` inatteignable).

**D6** — deux lignes de l'ancienne table de mutations étaient inexactes ; la table ci-dessous est celle qui a été rejouée.

**D7** — précondition de contrôle renforcée : `a_coordinator_that_resolves_is_reported_by_nobody` vérifie maintenant **quel** agent a atterri où.

**D9** — le wizard passe par `cli::style::warn()` comme `link`/`unlink` ; son doc-comment nomme les trois comportements pilotés par la config qu'il n'honore toujours pas (skills/prompts, garde d'orchestration, `register_project` — #411).

## Tests et mutations

Chaque test est validé par une expérience de mutation (casser, vérifier le rouge, restaurer). Suite complète, `--no-fail-fast`, mode `tui,storage,e2e-fake,web` (28 cibles).

### Mutations rejouées (celles de la revue, avant correctif)

| Mutation | Effet mesuré |
|---|---|
| bloc d'avertissement du wizard supprimé | **28 cibles vertes** — la 4ᵉ surface n'existait qu'en prose |
| `LINK_COORDINATOR_KEY` retiré de l'emplacement R7 | **28 cibles vertes** — `contains("link.coordinator")` est satisfait par le corps du message |
| `indent_continuation` rendue identité | **28 cibles vertes** — toute la présentation intestable |
| garde `!roster.is_empty()` retirée de R7 | **28 cibles vertes** |
| `generate(…, None, …)` **seul** | **1 rouge**, pas 2 : `take_coordinator` sort quand même `Dev Lead` du roster, donc le wizard n'écrit aucun fichier pour lui et l'aller-retour reste vert |
| revert pré-correctif **complet** du wizard (pas de `take_coordinator` **et** `None`) | **2 rouges** — c'est cette ligne-là qui vaut 2 |
| `name_matches_reference` → `==` | **7 rouges**, dont **un seul** test wizard : l'aller-retour reste vert, une mutation du résolveur *partagé* étant symétrique par construction |
| prédicat forcé à `true` | l'ancien contrôle négatif `a_coordinator_that_resolves_is_reported_by_nobody` restait **vert** |

### Mutations du correctif (après)

| # | Mutation | Rouges mesurés |
|---|---|---|
| M1 | question posée sur le roster **filtré** (le couplage d'origine) | `a_filter_that_excludes_the_coordinator_reports_nothing`, `a_filter_does_not_silence_a_genuinely_unmatched_coordinator` |
| M2 | émission de l'avertissement supprimée du wizard | `wizard_link_reports_a_coordinator_that_matches_no_agent` |
| M3 | `LINK_COORDINATOR_KEY` retiré de l'emplacement R7 | `validate_reports_a_coordinator_that_matches_no_agent`, `validate_stands_down_out_loud_…` |
| M4 | `indent_continuation` rendue identité | 6 rouges sur 4 cibles, dont le test unitaire dédié |
| M5 | R7 s'abstient en silence (état pré-correctif) | `validate_stands_down_out_loud_when_the_roster_did_not_fully_load` |
| M6 | garde `!roster.is_empty()` réintroduite | `validate_reports_a_coordinator_on_a_project_that_declares_no_agent` |
| M7 | prédicat d'appariement forcé à `true` | **16 rouges**, dont le contrôle négatif renforcé (D7) |
| M8 | le wizard avertit inconditionnellement | `wizard_link_says_nothing_when_the_coordinator_resolves` |
| M9 | remède court : se taire dès que `--agents` est actif | `a_filter_does_not_silence_a_genuinely_unmatched_coordinator` |
| M10 | `coordinator_no_match_warning` renvoie toujours `None` (pré-#371) | 9 rouges sur 4 cibles |

Les deux tests d'aller-retour suppriment `.armadai/` avant `unlink` : sans ça le manifeste répond et le test ne prouverait rien de l'appariement par nom (le motif déjà présent dans `tests/unlink_content_guard.rs`).

## Gate

- `cargo fmt --all -- --check` : OK
- clippy `-D warnings` dans les **5** modes : OK
- tests dans les **4** modes : **1598 / 1645 / 1701 / 1738** passés, 0 cible en échec
- gaveldrop : **13 cases · 13 passed · 0 failed · score 83/83**
- rebase sur `master` (`9149152`, #408) : sans conflit
- base SQLite réelle inchangée (`56a25ab6a69f4167accb608f003b00f6` avant et après), `projects.json` inchangé

Closes #371
Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
