### PR TITLE
fix(cli): un --dry-run qui n'écrit rien et dont le flux --json se termine

### DIFF
--- a/crates/armadai-core/src/events.rs
+++ b/crates/armadai-core/src/events.rs
@@ -72,6 +72,45 @@ pub enum RunEvent {
         selected: Vec<String>,
         reason: String,
     },
+    /// Terminal event of a `--dry-run` (#405).
+    ///
+    /// A preview emitted `run_start` and then nothing at all, so a consumer
+    /// of the JSONL stream could not tell "the preview is over" from "the
+    /// process died at startup" — the preview's own content (roster,
+    /// providers, models) goes to stderr, and the agent names to stdout only
+    /// when NOT emitting JSON.
+    ///
+    /// Deliberately **not** a `Result` with `tin`/`tout`/`cost` at zero,
+    /// which would have been the truth and still the wrong shape: zeroes are
+    /// exactly what a real run that happened to cost nothing looks like (a
+    /// cached answer, a relay that reports no tokens), so a consumer that
+    /// bills, records or reports on `result` would have counted a preview as
+    /// a run. A distinct `t` is the only form a consumer cannot mistake.
+    DryRun {
+        /// How the run would have been carried out: `sequential` (a single
+        /// agent or a `--pipe` chain), `orchestrated`, or `resume`.
+        mode: String,
+        /// Orchestration pattern (`ring`, `blackboard`, `hierarchical`,
+        /// `direct`); empty on the `sequential` path, which has none.
+        pattern: String,
+        /// The roster in the order it would execute, each entry carrying the
+        /// provider that would be used and the model string that would
+        /// actually be sent.
+        agents: Vec<DryRunAgent>,
+        /// Why this roster and not another — a C8 route/tag selection, an
+        /// explicit chain, a roster reloaded from a recorded run.
+        reason: String,
+    },
+}
+
+/// One roster entry of a [`RunEvent::DryRun`]. Keyed like `AgentStart`
+/// (`agent`/`prov`/`model`) so a consumer reads the same three fields
+/// whether the run happened or was only previewed.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DryRunAgent {
+    pub agent: String,
+    pub prov: String,
+    pub model: String,
 }
 
 /// Sink for run events. `NullSink` is a zero-cost no-op; `JsonlSink` writes JSONL to a writer.
@@ -327,6 +366,48 @@ mod tests {
             s,
             r#"{"t":"agent_select","selected":["rust-security","qa-specialist"],"reason":"route 'security-audit' → 2 agents"}"#
         );
+    }
+
+    #[test]
+    fn dry_run_serializes_with_short_keys() {
+        let ev = RunEvent::DryRun {
+            mode: "orchestrated".into(),
+            pattern: "ring".into(),
+            agents: vec![DryRunAgent {
+                agent: "alpha".into(),
+                prov: "cli".into(),
+                model: "(not sent — cli:echo chooses)".into(),
+            }],
+            reason: "no routing (full roster)".into(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            s,
+            r#"{"t":"dry_run","mode":"orchestrated","pattern":"ring","agents":[{"agent":"alpha","prov":"cli","model":"(not sent — cli:echo chooses)"}],"reason":"no routing (full roster)"}"#
+        );
+    }
+
+    #[test]
+    fn dry_run_is_not_a_zeroed_result() {
+        // The shape is the contract (#405): a consumer that bills, records
+        // or reports on `result` must not see one for a preview, and a
+        // `result` whose tokens are zero is indistinguishable from a real
+        // run that cost nothing.
+        let ev = RunEvent::DryRun {
+            mode: "sequential".into(),
+            pattern: String::new(),
+            agents: Vec::new(),
+            reason: "single agent".into(),
+        };
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap())
+            .expect("dry_run must serialize to valid JSON");
+        assert_ne!(v["t"], "result");
+        for absent in ["tin", "tout", "cost", "content"] {
+            assert!(
+                v.get(absent).is_none(),
+                "dry_run carries `{absent}`, which invites being read as a run: {v}"
+            );
+        }
     }
 
     // Test helper: a Write that appends to a shared buffer.

--- a/crates/armadai/src/cli/mod.rs
+++ b/crates/armadai/src/cli/mod.rs
@@ -100,9 +100,11 @@ pub enum Command {
         #[arg(long, value_name = "TAGS", value_delimiter = ',')]
         tags: Option<Vec<String>>,
         /// Resolve agents, providers and models and print what would run,
-        /// without calling any provider (0 tokens). Refuses whatever the real
-        /// run refuses, with the same exit code. Works on every path: a single
-        /// agent, --pipe, --orchestrate and --resume.
+        /// without calling any provider (0 tokens) and without writing
+        /// anything: the project is not registered and agent files are never
+        /// rewritten. Refuses whatever the real run refuses, with the same
+        /// exit code. Works on every path: a single agent, --pipe,
+        /// --orchestrate and --resume.
         #[arg(long)]
         dry_run: bool,
         /// Disable the live orchestration TUI (force plain headless output)

--- a/crates/armadai/src/cli/mod.rs
+++ b/crates/armadai/src/cli/mod.rs
@@ -100,12 +100,13 @@ pub enum Command {
         #[arg(long, value_name = "TAGS", value_delimiter = ',')]
         tags: Option<Vec<String>>,
         /// Resolve agents, providers and models and print what would run,
-        /// without calling any provider (0 tokens) and without writing
-        /// anything: the project is not registered and agent files are never
-        /// rewritten. Refuses whatever the real run refuses, with the same
-        /// exit code. Works on every path: a single agent, --pipe,
-        /// --orchestrate and --resume.
-        #[arg(long)]
+        /// without calling any provider (0 tokens): the project is not
+        /// registered and agent files are never rewritten. Refuses whatever
+        /// the real run refuses, with the same exit code. Works on every
+        /// path: a single agent, --pipe, --orchestrate and --resume — the
+        /// last of which still opens the run journal, read back to rebuild
+        /// the roster it previews.
+        #[arg(long, conflicts_with = "replay")]
         dry_run: bool,
         /// Disable the live orchestration TUI (force plain headless output)
         #[arg(long = "no-tui")]

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use armadai_core::agent::{Agent, AgentMode};
 use armadai_core::config::AppPaths;
-use armadai_core::events::{EventSink, RunEvent};
+use armadai_core::events::{DryRunAgent, EventSink, RunEvent};
 use armadai_core::orchestration::es::bridge::{SinkProjectingLog, to_orchestration_result};
 use armadai_core::orchestration::es::event::ExecutionEvent;
 use armadai_core::orchestration::es::log::{EventLog, InMemoryLog};
@@ -541,18 +541,30 @@ async fn resume_run(
             names.len(),
             names.join(", ")
         );
+        let mut roster = Vec::with_capacity(names.len());
         for name in &names {
             let (prov, model) = preview_provider_and_model(
                 &agents_map[name].metadata,
                 providers_map[name].as_ref(),
             );
             eprintln!("[dry-run]   {name} — provider={prov}, model={model}");
+            roster.push(DryRunAgent {
+                agent: name.clone(),
+                prov,
+                model,
+            });
         }
         eprintln!(
             "[dry-run] the remaining steps are decided by the engine as it runs, \
              so they cannot be listed without executing them"
         );
         eprintln!("{DRY_RUN_NO_EFFECTS}");
+        sink.emit(&RunEvent::DryRun {
+            mode: "resume".to_string(),
+            pattern: pattern.clone(),
+            agents: roster,
+            reason: format!("roster reloaded from run {run_id}"),
+        });
         if !json {
             println!("{}", names.join("\n"));
         }
@@ -842,7 +854,7 @@ async fn run_inner(
     // with the same message and the same code the real run would give.
     if dry_run {
         let links = load_chain(&resolution, &chain)?;
-        report_dry_run_chain(&chain, &links, json);
+        report_dry_run_chain(&chain, &links, json, sink);
         return Ok(());
     }
 
@@ -1152,12 +1164,18 @@ fn load_chain(resolution: &AgentResolution, chain: &[String]) -> anyhow::Result<
 ///
 /// What the provider/model column says, and why it is not just a copy of the
 /// agent file, is [`preview_provider_and_model`]'s job.
-fn report_dry_run_chain(chain: &[String], links: &[ChainLink], json: bool) {
+fn report_dry_run_chain(
+    chain: &[String],
+    links: &[ChainLink],
+    json: bool,
+    sink: &Arc<dyn EventSink>,
+) {
     let n = chain.len();
     eprintln!(
         "[dry-run] sequential chain ({n} agent(s)): {}",
         chain.join(", ")
     );
+    let mut roster = Vec::with_capacity(n);
     for (i, (name, link)) in chain.iter().zip(links).enumerate() {
         let (prov, model) =
             preview_provider_and_model(&link.agent.metadata, link.provider.as_ref());
@@ -1169,8 +1187,26 @@ fn report_dry_run_chain(chain: &[String], links: &[ChainLink], json: bool) {
             let s = crate::cli::style::warn();
             anstream::eprintln!("{s}[dry-run]   warn: {w}{s:#}");
         }
+        // Pushed from the same `(prov, model)` the line above printed, not
+        // recomputed: the machine stream and the human one cannot drift.
+        roster.push(DryRunAgent {
+            agent: name.clone(),
+            prov,
+            model,
+        });
     }
     eprintln!("{DRY_RUN_NO_EFFECTS}");
+    sink.emit(&RunEvent::DryRun {
+        mode: "sequential".to_string(),
+        pattern: String::new(),
+        agents: roster,
+        reason: if n == 1 {
+            "single agent"
+        } else {
+            "explicit chain"
+        }
+        .to_string(),
+    });
     if !json {
         println!("{}", chain.join("\n"));
     }
@@ -2267,6 +2303,7 @@ async fn run_orchestrated_inner(
         // `agents`/`providers` are aligned with `effective_names` in both
         // branches above: the C8 selection reassigns all three together, and
         // when it does not run they are the untouched load-loop order.
+        let mut roster = Vec::with_capacity(effective_names.len());
         for ((name, agent), provider) in effective_names
             .iter()
             .zip(agents.iter())
@@ -2274,12 +2311,23 @@ async fn run_orchestrated_inner(
         {
             let (prov, model) = preview_provider_and_model(&agent.metadata, provider.as_ref());
             eprintln!("[dry-run]   {name} — provider={prov}, model={model}");
+            roster.push(DryRunAgent {
+                agent: name.clone(),
+                prov,
+                model,
+            });
         }
         eprintln!(
             "[dry-run] which agent speaks when, and how often, is decided by the \
              engine as it runs, so it cannot be listed without executing it"
         );
         eprintln!("{DRY_RUN_NO_EFFECTS}");
+        sink.emit(&RunEvent::DryRun {
+            mode: "orchestrated".to_string(),
+            pattern: pattern.to_string(),
+            agents: roster,
+            reason: reason.to_string(),
+        });
         if !json {
             println!("{}", effective_names.join("\n"));
         }

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -33,6 +33,23 @@ accurate, relevant output.";
 /// files it was previewing. Both are gone (see [`resolve_agents_dir`]), so
 /// the line now states what it actually guarantees instead of a subset of
 /// it.
+///
+/// These three clauses are also, verbatim in substance, `--dry-run`'s help
+/// text — and the help says no more than they do. It briefly claimed the
+/// preview wrote "nothing", which measurement did not support: on a machine
+/// with no journal yet, `--resume`/`--replay` still call `db::init_db()`
+/// before they can read a roster back, and `armadai_storage::open` does
+/// `create_dir_all` + `Connection::open` + `schema::apply` — an 88 KB
+/// SQLite file with the full schema, created by a command that had just
+/// promised to write nothing. The three preview paths that own the promise
+/// (single agent, `--pipe`, `--orchestrate`) write nothing at all; the two
+/// journal paths cannot preview a recorded run without opening the record.
+/// So the wording was narrowed to the three guarantees actually kept rather
+/// than the journal being opened read-only — that second remedy is a change
+/// to `armadai-storage` (a read-only `open`, plus a missing-file fallback so
+/// a fresh machine still says "no run found for id …" instead of "unable to
+/// open database file"), and it is what would earn the stronger "writes
+/// nothing" wording back.
 const DRY_RUN_NO_EFFECTS: &str = "[dry-run] no provider called, no project registered, \
      no agent file rewritten; nothing was recorded or billed";
 

--- a/crates/armadai/src/cli/run.rs
+++ b/crates/armadai/src/cli/run.rs
@@ -23,6 +23,19 @@ significantly change your approach, ask 2-3 targeted clarifying questions first.
 Only proceed with your complete response once you have enough context to deliver \
 accurate, relevant output.";
 
+/// The line every `--dry-run` preview signs off with, in one place because
+/// there are three preview sites and a promise made in three wordings is
+/// three promises to keep.
+///
+/// It used to say only "no provider was called; nothing was recorded or
+/// billed" — true of the provider, false of the disk (#403): the preview
+/// registered the project and, on a terminal, offered to rewrite the agent
+/// files it was previewing. Both are gone (see [`resolve_agents_dir`]), so
+/// the line now states what it actually guarantees instead of a subset of
+/// it.
+const DRY_RUN_NO_EFFECTS: &str = "[dry-run] no provider called, no project registered, \
+     no agent file rewritten; nothing was recorded or billed";
+
 /// Execute a run command. Parameters are independent CLI options that map directly to
 /// configuration flags; grouping into a struct would obscure the caller's argument binding.
 #[allow(clippy::too_many_arguments)]
@@ -453,7 +466,7 @@ async fn resume_run(
     // pattern's config (`ConfigSnapshot`). `headless = true` here: a resume
     // is a non-interactive continuation, so it must never block on the
     // model-updater's interactive prompt the way a fresh `armadai run` might.
-    let resolution = resolve_agents_dir(true);
+    let resolution = resolve_agents_dir(true, dry_run);
     let routing_rules = match &resolution {
         AgentResolution::Project { config, .. } => config.routing.clone().unwrap_or_default(),
         _ => armadai_core::routing::RoutingRules::default(),
@@ -539,7 +552,7 @@ async fn resume_run(
             "[dry-run] the remaining steps are decided by the engine as it runs, \
              so they cannot be listed without executing them"
         );
-        eprintln!("[dry-run] no provider was called; nothing was recorded or billed");
+        eprintln!("{DRY_RUN_NO_EFFECTS}");
         if !json {
             println!("{}", names.join("\n"));
         }
@@ -703,7 +716,7 @@ async fn run_inner(
     sink: &Arc<dyn EventSink>,
 ) -> anyhow::Result<()> {
     let _ = (&resume, &replay);
-    let resolution = resolve_agents_dir(headless);
+    let resolution = resolve_agents_dir(headless, dry_run);
     let tags = tags.unwrap_or_default();
 
     // Build the execution chain: primary agent + piped agents
@@ -1157,7 +1170,7 @@ fn report_dry_run_chain(chain: &[String], links: &[ChainLink], json: bool) {
             anstream::eprintln!("{s}[dry-run]   warn: {w}{s:#}");
         }
     }
-    eprintln!("[dry-run] no provider was called; nothing was recorded or billed");
+    eprintln!("{DRY_RUN_NO_EFFECTS}");
     if !json {
         println!("{}", chain.join("\n"));
     }
@@ -1816,7 +1829,26 @@ fn atty_is_pipe() -> bool {
 
 /// Resolve agent source: walk up for `armadai.yaml`, detect format,
 /// and return the appropriate resolution strategy.
-fn resolve_agents_dir(headless: bool) -> AgentResolution {
+///
+/// `dry_run` is not a display concern here, it is an *effects* one (#403).
+/// Resolving the project is the first thing every `run` entry point does —
+/// before it knows, or cares, whether the run is a preview — and on the way
+/// through it used to perform the only two disk writes a `--dry-run` could
+/// possibly make:
+///
+/// - `register_project` writes `projects.json`. Being registered is a
+///   consequence of having *run* in a project, not of having previewed one.
+/// - `auto_check_and_prompt`, on a real terminal, offers to fix deprecated
+///   models — and on confirmation `apply_findings` rewrites the agent files
+///   themselves. A preview that edits the very files it is previewing is not
+///   a preview.
+///
+/// So under `dry_run` the registration is skipped outright and the
+/// auto-check is forced **non-interactive**: it still reports every
+/// deprecated model it finds (that a real run would rewrite them is exactly
+/// the kind of thing a preview exists to say), it just never offers, and
+/// therefore never writes.
+fn resolve_agents_dir(headless: bool, dry_run: bool) -> AgentResolution {
     // 1. Walk-up search for project config (new or legacy format).
     //
     // A project counts as having agents when `agents:` lists any, OR
@@ -1833,10 +1865,10 @@ fn resolve_agents_dir(headless: bool) -> AgentResolution {
             root.display(),
             config.agents.len()
         );
-        if let Err(e) = armadai_core::project_registry::register_project(&root) {
+        if !dry_run && let Err(e) = armadai_core::project_registry::register_project(&root) {
             tracing::warn!("Failed to register project in registry: {:?}", e);
         }
-        let interactive = !headless && !atty_is_pipe();
+        let interactive = !dry_run && !headless && !atty_is_pipe();
         armadai_core::model_updater::auto_check_and_prompt(&root, interactive);
         return AgentResolution::Project {
             root,
@@ -2247,7 +2279,7 @@ async fn run_orchestrated_inner(
             "[dry-run] which agent speaks when, and how often, is decided by the \
              engine as it runs, so it cannot be listed without executing it"
         );
-        eprintln!("[dry-run] no provider was called; nothing was recorded or billed");
+        eprintln!("{DRY_RUN_NO_EFFECTS}");
         if !json {
             println!("{}", effective_names.join("\n"));
         }
@@ -3088,8 +3120,16 @@ mod tests {
 
     #[test]
     fn test_resolve_agents_dir_returns_valid_resolution() {
-        // resolve_agents_dir should not panic regardless of cwd state
-        let resolution = resolve_agents_dir(false);
+        // resolve_agents_dir should not panic regardless of cwd state.
+        //
+        // `dry_run = true` (#403): this runs in the developer's own checkout,
+        // where the cwd walk-up can land on a real project — and the
+        // non-dry-run branch writes `projects.json` in the REAL config dir
+        // (no `ARMADAI_CONFIG_DIR` redirection reaches a unit test). The
+        // preview flag makes the call effect-free by construction; the
+        // registering branch is covered where it belongs, by the spawned
+        // binary in `tests/run_dry_run_spends_nothing.rs`.
+        let resolution = resolve_agents_dir(false, true);
         match resolution {
             AgentResolution::Project { root, config, .. } => {
                 assert!(!root.to_string_lossy().is_empty());

--- a/crates/armadai/src/shell/workroom.rs
+++ b/crates/armadai/src/shell/workroom.rs
@@ -544,6 +544,13 @@ impl Workroom {
                 }
             }
             RunEvent::Warning { .. } => {}
+            // A preview never reaches a Workroom: `use_live_workroom` has an
+            // explicit `&& !dry_run` term precisely because a dry run
+            // dispatches nothing and would leave the live view waiting for a
+            // terminal event forever (#398 review). Spelled out rather than
+            // folded into a wildcard so the next variant added to `RunEvent`
+            // is a compile error here, not a silently ignored event.
+            RunEvent::DryRun { .. } => {}
         }
     }
 

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -606,34 +606,115 @@ fn an_orchestrated_preview_names_each_agents_provider_and_model() {
     }
 }
 
-// ── The preview must not enter the live Workroom (#398 review) ───────
+// ── The preview writes nothing to disk (#403) ────────────────────────
 
-/// `--dry-run` on a **real terminal**.
+/// `--dry-run` promises "0 tokens" and signs off with "nothing was recorded
+/// or billed". That was true of the provider and false of the disk:
+/// `resolve_agents_dir` ran BEFORE the `dry_run` branch on every path, and
+/// registered the project in `projects.json` on the way through.
 ///
-/// Everything above runs with stdout on a pipe, where `IsTerminal` is false
-/// and the live Workroom is out of reach whatever the flags say. That makes
-/// the `&& !dry_run` term in [`use_live_workroom`](../src/cli/run.rs)
-/// invisible to the whole suite: remove it and every test stays green.
-///
-/// What it guards is not cosmetic. The Workroom drives its own event loop
-/// until the run produces a terminal event, and a dry run produces none — it
-/// never dispatches anything. On a terminal, without the term, the preview
-/// enters the alternate screen and stays there: the process does not exit.
-///
-/// So this test gives the binary an actual TTY (`openpty`, no fork — the
-/// child simply gets the slave side as its stdio) and asserts it *finishes*,
-/// having printed the preview. The timeout is the assertion: a hang is the
-/// failure mode, and a hang is what a plain `output()` would turn into a
-/// stuck test run rather than a red one.
-#[cfg(unix)]
+/// The control run is the point of the test. An assertion that a file is
+/// absent is worth nothing against a fixture that would never have written
+/// it, so the same sandbox is run for real straight after: the registry
+/// must appear then, and only then.
 #[test]
-fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
-    use std::io::Read;
+fn a_sequential_dry_run_does_not_register_the_project() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+    let registry = sb.config.join("projects.json");
+
+    let dry = sb.run(&["run", "alpha", "hello", "--dry-run", "--json"]);
+    assert!(dry.succeeded(), "dry-run failed: {}", dry.stderr());
+    assert!(
+        !registry.exists(),
+        "--dry-run registered the project:\n{}",
+        std::fs::read_to_string(&registry).unwrap_or_default()
+    );
+
+    let real = sb.run(&["run", "alpha", "hello", "--json"]);
+    assert!(real.succeeded(), "run failed: {}", real.stderr());
+    assert!(
+        registry.exists(),
+        "the fixture never registers a project at all — the assertion above \
+         proves nothing"
+    );
+}
+
+/// `--resume` builds its roster through its own `resolve_agents_dir` call,
+/// so the sequential fix does not reach it: it needs its own measurement.
+///
+/// The setup run registers the project (it is a real run), so the registry
+/// is deleted before the preview — otherwise "the file exists" would be
+/// true whatever the preview does.
+#[cfg(feature = "storage")]
+#[test]
+fn a_resume_dry_run_does_not_register_the_project() {
+    let sb = Sandbox::new(&[(
+        "alpha",
+        "- provider: cli\n- command: /nonexistent-armadai-cmd\n",
+    )]);
+    let registry = sb.config.join("projects.json");
+
+    // A run whose provider cannot execute dies mid-flight, leaving the
+    // event log in `Running` — i.e. resumable.
+    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
+    assert!(!setup.succeeded(), "the setup run was supposed to fail");
+    let run_id = setup
+        .stdout()
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["t"] == "run_start")
+        .and_then(|v| v["run_id"].as_str().map(str::to_string))
+        .expect("no run_start to take a run id from");
+
+    write_agent(&sb.root, "alpha", ECHO);
+    std::fs::remove_file(&registry).expect("the setup run should have registered the project");
+
+    let dry = sb.run(&[
+        "run",
+        "--resume",
+        &run_id,
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(dry.succeeded(), "resume dry-run failed: {}", dry.stderr());
+    assert!(
+        !registry.exists(),
+        "--resume --dry-run registered the project:\n{}",
+        std::fs::read_to_string(&registry).unwrap_or_default()
+    );
+
+    // Control: a real resume does register it.
+    let real = sb.run(&["run", "--resume", &run_id, "--json", "--no-tui"]);
+    assert!(real.succeeded(), "resume failed: {}", real.stderr());
+    assert!(
+        registry.exists(),
+        "a real resume does not register either — the assertion above proves \
+         nothing"
+    );
+}
+
+// ── The preview on a real terminal (#398 review, #403) ───────────────
+
+/// Spawn the binary with an actual TTY on all three stdio ends, feed it
+/// `stdin`, and return `(status, everything the terminal saw)`.
+///
+/// `openpty`, no fork — the child simply gets the slave side as its stdio.
+/// Two behaviours under test in this file are unreachable without it, and
+/// both fail as *hangs*: the live Workroom's `IsTerminal` gate, and
+/// `dialoguer`'s confirmation prompt, which only prompts on a terminal. The
+/// deadline below is therefore part of the assertion — it turns a hang into
+/// a red test instead of a stuck run.
+///
+/// The master is drained continuously by a thread: a pty buffer is a few KB,
+/// and a child blocked on a full one would look exactly like the hang under
+/// test.
+#[cfg(unix)]
+fn run_on_a_pty(sb: &Sandbox, args: &[&str], stdin: &str) -> (std::process::ExitStatus, String) {
+    use std::io::{Read, Write};
     use std::os::fd::{FromRawFd, OwnedFd};
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
-
-    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
 
     let (master, slave) = {
         let (mut m, mut s) = (0, 0);
@@ -660,16 +741,7 @@ fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
         .env("ARMADAI_CONFIG_DIR", &sb.config)
         .env("XDG_DATA_HOME", &sb.data)
         .env("NO_COLOR", "1")
-        .args([
-            "run",
-            "alpha",
-            "hello",
-            "--pipe",
-            "beta",
-            "--orchestrate",
-            "ring",
-            "--dry-run",
-        ])
+        .args(args)
         .stdin(std::process::Stdio::from(slave.try_clone().unwrap()))
         .stdout(std::process::Stdio::from(slave.try_clone().unwrap()))
         .stderr(std::process::Stdio::from(slave.try_clone().unwrap()));
@@ -677,16 +749,22 @@ fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
     // The parent must not keep the slave open, or the master never sees EOF.
     drop(slave);
 
-    // Drain the master continuously: a pty buffer is a few KB, and a child
-    // blocked on a full one would look exactly like the hang under test.
+    let mut master = std::fs::File::from(master);
+    if !stdin.is_empty() {
+        master
+            .write_all(stdin.as_bytes())
+            .expect("write to the pty");
+        master.flush().unwrap();
+    }
+
     let seen: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&seen);
+    let mut drain = master.try_clone().expect("clone the pty master");
     std::thread::spawn(move || {
-        let mut f = std::fs::File::from(master);
         let mut buf = [0u8; 4096];
         // Linux reports EIO (not EOF) once the last slave closes; any error
         // is the end as far as this drain is concerned.
-        while let Ok(n) = f.read(&mut buf) {
+        while let Ok(n) = drain.read(&mut buf) {
             if n == 0 {
                 break;
             }
@@ -702,9 +780,9 @@ fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
                 let _ = child.kill();
                 let _ = child.wait();
                 panic!(
-                    "--dry-run never returned on a terminal — it entered the live \
-                     Workroom, which waits for a run that will never dispatch. \
-                     Output so far:\n{}",
+                    "armadai never returned on a terminal — a preview that enters \
+                     the live Workroom, and a prompt nobody answers, both hang \
+                     exactly here. Output so far:\n{}",
                     String::from_utf8_lossy(&seen.lock().unwrap())
                 );
             }
@@ -714,6 +792,39 @@ fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
     // Let the drain thread pick up whatever was still in the pty buffer.
     std::thread::sleep(Duration::from_millis(100));
     let out = String::from_utf8_lossy(&seen.lock().unwrap()).into_owned();
+    (status, out)
+}
+
+/// `--dry-run` on a **real terminal**.
+///
+/// Everything above runs with stdout on a pipe, where `IsTerminal` is false
+/// and the live Workroom is out of reach whatever the flags say. That makes
+/// the `&& !dry_run` term in [`use_live_workroom`](../src/cli/run.rs)
+/// invisible to the whole suite: remove it and every test stays green.
+///
+/// What it guards is not cosmetic. The Workroom drives its own event loop
+/// until the run produces a terminal event, and a dry run produces none — it
+/// never dispatches anything. On a terminal, without the term, the preview
+/// enters the alternate screen and stays there: the process does not exit.
+#[cfg(unix)]
+#[test]
+fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+
+    let (status, out) = run_on_a_pty(
+        &sb,
+        &[
+            "run",
+            "alpha",
+            "hello",
+            "--pipe",
+            "beta",
+            "--orchestrate",
+            "ring",
+            "--dry-run",
+        ],
+        "",
+    );
 
     assert!(status.success(), "--dry-run on a terminal failed:\n{out}");
     assert!(
@@ -723,5 +834,62 @@ fn a_dry_run_on_a_terminal_prints_a_preview_and_exits() {
     assert!(
         !out.contains("\u{1b}[?1049h"),
         "--dry-run entered the alternate screen (the live Workroom):\n{out}"
+    );
+}
+
+/// The second half of #403, and the one no piped test can reach.
+///
+/// `resolve_agents_dir` calls `model_updater::auto_check_and_prompt` with
+/// `interactive = !headless && !atty_is_pipe()`. On a pipe that is always
+/// false, so the whole suite above only ever saw the "hint:" branch. On a
+/// terminal it prompts, and on confirmation `apply_findings` REWRITES the
+/// agent files — under `--dry-run`, on a command whose last line claims
+/// nothing was recorded.
+///
+/// The control run is what makes the dry-run assertion mean anything: the
+/// same fixture, the same terminal, the same answer, without `--dry-run`.
+/// It must rewrite the file. If it does not, the fixture never reached the
+/// prompt and "the file is unchanged" would be true for the wrong reason.
+///
+/// `gpt-3.5-turbo` is an embedded deprecation in `model_aliases`
+/// (→ `gpt-4o-mini`), so nothing here depends on the network or on the
+/// user's `model-aliases.json` — `ARMADAI_CONFIG_DIR` points at an empty
+/// sandbox, so no local override can be loaded.
+#[cfg(unix)]
+#[test]
+fn a_dry_run_on_a_terminal_never_rewrites_an_agent_file() {
+    const DEPRECATED: &str = "- provider: cli\n- command: echo\n- model: gpt-3.5-turbo\n";
+
+    let control = Sandbox::new(&[("alpha", DEPRECATED)]);
+    let file = control.root.join("agents").join("alpha.md");
+    let before = std::fs::read_to_string(&file).unwrap();
+
+    let (status, out) = run_on_a_pty(&control, &["run", "alpha", "hello"], "y\n");
+    assert!(status.success(), "the control run failed:\n{out}");
+    let rewritten = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        rewritten.contains("gpt-4o-mini") && rewritten != before,
+        "the control run never reached the interactive prompt, so the \
+         dry-run assertion below would prove nothing. Terminal saw:\n{out}"
+    );
+
+    let sb = Sandbox::new(&[("alpha", DEPRECATED)]);
+    let file = sb.root.join("agents").join("alpha.md");
+    let (status, out) = run_on_a_pty(&sb, &["run", "alpha", "hello", "--dry-run"], "y\n");
+
+    assert!(status.success(), "--dry-run on a terminal failed:\n{out}");
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        before,
+        "--dry-run rewrote an agent file. Terminal saw:\n{out}"
+    );
+    assert!(
+        !out.contains("Update deprecated models now?"),
+        "--dry-run offered to write:\n{out}"
+    );
+    // Reporting the finding is the part that belongs in a preview.
+    assert!(
+        out.contains("gpt-3.5-turbo -> gpt-4o-mini"),
+        "the preview stopped reporting the deprecation it would fix:\n{out}"
     );
 }

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -893,3 +893,234 @@ fn a_dry_run_on_a_terminal_never_rewrites_an_agent_file() {
         "the preview stopped reporting the deprecation it would fix:\n{out}"
     );
 }
+
+// ── The --json stream of a preview terminates (#405) ─────────────────
+
+/// The last line of stdout that parses as JSON.
+///
+/// `--dry-run --json` emitted `run_start` and then nothing at all, so a
+/// consumer could not tell "the preview is over" from "the process died at
+/// startup". Reading the LAST line — rather than searching the stream for a
+/// `dry_run` anywhere in it — is the whole point: the event has to be
+/// terminal to answer that question.
+fn terminal_event(out: &Output) -> serde_json::Value {
+    out.stdout()
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .next_back()
+        .unwrap_or_else(|| panic!("no JSON on stdout at all:\n{}", out.stdout()))
+}
+
+/// `[(agent, prov, model), …]` of a `dry_run` event, in emission order.
+fn roster(ev: &serde_json::Value) -> Vec<(String, String, String)> {
+    ev["agents"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no agents array in {ev}"))
+        .iter()
+        .map(|a| {
+            (
+                a["agent"].as_str().unwrap_or_default().to_string(),
+                a["prov"].as_str().unwrap_or_default().to_string(),
+                a["model"].as_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
+}
+
+/// One test per preview site, deliberately: an assertion on the whole
+/// stream's concatenation would stay green with a single site wired, and
+/// there are three (#398 found five sites of that same class, not one of
+/// which was covered by any of the others).
+#[test]
+fn a_pipe_chain_dry_run_ends_its_json_stream_with_a_dry_run_event() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+
+    let out = sb.run(&[
+        "run",
+        "alpha",
+        "hello",
+        "--pipe",
+        "beta",
+        "--dry-run",
+        "--json",
+    ]);
+    assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+
+    let ev = terminal_event(&out);
+    assert_eq!(
+        ev["t"],
+        "dry_run",
+        "the sequential preview's stream does not end on a terminal event:\n{}",
+        out.stdout()
+    );
+    assert_eq!(ev["mode"], "sequential", "in {ev}");
+    assert_eq!(
+        roster(&ev)
+            .iter()
+            .map(|(a, _, _)| a.clone())
+            .collect::<Vec<_>>(),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "roster missing or out of execution order in {ev}"
+    );
+    for (agent, prov, model) in roster(&ev) {
+        assert_eq!(prov, "cli", "no provider for {agent} in {ev}");
+        assert!(
+            model.contains("echo"),
+            "no model for {agent} in {ev} (got {model})"
+        );
+    }
+    assert!(
+        !ev["reason"].as_str().unwrap_or_default().is_empty(),
+        "no selection reason in {ev}"
+    );
+}
+
+#[test]
+fn an_orchestrated_dry_run_ends_its_json_stream_with_a_dry_run_event() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+
+    let out = sb.run(&[
+        "run",
+        "alpha",
+        "hello",
+        "--pipe",
+        "beta",
+        "--orchestrate",
+        "ring",
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+
+    let ev = terminal_event(&out);
+    assert_eq!(
+        ev["t"],
+        "dry_run",
+        "the orchestrated preview's stream does not end on a terminal event:\n{}",
+        out.stdout()
+    );
+    assert_eq!(ev["mode"], "orchestrated", "in {ev}");
+    assert_eq!(ev["pattern"], "ring", "in {ev}");
+    assert_eq!(
+        roster(&ev)
+            .iter()
+            .map(|(a, _, _)| a.clone())
+            .collect::<Vec<_>>(),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "roster missing or out of order in {ev}"
+    );
+    for (agent, prov, model) in roster(&ev) {
+        assert_eq!(prov, "cli", "no provider for {agent} in {ev}");
+        assert!(
+            model.contains("echo"),
+            "no model for {agent} in {ev} (got {model})"
+        );
+    }
+    assert!(
+        !ev["reason"].as_str().unwrap_or_default().is_empty(),
+        "no selection reason in {ev}"
+    );
+}
+
+#[cfg(feature = "storage")]
+#[test]
+fn a_resume_dry_run_ends_its_json_stream_with_a_dry_run_event() {
+    let sb = Sandbox::new(&[(
+        "alpha",
+        "- provider: cli\n- command: /nonexistent-armadai-cmd\n",
+    )]);
+
+    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
+    assert!(!setup.succeeded(), "the setup run was supposed to fail");
+    let run_id = setup
+        .stdout()
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["t"] == "run_start")
+        .and_then(|v| v["run_id"].as_str().map(str::to_string))
+        .expect("no run_start to take a run id from");
+
+    write_agent(&sb.root, "alpha", ECHO);
+
+    let out = sb.run(&[
+        "run",
+        "--resume",
+        &run_id,
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(out.succeeded(), "resume dry-run failed: {}", out.stderr());
+
+    let ev = terminal_event(&out);
+    assert_eq!(
+        ev["t"],
+        "dry_run",
+        "the resume preview's stream does not end on a terminal event:\n{}",
+        out.stdout()
+    );
+    assert_eq!(ev["mode"], "resume", "in {ev}");
+    assert_eq!(ev["pattern"], "direct", "in {ev}");
+    assert_eq!(
+        roster(&ev),
+        vec![(
+            "alpha".to_string(),
+            "cli".to_string(),
+            "(not sent — cli:echo chooses)".to_string()
+        )],
+        "in {ev}"
+    );
+    assert!(
+        !ev["reason"].as_str().unwrap_or_default().is_empty(),
+        "no selection reason in {ev}"
+    );
+}
+
+/// A preview must not be mistakable for a run. `result` is what a consumer
+/// bills, records and reports on, and a `result` with zeroed tokens is
+/// exactly what a real run that cost nothing looks like — a cached answer,
+/// a zero-token relay. So the preview gets its own event and emits no
+/// `result` at all.
+#[test]
+fn a_dry_run_never_emits_a_result_event() {
+    let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+
+    for args in [
+        vec![
+            "run",
+            "alpha",
+            "hello",
+            "--pipe",
+            "beta",
+            "--dry-run",
+            "--json",
+        ],
+        vec![
+            "run",
+            "alpha",
+            "hello",
+            "--pipe",
+            "beta",
+            "--orchestrate",
+            "ring",
+            "--dry-run",
+            "--json",
+            "--no-tui",
+        ],
+    ] {
+        let out = sb.run(&args);
+        assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+        let kinds: Vec<String> = out
+            .stdout()
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .map(|v| v["t"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert!(
+            !kinds.iter().any(|k| k == "result"),
+            "a preview emitted a `result` a consumer would count as a run \
+             ({args:?}): {kinds:?}"
+        );
+    }
+}

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -89,6 +89,12 @@ impl Sandbox {
     /// Empty before any command runs (`with_config` creates the directory
     /// and nothing else), so a non-empty result is always something the
     /// command under test wrote.
+    ///
+    /// Gated with its only caller: without `storage` a real run writes no
+    /// journal either, so the test that uses this is gated too — and an
+    /// ungated helper is dead code under `--features tui` alone, which CI
+    /// lints as an error.
+    #[cfg(feature = "storage")]
     fn data_files(&self) -> Vec<String> {
         fn walk(dir: &Path, base: &Path, out: &mut Vec<String>) {
             let Ok(entries) = std::fs::read_dir(dir) else {

--- a/crates/armadai/tests/run_dry_run_spends_nothing.rs
+++ b/crates/armadai/tests/run_dry_run_spends_nothing.rs
@@ -84,6 +84,36 @@ impl Sandbox {
         self.run_env(args, &[])
     }
 
+    /// Every file the binary left under `XDG_DATA_HOME`, relative to it.
+    ///
+    /// Empty before any command runs (`with_config` creates the directory
+    /// and nothing else), so a non-empty result is always something the
+    /// command under test wrote.
+    fn data_files(&self) -> Vec<String> {
+        fn walk(dir: &Path, base: &Path, out: &mut Vec<String>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, base, out);
+                } else {
+                    out.push(
+                        path.strip_prefix(base)
+                            .unwrap_or(&path)
+                            .display()
+                            .to_string(),
+                    );
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(&self.data, &self.data, &mut out);
+        out.sort();
+        out
+    }
+
     /// [`Sandbox::run`] plus extra environment variables — an API key, for a
     /// test whose agent is on an HTTP provider (`create_provider` builds it
     /// even on the preview, and refuses without one).
@@ -129,6 +159,69 @@ impl Output {
             .filter(|v| v["t"] == t)
             .map(|v| v["agent"].as_str().unwrap_or("").to_string())
             .collect()
+    }
+}
+
+/// Record a run that dies mid-flight and return its id — i.e. a run the
+/// event log left in `Running`, the only kind `--resume` accepts.
+///
+/// The agent is rewritten to [`ECHO`] on the way out, so the caller resumes
+/// a roster that can actually execute. Four tests need this exact fixture;
+/// it is a function because the file already carried three copies of it and
+/// a fourth is how a fixture starts drifting from its siblings.
+#[cfg(feature = "storage")]
+fn resumable_run_id(sb: &Sandbox) -> String {
+    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
+    assert!(!setup.succeeded(), "the setup run was supposed to fail");
+    let run_id = setup
+        .stdout()
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["t"] == "run_start")
+        .and_then(|v| v["run_id"].as_str().map(str::to_string))
+        .expect("no run_start to take a run id from");
+    write_agent(&sb.root, "alpha", ECHO);
+    run_id
+}
+
+/// The agent of [`resumable_run_id`]'s setup run: a `cli` relay pointed at a
+/// command that cannot execute, so the run fails after `RunStarted` is
+/// persisted and before anything completes.
+#[cfg(feature = "storage")]
+const BROKEN: &str = "- provider: cli\n- command: /nonexistent-armadai-cmd\n";
+
+/// Every preview signs off on the three guarantees `--dry-run`'s help makes,
+/// asserted **clause by clause and per site**.
+///
+/// Each clause was false at some point in this command's history (#403): the
+/// preview registered the project, and on a terminal it offered to rewrite
+/// the very agent files it was previewing. The line was widened to say so —
+/// and nothing held it there. Restoring the older, measured-false wording
+/// ("no provider was called; nothing was recorded or billed" — true of the
+/// provider, silent about the disk) left all 19 tests in this file green,
+/// as did deleting the line outright from the `--resume` site.
+///
+/// Naming each clause pins the *promise* rather than the punctuation, and
+/// asserting it per site is the same discipline the terminal-event tests
+/// already apply: there are three preview sites and dropping the sign-off
+/// from any one of them must be red on its own.
+///
+/// The clauses are spelled out rather than compared against the binary's own
+/// `DRY_RUN_NO_EFFECTS`: `crates/armadai` has no `lib.rs`, so an integration
+/// test cannot import that constant at all — and a test that compared the
+/// output to the constant would agree with any rewording of it, which is the
+/// regression being guarded.
+fn assert_signs_off_on_every_guarantee(out: &Output, site: &str) {
+    let err = out.stderr();
+    for clause in [
+        "no provider called",
+        "no project registered",
+        "no agent file rewritten",
+    ] {
+        assert!(
+            err.contains(clause),
+            "the {site} preview never promises `{clause}`; stderr was:\n{err}"
+        );
     }
 }
 
@@ -310,24 +403,8 @@ fn a_single_agent_dry_run_refuses_in_the_same_words_as_the_real_pass() {
 #[cfg(feature = "storage")]
 #[test]
 fn a_resume_dry_run_calls_no_provider_and_leaves_the_run_resumable() {
-    let sb = Sandbox::new(&[(
-        "alpha",
-        "- provider: cli\n- command: /nonexistent-armadai-cmd\n",
-    )]);
-
-    // A run whose provider cannot execute dies mid-flight, leaving the
-    // event log in `Running` — i.e. resumable.
-    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
-    assert!(!setup.succeeded(), "the setup run was supposed to fail");
-    let run_id = setup
-        .stdout()
-        .lines()
-        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
-        .find(|v| v["t"] == "run_start")
-        .and_then(|v| v["run_id"].as_str().map(str::to_string))
-        .expect("no run_start to take a run id from");
-
-    write_agent(&sb.root, "alpha", ECHO);
+    let sb = Sandbox::new(&[("alpha", BROKEN)]);
+    let run_id = resumable_run_id(&sb);
 
     let dry = sb.run(&[
         "run",
@@ -648,25 +725,9 @@ fn a_sequential_dry_run_does_not_register_the_project() {
 #[cfg(feature = "storage")]
 #[test]
 fn a_resume_dry_run_does_not_register_the_project() {
-    let sb = Sandbox::new(&[(
-        "alpha",
-        "- provider: cli\n- command: /nonexistent-armadai-cmd\n",
-    )]);
+    let sb = Sandbox::new(&[("alpha", BROKEN)]);
     let registry = sb.config.join("projects.json");
-
-    // A run whose provider cannot execute dies mid-flight, leaving the
-    // event log in `Running` — i.e. resumable.
-    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
-    assert!(!setup.succeeded(), "the setup run was supposed to fail");
-    let run_id = setup
-        .stdout()
-        .lines()
-        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
-        .find(|v| v["t"] == "run_start")
-        .and_then(|v| v["run_id"].as_str().map(str::to_string))
-        .expect("no run_start to take a run id from");
-
-    write_agent(&sb.root, "alpha", ECHO);
+    let run_id = resumable_run_id(&sb);
     std::fs::remove_file(&registry).expect("the setup run should have registered the project");
 
     let dry = sb.run(&[
@@ -709,6 +770,55 @@ fn a_resume_dry_run_does_not_register_the_project() {
 /// The master is drained continuously by a thread: a pty buffer is a few KB,
 /// and a child blocked on a full one would look exactly like the hang under
 /// test.
+/// A pty transcript with its control sequences made readable, keeping real
+/// newlines so it still reads as lines.
+///
+/// The diagnostic below is printed only when the child hung, and what a hung
+/// `armadai` has written by then begins with `ESC [ ? 1049 h` — "switch to
+/// the alternate screen", emitted by the live Workroom on the way in.
+/// Interpolated raw into a panic message, every byte after that one is
+/// painted into the alternate buffer and is gone the instant the harness
+/// restores the primary screen: the #413 reviewer read "Output so far:" as
+/// empty while the pty had in fact captured 1.6 KB, and concluded the
+/// diagnostic was less useful than it looked. It was the escape sequence
+/// hiding it, not a missing capture.
+#[cfg(unix)]
+fn visible(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        if c == '\n' || !c.is_control() {
+            out.push(c);
+        } else {
+            out.extend(c.escape_debug());
+        }
+    }
+    out
+}
+
+/// The escaping above is the whole diagnostic, and it is only ever exercised
+/// on a hang — which no green run produces. So it is asserted directly, on
+/// the exact byte that caused the problem.
+#[cfg(unix)]
+#[test]
+fn a_hung_pty_transcript_survives_being_printed() {
+    let shown = visible("before\x1b[?1049hafter\r\nnext\n");
+
+    assert!(
+        !shown.contains('\x1b'),
+        "an ESC survived into the panic message, which will swallow \
+         everything after it: {shown:?}"
+    );
+    assert!(
+        shown.contains("before") && shown.contains("after") && shown.contains("next"),
+        "the transcript lost text it was supposed to show: {shown:?}"
+    );
+    assert!(
+        shown.ends_with('\n'),
+        "real newlines must survive, or the transcript stops reading as \
+         lines: {shown:?}"
+    );
+}
+
 #[cfg(unix)]
 fn run_on_a_pty(sb: &Sandbox, args: &[&str], stdin: &str) -> (std::process::ExitStatus, String) {
     use std::io::{Read, Write};
@@ -783,7 +893,7 @@ fn run_on_a_pty(sb: &Sandbox, args: &[&str], stdin: &str) -> (std::process::Exit
                     "armadai never returned on a terminal — a preview that enters \
                      the live Workroom, and a prompt nobody answers, both hang \
                      exactly here. Output so far:\n{}",
-                    String::from_utf8_lossy(&seen.lock().unwrap())
+                    visible(&String::from_utf8_lossy(&seen.lock().unwrap()))
                 );
             }
             None => std::thread::sleep(Duration::from_millis(20)),
@@ -969,10 +1079,41 @@ fn a_pipe_chain_dry_run_ends_its_json_stream_with_a_dry_run_event() {
             "no model for {agent} in {ev} (got {model})"
         );
     }
-    assert!(
-        !ev["reason"].as_str().unwrap_or_default().is_empty(),
-        "no selection reason in {ev}"
+    // The value, not merely its presence. `reason` is picked by a two-branch
+    // `if n == 1`, and swapping those branches — a preview of two agents
+    // explaining itself as "single agent" — left all 19 tests green while
+    // they only asserted the field was non-empty, which any string satisfies.
+    assert_eq!(ev["reason"], "explicit chain", "in {ev}");
+    assert_signs_off_on_every_guarantee(&out, "sequential");
+}
+
+/// The `n == 1` half of that same branch, which no test reached: every
+/// sequential preview under test was a `--pipe` chain of two.
+#[test]
+fn a_single_agent_dry_run_ends_its_json_stream_with_a_dry_run_event() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+
+    let out = sb.run(&["run", "alpha", "hello", "--dry-run", "--json"]);
+    assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+
+    let ev = terminal_event(&out);
+    assert_eq!(
+        ev["t"],
+        "dry_run",
+        "the single-agent preview's stream does not end on a terminal event:\n{}",
+        out.stdout()
     );
+    assert_eq!(ev["mode"], "sequential", "in {ev}");
+    assert_eq!(
+        roster(&ev)
+            .iter()
+            .map(|(a, _, _)| a.clone())
+            .collect::<Vec<_>>(),
+        vec!["alpha".to_string()],
+        "roster missing in {ev}"
+    );
+    assert_eq!(ev["reason"], "single agent", "in {ev}");
+    assert_signs_off_on_every_guarantee(&out, "single-agent");
 }
 
 #[test]
@@ -1017,31 +1158,15 @@ fn an_orchestrated_dry_run_ends_its_json_stream_with_a_dry_run_event() {
             "no model for {agent} in {ev} (got {model})"
         );
     }
-    assert!(
-        !ev["reason"].as_str().unwrap_or_default().is_empty(),
-        "no selection reason in {ev}"
-    );
+    assert_eq!(ev["reason"], "no routing (full roster)", "in {ev}");
+    assert_signs_off_on_every_guarantee(&out, "orchestrated");
 }
 
 #[cfg(feature = "storage")]
 #[test]
 fn a_resume_dry_run_ends_its_json_stream_with_a_dry_run_event() {
-    let sb = Sandbox::new(&[(
-        "alpha",
-        "- provider: cli\n- command: /nonexistent-armadai-cmd\n",
-    )]);
-
-    let setup = sb.run(&["run", "alpha", "hello", "--json"]);
-    assert!(!setup.succeeded(), "the setup run was supposed to fail");
-    let run_id = setup
-        .stdout()
-        .lines()
-        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
-        .find(|v| v["t"] == "run_start")
-        .and_then(|v| v["run_id"].as_str().map(str::to_string))
-        .expect("no run_start to take a run id from");
-
-    write_agent(&sb.root, "alpha", ECHO);
+    let sb = Sandbox::new(&[("alpha", BROKEN)]);
+    let run_id = resumable_run_id(&sb);
 
     let out = sb.run(&[
         "run",
@@ -1071,10 +1196,15 @@ fn a_resume_dry_run_ends_its_json_stream_with_a_dry_run_event() {
         )],
         "in {ev}"
     );
-    assert!(
-        !ev["reason"].as_str().unwrap_or_default().is_empty(),
-        "no selection reason in {ev}"
+    // Names the run it reloaded from: the resume preview's whole claim is
+    // that this roster is the *recorded* one, so a reason that does not
+    // identify the record explains nothing.
+    assert_eq!(
+        ev["reason"],
+        serde_json::Value::String(format!("roster reloaded from run {run_id}")),
+        "in {ev}"
     );
+    assert_signs_off_on_every_guarantee(&out, "resume");
 }
 
 /// A preview must not be mistakable for a run. `result` is what a consumer
@@ -1123,4 +1253,203 @@ fn a_dry_run_never_emits_a_result_event() {
              ({args:?}): {kinds:?}"
         );
     }
+}
+
+/// The same guarantee on the third site, which the loop above cannot reach:
+/// `--resume` needs a recorded run, so it needs its own fixture — and having
+/// no test at all, it was the one site where emitting a zeroed `result`
+/// before the `dry_run` event left every test in this file green.
+///
+/// That is the same "one test per site" argument the terminal-event tests
+/// make against asserting on the concatenated stream, applied to the site it
+/// had been left out of.
+#[cfg(feature = "storage")]
+#[test]
+fn a_resume_dry_run_never_emits_a_result_event() {
+    let sb = Sandbox::new(&[("alpha", BROKEN)]);
+    let run_id = resumable_run_id(&sb);
+
+    let out = sb.run(&[
+        "run",
+        "--resume",
+        &run_id,
+        "--dry-run",
+        "--json",
+        "--no-tui",
+    ]);
+    assert!(out.succeeded(), "resume dry-run failed: {}", out.stderr());
+
+    let kinds: Vec<String> = out
+        .stdout()
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .map(|v| v["t"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        !kinds.iter().any(|k| k == "result"),
+        "the resume preview emitted a `result` a consumer would count as a \
+         run: {kinds:?}"
+    );
+}
+
+// ── What the preview promises on disk (#413 review) ──────────────────
+
+/// The three paths whose promise is unqualified write **nothing**.
+///
+/// `--dry-run`'s help claimed for a while that the preview wrote "nothing"
+/// at all. Measured false: `--resume` and `--replay` both call
+/// `db::init_db()` before they can read a roster back, and
+/// `armadai_storage::open` does `create_dir_all` + `Connection::open` +
+/// `schema::apply` — so on a machine with no journal yet, a preview that had
+/// just promised to write nothing left an 88 KB SQLite behind with the full
+/// schema, then exited 1 on an unknown id. The help was narrowed to the
+/// three guarantees it actually keeps.
+///
+/// This pins the other half of that measurement, which is the half worth
+/// keeping: on the paths that consult no journal, the promise is total. An
+/// `init_db()` drifting above a `dry_run` branch — exactly how the two
+/// journal paths came by theirs — must be red here.
+///
+/// The control run is the point, as in the registration tests: "no file
+/// appeared" is worth nothing against a fixture that never writes one, so
+/// the same sandbox then runs for real and must produce the journal.
+///
+/// That control is also why this is gated on `storage`: without the feature
+/// there is no journal for anyone to write, the real run leaves the data
+/// directory as empty as the preview did, and the test would pass while
+/// proving nothing. It says so out loud rather than being quietly vacuous —
+/// run under `--features tui` alone it fails on the control, which is how
+/// the gate was found.
+#[cfg(feature = "storage")]
+#[test]
+fn a_preview_that_consults_no_journal_creates_no_journal() {
+    for (site, args) in [
+        (
+            "single agent",
+            vec!["run", "alpha", "hello", "--dry-run", "--json"],
+        ),
+        (
+            "pipe chain",
+            vec![
+                "run",
+                "alpha",
+                "hello",
+                "--pipe",
+                "beta",
+                "--dry-run",
+                "--json",
+            ],
+        ),
+        (
+            "orchestrated",
+            vec![
+                "run",
+                "alpha",
+                "hello",
+                "--pipe",
+                "beta",
+                "--orchestrate",
+                "ring",
+                "--dry-run",
+                "--json",
+                "--no-tui",
+            ],
+        ),
+    ] {
+        let sb = Sandbox::new(&[("alpha", ECHO), ("beta", ECHO)]);
+        let dry = sb.run(&args);
+        assert!(dry.succeeded(), "{site} dry-run failed: {}", dry.stderr());
+        assert_eq!(
+            sb.data_files(),
+            Vec::<String>::new(),
+            "the {site} preview wrote to the data directory"
+        );
+
+        let real = sb.run(&["run", "alpha", "hello", "--json"]);
+        assert!(real.succeeded(), "run failed: {}", real.stderr());
+        assert!(
+            !sb.data_files().is_empty(),
+            "the fixture never writes to the data directory at all — the \
+             assertion above proves nothing about {site}"
+        );
+    }
+}
+
+/// `--dry-run` and `--replay` are refused together rather than silently
+/// disagreeing.
+///
+/// `--dry-run` was outside the `agent`/`resume`/`replay` `ArgGroup`, so clap
+/// accepted the pair and `execute_replay` — which never took the flag — went
+/// on to replay the recorded run in full. The user asking for a preview got
+/// a `result` with zeroed tokens: precisely the shape `RunEvent::DryRun`
+/// exists to keep out of a consumer's hands, since zeroes are also what a
+/// real run that cost nothing looks like.
+///
+/// Refused rather than honoured, because a replay already calls no provider
+/// and spends nothing: previewing one would describe a cheaper operation
+/// than simply performing it. Exit 2 is the documented usage-error code.
+#[test]
+fn a_dry_run_cannot_be_combined_with_replay() {
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+
+    let out = sb.run(&[
+        "run",
+        "--replay",
+        "00000000-0000-0000-0000-000000000000",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert_eq!(
+        out.0.status.code(),
+        Some(2),
+        "--replay --dry-run was not refused as a usage error; stdout:\n{}\nstderr:\n{}",
+        out.stdout(),
+        out.stderr()
+    );
+    assert!(
+        out.stderr().contains("--replay") && out.stderr().contains("--dry-run"),
+        "the refusal does not name both flags:\n{}",
+        out.stderr()
+    );
+    // The silent-drop symptom itself: not one recorded event was re-emitted.
+    assert_nothing_ran(&out);
+    assert!(
+        !out.stdout().contains("\"result\""),
+        "a refused preview still emitted a result:\n{}",
+        out.stdout()
+    );
+}
+
+/// The sign-off is printed by the binary and quoted verbatim in the wiki,
+/// and until now nothing linked the two.
+///
+/// It is exactly the kind of line that goes stale: its whole content is a
+/// list of promises, and that list has already grown once (#403 added the
+/// two disk clauses). A reader who trusts the page would be told the preview
+/// guarantees something it no longer does — or, worse, would not be told
+/// about a guarantee it gained.
+///
+/// `include_str!` rather than a runtime read, so a moved or renamed page is
+/// a compile error here instead of a test that quietly stops checking.
+#[test]
+fn the_wiki_quotes_the_sign_off_the_binary_actually_prints() {
+    const WIKI: &str = include_str!("../../../docs/wiki/declarative-agents.md");
+
+    let sb = Sandbox::new(&[("alpha", ECHO)]);
+    let out = sb.run(&["run", "alpha", "hello", "--dry-run", "--json"]);
+    assert!(out.succeeded(), "dry-run failed: {}", out.stderr());
+
+    let printed = out
+        .stderr()
+        .lines()
+        .find(|l| l.contains("[dry-run] no provider"))
+        .unwrap_or_else(|| panic!("the preview printed no sign-off:\n{}", out.stderr()))
+        .to_string();
+
+    assert!(
+        WIKI.contains(&printed),
+        "docs/wiki/declarative-agents.md quotes a `--dry-run` sign-off the \
+         binary no longer prints.\n  printed: {printed}"
+    );
 }

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -231,12 +231,28 @@ looked at one), and the deprecated-model auto-check runs non-interactively: it s
 deprecated model it finds — a real run would offer to rewrite them, which is worth knowing before
 you launch it — but it never offers, and therefore never touches an agent file.
 
+It says those two things, and not "writes nothing", because that stronger claim would be false on
+one path. A single agent, a `--pipe` chain and `--orchestrate` leave the disk entirely alone.
+`--resume` cannot: to preview the roster of a recorded run it has to read the run journal, and
+opening the journal creates it — so a `--resume --dry-run` on a machine that has never run
+`armadai` leaves an empty SQLite database behind. That is the record it was asked to look at, not
+a side effect of the preview, but it is a write, and the promise is worded to say only what it
+keeps.
+
 Because it is the same pass, the preview **refuses whatever the real run refuses**, with the same
 message and the same non-zero exit — an unresolvable link, a colliding name, a provider that
 cannot be built. A preview that cannot fail would pre-check nothing. This holds for a single agent
 (`armadai run <name> --dry-run`), for `--orchestrate` (which previews provider and model per
 roster member, then says plainly that who speaks when is the engine's to decide), and for
-`--resume` too, which previews the roster it reloaded and leaves the run resumable. `latest:auto` is the one thing a dry run cannot resolve: its tier is
+`--resume` too, which previews the roster it reloaded and leaves the run resumable.
+
+`--replay` is the one mode `--dry-run` refuses outright, as a usage error (exit 2). A replay
+re-emits a recorded run from the event log and calls no provider at all, so previewing one would
+describe something cheaper than simply doing it. Until it was refused, `--replay --dry-run` was
+accepted and the flag silently dropped: the caller asked for a preview and got the full replay,
+ending on the zeroed `result` the `dry_run` event exists to keep out of a consumer's hands.
+
+`latest:auto` is the one thing a dry run cannot resolve: its tier is
 chosen from each link's own input, and for every link but the first that input is the previous
 link's output — precisely what a dry run declines to compute.
 

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -240,6 +240,25 @@ roster member, then says plainly that who speaks when is the engine's to decide)
 chosen from each link's own input, and for every link but the first that input is the previous
 link's output — precisely what a dry run declines to compute.
 
+With `--json`, the preview closes its JSONL stream on a `dry_run` event. It used to emit
+`run_start` and then nothing at all — the preview itself goes to stderr, and the agent names to
+stdout only when *not* emitting JSON — so a consumer could not tell "the preview is over" from
+"the process died at startup":
+
+```
+{"t":"run_start","run_id":"…","v":1,"agents":["alpha","beta"],"prov":"","model":"ring","in_chars":5}
+{"t":"dry_run","mode":"orchestrated","pattern":"ring","agents":[{"agent":"alpha","prov":"cli","model":"(not sent — cli:echo chooses)"},{"agent":"beta","prov":"cli","model":"(not sent — cli:echo chooses)"}],"reason":"no routing (full roster)"}
+```
+
+`mode` is `sequential` (a single agent or a `--pipe` chain), `orchestrated`, or `resume`;
+`pattern` is the orchestration pattern, empty on the sequential path; `agents` is the roster in
+execution order with the same provider and model the stderr lines show; `reason` says why this
+roster and not another. It is deliberately **not** a `result` with zeroed tokens — those zeroes
+would be the truth and still the wrong shape, since a real run that cost nothing looks exactly the
+same, and a consumer that bills or records on `result` would count a preview as a run. Nothing
+else in the stream changed, so a consumer that only reads `result` still sees exactly what it saw
+before: nothing.
+
 ## Long compositions still get audited
 
 Composing several fragments is easy to do without noticing how long the result got. `armadai

--- a/docs/wiki/declarative-agents.md
+++ b/docs/wiki/declarative-agents.md
@@ -217,13 +217,19 @@ and the model each would use, and calls nothing:
 [dry-run]   1/3 reader — provider=cli, model=(not sent — cli:jq chooses)
 [dry-run]   2/3 summariser — provider=anthropic, model=claude-sonnet-4-5-20250929
 [dry-run]   3/3 reviewer — provider=anthropic, model=latest:auto (tier chosen per call)
-[dry-run] no provider was called; nothing was recorded or billed
+[dry-run] no provider called, no project registered, no agent file rewritten; nothing was recorded or billed
 ```
 
 The model column is the string the run would really send, not the one written in the agent
 file: deprecated aliases and tier placeholders are already resolved. An agent relayed by a
 command-line tool is the exception — the relay never receives `model`, it picks its own — so the
 preview says so rather than naming an id that would never be asked for.
+
+The sign-off line is about the **disk**, not only the bill. A preview does not add the project to
+`projects.json` (being registered is a consequence of having run in a project, not of having
+looked at one), and the deprecated-model auto-check runs non-interactively: it still reports every
+deprecated model it finds — a real run would offer to rewrite them, which is worth knowing before
+you launch it — but it never offers, and therefore never touches an agent file.
 
 Because it is the same pass, the preview **refuses whatever the real run refuses**, with the same
 message and the same non-zero exit — an unresolvable link, a colliding name, a provider that


### PR DESCRIPTION
Deux défauts mesurés de `armadai run --dry-run`, un commit par issue.

## #403 — un aperçu qui écrit n'est plus un aperçu

`resolve_agents_dir` est appelé **avant** le branchement `dry_run` sur tous les points d'entrée, et faisait au passage les deux seules écritures disque qu'un `--dry-run` pouvait produire.

**Mesuré avant** (binaire réel, `ARMADAI_CONFIG_DIR` vide au départ) :

```
$ armadai run alpha hello --dry-run --json
[dry-run] no provider was called; nothing was recorded or billed
$ find $CFG -type f
$CFG/projects.json
```

Et sur un vrai TTY (`script -q /dev/null`, réponse `y`) — la partie que l'issue disait « mesurée par la revue » et non reproduite, que j'ai reproduite :

```
Update deprecated models now? [Y/n] yes
  Updated 1 model(s).
[dry-run] no provider was called; nothing was recorded or billed
```
`agents/alpha.md` : md5 `ac283a62…` → `b53e2e50…`. Le fichier d'agent a été **réécrit par un aperçu**.

**Option 1 appliquée, avec la nuance de l'issue.** Sous `--dry-run` : pas d'enregistrement de projet, et l'auto-check déprécié est forcé **non interactif** — il signale, ne propose jamais, n'écrit jamais.

**Mesuré après**, même fixture, même TTY, même `y` :

```
hint: 1 deprecated model(s) found:
  alpha [model]: gpt-3.5-turbo -> gpt-4o-mini
hint: run `armadai models update` to fix.

[dry-run] sequential chain (1 agent(s)): alpha
[dry-run]   1/1 alpha — provider=cli, model=(not sent — cli:echo chooses)
[dry-run] no provider called, no project registered, no agent file rewritten; nothing was recorded or billed
```
`agents/alpha.md` : md5 `ac283a62…` inchangé. Répertoire de config : **vide**.

### Sortie utilisateur modifiée — à valider

1. La ligne finale, désormais partagée par les trois sites d'aperçu :
   `[dry-run] no provider called, no project registered, no agent file rewritten; nothing was recorded or billed`
2. Le signalement non interactif sous `--dry-run` (texte existant de `auto_check_and_prompt`, désormais atteint là où la question était posée) :
   ```
   hint: 1 deprecated model(s) found:
     alpha [model]: gpt-3.5-turbo -> gpt-4o-mini
   hint: run `armadai models update` to fix.
   ```

## #405 — le flux `--json` d'un aperçu n'avait pas d'événement terminal

Un consommateur ne pouvait pas distinguer « aperçu fini » de « processus mort au démarrage ».

**Avant** :
```
{"t":"run_start","run_id":"…","agents":["alpha","beta"],"prov":"","model":"ring","in_chars":5}
(rien d'autre)
```

**Après** :
```
{"t":"dry_run","mode":"orchestrated","pattern":"ring","agents":[{"agent":"alpha","prov":"cli","model":"(not sent — cli:echo chooses)"},{"agent":"beta","prov":"cli","model":"(not sent — cli:echo chooses)"}],"reason":"no routing (full roster)"}
```

Événement dédié, **pas un `result` à zéro** : des zéros seraient la vérité mais la mauvaise forme — un vrai run qui n'a rien coûté est indiscernable, et un consommateur qui facture sur `result` compterait un aperçu comme un run. Un test dédié interdit tout `result` sur un aperçu.

Les **trois** sites d'aperçu sont câblés (chaîne séquentielle, `--resume`, `run_orchestrated_inner`), depuis le même couple `(prov, model)` qu'affiche la ligne stderr, pour que flux machine et sortie humaine ne puissent pas diverger. Il n'y a pas de quatrième site : `grep 'no provider was called'` en donnait exactement trois avant le correctif, et `link`/`unlink` ont leurs propres `--dry-run`, hors périmètre.

### Compatibilité du flux machine

Aucun format persisté ne change : `RunEvent` n'a **aucune** implémentation `Deserialize` dans le dépôt (le journal stocke `ExecutionEvent`, intouché). Mesuré, pas seulement raisonné : un journal de **18 événements écrit par un binaire antérieur** (copie de la base réelle) rejoué par le nouveau binaire donne un flux identique, terminé par `result`, exit 0.

Un consommateur qui ne lit que `result` voit exactement ce qu'il voyait avant : rien. Un consommateur qui traite `t` de façon exhaustive verra une valeur inconnue — c'est le seul risque, et c'est le prix d'un événement qu'on ne peut pas confondre avec un run.

## Mutations

| # | Mutation | Test devenu rouge |
|---|---|---|
| A | `register_project` rétabli sous `--dry-run` | `a_sequential_dry_run_does_not_register_the_project` + `a_resume_dry_run_does_not_register_the_project` (2) |
| B | `interactive` rétabli sous `--dry-run` | `a_dry_run_on_a_terminal_never_rewrites_an_agent_file` (1) |
| C | site `--resume` repasse `false` au lieu de `dry_run` | `a_resume_dry_run_does_not_register_the_project` (1) |
| D | `&& !dry_run` retiré de `use_live_workroom` | `a_dry_run_on_a_terminal_prints_a_preview_and_exits` (1, par timeout — harnais PTY refactorisé, toujours réel) |
| E | émission `dry_run` supprimée du site séquentiel | `a_pipe_chain_dry_run_ends_its_json_stream_with_a_dry_run_event` (1) |
| F | émission `dry_run` supprimée du site `--resume` | `a_resume_dry_run_ends_its_json_stream_with_a_dry_run_event` (1) |
| G | émission `dry_run` supprimée du site orchestré | `an_orchestrated_dry_run_ends_its_json_stream_with_a_dry_run_event` (1) |
| H | `Result` à zéro émis sur l'aperçu séquentiel | `a_dry_run_never_emits_a_result_event` (1) |
| I | clé `pattern` renommée `pat` | `dry_run_serializes_with_short_keys` (1) |
| J | variante sérialisée sous `t: "result"` | `dry_run_is_not_a_zeroed_result` + `dry_run_serializes_with_short_keys` (2) |

Aucune mutation n'est restée verte. E/F/G isolent bien **un site chacune** : une assertion sur la concaténation du flux aurait survécu à deux d'entre elles.

## Gate

- `cargo fmt --all -- --check` : propre
- clippy `-D warnings` dans les **5** modes : `rc=0` partout
- `cargo test --no-fail-fast` dans les **4** modes : 0 échec
- gaveldrop : `13 cases · 13 passed · 0 failed · 0 tolerated · score 83/83`

Closes #403
Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)
