### PR TITLE
fix(audit): racines de résolution, packs fidèles et alias de palier résolu (#399, #400, #401)

### DIFF
--- a/crates/armadai/src/audit/deep.rs
+++ b/crates/armadai/src/audit/deep.rs
@@ -22,7 +22,11 @@ use super::rules::{Finding, Severity};
 /// `opencode` invoked bare (no subcommand/flags) open an interactive/TUI
 /// mode that hangs until timeout, and `aider` auto-commits edits to the
 /// audited repo, which is unacceptable during a read-only audit.
-const DEEP_CLIS: [&str; 2] = ["claude", "gemini"];
+/// The CLIs `--deep` will drive, in preference order.
+///
+/// `pub(crate)` so `cli::audit` can prove its in-memory auditor agent is
+/// buildable for each of them without restating the list.
+pub(crate) const DEEP_CLIS: [&str; 2] = ["claude", "gemini"];
 
 #[cfg(not(windows))]
 fn cli_is_available(cli: &str) -> bool {

--- a/crates/armadai/src/audit/proposal.rs
+++ b/crates/armadai/src/audit/proposal.rs
@@ -37,30 +37,45 @@ fn one_line(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// How many levels every heading in an imported prompt is pushed down.
+///
+/// Two, and not one: the shift has to clear both `#` and `##`, so the shallower
+/// of the two must land on `###`.
+const HEADING_SHIFT: usize = 2;
+
+/// The deepest ATX level markdown has. Headings already at or near it are
+/// capped rather than promoted, which is the one place the shift is lossy: two
+/// distinct source levels can end up equal. It never loses content.
+const MAX_HEADING_LEVEL: usize = 6;
+
 /// The ArmadAI agent format terminates a `##` section at the next heading of
 /// level <= H2, so a system prompt cannot contain an `#`/`##` heading (before
 /// #392 it could contain no heading at all). Native Claude Code prompts are
 /// often full markdown documents with headings (including literal `## Metadata`
 /// / `## System Prompt` lines that would otherwise clobber the agent's real
-/// sections on re-parse). Demote ATX headings to bold text: content and visual
-/// emphasis are preserved, and no heading survives to break section parsing.
+/// sections on re-parse). Push every heading down [`HEADING_SHIFT`] levels:
+/// no `#`/`##` survives to break section parsing, and the document keeps its
+/// structure.
 ///
-/// All six levels are still demoted, not just `#`/`##`: keeping `###`+ as real
-/// headings is now *safe* for the parser (#392), but it would change the
-/// rendering of every generated proposal, which is a separate change with its
-/// own before/after to measure. Demoting more than strictly necessary loses
-/// visual hierarchy in the proposal; it never loses content.
+/// Bolding every heading instead was *forced* before #392 (fixed by #394),
+/// when a section ended at a heading of any level and a `###` truncated the
+/// file. Keeping `###`+ became safe then, and this function's own doc comment
+/// asked for the change "with its own before/after to measure" — issue #400 is
+/// that measurement. The shift is uniform because demoting `#`/`##` alone would
+/// land them on `###`, colliding with the `###` already in the document and
+/// inverting the hierarchy it is supposed to preserve.
 ///
 /// Fenced code blocks (``` or ~~~) are left completely untouched — a line
 /// starting with `#` inside a fence is code, not a heading. Setext headings
 /// (`Title` followed by a line of only `=` or only `-`) are handled too:
 /// they truncate the ArmadAI parser's System Prompt section just as ATX
-/// headings do, so the underline is dropped and the title line is bolded in
-/// place, unless the previous line doesn't look like a plain paragraph (e.g.
+/// headings do, so the underline is dropped and the title line becomes an ATX
+/// heading of the shifted level in place (`=` is H1, `-` is H2), unless the
+/// previous line doesn't look like a plain paragraph (e.g.
 /// it is blank, a list/quote/table line, or already a heading/underline) —
 /// in that case the `---`/`===` line is kept, but CommonMark doesn't only
 /// treat "plain paragraphs" as valid setext-underline targets: list items,
-/// blockquotes, table rows, and even the `**bold**` lines this function
+/// blockquotes, table rows, and even the heading lines this function
 /// itself emits can all still form a setext heading with a `=`/`-` line
 /// directly below them. So whenever such a line is kept verbatim (not
 /// demoted), a blank line is inserted first if the previously emitted line
@@ -100,8 +115,10 @@ fn demote_headings(prompt: &str) -> String {
                     && !prev.chars().all(|c| c == '-');
                 if is_plain_paragraph {
                     let title = prev.trim().to_string();
+                    // `===` is a setext H1, `---` a setext H2.
+                    let level = if is_all_eq { 1 } else { 2 };
                     if let Some(last) = out.last_mut() {
-                        *last = format!("**{title}**");
+                        *last = shifted_heading(level, &title);
                     }
                     continue; // drop the underline line
                 }
@@ -121,10 +138,10 @@ fn demote_headings(prompt: &str) -> String {
         if let Some(rest) = trimmed_start.strip_prefix('#') {
             let hashes = 1 + rest.chars().take_while(|&c| c == '#').count();
             let after = &trimmed_start[hashes..];
-            if hashes <= 6 && after.starts_with(' ') {
+            if hashes <= MAX_HEADING_LEVEL && after.starts_with(' ') {
                 let title = after.trim().trim_end_matches('#').trim();
                 if !title.is_empty() {
-                    out.push(format!("**{title}**"));
+                    out.push(shifted_heading(hashes, title));
                     continue;
                 }
             }
@@ -135,8 +152,53 @@ fn demote_headings(prompt: &str) -> String {
     out.join("\n")
 }
 
+/// One ATX heading, [`HEADING_SHIFT`] levels deeper than `level` and never
+/// past [`MAX_HEADING_LEVEL`].
+fn shifted_heading(level: usize, title: &str) -> String {
+    let depth = (level + HEADING_SHIFT).min(MAX_HEADING_LEVEL);
+    format!("{} {title}", "#".repeat(depth))
+}
+
+/// The exact prose written under `## System Prompt`, for one imported agent.
+///
+/// A native prompt is an arbitrary markdown document and gets its headings
+/// shifted out of the way ([`demote_headings`]). An ArmadAI body is already in
+/// this format: `armadai::prompt_text` builds it from sections the product
+/// parser produced, so its only `#`/`##` lines are the `## Instructions` /
+/// `## Output Format` / `## Context` headings that function re-inserted, and
+/// those must stay real sections. Shifting them turned the pack's whole
+/// structure into bold text (issue #400).
+///
+/// Shared with `generate_proposal`, which needs the *written* text to compute
+/// its truncation sentinel — a sentinel taken from a differently-rendered
+/// string would police nothing.
+fn rendered_prompt(agent: &ImportedAgent) -> String {
+    match agent.armadai_metadata {
+        Some(_) => agent.system_prompt.clone(),
+        None => demote_headings(&agent.system_prompt),
+    }
+}
+
 /// Render an imported agent in the ArmadAI agent format
 /// (H1 + `## Metadata` list + `## System Prompt`).
+///
+/// A function of the *origin format*, following the shape #393 introduced for
+/// `A08`: a native config is **converted** (model mapped to a portable tier,
+/// provenance tag, headings shifted), an ArmadAI source is **reproduced**.
+/// Since #393 the global pass reads `~/.config/armadai/agents`, so
+/// `--propose --global` runs this on a library that is already in the target
+/// format, and converting it a second time only removed things — measured on
+/// one agent: `temperature`, `max_tokens`, `stacks` dropped, `tags`
+/// overwritten, sections flattened (issue #400).
+///
+/// The H1 stays the slug in **both** paths, and that is not an oversight: the
+/// runtime matches a prompt's `apply_to` against the agent's H1 name
+/// (`armadai_core::prompt::prompts_for_agent`) while `pack_validation`'s R5
+/// matches it against the pack's slug list, so the two agree only when H1 ==
+/// slug. An ArmadAI file's routable name is its stem anyway
+/// (`project::resolve_agent` looks up `<dir>/<name>.md`), which is what the
+/// slug is derived from; the human-readable title is the one thing this path
+/// cannot carry back.
 pub(crate) fn render_agent(agent: &ImportedAgent) -> String {
     let mut md = String::new();
     let _ = writeln!(md, "# {}\n", agent.name);
@@ -150,6 +212,17 @@ pub(crate) fn render_agent(agent: &ImportedAgent) -> String {
     let description = one_line(description);
     let _ = writeln!(md, "> {description}\n");
     let _ = writeln!(md, "## Metadata");
+    match &agent.armadai_metadata {
+        Some(source) => write_source_metadata(&mut md, source, &description),
+        None => write_converted_metadata(&mut md, agent, &description),
+    }
+    let _ = writeln!(md, "\n## System Prompt\n");
+    let _ = writeln!(md, "{}", rendered_prompt(agent));
+    md
+}
+
+/// `## Metadata` for a native config: one portable tier, one provenance tag.
+fn write_converted_metadata(md: &mut String, agent: &ImportedAgent, description: &str) {
     let _ = writeln!(md, "- provider: claude");
     let _ = writeln!(
         md,
@@ -168,9 +241,82 @@ pub(crate) fn render_agent(agent: &ImportedAgent) -> String {
     if !globs.is_empty() {
         let _ = writeln!(md, "- scope: [{}]", globs.join(", "));
     }
-    let _ = writeln!(md, "\n## System Prompt\n");
-    let _ = writeln!(md, "{}", demote_headings(&agent.system_prompt));
-    md
+}
+
+/// `## Metadata` reproduced from an ArmadAI source.
+///
+/// Every key here is one `parser::metadata::parse_metadata` reads back, so the
+/// pack round-trips — which is what the tests assert, on a re-parse rather than
+/// on this string.
+///
+/// Two fields are deliberately not reproduced, for the same reason
+/// `## Pipeline` is not: they are not scalars this list can carry back.
+/// `orchestration` is worse than absent — `parse_metadata` accepts only
+/// `direct`, `blackboard` and `ring`, so writing back a `Hierarchical` or
+/// `Auto` agent would produce a pack the product's own parser refuses.
+/// `triggers` and `ring_config` are whole `##` sections of their own.
+fn write_source_metadata(
+    md: &mut String,
+    source: &armadai_core::agent::AgentMetadata,
+    description: &str,
+) {
+    let _ = writeln!(md, "- provider: {}", source.provider);
+    if let Some(model) = &source.model {
+        // Not `portable_model`: the author of an ArmadAI library already chose
+        // how portable they wanted to be, and re-mapping it is the "convert"
+        // path this branch exists to avoid.
+        let _ = writeln!(md, "- model: {model}");
+    }
+    if let Some(command) = &source.command {
+        let _ = writeln!(md, "- command: {command}");
+    }
+    write_list(md, "args", source.args.as_deref().unwrap_or(&[]));
+    let _ = writeln!(md, "- description: {description}");
+    // A source with no tags still gets the provenance marker: the pack is an
+    // import either way, and an empty `- tags: []` says less than nothing.
+    if source.tags.is_empty() {
+        let _ = writeln!(md, "- tags: [imported]");
+    } else {
+        write_list(md, "tags", &source.tags);
+    }
+    if (source.temperature - armadai_core::agent::default_temperature()).abs() > f32::EPSILON {
+        let _ = writeln!(md, "- temperature: {}", source.temperature);
+    }
+    if let Some(max_tokens) = source.max_tokens {
+        let _ = writeln!(md, "- max_tokens: {max_tokens}");
+    }
+    if let Some(timeout) = source.timeout {
+        let _ = writeln!(md, "- timeout: {timeout}");
+    }
+    write_list(md, "stacks", &source.stacks);
+    write_list(md, "scope", &source.scope);
+    write_list(md, "model_fallback", &source.model_fallback);
+    if let Some(cost_limit) = source.cost_limit {
+        let _ = writeln!(md, "- cost_limit: {cost_limit}");
+    }
+    if let Some(rate_limit) = &source.rate_limit {
+        let _ = writeln!(md, "- rate_limit: {rate_limit}");
+    }
+    if let Some(context_window) = source.context_window {
+        let _ = writeln!(md, "- context_window: {context_window}");
+    }
+    if let Some(mode) = source.mode {
+        let _ = writeln!(
+            md,
+            "- mode: {}",
+            match mode {
+                armadai_core::agent::AgentMode::Guided => "guided",
+                armadai_core::agent::AgentMode::Autonomous => "autonomous",
+            }
+        );
+    }
+}
+
+/// `- key: [a, b]`, or nothing at all when the list is empty.
+fn write_list(md: &mut String, key: &str, values: &[String]) {
+    if !values.is_empty() {
+        let _ = writeln!(md, "- {key}: [{}]", values.join(", "));
+    }
 }
 
 /// A prompt fragment shared by several agents, extracted from a duplication cluster.
@@ -549,7 +695,7 @@ pub fn generate_proposal(root: &Path, config: &ImportedConfig) -> anyhow::Result
                     agent.system_prompt = strip_fragment(&agent.system_prompt, &f.body);
                 }
             }
-            let written_prompt = demote_headings(&agent.system_prompt);
+            let written_prompt = rendered_prompt(&agent);
             if let Some(tail) = written_prompt.lines().rev().find(|l| !l.trim().is_empty()) {
                 prompt_tails.insert(slug.clone(), tail.trim().to_string());
             }
@@ -644,14 +790,20 @@ pub fn generate_proposal(root: &Path, config: &ImportedConfig) -> anyhow::Result
             let file = out_dir.join("agents").join(format!("{slug}.md"));
             match armadai_core::parser::parse_agent_file(&file) {
                 Ok(parsed) => {
-                    if parsed.system_prompt.trim().is_empty() && !a.system_prompt.trim().is_empty()
-                    {
+                    // The whole prose, not just `## System Prompt`: an ArmadAI
+                    // source is written back with its `## Instructions` /
+                    // `## Output Format` / `## Context` sections intact, so its
+                    // last line lands in one of those. Identical to reading
+                    // `system_prompt` for a converted native agent, which has
+                    // no other section.
+                    let body = crate::audit::reverse::armadai::prompt_text(&parsed);
+                    if body.trim().is_empty() && !a.system_prompt.trim().is_empty() {
                         errors.push(format!(
                             "agents/{slug}.md: system prompt became empty on re-parse"
                         ));
                     } else if let Some(tail) = prompt_tails.get(slug)
                         && !tail.is_empty()
-                        && !parsed.system_prompt.contains(tail.as_str())
+                        && !body.contains(tail.as_str())
                     {
                         errors.push(format!(
                             "agents/{slug}.md: system prompt lost its final line on re-parse \
@@ -715,32 +867,40 @@ mod tests {
     fn demote_headings_handles_setext_and_skips_fences() {
         let input = "Workflow\n---\nkeep me\n\n```bash\n# not a heading\n```\n\nTitle\n===";
         let out = demote_headings(input);
-        assert!(out.contains("**Workflow**"));
+        // `---` is a setext H2, `===` a setext H1: shifted to H4 and H3.
+        assert!(out.contains("#### Workflow"), "got:\n{out}");
         assert!(!out.lines().any(|l| l.trim() == "---")); // setext underline dropped
         assert!(out.contains("keep me"));
         assert!(out.contains("# not a heading")); // untouched inside fence
-        assert!(out.contains("**Title**"));
+        assert!(out.contains("### Title"), "got:\n{out}");
     }
 
     #[test]
     fn demote_headings_neutralizes_atx_headings() {
         let input = "# Title\n\nsome text\n\n## Metadata\n- provider: x\n\n### Deep\nmore";
         let out = demote_headings(input);
-        assert!(!out.contains("# Title"));
-        assert!(out.contains("**Title**"));
-        assert!(out.contains("**Metadata**"));
-        assert!(out.contains("**Deep**"));
+        // Nothing that ends an ArmadAI section survives, at any level.
+        for line in out.lines() {
+            let t = line.trim_start();
+            assert!(
+                !(t.starts_with("# ") || t.starts_with("## ")),
+                "an H1/H2 survived: {line:?}"
+            );
+        }
+        assert!(out.contains("### Title"), "got:\n{out}");
+        assert!(out.contains("#### Metadata"), "got:\n{out}");
+        assert!(out.contains("##### Deep"), "got:\n{out}");
         assert!(out.contains("some text"));
         assert!(out.contains("- provider: x")); // list items untouched
     }
 
     #[test]
     fn demote_headings_defuses_setext_after_bold_and_atx_rule() {
-        // ATX heading immediately followed by a rule: after ATX->bold, the `---`
-        // must NOT become a setext underline of the bold line.
+        // ATX heading immediately followed by a rule: after the shift, the `---`
+        // must NOT become a setext underline of the heading line.
         let out = demote_headings("# Setup\n---\nTAIL_MUST_SURVIVE");
         // No line pair forms a setext heading: the `---` is preceded by a blank line.
-        assert!(out.contains("**Setup**"));
+        assert!(out.contains("### Setup"), "got:\n{out}");
         assert!(out.contains("TAIL_MUST_SURVIVE"));
         // Round-trip: the tail survives re-parsing as an ArmadAI agent.
         use crate::audit::rules::test_support::agent;
@@ -768,7 +928,15 @@ mod tests {
         let parsed = armadai_core::parser::parse_agent_file(&file).unwrap();
         assert_eq!(parsed.metadata.provider, "claude");
         assert!(parsed.system_prompt.contains("Does things."));
-        assert!(parsed.system_prompt.contains("**Overview**"));
+        assert!(
+            parsed.system_prompt.contains("### Overview"),
+            "got:\n{}",
+            parsed.system_prompt
+        );
+        // The literal `## Metadata` / `## System Prompt` lines the native
+        // prompt carried must not have clobbered the agent's real sections.
+        assert!(parsed.system_prompt.contains("#### Metadata"));
+        assert!(parsed.system_prompt.contains("nested"));
     }
 
     #[test]
@@ -787,6 +955,164 @@ mod tests {
         assert!(md.contains("- scope: [src/**]"));
         assert!(md.contains("## System Prompt"));
         assert!(md.contains("You review code."));
+    }
+
+    /// Issue #400. Flattening every heading to bold was *forced* before #394,
+    /// when a section ended at the next heading of any level: a `###` in a
+    /// prompt truncated the file. Since #394 only `#`/`##` end a section, so a
+    /// native document's hierarchy can be kept by shifting it down two levels
+    /// instead of erasing it. `demote_headings`' own doc comment asked for
+    /// exactly this change, "with its own before/after to measure".
+    ///
+    /// The shift must be uniform: demoting `#`/`##` alone would land them on
+    /// `###`, colliding with the `###` already there and inverting the very
+    /// hierarchy this preserves.
+    #[test]
+    fn demote_headings_shifts_the_hierarchy_down_instead_of_erasing_it() {
+        let out = demote_headings("# Title\n\ntext\n\n## Part\n\n### Detail\n\n###### Deep");
+        assert!(out.contains("### Title"), "got:\n{out}");
+        assert!(out.contains("#### Part"), "got:\n{out}");
+        assert!(out.contains("##### Detail"), "got:\n{out}");
+        // Level 6 has nowhere to go: it is capped, never promoted.
+        assert!(out.contains("###### Deep"), "got:\n{out}");
+        // The invariant that made this function exist: nothing that ends an
+        // ArmadAI section may survive.
+        for line in out.lines() {
+            let t = line.trim_start();
+            assert!(
+                !(t.starts_with("# ") || t.starts_with("## ")),
+                "an H1/H2 survived and would truncate the section: {line:?}"
+            );
+        }
+    }
+
+    /// One real-shaped ArmadAI agent: a title that does not equal its stem,
+    /// every scalar `## Metadata` field the format can express, and `###`
+    /// sub-headings inside two different `##` sections.
+    const ARMADAI_SOURCE: &str = "\
+# Platodin Java Lead
+
+## Metadata
+- provider: claude
+- model: claude-sonnet-5
+- temperature: 0.4
+- max_tokens: 8192
+- tags: coordinator, lead, analysis
+- stacks: java, spring-boot, platodin
+- scope: src/main/java/**, pom.xml
+
+## System Prompt
+
+You are the Platodin Java Lead.
+
+### Scope
+
+You own the Platodin framework surface.
+
+## Instructions
+
+### Review checklist
+
+- Check the module layout.
+
+## Output Format
+
+A table of findings.
+";
+
+    /// Import one ArmadAI-format file through the product's own parser, the
+    /// way `--global` does.
+    fn imported_armadai_agent(dir: &Path, stem: &str, content: &str) -> ImportedAgent {
+        let agents = dir.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join(format!("{stem}.md")), content).unwrap();
+        crate::audit::reverse::armadai::parse_agents(&agents, dir).remove(0)
+    }
+
+    /// Write a rendered agent out and read it back through the product parser
+    /// — the only check that says the pack is what a user would install.
+    fn reparse(md: &str) -> armadai_core::agent::Agent {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("x.md");
+        std::fs::write(&file, md).unwrap();
+        armadai_core::parser::parse_agent_file(&file).unwrap()
+    }
+
+    /// Issue #400. `render_agent` converts native → ArmadAI, and since #393
+    /// `--propose --global` runs it on a source that is *already* ArmadAI.
+    /// Measured on one library agent: `temperature: 0.4`, `max_tokens: 8192`
+    /// and `stacks:` were dropped, `tags:` was overwritten with `[imported]`,
+    /// and `## Instructions` / `## Output Format` / their `###` sub-headings
+    /// were flattened into bold text inside one `## System Prompt`.
+    ///
+    /// Everything is asserted through a real re-parse rather than on the
+    /// rendered string: a `- temperature: 0.4` line the parser rejects would
+    /// pass a `contains` check and still lose the field.
+    #[test]
+    fn render_agent_reproduces_an_armadai_source_instead_of_reconverting_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = imported_armadai_agent(dir.path(), "platodin-java-lead", ARMADAI_SOURCE);
+        let parsed = reparse(&render_agent(&a));
+
+        assert_eq!(parsed.metadata.provider, "claude");
+        assert_eq!(parsed.metadata.model.as_deref(), Some("claude-sonnet-5"));
+        assert!((parsed.metadata.temperature - 0.4).abs() < f32::EPSILON);
+        assert_eq!(parsed.metadata.max_tokens, Some(8192));
+        assert_eq!(parsed.metadata.tags, ["coordinator", "lead", "analysis"]);
+        assert_eq!(parsed.metadata.stacks, ["java", "spring-boot", "platodin"]);
+        assert_eq!(parsed.metadata.scope, ["src/main/java/**", "pom.xml"]);
+
+        // The prose sections come back as sections, not as bold lines inside
+        // one prompt, and their `###` sub-headings survive (#394 made that
+        // safe; before it a `###` truncated the section).
+        assert_eq!(
+            parsed.instructions.as_deref().map(str::trim),
+            Some("### Review checklist\n\n- Check the module layout.")
+        );
+        assert_eq!(
+            parsed.output_format.as_deref().map(str::trim),
+            Some("A table of findings.")
+        );
+        assert!(
+            parsed.system_prompt.contains("### Scope"),
+            "a `###` inside the system prompt must stay a heading, got:\n{}",
+            parsed.system_prompt
+        );
+    }
+
+    /// The control: a *native* source is still converted, not reproduced.
+    /// Without it, "reproduce the source" could be implemented as "never
+    /// convert anything" and every assertion above would still pass.
+    #[test]
+    fn render_agent_still_converts_a_native_source() {
+        let mut a = agent("reviewer", "You review code.");
+        a.metadata.model = Some("opus".to_string());
+        let parsed = reparse(&render_agent(&a));
+        assert_eq!(parsed.metadata.provider, "claude");
+        assert_eq!(
+            parsed.metadata.model.as_deref(),
+            Some("latest:max"),
+            "a native model must still be mapped to a portable tier"
+        );
+        assert_eq!(
+            parsed.metadata.tags,
+            ["imported"],
+            "a native file carries no tags, so the pack marks the provenance"
+        );
+    }
+
+    /// An ArmadAI source with no `tags:` still gets the provenance marker —
+    /// reproducing the source must not mean emitting an empty tag list.
+    #[test]
+    fn an_armadai_source_without_tags_keeps_the_imported_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = imported_armadai_agent(
+            dir.path(),
+            "bare",
+            "# Bare\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nBody.\n",
+        );
+        let parsed = reparse(&render_agent(&a));
+        assert_eq!(parsed.metadata.tags, ["imported"]);
     }
 
     fn block() -> String {

--- a/crates/armadai/src/audit/proposal.rs
+++ b/crates/armadai/src/audit/proposal.rs
@@ -191,17 +191,25 @@ fn rendered_prompt(agent: &ImportedAgent) -> String {
 /// one agent: `temperature`, `max_tokens`, `stacks` dropped, `tags`
 /// overwritten, sections flattened (issue #400).
 ///
-/// The H1 stays the slug in **both** paths, and that is not an oversight: the
-/// runtime matches a prompt's `apply_to` against the agent's H1 name
-/// (`armadai_core::prompt::prompts_for_agent`) while `pack_validation`'s R5
-/// matches it against the pack's slug list, so the two agree only when H1 ==
-/// slug. An ArmadAI file's routable name is its stem anyway
-/// (`project::resolve_agent` looks up `<dir>/<name>.md`), which is what the
-/// slug is derived from; the human-readable title is the one thing this path
-/// cannot carry back.
+/// The H1 is the source's own title when it had one
+/// ([`ImportedAgent::title`]), and the slug otherwise. Nothing in the product
+/// requires H1 == slug, and the claim that it did — made by an earlier version
+/// of this comment — was measured false:
+/// `armadai_core::prompt::prompts_for_agent` does not exist, and the function
+/// that does, `prompt::matching_prompts`, is called by its only production
+/// caller (`dependency_resolver::resolve_dependencies`) with the agent's *file
+/// stem*, explicitly and by comment. `pack_validation`'s R1 and R5 read the
+/// pack's slug list, and the pack writes `agents/<slug>.md`, so that stem is
+/// the slug. Both sides agree whatever the H1 says, and the display title
+/// becomes one more thing #400's "reproduce, don't convert" carries back
+/// instead of dropping.
+///
+/// A native config keeps the slug as its H1: there the `name:` frontmatter *is*
+/// the routing key a router enumerates, and the human-readable form stays on
+/// the `- description:` line the caller synthesizes.
 pub(crate) fn render_agent(agent: &ImportedAgent) -> String {
     let mut md = String::new();
-    let _ = writeln!(md, "# {}\n", agent.name);
+    let _ = writeln!(md, "# {}\n", agent.title.as_deref().unwrap_or(&agent.name));
     let description = agent
         .metadata
         .description
@@ -458,6 +466,49 @@ pub(crate) fn strip_fragment(prompt: &str, fragment_body: &str) -> String {
     out
 }
 
+/// Merge fragments whose body is byte-identical into one, then renumber the
+/// survivors `shared-conventions-1..n` so the names stay contiguous.
+///
+/// A duplication cluster never crosses a
+/// [`ResolutionSpace`](crate::audit::reverse::ResolutionSpace) since #399, and
+/// `armadai link` republishes the whole ArmadAI library into `~/.claude` — so
+/// `--propose --global` sees *one* shared block as one cluster per tree and
+/// built one fragment per cluster. Measured on the canonical #399 fixture (a
+/// two-agent library plus the copies `link` publishes): the pack shipped
+/// `shared-conventions-1` (`apply_to: [dev-lead, qa]`) and
+/// `shared-conventions-2` (`apply_to: [dev-lead-2, qa-2]`) with byte-identical
+/// 418-byte bodies, for a single shared block — the exact opposite of A06's
+/// own remedy, "extract the shared block into **one** reusable prompt
+/// fragment".
+///
+/// Two clusters is the right *report*: the change A06 asks for is a change to
+/// one library, and a finding per tree is what names each agent once. The pack
+/// is one artifact, though, so the two clusters are one fragment there.
+///
+/// The merge is behaviour-preserving and that is why equality is on the raw
+/// body, not on a similarity score: an identical body applied to the union of
+/// the `apply_to` lists injects exactly the same text into exactly the same
+/// agents, and two *different* shared blocks stay two fragments.
+fn dedupe_fragments(fragments: Vec<SharedFragment>) -> Vec<SharedFragment> {
+    let mut merged: Vec<SharedFragment> = Vec::new();
+    for f in fragments {
+        match merged.iter_mut().find(|m| m.body == f.body) {
+            Some(existing) => {
+                for slug in f.apply_to {
+                    if !existing.apply_to.contains(&slug) {
+                        existing.apply_to.push(slug);
+                    }
+                }
+            }
+            None => merged.push(f),
+        }
+    }
+    for (i, f) in merged.iter_mut().enumerate() {
+        f.name = format!("shared-conventions-{}", i + 1);
+    }
+    merged
+}
+
 /// Render a shared fragment in the ArmadAI prompt-fragment format
 /// (YAML frontmatter + body).
 pub(crate) fn render_prompt(f: &SharedFragment) -> String {
@@ -634,11 +685,12 @@ pub fn generate_proposal(root: &Path, config: &ImportedConfig) -> anyhow::Result
         // Compute each agent's final slug once, disambiguating collisions (e.g. a
         // `name:` frontmatter and a filename-stem fallback both slugifying to the
         // same value). Both the fragment `apply_to` lists and the agent-write
-        // loop reuse this exact pairing: the generated agent's H1/name is set to
-        // its slug (not its raw display name), because runtime prompt matching
-        // (`armadai_core::prompt`) matches `apply_to` against the H1 name while pack.yaml
-        // validation (R5) matches it against the pack's slug list — the two can
-        // only agree if H1 == slug.
+        // loop reuse this exact pairing: the fragment `apply_to` lists, the
+        // `agents/<slug>.md` filenames and pack.yaml's `agents:` list are the
+        // same strings, which is what makes `pack_validation`'s R1/R5 and
+        // `dependency_resolver` (which matches `apply_to` against the *file
+        // stem*) agree. The H1 is free of that constraint — see
+        // [`render_agent`].
         let mut used_agent_slugs = std::collections::HashSet::new();
         let agent_slugs: Vec<String> = owned
             .iter()
@@ -667,12 +719,16 @@ pub fn generate_proposal(root: &Path, config: &ImportedConfig) -> anyhow::Result
                 fragments.push(f);
             }
         }
+        // One fragment per *distinct* shared block, not per cluster — see
+        // `dedupe_fragments`.
+        let fragments = dedupe_fragments(fragments);
 
         std::fs::create_dir_all(out_dir.join("agents"))?;
         // Agents: render with their shared fragments stripped out. The clone's
         // name is set to its slug BEFORE the strip loop so `apply_to` (slugs)
-        // matches, and BEFORE `render_agent` so the H1 is the slug too. The
-        // original display name stays visible via `metadata.description`.
+        // matches. The H1 is `title` when the source declared one and the slug
+        // otherwise (see `render_agent`); either way the original display name
+        // stays visible on the `- description:` line.
         //
         // `prompt_tails` records, per slug, the last non-empty line of the
         // exact text written to that agent's System Prompt section (after
@@ -683,7 +739,7 @@ pub fn generate_proposal(root: &Path, config: &ImportedConfig) -> anyhow::Result
         for (a, slug) in owned.iter().zip(agent_slugs.iter()) {
             let mut agent = a.clone();
             if agent.metadata.description.is_none() {
-                // The H1 is about to become the slug: synthesize a
+                // `name` is about to become the slug: synthesize a
                 // description from the original human-readable name so it
                 // stays discoverable in the file (render_agent always emits
                 // the `- description:` metadata line).
@@ -846,6 +902,21 @@ mod tests {
     use super::*;
     use crate::audit::rules::test_support::{agent, config_with};
 
+    /// Does `text` carry `expected` as a **whole trimmed line**?
+    ///
+    /// Never `contains` for a heading: `"#### Title".contains("### Title")` is
+    /// `true`, so every `contains("### …")` assertion in this module was
+    /// insensitive to the one constant that decides them all. Measured on this
+    /// branch — setting `HEADING_SHIFT` to 3 left 759 unit tests and 29
+    /// `audit_scopes` cases green while every heading in the pack moved a level
+    /// down and `##### Deep` collided with the capped `###### Deep`. The
+    /// integration test written for the same issue already compared whole
+    /// trimmed lines for exactly this reason; this brings the unit tests to the
+    /// same standard.
+    fn has_line(text: &str, expected: &str) -> bool {
+        text.lines().any(|l| l.trim() == expected)
+    }
+
     #[test]
     fn portable_model_maps_concrete_models_to_tiers() {
         assert_eq!(portable_model(Some("opus")), "latest:max");
@@ -868,11 +939,11 @@ mod tests {
         let input = "Workflow\n---\nkeep me\n\n```bash\n# not a heading\n```\n\nTitle\n===";
         let out = demote_headings(input);
         // `---` is a setext H2, `===` a setext H1: shifted to H4 and H3.
-        assert!(out.contains("#### Workflow"), "got:\n{out}");
+        assert!(has_line(&out, "#### Workflow"), "got:\n{out}");
         assert!(!out.lines().any(|l| l.trim() == "---")); // setext underline dropped
         assert!(out.contains("keep me"));
-        assert!(out.contains("# not a heading")); // untouched inside fence
-        assert!(out.contains("### Title"), "got:\n{out}");
+        assert!(has_line(&out, "# not a heading")); // untouched inside fence
+        assert!(has_line(&out, "### Title"), "got:\n{out}");
     }
 
     #[test]
@@ -887,9 +958,9 @@ mod tests {
                 "an H1/H2 survived: {line:?}"
             );
         }
-        assert!(out.contains("### Title"), "got:\n{out}");
-        assert!(out.contains("#### Metadata"), "got:\n{out}");
-        assert!(out.contains("##### Deep"), "got:\n{out}");
+        assert!(has_line(&out, "### Title"), "got:\n{out}");
+        assert!(has_line(&out, "#### Metadata"), "got:\n{out}");
+        assert!(has_line(&out, "##### Deep"), "got:\n{out}");
         assert!(out.contains("some text"));
         assert!(out.contains("- provider: x")); // list items untouched
     }
@@ -900,7 +971,7 @@ mod tests {
         // must NOT become a setext underline of the heading line.
         let out = demote_headings("# Setup\n---\nTAIL_MUST_SURVIVE");
         // No line pair forms a setext heading: the `---` is preceded by a blank line.
-        assert!(out.contains("### Setup"), "got:\n{out}");
+        assert!(has_line(&out, "### Setup"), "got:\n{out}");
         assert!(out.contains("TAIL_MUST_SURVIVE"));
         // Round-trip: the tail survives re-parsing as an ArmadAI agent.
         use crate::audit::rules::test_support::agent;
@@ -929,13 +1000,13 @@ mod tests {
         assert_eq!(parsed.metadata.provider, "claude");
         assert!(parsed.system_prompt.contains("Does things."));
         assert!(
-            parsed.system_prompt.contains("### Overview"),
+            has_line(&parsed.system_prompt, "### Overview"),
             "got:\n{}",
             parsed.system_prompt
         );
         // The literal `## Metadata` / `## System Prompt` lines the native
         // prompt carried must not have clobbered the agent's real sections.
-        assert!(parsed.system_prompt.contains("#### Metadata"));
+        assert!(has_line(&parsed.system_prompt, "#### Metadata"));
         assert!(parsed.system_prompt.contains("nested"));
     }
 
@@ -949,11 +1020,11 @@ mod tests {
         );
         let md = render_agent(&a);
         assert!(md.starts_with("# reviewer\n"));
-        assert!(md.contains("## Metadata"));
+        assert!(has_line(&md, "## Metadata"));
         assert!(md.contains("- provider: claude"));
         assert!(md.contains("- model: latest:max"));
         assert!(md.contains("- scope: [src/**]"));
-        assert!(md.contains("## System Prompt"));
+        assert!(has_line(&md, "## System Prompt"));
         assert!(md.contains("You review code."));
     }
 
@@ -970,11 +1041,11 @@ mod tests {
     #[test]
     fn demote_headings_shifts_the_hierarchy_down_instead_of_erasing_it() {
         let out = demote_headings("# Title\n\ntext\n\n## Part\n\n### Detail\n\n###### Deep");
-        assert!(out.contains("### Title"), "got:\n{out}");
-        assert!(out.contains("#### Part"), "got:\n{out}");
-        assert!(out.contains("##### Detail"), "got:\n{out}");
+        assert!(has_line(&out, "### Title"), "got:\n{out}");
+        assert!(has_line(&out, "#### Part"), "got:\n{out}");
+        assert!(has_line(&out, "##### Detail"), "got:\n{out}");
         // Level 6 has nowhere to go: it is capped, never promoted.
-        assert!(out.contains("###### Deep"), "got:\n{out}");
+        assert!(has_line(&out, "###### Deep"), "got:\n{out}");
         // The invariant that made this function exist: nothing that ends an
         // ArmadAI section may survive.
         for line in out.lines() {
@@ -987,19 +1058,39 @@ mod tests {
     }
 
     /// One real-shaped ArmadAI agent: a title that does not equal its stem,
-    /// every scalar `## Metadata` field the format can express, and `###`
-    /// sub-headings inside two different `##` sections.
+    /// **every** scalar `## Metadata` field `write_source_metadata` emits, and
+    /// `###` sub-headings inside two different `##` sections.
+    ///
+    /// All fifteen keys, not the four the first version carried: eight of them
+    /// (`command`, `args`, `timeout`, `model_fallback`, `cost_limit`,
+    /// `rate_limit`, `context_window`, `mode`) were emitted by code no test
+    /// read back, and deleting their writers left the whole suite green
+    /// (measured). `provider: cli` + `command:` is the shape that made the
+    /// omission concrete: an agent whose command is dropped no longer runs.
+    ///
+    /// `orchestration` is deliberately absent — `write_source_metadata`
+    /// refuses to write it back (a `Hierarchical`/`Auto` value would produce a
+    /// pack the product's own parser rejects), so the round-trip below would
+    /// rightly fail on it.
     const ARMADAI_SOURCE: &str = "\
 # Platodin Java Lead
 
 ## Metadata
-- provider: claude
+- provider: cli
 - model: claude-sonnet-5
+- command: my-java-tool
+- args: --json, --quiet
 - temperature: 0.4
 - max_tokens: 8192
+- timeout: 900
 - tags: coordinator, lead, analysis
 - stacks: java, spring-boot, platodin
 - scope: src/main/java/**, pom.xml
+- model_fallback: claude-haiku-5, latest:fast
+- cost_limit: 2.5
+- rate_limit: 10/min
+- context_window: 200000
+- mode: autonomous
 
 ## System Prompt
 
@@ -1054,7 +1145,7 @@ A table of findings.
         let a = imported_armadai_agent(dir.path(), "platodin-java-lead", ARMADAI_SOURCE);
         let parsed = reparse(&render_agent(&a));
 
-        assert_eq!(parsed.metadata.provider, "claude");
+        assert_eq!(parsed.metadata.provider, "cli");
         assert_eq!(parsed.metadata.model.as_deref(), Some("claude-sonnet-5"));
         assert!((parsed.metadata.temperature - 0.4).abs() < f32::EPSILON);
         assert_eq!(parsed.metadata.max_tokens, Some(8192));
@@ -1074,9 +1165,50 @@ A table of findings.
             Some("A table of findings.")
         );
         assert!(
-            parsed.system_prompt.contains("### Scope"),
+            has_line(&parsed.system_prompt, "### Scope"),
             "a `###` inside the system prompt must stay a heading, got:\n{}",
             parsed.system_prompt
+        );
+    }
+
+    /// The whole `## Metadata` block, compared field by field through serde
+    /// rather than key by key by hand.
+    ///
+    /// The test above names seven fields; `write_source_metadata` emits
+    /// fifteen. Deleting the writers of the other eight (`command`, `args`,
+    /// `timeout`, `model_fallback`, `cost_limit`, `rate_limit`,
+    /// `context_window`, `mode`) left 759 unit tests and 29 `audit_scopes`
+    /// cases green — `command` among them, so an agent that runs a tool came
+    /// out of the pack with no tool to run, which is the same impoverishment
+    /// #400 is about.
+    ///
+    /// Structural equality rather than a longer list of `assert_eq!`: a key
+    /// added to `AgentMetadata` and to the writer, but never read back,
+    /// fails here without anyone remembering to extend the test. The one
+    /// deliberate exclusion is `orchestration`, and the fixture leaves it
+    /// unset so the two sides agree on `None`.
+    #[test]
+    fn every_metadata_field_the_pack_writes_is_read_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = imported_armadai_agent(dir.path(), "platodin-java-lead", ARMADAI_SOURCE);
+        let source = armadai_core::parser::parse_agent_file(
+            &dir.path().join("agents/platodin-java-lead.md"),
+        )
+        .unwrap();
+        let round_tripped = reparse(&render_agent(&a));
+
+        // Sanity: the fixture really does declare the fields, so an equality
+        // between two empty metadata blocks cannot pass for a round trip.
+        assert_eq!(source.metadata.command.as_deref(), Some("my-java-tool"));
+        assert_eq!(
+            source.metadata.mode,
+            Some(armadai_core::agent::AgentMode::Autonomous)
+        );
+
+        assert_eq!(
+            serde_yaml_ng::to_value(&round_tripped.metadata).unwrap(),
+            serde_yaml_ng::to_value(&source.metadata).unwrap(),
+            "the pack must read back the same `## Metadata` the source declared"
         );
     }
 
@@ -1102,17 +1234,35 @@ A table of findings.
     }
 
     /// An ArmadAI source with no `tags:` still gets the provenance marker —
-    /// reproducing the source must not mean emitting an empty tag list.
+    /// reproducing the source must not mean emitting an empty tag list — and
+    /// it is still **reproduced**, not converted.
+    ///
+    /// The second half is what makes the test a control. `tags == ["imported"]`
+    /// alone is produced by *both* branches, so the first version of this test
+    /// could not tell them apart: making `render_agent` fall back to the
+    /// convert path whenever `tags` is empty — a very common shape — left 759
+    /// unit tests and 29 `audit_scopes` cases green while re-introducing #400
+    /// itself (`model` back to `latest:pro`, `temperature`/`max_tokens`/
+    /// `stacks`/`scope` gone). So the fixture declares fields only the
+    /// reproduce path keeps, and they are asserted here.
     #[test]
     fn an_armadai_source_without_tags_keeps_the_imported_marker() {
         let dir = tempfile::tempdir().unwrap();
         let a = imported_armadai_agent(
             dir.path(),
             "bare",
-            "# Bare\n\n## Metadata\n- provider: claude\n\n## System Prompt\n\nBody.\n",
+            "# Bare\n\n## Metadata\n- provider: claude\n- model: claude-sonnet-5\n\
+             - temperature: 0.2\n- stacks: rust\n\n## System Prompt\n\nBody.\n",
         );
         let parsed = reparse(&render_agent(&a));
         assert_eq!(parsed.metadata.tags, ["imported"]);
+        assert_eq!(
+            parsed.metadata.model.as_deref(),
+            Some("claude-sonnet-5"),
+            "an empty `tags:` must not send the source back through `portable_model`"
+        );
+        assert!((parsed.metadata.temperature - 0.2).abs() < f32::EPSILON);
+        assert_eq!(parsed.metadata.stacks, ["rust"]);
     }
 
     fn block() -> String {
@@ -1168,6 +1318,128 @@ A table of findings.
         let prompt = std::fs::read_to_string(out.join("prompts/shared-conventions-1.md")).unwrap();
         assert!(prompt.contains("  - nested detail one"));
         assert!(prompt.contains("  - nested detail two"));
+    }
+
+    /// Issue #399's shape at the pack level: the same shared block seen
+    /// through two trees is two clusters, and the pack must still ship **one**
+    /// fragment.
+    ///
+    /// Measured on the canonical fixture before this: `--propose --global`
+    /// wrote `shared-conventions-1` (`apply_to: [dev-lead, qa]`) and
+    /// `shared-conventions-2` (`apply_to: [dev-lead-2, qa-2]`) with
+    /// byte-identical 418-byte bodies, for one shared block — while announcing
+    /// A06's own remedy, "extract the shared block into one reusable prompt
+    /// fragment".
+    ///
+    /// Two claims, and the second is what stops "always return one fragment"
+    /// from passing: a *different* block stays its own fragment.
+    #[test]
+    fn dedupe_fragments_merges_identical_bodies_and_keeps_distinct_ones() {
+        let same = |name: &str, apply: &[&str]| SharedFragment {
+            name: name.into(),
+            apply_to: apply.iter().map(|s| s.to_string()).collect(),
+            body: "Shared block.".into(),
+        };
+        let merged = dedupe_fragments(vec![
+            same("shared-conventions-1", &["dev-lead", "qa"]),
+            same("shared-conventions-2", &["dev-lead-2", "qa-2"]),
+            SharedFragment {
+                name: "shared-conventions-3".into(),
+                apply_to: vec!["other".into()],
+                body: "A different block.".into(),
+            },
+        ]);
+
+        assert_eq!(merged.len(), 2, "got {merged:#?}");
+        assert_eq!(merged[0].apply_to, ["dev-lead", "qa", "dev-lead-2", "qa-2"]);
+        assert_eq!(merged[0].body, "Shared block.");
+        // Renumbered, not left with the gap the merge would otherwise open:
+        // the file names and pack.yaml's `prompts:` list are this string.
+        assert_eq!(merged[0].name, "shared-conventions-1");
+        assert_eq!(merged[1].name, "shared-conventions-2");
+        assert_eq!(merged[1].body, "A different block.");
+    }
+
+    /// The same claim on the file the generator writes, since `--propose` is
+    /// where the duplicate was observed: one shared block, two clusters (two
+    /// resolution spaces), one fragment on disk, every agent listed once.
+    #[test]
+    fn generate_proposal_ships_one_fragment_per_distinct_shared_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = block();
+        // Two trees, each with two agents sharing the *same* block — what
+        // `armadai link` produces by republishing a library into `~/.claude`.
+        let mut agents = Vec::new();
+        for (i, space) in [".claude", ".config/armadai"].into_iter().enumerate() {
+            for name in ["dev-lead", "qa"] {
+                // Distinct prose around the block, or the "shared" block would
+                // swallow the whole prompt and leave nothing behind.
+                let slug = format!("{name}-{i}");
+                let mut a = agent(&slug, &format!("Intro {slug}.\n\n{b}Outro {slug}."));
+                a.space = std::path::PathBuf::from(space);
+                agents.push(a);
+            }
+        }
+        let config = config_with(agents);
+
+        let summary = generate_proposal(dir.path(), &config).unwrap();
+        assert_eq!(summary.agents, 4);
+        assert_eq!(
+            summary.prompts, 1,
+            "one shared block must yield one fragment, whatever the tree count"
+        );
+
+        let prompts = dir.path().join(".armadai-proposal/prompts");
+        let written: Vec<String> = std::fs::read_dir(&prompts)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(written, ["shared-conventions-1.md"], "got {written:?}");
+
+        let fragment = std::fs::read_to_string(prompts.join("shared-conventions-1.md")).unwrap();
+        for slug in ["dev-lead-0", "qa-0", "dev-lead-1", "qa-1"] {
+            assert!(
+                has_line(&fragment, &format!("- {slug}")),
+                "every agent sharing the block must be in `apply_to`:\n{fragment}"
+            );
+        }
+    }
+
+    /// Issue #400, the field the earlier fix left behind: an ArmadAI library
+    /// agent titled `# Platodin Java Lead` must not come out of the pack
+    /// renamed `# platodin-java-lead`.
+    ///
+    /// The renaming was justified by a constraint that does not exist — the
+    /// comment named `armadai_core::prompt::prompts_for_agent`, a function no
+    /// crate defines. What does exist, `prompt::matching_prompts`, is called by
+    /// `dependency_resolver` with the agent's *file stem*, and the pack writes
+    /// `agents/<slug>.md`, so `apply_to`, pack.yaml and R5 agree on the slug
+    /// whatever the H1 says. Asserted here rather than argued: the fragment's
+    /// `apply_to` still names the slug, and the file still re-parses.
+    #[test]
+    fn the_pack_keeps_an_armadai_source_title_and_still_routes_on_the_slug() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = imported_armadai_agent(dir.path(), "platodin-java-lead", ARMADAI_SOURCE);
+        assert_eq!(a.name, "platodin-java-lead", "`name` is what routes");
+        assert_eq!(a.title.as_deref(), Some("Platodin Java Lead"));
+
+        let md = render_agent(&a);
+        assert!(has_line(&md, "# Platodin Java Lead"), "got:\n{md}");
+        assert_eq!(reparse(&md).name, "Platodin Java Lead");
+
+        // The control, through the generator so the slug is real: a native
+        // config keeps the slug as its H1, because there the `name:` a router
+        // enumerates *is* the routing key. Without it, "keep the title" could
+        // be implemented as "never slugify" and the assertions above would
+        // still pass.
+        let out = tempfile::tempdir().unwrap();
+        let native = agent("Code Reviewer", "You review code.");
+        assert_eq!(native.title, None, "a native file declares no title");
+        generate_proposal(out.path(), &config_with(vec![native])).unwrap();
+        let written =
+            std::fs::read_to_string(out.path().join(".armadai-proposal/agents/code-reviewer.md"))
+                .unwrap();
+        assert!(has_line(&written, "# code-reviewer"), "got:\n{written}");
     }
 
     #[test]

--- a/crates/armadai/src/audit/reverse/armadai.rs
+++ b/crates/armadai/src/audit/reverse/armadai.rs
@@ -89,6 +89,8 @@ fn parse_one(path: &Path, space: &Path) -> ImportedAgent {
             }],
             format: AgentFormat::Armadai,
             space: space.to_path_buf(),
+            // Nothing was parsed, so there is nothing to reproduce.
+            armadai_metadata: None,
         },
     }
 }
@@ -125,6 +127,8 @@ fn imported(path: &Path, agent: &Agent, space: &Path) -> ImportedAgent {
         issues: Vec::new(),
         format: AgentFormat::Armadai,
         space: space.to_path_buf(),
+        // Everything `PartialMetadata` cannot hold, for `--propose` only.
+        armadai_metadata: Some(agent.metadata.clone()),
     }
 }
 
@@ -160,7 +164,11 @@ fn imported(path: &Path, agent: &Agent, space: &Path) -> ImportedAgent {
 /// the linkers normalise, so a section already ending in a newline gained a
 /// third one here and nowhere else. The audit must read exactly the text a
 /// model gets, which is now one function away rather than a re-derivation.
-fn prompt_text(agent: &Agent) -> String {
+///
+/// `pub(crate)` because `--propose` reproduces this same body when the source
+/// is already an ArmadAI agent (#400) — the pack must carry the text the
+/// audit measured, not a second rendering of it.
+pub(crate) fn prompt_text(agent: &Agent) -> String {
     agent.composed_prompt()
 }
 

--- a/crates/armadai/src/audit/reverse/armadai.rs
+++ b/crates/armadai/src/audit/reverse/armadai.rs
@@ -46,7 +46,10 @@ use super::{AgentFormat, ImportedAgent, ParseIssue, PartialMetadata};
 /// (`armadai_core::project::resolve_agent`), so a file in a subdirectory is
 /// not an agent this library can run, and reporting findings against it would
 /// be reporting on something unreachable.
-pub(crate) fn parse_agents(dir: &Path) -> Vec<ImportedAgent> {
+///
+/// `space` is the tree `dir` belongs to (`~/.config/armadai`), not `dir`
+/// itself — see [`ResolutionSpace`](super::ResolutionSpace).
+pub(crate) fn parse_agents(dir: &Path, space: &Path) -> Vec<ImportedAgent> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
     };
@@ -56,7 +59,7 @@ pub(crate) fn parse_agents(dir: &Path) -> Vec<ImportedAgent> {
         .filter(|p| p.is_file() && p.extension().is_some_and(|ext| ext == "md"))
         .collect();
     files.sort();
-    let mut agents: Vec<ImportedAgent> = files.iter().map(|p| parse_one(p)).collect();
+    let mut agents: Vec<ImportedAgent> = files.iter().map(|p| parse_one(p, space)).collect();
     agents.sort_by(|a, b| a.name.cmp(&b.name));
     agents
 }
@@ -68,9 +71,9 @@ fn stem(path: &Path) -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-fn parse_one(path: &Path) -> ImportedAgent {
+fn parse_one(path: &Path, space: &Path) -> ImportedAgent {
     match parse_agent_file(path) {
-        Ok(agent) => imported(path, &agent),
+        Ok(agent) => imported(path, &agent, space),
         // Every refusal of the product parser is a real defect in the file:
         // it means `armadai run` cannot load it either. `{e:#}` keeps the
         // anyhow context chain ("reading <path>", "Missing ## Metadata
@@ -85,11 +88,12 @@ fn parse_one(path: &Path) -> ImportedAgent {
                 message: format!("{e:#}"),
             }],
             format: AgentFormat::Armadai,
+            space: space.to_path_buf(),
         },
     }
 }
 
-fn imported(path: &Path, agent: &Agent) -> ImportedAgent {
+fn imported(path: &Path, agent: &Agent, space: &Path) -> ImportedAgent {
     // The single existing implementation of "what description does ArmadAI
     // publish for this agent", reused rather than restated: `link` writes
     // this exact string into the native config a router then reads.
@@ -120,6 +124,7 @@ fn imported(path: &Path, agent: &Agent) -> ImportedAgent {
         system_prompt: prompt_text(agent),
         issues: Vec::new(),
         format: AgentFormat::Armadai,
+        space: space.to_path_buf(),
     }
 }
 
@@ -202,7 +207,7 @@ A code block, ready to save.
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "agents/agent-builder.md", FULL);
 
-        let agents = parse_agents(&dir.path().join("agents"));
+        let agents = parse_agents(&dir.path().join("agents"), dir.path());
 
         assert_eq!(agents.len(), 1, "{agents:?}");
         let a = &agents[0];
@@ -231,7 +236,7 @@ A code block, ready to save.
              ## System Prompt\n\nYou manage applications.",
         );
 
-        let agents = parse_agents(&dir.path().join("agents"));
+        let agents = parse_agents(&dir.path().join("agents"), dir.path());
 
         assert_eq!(
             agents[0].name, "gravitee-am-app-manager",
@@ -250,7 +255,7 @@ A code block, ready to save.
         let dir = tempfile::tempdir().unwrap();
         let path = write(dir.path(), "agents/agent-builder.md", FULL);
 
-        let agents = parse_agents(&dir.path().join("agents"));
+        let agents = parse_agents(&dir.path().join("agents"), dir.path());
 
         let published =
             crate::linker::LinkAgent::from(&armadai_core::parser::parse_agent_file(&path).unwrap())
@@ -274,7 +279,7 @@ A code block, ready to save.
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "agents/agent-builder.md", FULL);
 
-        let agents = parse_agents(&dir.path().join("agents"));
+        let agents = parse_agents(&dir.path().join("agents"), dir.path());
 
         let prompt = &agents[0].system_prompt;
         for needle in [
@@ -297,7 +302,7 @@ A code block, ready to save.
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "agents/my-agent.md", "# My Agent\n");
 
-        let agents = parse_agents(&dir.path().join("agents"));
+        let agents = parse_agents(&dir.path().join("agents"), dir.path());
 
         assert_eq!(agents.len(), 1);
         let a = &agents[0];
@@ -321,7 +326,7 @@ A code block, ready to save.
         write(dir.path(), "agents/team/nested.md", FULL);
         write(dir.path(), "agents/notes.txt", FULL);
 
-        let agents = parse_agents(&dir.path().join("agents"));
+        let agents = parse_agents(&dir.path().join("agents"), dir.path());
         let names: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
 
         assert_eq!(names, vec!["top"]);
@@ -343,7 +348,7 @@ A code block, ready to save.
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "agents/agent-builder.md", FULL);
 
-        let a = parse_agents(&dir.path().join("agents")).remove(0);
+        let a = parse_agents(&dir.path().join("agents"), dir.path()).remove(0);
 
         assert!(a.metadata.tools.is_none());
         assert!(!a.format.declares_tools());
@@ -371,7 +376,7 @@ A code block, ready to save.
              ## Instructions\n\nDo things.",
         );
 
-        let a = parse_agents(&dir.path().join("agents")).remove(0);
+        let a = parse_agents(&dir.path().join("agents"), dir.path()).remove(0);
 
         assert!(a.issues.is_empty(), "{:?}", a.issues);
         assert!(
@@ -384,6 +389,6 @@ A code block, ready to save.
     #[test]
     fn an_absent_directory_yields_nothing() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(parse_agents(&dir.path().join("nope")).is_empty());
+        assert!(parse_agents(&dir.path().join("nope"), dir.path()).is_empty());
     }
 }

--- a/crates/armadai/src/audit/reverse/armadai.rs
+++ b/crates/armadai/src/audit/reverse/armadai.rs
@@ -91,6 +91,7 @@ fn parse_one(path: &Path, space: &Path) -> ImportedAgent {
             space: space.to_path_buf(),
             // Nothing was parsed, so there is nothing to reproduce.
             armadai_metadata: None,
+            title: None,
         },
     }
 }
@@ -100,8 +101,9 @@ fn imported(path: &Path, agent: &Agent, space: &Path) -> ImportedAgent {
     // publish for this agent", reused rather than restated: `link` writes
     // this exact string into the native config a router then reads.
     let description = crate::linker::LinkAgent::from(agent).description;
+    let stem = stem(path);
     ImportedAgent {
-        name: stem(path),
+        name: stem.clone(),
         source_path: path.to_path_buf(),
         metadata: PartialMetadata {
             description,
@@ -129,6 +131,10 @@ fn imported(path: &Path, agent: &Agent, space: &Path) -> ImportedAgent {
         space: space.to_path_buf(),
         // Everything `PartialMetadata` cannot hold, for `--propose` only.
         armadai_metadata: Some(agent.metadata.clone()),
+        // What routes is the stem, so that is `name`; the `# H1` is the
+        // display title and is kept only when it says something the stem
+        // does not.
+        title: (agent.name != stem).then(|| agent.name.clone()),
     }
 }
 

--- a/crates/armadai/src/audit/reverse/claude.rs
+++ b/crates/armadai/src/audit/reverse/claude.rs
@@ -199,6 +199,7 @@ fn parse_agent_file(path: &Path, space: &Path) -> ImportedAgent {
                 issues: vec![issue(path, format!("unreadable file: {e}"))],
                 format: AgentFormat::ClaudeFrontmatter,
                 space: space.to_path_buf(),
+                armadai_metadata: None,
             };
         }
     };
@@ -233,6 +234,8 @@ fn parse_agent_file(path: &Path, space: &Path) -> ImportedAgent {
         issues,
         format: AgentFormat::ClaudeFrontmatter,
         space: space.to_path_buf(),
+        // A native file has no syntax for most of what this carries.
+        armadai_metadata: None,
     }
 }
 

--- a/crates/armadai/src/audit/reverse/claude.rs
+++ b/crates/armadai/src/audit/reverse/claude.rs
@@ -57,8 +57,8 @@ impl ReverseLinker for ClaudeReverseLinker {
 
     fn parse(&self, root: &Path) -> ImportedConfig {
         ImportedConfig {
-            agents: parse_agents(&root.join(".claude/agents")),
-            skills: parse_skills(&root.join(".claude/skills")),
+            agents: parse_agents(&root.join(".claude/agents"), root),
+            skills: parse_skills(&root.join(".claude/skills"), root),
             instructions: parse_instructions(&root.join("CLAUDE.md")),
         }
     }
@@ -70,10 +70,14 @@ const MAX_AGENT_SCAN_DEPTH: u32 = 3;
 
 /// `pub(crate)` so the global scope can point the same parser at
 /// `~/.claude/agents` — see `crate::audit::scope`.
-pub(crate) fn parse_agents(dir: &Path) -> Vec<ImportedAgent> {
+///
+/// `space` is the *tree* `dir` belongs to, not `dir` itself: the caller knows
+/// it (a repository root, or `~/.claude`) and the parser does not. See
+/// [`ResolutionSpace`](super::ResolutionSpace).
+pub(crate) fn parse_agents(dir: &Path, space: &Path) -> Vec<ImportedAgent> {
     let mut files = Vec::new();
     collect_agent_files(dir, MAX_AGENT_SCAN_DEPTH, &mut files);
-    let mut agents: Vec<ImportedAgent> = files.iter().map(|p| parse_agent_file(p)).collect();
+    let mut agents: Vec<ImportedAgent> = files.iter().map(|p| parse_agent_file(p, space)).collect();
     agents.sort_by(|a, b| a.name.cmp(&b.name));
     agents
 }
@@ -107,7 +111,7 @@ struct SkillFm {
 
 /// `pub(crate)` so the global scope can point the same parser at both
 /// `~/.claude/skills` and `~/.config/armadai/skills`.
-pub(crate) fn parse_skills(dir: &Path) -> Vec<ImportedSkill> {
+pub(crate) fn parse_skills(dir: &Path, space: &Path) -> Vec<ImportedSkill> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
     };
@@ -115,13 +119,13 @@ pub(crate) fn parse_skills(dir: &Path) -> Vec<ImportedSkill> {
         .flatten()
         .map(|e| e.path())
         .filter(|p| p.is_dir())
-        .map(|p| parse_skill_dir(&p))
+        .map(|p| parse_skill_dir(&p, space))
         .collect();
     skills.sort_by(|a, b| a.name.cmp(&b.name));
     skills
 }
 
-fn parse_skill_dir(dir: &Path) -> ImportedSkill {
+fn parse_skill_dir(dir: &Path, space: &Path) -> ImportedSkill {
     let dir_name = dir
         .file_name()
         .map(|s| s.to_string_lossy().to_string())
@@ -137,6 +141,7 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
             body_tokens: 0,
             issues: Vec::new(),
             extra: BTreeMap::new(),
+            space: space.to_path_buf(),
         };
     };
     let mut issues = Vec::new();
@@ -164,6 +169,7 @@ fn parse_skill_dir(dir: &Path) -> ImportedSkill {
         body_tokens: crate::audit::rules::estimate_tokens(&content),
         issues,
         extra: fm.extra,
+        space: space.to_path_buf(),
     }
 }
 
@@ -177,7 +183,7 @@ pub(crate) fn parse_instructions(path: &Path) -> Option<ImportedInstructions> {
     })
 }
 
-fn parse_agent_file(path: &Path) -> ImportedAgent {
+fn parse_agent_file(path: &Path, space: &Path) -> ImportedAgent {
     let stem = path
         .file_stem()
         .map(|s| s.to_string_lossy().to_string())
@@ -192,6 +198,7 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
                 system_prompt: String::new(),
                 issues: vec![issue(path, format!("unreadable file: {e}"))],
                 format: AgentFormat::ClaudeFrontmatter,
+                space: space.to_path_buf(),
             };
         }
     };
@@ -225,6 +232,7 @@ fn parse_agent_file(path: &Path) -> ImportedAgent {
         system_prompt: body.trim().to_string(),
         issues,
         format: AgentFormat::ClaudeFrontmatter,
+        space: space.to_path_buf(),
     }
 }
 
@@ -389,7 +397,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let bad_path = dir.path().join("agent-dir.md");
         std::fs::create_dir_all(&bad_path).unwrap();
-        let agent = parse_agent_file(&bad_path);
+        let agent = parse_agent_file(&bad_path, dir.path());
         assert_eq!(agent.issues.len(), 1);
         assert!(agent.issues[0].message.contains("unreadable file"));
         assert!(agent.system_prompt.is_empty());
@@ -626,7 +634,7 @@ mod tests {
         )
         .unwrap();
 
-        let parsed = parse_skill_dir(&skills);
+        let parsed = parse_skill_dir(&skills, dir.path());
 
         assert_eq!(
             parsed.body_tokens, 108,

--- a/crates/armadai/src/audit/reverse/claude.rs
+++ b/crates/armadai/src/audit/reverse/claude.rs
@@ -200,6 +200,7 @@ fn parse_agent_file(path: &Path, space: &Path) -> ImportedAgent {
                 format: AgentFormat::ClaudeFrontmatter,
                 space: space.to_path_buf(),
                 armadai_metadata: None,
+                title: None,
             };
         }
     };
@@ -236,6 +237,7 @@ fn parse_agent_file(path: &Path, space: &Path) -> ImportedAgent {
         space: space.to_path_buf(),
         // A native file has no syntax for most of what this carries.
         armadai_metadata: None,
+        title: None,
     }
 }
 

--- a/crates/armadai/src/audit/reverse/mod.rs
+++ b/crates/armadai/src/audit/reverse/mod.rs
@@ -77,6 +77,30 @@ impl AgentFormat {
     }
 }
 
+/// The tree an asset was read from: the repository root in project scope,
+/// `~/.claude` or `~/.config/armadai` in the global one.
+///
+/// Not decoration either, and not [`AuditScope`] in disguise: it is what lets
+/// a rule ask **"are these two files in the same resolution space?"** — the
+/// question every rule that compares two assets is really asking.
+///
+/// `C01` reports two files claiming one name as ambiguous routing, and `A06`
+/// / `A07` report two agents as redundant. All three are only true of assets
+/// something resolves *together*. The global pass assembles two unrelated
+/// trees, and `armadai link` publishes the ArmadAI library into the native one
+/// by design, so a healthy library seen through both roots produced
+/// `2 critical` and a non-zero exit — one per agent the user had linked
+/// (measured, issue #399). A name is ambiguous inside one tree; the same name
+/// in two trees is one asset and its published copy.
+///
+/// Scope stays unavailable to rules: it says which surface the *run* reads, so
+/// branching on it would make one rule behave two ways. A space is a property
+/// of the *file*, like a format, and every rule treats every file the same way
+/// whatever the scope filled it.
+///
+/// [`AuditScope`]: crate::audit::AuditScope
+pub type ResolutionSpace = PathBuf;
+
 /// An agent imported from a native config.
 #[derive(Debug, Clone)]
 pub struct ImportedAgent {
@@ -87,6 +111,8 @@ pub struct ImportedAgent {
     pub issues: Vec<ParseIssue>,
     /// What the file it came from is able to declare — see [`AgentFormat`].
     pub format: AgentFormat,
+    /// The tree this file was read from — see [`ResolutionSpace`].
+    pub space: ResolutionSpace,
 }
 
 /// A skill imported from a native config (Agent Skills standard layout).
@@ -108,6 +134,8 @@ pub struct ImportedSkill {
     /// Frontmatter fields we do not type (kept verbatim for --propose and
     /// custom-field rules). Never populated by salvage.
     pub extra: BTreeMap<String, serde_yaml_ng::Value>,
+    /// The tree this skill was read from — see [`ResolutionSpace`].
+    pub space: ResolutionSpace,
 }
 
 /// Root instructions file (e.g. CLAUDE.md).

--- a/crates/armadai/src/audit/reverse/mod.rs
+++ b/crates/armadai/src/audit/reverse/mod.rs
@@ -132,6 +132,15 @@ pub struct ImportedAgent {
     /// `scope` into 149 phantom overlapping pairs. A separate field is what
     /// lets the proposal see the fields while the rules keep not seeing them.
     pub armadai_metadata: Option<armadai_core::agent::AgentMetadata>,
+    /// The human-readable title an ArmadAI-format source declares as its `# H1`,
+    /// when it differs from [`name`](Self::name) (which is the stem, i.e. what
+    /// routes). `None` for a native file, and `None` when title == stem.
+    ///
+    /// The same reasoning as [`armadai_metadata`](Self::armadai_metadata) and
+    /// the same single consumer: no rule reads it — `A02`/`A07`/`C01` all speak
+    /// about the *routable* name — but `--propose` reproducing an ArmadAI
+    /// library must not silently rename its agents.
+    pub title: Option<String>,
 }
 
 /// A skill imported from a native config (Agent Skills standard layout).

--- a/crates/armadai/src/audit/reverse/mod.rs
+++ b/crates/armadai/src/audit/reverse/mod.rs
@@ -113,6 +113,25 @@ pub struct ImportedAgent {
     pub format: AgentFormat,
     /// The tree this file was read from — see [`ResolutionSpace`].
     pub space: ResolutionSpace,
+    /// The typed `## Metadata` block an ArmadAI-format source carried, kept
+    /// verbatim for `--propose`. `None` for a native file.
+    ///
+    /// [`PartialMetadata`] is the *shared* view every rule reads, and it is
+    /// deliberately the intersection of what both formats express: a
+    /// description, a model, a tool list. An ArmadAI file says more —
+    /// `temperature`, `max_tokens`, `tags`, `stacks`, `scope` — and `--propose`
+    /// is the one consumer that must not lose it, because since #393 it can
+    /// run on a library that is *already* ArmadAI and its output is offered as
+    /// an installable replacement for it (issue #400).
+    ///
+    /// Kept out of [`PartialMetadata::extra`] on purpose, and the reason is
+    /// measured: `extra` is Claude Code frontmatter the audit does not type, so
+    /// `A12` reports its keys as non-standard and `C02`/`C05` read `paths` out
+    /// of it. Routing ArmadAI's own vocabulary through it announced
+    /// `provider (76), model (76), tags (76)` on a healthy library and turned
+    /// `scope` into 149 phantom overlapping pairs. A separate field is what
+    /// lets the proposal see the fields while the rules keep not seeing them.
+    pub armadai_metadata: Option<armadai_core::agent::AgentMetadata>,
 }
 
 /// A skill imported from a native config (Agent Skills standard layout).

--- a/crates/armadai/src/audit/rules/assets.rs
+++ b/crates/armadai/src/audit/rules/assets.rs
@@ -498,6 +498,7 @@ mod tests {
                     body_tokens: 0,
                     issues: Vec::new(),
                     extra: BTreeMap::new(),
+                    space: ".claude".into(),
                 },
                 ImportedSkill {
                     name: "fine".into(),
@@ -508,6 +509,7 @@ mod tests {
                     body_tokens: 0,
                     issues: Vec::new(),
                     extra: BTreeMap::new(),
+                    space: ".claude".into(),
                 },
             ],
             ..Default::default()
@@ -536,6 +538,7 @@ mod tests {
                 body_tokens: 0,
                 issues: Vec::new(),
                 extra: BTreeMap::new(),
+                space: ".claude".into(),
             }],
             ..Default::default()
         };
@@ -567,6 +570,7 @@ mod tests {
                     message: "unquoted value".into(),
                 }],
                 extra: BTreeMap::new(),
+                space: ".claude".into(),
             }],
             ..Default::default()
         };
@@ -599,6 +603,7 @@ mod tests {
                         message: "bad".into(),
                     }],
                     extra: BTreeMap::new(),
+                    space: ".claude".into(),
                 },
                 // No frontmatter at all: A09 Warning.
                 ImportedSkill {
@@ -610,6 +615,7 @@ mod tests {
                     body_tokens: 0,
                     issues: Vec::new(),
                     extra: BTreeMap::new(),
+                    space: ".claude".into(),
                 },
             ],
             ..Default::default()

--- a/crates/armadai/src/audit/rules/collisions.rs
+++ b/crates/armadai/src/audit/rules/collisions.rs
@@ -4,27 +4,36 @@ use std::collections::BTreeMap;
 use super::similarity::jaccard;
 use super::{AuditContext, Finding, Severity};
 
-/// C01 — two assets claim the same name.
+/// The key every name-based grouping is built on: a name is only ambiguous
+/// against the other names **one resolver** enumerates.
+///
+/// See [`ResolutionSpace`](crate::audit::reverse::ResolutionSpace): the global
+/// pass assembles two unrelated trees, so grouping by name alone made every
+/// agent `armadai link` had published collide with the library file it was
+/// generated from (issue #399).
+type NameKey<'a> = (&'a std::path::Path, &'a str);
+
+/// C01 — two assets claim the same name **inside one resolution space**.
 /// Same-kind duplicates are Critical (routing is ambiguous); an agent/skill
 /// homonym is Warning (different namespaces, but confusing).
 pub(super) fn c01_name_collisions(ctx: &AuditContext) -> Vec<Finding> {
     let mut findings = Vec::new();
-    let mut agents_by_name: BTreeMap<&str, Vec<&std::path::Path>> = BTreeMap::new();
+    let mut agents_by_name: BTreeMap<NameKey, Vec<&std::path::Path>> = BTreeMap::new();
     for a in ctx.config.agents.iter().filter(|a| a.issues.is_empty()) {
         agents_by_name
-            .entry(a.name.as_str())
+            .entry((a.space.as_path(), a.name.as_str()))
             .or_default()
             .push(&a.source_path);
     }
-    let mut skills_by_name: BTreeMap<&str, Vec<&std::path::Path>> = BTreeMap::new();
+    let mut skills_by_name: BTreeMap<NameKey, Vec<&std::path::Path>> = BTreeMap::new();
     for s in ctx.config.skills.iter().filter(|s| s.issues.is_empty()) {
         skills_by_name
-            .entry(s.name.as_str())
+            .entry((s.space.as_path(), s.name.as_str()))
             .or_default()
             .push(&s.source_path);
     }
     for (kind, by_name) in [("agent", &agents_by_name), ("skill", &skills_by_name)] {
-        for (name, paths) in by_name {
+        for (&(_, name), paths) in by_name {
             if paths.len() > 1 {
                 findings.push(Finding {
                     rule: "C01",
@@ -40,8 +49,10 @@ pub(super) fn c01_name_collisions(ctx: &AuditContext) -> Vec<Finding> {
             }
         }
     }
-    for (name, agent_paths) in &agents_by_name {
-        if let Some(skill_paths) = skills_by_name.get(name) {
+    // Agent↔skill homonyms are cross-*namespace* but still same-space: the
+    // two are confusing only to someone reading one tree.
+    for (&(space, name), agent_paths) in &agents_by_name {
+        if let Some(skill_paths) = skills_by_name.get(&(space, name)) {
             findings.push(Finding {
                 rule: "C01",
                 severity: Severity::Warning,
@@ -62,16 +73,16 @@ pub(super) fn c01_name_collisions(ctx: &AuditContext) -> Vec<Finding> {
 /// Findings are aggregated into clusters (like A06/C02) to avoid N² noise.
 pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
     let threshold = ctx.settings.activation_similarity;
-    // (kind, name, path, description)
-    let mut surfaces: Vec<(&str, &str, &std::path::Path, &str)> = Vec::new();
+    // (kind, name, path, description, space)
+    let mut surfaces: Vec<(&str, &str, &std::path::Path, &str, &std::path::Path)> = Vec::new();
     for s in ctx.config.skills.iter().filter(|s| s.issues.is_empty()) {
         if let Some(d) = &s.description {
-            surfaces.push(("skill", &s.name, &s.source_path, d));
+            surfaces.push(("skill", &s.name, &s.source_path, d, &s.space));
         }
     }
     for a in ctx.config.agents.iter().filter(|a| a.issues.is_empty()) {
         if let Some(d) = &a.metadata.description {
-            surfaces.push(("agent", &a.name, &a.source_path, d));
+            surfaces.push(("agent", &a.name, &a.source_path, d, &a.space));
         }
     }
 
@@ -79,10 +90,15 @@ pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
     let mut uf = super::UnionFind::new(surfaces.len());
     for i in 0..surfaces.len() {
         for j in (i + 1)..surfaces.len() {
-            let (ka, _, _, da) = surfaces[i];
-            let (kb, _, _, db) = surfaces[j];
+            let (ka, _, _, da, sa) = surfaces[i];
+            let (kb, _, _, db, sb) = surfaces[j];
             if ka == "agent" && kb == "agent" {
                 continue; // A07's turf
+            }
+            // Two routers, one entry each: an installed copy cannot make the
+            // description it was copied from ambiguous (issue #399).
+            if sa != sb {
+                continue;
             }
             if jaccard(da, db) >= threshold {
                 uf.union(i, j);
@@ -101,7 +117,7 @@ pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
         .into_values()
         .filter(|members| members.len() >= 2)
         .map(|members| {
-            let (_, _, first_path, _) = surfaces[members[0]];
+            let (_, _, first_path, _, _) = surfaces[members[0]];
             let related: Vec<_> = members[1..]
                 .iter()
                 .map(|&i| surfaces[i].2.to_path_buf())
@@ -109,7 +125,7 @@ pub(super) fn c03_activation_overlap(ctx: &AuditContext) -> Vec<Finding> {
             let names: Vec<String> = members
                 .iter()
                 .map(|&i| {
-                    let (kind, name, _, _) = surfaces[i];
+                    let (kind, name, _, _, _) = surfaces[i];
                     format!("{kind} '{name}'")
                 })
                 .collect();
@@ -390,6 +406,87 @@ mod tests {
         assert_eq!(f[0].related.len(), 1);
     }
 
+    /// Issue #399. `armadai link --target claude` publishes the ArmadAI
+    /// library into `~/.claude`, so the global pass reads the very same agent
+    /// from two trees. Nothing resolves those two together — `~/.claude` is
+    /// the native config, `~/.config/armadai` the source library — so the name
+    /// is not ambiguous, and a healthy library must not exit 1.
+    ///
+    /// `armadai_agent` and `agent` carry different spaces by construction;
+    /// `c01_flags_duplicate_agent_names` above is the control that a homonym
+    /// *within* one tree stays Critical.
+    #[test]
+    fn c01_ignores_an_agent_published_into_a_second_root() {
+        use crate::audit::rules::test_support::armadai_agent;
+        let config = config_with(vec![
+            armadai_agent("dev-lead", "You are the Dev Lead."),
+            agent("dev-lead", "You are the Dev Lead."),
+        ]);
+        let settings = AuditSettings::default();
+        let f = c01_name_collisions(&AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: None,
+        });
+        assert!(
+            f.is_empty(),
+            "one agent seen through two roots is not a collision, got {:?}",
+            f.iter().map(|x| &x.message).collect::<Vec<_>>()
+        );
+    }
+
+    /// Same shape for skills, which is where the defect was already reachable
+    /// before #393: `~/.claude/skills/<x>` and `~/.config/armadai/skills/<x>`
+    /// are the installed copy and the library it came from.
+    #[test]
+    fn c01_ignores_a_skill_installed_in_two_roots() {
+        use crate::audit::reverse::ImportedConfig;
+        let mut installed = skill("graphify", "turns any input into a knowledge graph");
+        installed.space = ".claude".into();
+        let mut library = skill("graphify", "turns any input into a knowledge graph");
+        library.space = ".config/armadai".into();
+        library.source_path = ".config/armadai/skills/graphify/SKILL.md".into();
+        let config = ImportedConfig {
+            skills: vec![installed, library],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c01_name_collisions(&AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: None,
+        });
+        assert!(
+            f.is_empty(),
+            "one skill seen through two roots is not a collision, got {:?}",
+            f.iter().map(|x| &x.message).collect::<Vec<_>>()
+        );
+    }
+
+    /// The control for the skill case: two skills of one name *inside* one
+    /// tree stay Critical. Without it, gating C01 on the space could be
+    /// implemented as "never report skills" and stay green.
+    #[test]
+    fn c01_still_flags_two_skills_of_one_name_in_one_root() {
+        use crate::audit::reverse::ImportedConfig;
+        let a = skill("graphify", "turns any input into a knowledge graph");
+        let mut b = skill("graphify", "turns any input into a knowledge graph");
+        b.source_path = ".claude/skills/graphify-2/SKILL.md".into();
+        let config = ImportedConfig {
+            skills: vec![a, b],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c01_name_collisions(&AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: None,
+        });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Critical);
+        assert!(f[0].message.contains("graphify"));
+    }
+
     #[test]
     fn c01_flags_agent_skill_homonym_as_warning() {
         use crate::audit::reverse::{ImportedConfig, ImportedSkill};
@@ -405,6 +502,7 @@ mod tests {
                 body_tokens: 0,
                 issues: Vec::new(),
                 extra: BTreeMap::new(),
+                space: ".claude".into(),
             }],
             ..Default::default()
         };
@@ -428,6 +526,7 @@ mod tests {
             body_tokens: 0,
             issues: Vec::new(),
             extra: std::collections::BTreeMap::new(),
+            space: ".claude".into(),
         }
     }
 
@@ -470,6 +569,35 @@ mod tests {
             usage: None,
         });
         assert_eq!(f.len(), 1);
+    }
+
+    /// Issue #399, `C03`'s share of it: one skill installed in two trees has
+    /// the *same* description by construction, which is a perfect activation
+    /// overlap and a Warning about nothing. Two routers, one entry each.
+    /// `c03_flags_ambiguous_skill_descriptions` above is the control.
+    #[test]
+    fn c03_ignores_a_skill_installed_in_two_roots() {
+        use crate::audit::reverse::ImportedConfig;
+        let installed = skill("graphify", "turns any input into a knowledge graph");
+        let mut library = skill("graphify", "turns any input into a knowledge graph");
+        library.space = ".config/armadai".into();
+        library.source_path = ".config/armadai/skills/graphify/SKILL.md".into();
+        let config = ImportedConfig {
+            skills: vec![installed, library],
+            ..Default::default()
+        };
+        let settings = AuditSettings::default();
+        let f = c03_activation_overlap(&AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: None,
+        });
+        assert!(
+            f.is_empty(),
+            "one skill seen through two roots cannot make its own routing \
+             ambiguous, got {:?}",
+            f.iter().map(|x| &x.message).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/armadai/src/audit/rules/collisions.rs
+++ b/crates/armadai/src/audit/rules/collisions.rs
@@ -184,12 +184,27 @@ fn scoped_agents<'a>(
         .collect()
 }
 
+/// Pairs of scoped agents whose globs overlap, **inside one resolution
+/// space** — `C02` and `C05` both build on this.
+///
+/// The space guard is the same one `C01`/`A06`/`A07` carry, for the same
+/// reason: two agents claiming `src/**` are only in conflict if one resolver
+/// enumerates both. It is unreachable today and stays here on purpose — the
+/// glob source is `PartialMetadata::extra["paths"]`, Claude Code frontmatter
+/// the ArmadAI reverse pass deliberately leaves empty, so every scoped agent
+/// currently comes from a single native tree. The day a second native root is
+/// assembled, the alternative is not "a latent bug" but "the same false
+/// positive #399 measured", and a rule that compares two assets without asking
+/// which tree they came from is exactly what that issue was.
 fn overlapping_pairs(
     scoped: &[(&crate::audit::reverse::ImportedAgent, Vec<String>)],
 ) -> Vec<(usize, usize)> {
     let mut pairs = Vec::new();
     for i in 0..scoped.len() {
         for j in (i + 1)..scoped.len() {
+            if scoped[i].0.space != scoped[j].0.space {
+                continue;
+            }
             let overlap = scoped[i]
                 .1
                 .iter()
@@ -733,6 +748,56 @@ mod tests {
         assert_eq!(f.len(), 1);
         assert!(f[0].message.contains("wide") && f[0].message.contains("narrow"));
         assert!(!f[0].message.contains("docs"));
+    }
+
+    /// `C02` and `C05` are the two rules built on `overlapping_pairs`, and
+    /// they compare two assets exactly as `C01`/`A06`/`A07` do — so they ask
+    /// the same question those three learned to ask in #399: are these files
+    /// in one resolution space? Two agents claiming `src/**` in two unrelated
+    /// trees are not competing for anything.
+    ///
+    /// Unreachable through today's importers (the glob source is Claude Code
+    /// frontmatter, and every scoped agent therefore comes from one native
+    /// tree), which is why it is pinned here at the rule's own level rather
+    /// than through the binary.
+    #[test]
+    fn c02_and_c05_do_not_compare_agents_from_two_trees() {
+        use serde_yaml_ng::Value;
+        let scoped = |name: &str, globs: &str, space: &str, tools: Option<Vec<String>>| {
+            let mut a = agent(name, "Body");
+            a.metadata
+                .extra
+                .insert("paths".into(), Value::String(globs.into()));
+            a.metadata.tools = tools;
+            a.space = std::path::PathBuf::from(space);
+            a
+        };
+        let settings = AuditSettings::default();
+        let run = |config: &crate::audit::reverse::ImportedConfig| {
+            let ctx = AuditContext {
+                config,
+                settings: &settings,
+                usage: None,
+            };
+            (
+                c02_scope_overlap(&ctx).len(),
+                c05_inconsistent_tools(&ctx).len(),
+            )
+        };
+
+        let across = config_with(vec![
+            scoped("wide", "src/**", ".claude", Some(vec!["Read".into()])),
+            scoped("narrow", "src/cli/**", ".config/armadai", None),
+        ]);
+        assert_eq!(run(&across), (0, 0), "two trees, two independent scopes");
+
+        // The control: the same pair inside one tree is what both rules exist
+        // to report, so the silence above is a guard and not a broken rule.
+        let inside = config_with(vec![
+            scoped("wide", "src/**", ".claude", Some(vec!["Read".into()])),
+            scoped("narrow", "src/cli/**", ".claude", None),
+        ]);
+        assert_eq!(run(&inside), (1, 1));
     }
 
     #[test]

--- a/crates/armadai/src/audit/rules/mod.rs
+++ b/crates/armadai/src/audit/rules/mod.rs
@@ -291,6 +291,7 @@ pub(crate) mod test_support {
             issues: Vec::new(),
             format: AgentFormat::ClaudeFrontmatter,
             space: PathBuf::from(".claude"),
+            armadai_metadata: None,
         }
     }
 
@@ -311,6 +312,7 @@ pub(crate) mod test_support {
             issues: Vec::new(),
             format: AgentFormat::Armadai,
             space: PathBuf::from(".config/armadai"),
+            armadai_metadata: None,
         }
     }
 

--- a/crates/armadai/src/audit/rules/mod.rs
+++ b/crates/armadai/src/audit/rules/mod.rs
@@ -290,6 +290,7 @@ pub(crate) mod test_support {
             system_prompt: prompt.to_string(),
             issues: Vec::new(),
             format: AgentFormat::ClaudeFrontmatter,
+            space: PathBuf::from(".claude"),
         }
     }
 
@@ -309,6 +310,7 @@ pub(crate) mod test_support {
             system_prompt: prompt.to_string(),
             issues: Vec::new(),
             format: AgentFormat::Armadai,
+            space: PathBuf::from(".config/armadai"),
         }
     }
 
@@ -325,6 +327,7 @@ pub(crate) mod test_support {
             body_tokens,
             issues: Vec::new(),
             extra: BTreeMap::new(),
+            space: PathBuf::from(".claude"),
         }
     }
 

--- a/crates/armadai/src/audit/rules/mod.rs
+++ b/crates/armadai/src/audit/rules/mod.rs
@@ -292,12 +292,21 @@ pub(crate) mod test_support {
             format: AgentFormat::ClaudeFrontmatter,
             space: PathBuf::from(".claude"),
             armadai_metadata: None,
+            title: None,
         }
     }
 
     /// The same shape read from an ArmadAI-format file: a description derived
     /// from the prompt (the format has no `description` field), and no tool
     /// list, because the format cannot express one.
+    ///
+    /// `armadai_metadata` is `Some`, never `None`: `armadai::imported` always
+    /// fills it, and the pair (`space = .config/armadai`, `armadai_metadata =
+    /// None`) does not exist in production. It was inert for the rules — none
+    /// of them reads the field — but it is the input on which `render_agent`
+    /// takes the *convert* branch, i.e. exactly the #400 defect this PR fixes,
+    /// so a fixture shaped that way is a trap for the next test written
+    /// against it.
     pub fn armadai_agent(name: &str, prompt: &str) -> ImportedAgent {
         ImportedAgent {
             name: name.to_string(),
@@ -312,7 +321,27 @@ pub(crate) mod test_support {
             issues: Vec::new(),
             format: AgentFormat::Armadai,
             space: PathBuf::from(".config/armadai"),
-            armadai_metadata: None,
+            armadai_metadata: Some(armadai_core::agent::AgentMetadata {
+                provider: "claude".to_string(),
+                model: Some("latest:pro".to_string()),
+                command: None,
+                args: None,
+                temperature: armadai_core::agent::default_temperature(),
+                max_tokens: None,
+                timeout: None,
+                tags: Vec::new(),
+                stacks: Vec::new(),
+                scope: Vec::new(),
+                model_fallback: Vec::new(),
+                cost_limit: None,
+                rate_limit: None,
+                context_window: None,
+                mode: None,
+                orchestration: None,
+                triggers: None,
+                ring_config: None,
+            }),
+            title: None,
         }
     }
 

--- a/crates/armadai/src/audit/rules/similarity.rs
+++ b/crates/armadai/src/audit/rules/similarity.rs
@@ -44,6 +44,15 @@ pub(super) fn jaccard(a: &str, b: &str) -> f64 {
 /// window, computed via union-find over pairwise window-hash intersections.
 /// Only components with 2+ members are kept; components are sorted by their
 /// lowest member index. Shared by A06 and `--propose`'s fragment extraction.
+///
+/// Clusters never cross a
+/// [`ResolutionSpace`](crate::audit::reverse::ResolutionSpace). The remedy
+/// this rule proposes — "extract the shared block into one reusable prompt
+/// fragment" — is a change to *one* library, and `armadai link` republishes
+/// every library agent into `~/.claude`, so a global run folded the source
+/// and its published copies into a single cluster naming each agent twice
+/// (issue #399). One cluster per tree names each agent once, and `--propose`
+/// gets fragments a single pack can actually carry.
 pub(crate) fn duplication_clusters(agents: &[ImportedAgent]) -> Vec<Vec<usize>> {
     let hashes: Vec<HashSet<u64>> = agents
         .iter()
@@ -52,6 +61,9 @@ pub(crate) fn duplication_clusters(agents: &[ImportedAgent]) -> Vec<Vec<usize>> 
     let mut uf = UnionFind::new(agents.len());
     for i in 0..agents.len() {
         for j in (i + 1)..agents.len() {
+            if agents[i].space != agents[j].space {
+                continue;
+            }
             if hashes[i].intersection(&hashes[j]).next().is_some() {
                 uf.union(i, j);
             }
@@ -108,11 +120,20 @@ pub(super) fn a06_duplicated_blocks(ctx: &AuditContext) -> Vec<Finding> {
 }
 
 /// A07 — two agents look interchangeable (near-identical descriptions).
+///
+/// Within one [`ResolutionSpace`](crate::audit::reverse::ResolutionSpace)
+/// only: the description an ArmadAI agent is judged on is exactly the one
+/// `armadai link` writes into the copy it publishes, so across the two global
+/// trees every linked agent was reported near-identical to itself — `agents
+/// 'dev-lead' and 'dev-lead'` (issue #399).
 pub(super) fn a07_redundant_agents(ctx: &AuditContext) -> Vec<Finding> {
     let agents = &ctx.config.agents;
     let mut findings = Vec::new();
     for i in 0..agents.len() {
         for j in (i + 1)..agents.len() {
+            if agents[i].space != agents[j].space {
+                continue;
+            }
             let (Some(da), Some(db)) = (
                 &agents[i].metadata.description,
                 &agents[j].metadata.description,
@@ -222,6 +243,69 @@ mod tests {
         });
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].rule, "A07");
+    }
+
+    /// Issue #399. `armadai link` republishes every library agent into
+    /// `~/.claude`, so in global scope `A06` saw each of them twice and folded
+    /// the two trees into a single cluster: measured on a two-agent library,
+    /// `4 agents share duplicated content: dev-lead, dev-lead, qa-specialist,
+    /// qa-specialist`. The block is real and worth extracting — once per tree,
+    /// naming each agent once.
+    #[test]
+    fn a06_clusters_within_a_tree_not_across_two() {
+        use crate::audit::rules::test_support::armadai_agent;
+        let block = shared_block();
+        let config = config_with(vec![
+            armadai_agent("dev-lead", &format!("{block}Specific to dev-lead.")),
+            armadai_agent("qa", &format!("{block}Specific to qa.")),
+            agent("dev-lead", &format!("{block}Specific to dev-lead.")),
+            agent("qa", &format!("{block}Specific to qa.")),
+        ]);
+        let settings = AuditSettings::default();
+        let f = a06_duplicated_blocks(&AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: None,
+        });
+        assert_eq!(
+            f.len(),
+            2,
+            "one cluster per tree, got {:?}",
+            f.iter().map(|x| &x.message).collect::<Vec<_>>()
+        );
+        for finding in &f {
+            assert!(
+                finding.message.contains("2 agents"),
+                "a cluster must name each agent once, got {:?}",
+                finding.message
+            );
+        }
+    }
+
+    /// `A07`'s share of #399: the description an ArmadAI agent is judged on is
+    /// exactly the one `link` writes into the published copy, so every linked
+    /// agent was reported near-identical to itself — `agents 'dev-lead' and
+    /// 'dev-lead' have near-identical descriptions`.
+    /// `a07_flags_near_identical_descriptions` above is the control.
+    #[test]
+    fn a07_ignores_an_agent_published_into_a_second_root() {
+        use crate::audit::rules::test_support::armadai_agent;
+        let mut library = armadai_agent("dev-lead", "You are the Dev Lead.");
+        let mut published = agent("dev-lead", "You are the Dev Lead.");
+        library.metadata.description = Some("you are the dev lead".to_string());
+        published.metadata.description = Some("you are the dev lead".to_string());
+        let config = config_with(vec![library, published]);
+        let settings = AuditSettings::default();
+        let f = a07_redundant_agents(&AuditContext {
+            config: &config,
+            settings: &settings,
+            usage: None,
+        });
+        assert!(
+            f.is_empty(),
+            "an agent is not redundant with its own published copy, got {:?}",
+            f.iter().map(|x| &x.message).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/armadai/src/audit/rules/similarity.rs
+++ b/crates/armadai/src/audit/rules/similarity.rs
@@ -51,8 +51,13 @@ pub(super) fn jaccard(a: &str, b: &str) -> f64 {
 /// fragment" — is a change to *one* library, and `armadai link` republishes
 /// every library agent into `~/.claude`, so a global run folded the source
 /// and its published copies into a single cluster naming each agent twice
-/// (issue #399). One cluster per tree names each agent once, and `--propose`
-/// gets fragments a single pack can actually carry.
+/// (issue #399). One cluster per tree names each agent once.
+///
+/// That is the right *report* and not yet the right *pack*: one shared block
+/// seen through two trees is two clusters, and building one fragment per
+/// cluster shipped two byte-identical fragments — measured on the #399 fixture.
+/// Collapsing them is `proposal::dedupe_fragments`' job, not this function's:
+/// A06's finding is per library, the pack is one artifact.
 pub(crate) fn duplication_clusters(agents: &[ImportedAgent]) -> Vec<Vec<usize>> {
     let hashes: Vec<HashSet<u64>> = agents
         .iter()

--- a/crates/armadai/src/audit/rules/usage_rules.rs
+++ b/crates/armadai/src/audit/rules/usage_rules.rs
@@ -343,6 +343,7 @@ mod tests {
             body_tokens: 0,
             issues: vec![],
             extra: Default::default(),
+            space: ".claude".into(),
         });
         let settings = AuditSettings::default();
         let mut usage = UsageFacts::default();
@@ -588,6 +589,7 @@ mod tests {
             body_tokens: 0,
             issues: vec![],
             extra: Default::default(),
+            space: ".claude".into(),
         });
         let settings = AuditSettings::default();
         let mut usage = UsageFacts {

--- a/crates/armadai/src/audit/scope.rs
+++ b/crates/armadai/src/audit/scope.rs
@@ -116,8 +116,12 @@ pub fn import_global_surfaces(layout: &GlobalLayout) -> GlobalImport {
     let claude_md = layout.claude_home.join("CLAUDE.md");
     if claude_agents.is_dir() || claude_skills.is_dir() || claude_md.is_file() {
         detected.push(format!("claude ({})", tildify(layout, &layout.claude_home)));
-        config.agents.extend(parse_agents(&claude_agents));
-        config.skills.extend(parse_skills(&claude_skills));
+        config
+            .agents
+            .extend(parse_agents(&claude_agents, &layout.claude_home));
+        config
+            .skills
+            .extend(parse_skills(&claude_skills, &layout.claude_home));
         config.instructions = parse_instructions(&claude_md);
     }
 
@@ -128,8 +132,13 @@ pub fn import_global_surfaces(layout: &GlobalLayout) -> GlobalImport {
             "armadai ({})",
             tildify(layout, &layout.armadai_config)
         ));
-        config.skills.extend(parse_skills(&armadai_skills));
-        config.agents.extend(armadai::parse_agents(&armadai_agents));
+        config
+            .skills
+            .extend(parse_skills(&armadai_skills, &layout.armadai_config));
+        config.agents.extend(armadai::parse_agents(
+            &armadai_agents,
+            &layout.armadai_config,
+        ));
     }
 
     config.agents.sort_by(|a, b| a.name.cmp(&b.name));

--- a/crates/armadai/src/cli/audit.rs
+++ b/crates/armadai/src/cli/audit.rs
@@ -37,11 +37,16 @@ const DEEP_AUDITOR_TIER: &str = "latest:pro";
 /// on the five `run` paths, and (measured over every
 /// `Provider::complete`/`stream` call site) the last one left (issue #401).
 ///
-/// Latent, not active: `--deep` is only reached after `which claude|gemini`
-/// succeeds, so `create_provider` returns the CLI relay, which reads
-/// `request.model` nowhere. It arms the day that unified name resolves to an
-/// API instead, which is what `create_provider` does when the binary is
-/// absent.
+/// Latent on Unix, **active on Windows**. On Unix the two probes are the same
+/// program: `--deep` is only reached after `deep::cli_is_available` runs
+/// `which claude|gemini`, so `create_provider`'s own `which` agrees and returns
+/// the CLI relay, which reads `request.model` nowhere. Under `#[cfg(windows)]`
+/// `deep::cli_is_available` runs `where` while `factory::cli_available` still
+/// runs `which` on every platform, so an installed CLI passes the first probe
+/// and fails the second: `create_provider` falls back to the API, which
+/// *honors* `request.model`, and the placeholder would become the model name.
+/// That asymmetry is pre-existing and tracked separately (issue #420); this
+/// function is correct either way.
 ///
 /// When no vendor catalog names the CLI's models the placeholder is kept, not
 /// replaced by a guess: that is the case `resolve_tier_placeholder` answers
@@ -682,13 +687,13 @@ mod tests {
     /// the five `run` paths: a `latest:*` tier placeholder must never become a
     /// provider's model name.
     ///
-    /// Latent today — `--deep` is only reached after `which claude|gemini`
-    /// succeeds, so `create_provider` returns the CLI relay, which reads
+    /// Latent on Unix, active on Windows (see [`deep_auditor_model`]): there
+    /// `--deep`'s `where` probe and `create_provider`'s `which` probe disagree,
+    /// so an installed CLI still routes to the API — which *does* honor
+    /// `request.model`. On Unix both probes agree and the CLI relay reads
     /// `request.model` nowhere (`CliProvider::honors_request_model` is
-    /// `false`). That is also why there is no output surface to assert on: the
-    /// constructor is the whole of it. It arms the moment that unified name
-    /// resolves to an API instead, which is exactly what `create_provider`
-    /// does when the binary is absent.
+    /// `false`). Either way the constructor is the whole surface there is to
+    /// assert on, which is why this test asserts on it.
     ///
     /// Two claims, and the second is what makes the first non-tautological:
     /// no placeholder survives, and the two CLIs resolve to *different*

--- a/crates/armadai/src/cli/audit.rs
+++ b/crates/armadai/src/cli/audit.rs
@@ -701,6 +701,12 @@ mod tests {
     /// same Anthropic id.
     #[test]
     fn the_deep_auditor_carries_a_concrete_model_not_a_tier_placeholder() {
+        // `resolve_tier_placeholder` reads `<ARMADAI_CONFIG_DIR>/models-cache.json`
+        // before falling back to the static table, so without this guard the
+        // test reads whatever catalogue the developer last synced. The static
+        // fallback made it pass either way; an undeclared environment read is
+        // still an environment read.
+        let _config = armadai_core::test_support::IsolatedConfigDir::enter();
         for cli in crate::audit::deep::DEEP_CLIS {
             let model = build_deep_auditor(cli)
                 .metadata
@@ -733,6 +739,7 @@ mod tests {
     /// `copilot` is such a tool (`model_catalog_provider` returns `None`).
     #[test]
     fn a_cli_with_no_vendor_catalog_keeps_the_placeholder() {
+        let _config = armadai_core::test_support::IsolatedConfigDir::enter();
         assert_eq!(deep_auditor_model("copilot"), DEEP_AUDITOR_TIER);
     }
 

--- a/crates/armadai/src/cli/audit.rs
+++ b/crates/armadai/src/cli/audit.rs
@@ -22,18 +22,52 @@ pub(crate) fn min_severity_from(flag: &str, quiet: bool) -> Severity {
     }
 }
 
+/// The tier the deep-pass auditor asks for.
+///
+/// Named rather than inlined so the test below pins the same one
+/// [`deep_auditor_model`] uses; the string itself never leaves this module.
+const DEEP_AUDITOR_TIER: &str = "latest:pro";
+
+/// The concrete model id the deep-pass auditor declares, for `cli`'s vendor.
+///
+/// [`DEEP_AUDITOR_TIER`] is resolved here rather than handed to the provider
+/// as-is: `call_deep_auditor` copies `metadata.model` straight into its
+/// `CompletionRequest`, so this is the last gate before the string would
+/// become a provider's model name — the same class #376 named and #398 closed
+/// on the five `run` paths, and (measured over every
+/// `Provider::complete`/`stream` call site) the last one left (issue #401).
+///
+/// Latent, not active: `--deep` is only reached after `which claude|gemini`
+/// succeeds, so `create_provider` returns the CLI relay, which reads
+/// `request.model` nowhere. It arms the day that unified name resolves to an
+/// API instead, which is what `create_provider` does when the binary is
+/// absent.
+///
+/// When no vendor catalog names the CLI's models the placeholder is kept, not
+/// replaced by a guess: that is the case `resolve_tier_placeholder` answers
+/// `None` for, and there the placeholder is the more useful of the two strings
+/// (#398 review, F1). Neither entry of `DEEP_CLIS` is in that case today, so
+/// this branch only matters the day one is added.
+fn deep_auditor_model(cli: &str) -> String {
+    armadai_core::model_resolution::resolve_tier_placeholder(DEEP_AUDITOR_TIER, cli)
+        .unwrap_or_else(|| DEEP_AUDITOR_TIER.to_string())
+}
+
 /// Build the in-memory auditor agent for the given detected CLI.
 ///
 /// Only `claude` and `gemini` are supported (see `deep::DEEP_CLIS`), both
 /// through the standard unified-tool resolution (`provider = cli`, no
 /// explicit `command`), which invokes them non-interactively via `-p`.
+///
+/// The model is a concrete id, never a tier placeholder — see
+/// [`deep_auditor_model`].
 fn build_deep_auditor(cli: &str) -> Agent {
     Agent {
         name: "deep-auditor".to_string(),
         source: PathBuf::from("<in-memory>"),
         metadata: AgentMetadata {
             provider: cli.to_string(),
-            model: Some("latest:pro".to_string()),
+            model: Some(deep_auditor_model(cli)),
             command: None,
             args: None,
             temperature: 0.2,
@@ -642,6 +676,59 @@ mod tests {
             global.contains("global agents"),
             "and the prompts of their global agents: {global}"
         );
+    }
+
+    /// Issue #401, the sixth site of the class #376 named and #398 closed on
+    /// the five `run` paths: a `latest:*` tier placeholder must never become a
+    /// provider's model name.
+    ///
+    /// Latent today — `--deep` is only reached after `which claude|gemini`
+    /// succeeds, so `create_provider` returns the CLI relay, which reads
+    /// `request.model` nowhere (`CliProvider::honors_request_model` is
+    /// `false`). That is also why there is no output surface to assert on: the
+    /// constructor is the whole of it. It arms the moment that unified name
+    /// resolves to an API instead, which is exactly what `create_provider`
+    /// does when the binary is absent.
+    ///
+    /// Two claims, and the second is what makes the first non-tautological:
+    /// no placeholder survives, and the two CLIs resolve to *different*
+    /// models — a tier resolved against a hardcoded vendor would give both the
+    /// same Anthropic id.
+    #[test]
+    fn the_deep_auditor_carries_a_concrete_model_not_a_tier_placeholder() {
+        for cli in crate::audit::deep::DEEP_CLIS {
+            let model = build_deep_auditor(cli)
+                .metadata
+                .model
+                .expect("the auditor always declares a model");
+            assert!(
+                armadai_core::model_resolution::parse_latest_placeholder(&model).is_none(),
+                "'{cli}' would be asked for a model literally called {model:?}"
+            );
+            assert_eq!(
+                model,
+                armadai_core::model_resolution::resolve_tier_placeholder(DEEP_AUDITOR_TIER, cli)
+                    .expect("both deep CLIs name a vendor catalog"),
+                "the auditor must ask for the {DEEP_AUDITOR_TIER} model of '{cli}'s own vendor"
+            );
+        }
+
+        let claude = build_deep_auditor("claude").metadata.model.unwrap();
+        let gemini = build_deep_auditor("gemini").metadata.model.unwrap();
+        assert_ne!(
+            claude, gemini,
+            "the tier must resolve against each CLI's own vendor catalog, not a fixed one"
+        );
+    }
+
+    /// The other half of the contract, and the branch neither `DEEP_CLIS`
+    /// entry reaches today: when no vendor catalog names a tool's models,
+    /// `resolve_tier_placeholder` answers `None` and the placeholder is the
+    /// string to keep — never an empty model, never another vendor's guess.
+    /// `copilot` is such a tool (`model_catalog_provider` returns `None`).
+    #[test]
+    fn a_cli_with_no_vendor_catalog_keeps_the_placeholder() {
+        assert_eq!(deep_auditor_model("copilot"), DEEP_AUDITOR_TIER);
     }
 
     #[tokio::test]

--- a/crates/armadai/tests/audit_scopes.rs
+++ b/crates/armadai/tests/audit_scopes.rs
@@ -955,6 +955,80 @@ mod tests {
         );
     }
 
+    /// Issue #400. `--propose --global` offers its pack as an installable
+    /// replacement for what it read (`Install it with: armadai init --pack …`),
+    /// and since #393 what it reads can already be an ArmadAI library. Measured
+    /// on one library agent, the pack it produced had dropped `temperature`,
+    /// `max_tokens` and `stacks`, replaced `tags` with `[imported]`, and
+    /// flattened `## Instructions` / `## Output Format` and every `###` into
+    /// bold lines inside a single `## System Prompt`.
+    ///
+    /// Asserted on the file the binary wrote, re-read from disk: the unit
+    /// tests prove `render_agent`, they cannot prove `--propose --global`
+    /// reaches it with the source metadata still attached.
+    #[test]
+    fn a_global_propose_reproduces_an_armadai_library_instead_of_impoverishing_it() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.config/armadai/agents/platodin-java-lead.md",
+            "# Platodin Java Lead\n\n\
+             ## Metadata\n\
+             - provider: claude\n\
+             - model: claude-sonnet-5\n\
+             - temperature: 0.4\n\
+             - max_tokens: 8192\n\
+             - tags: coordinator, lead, analysis\n\
+             - stacks: java, spring-boot, platodin\n\n\
+             ## System Prompt\n\n\
+             You are the Platodin Java Lead.\n\n\
+             ### Scope\n\n\
+             You own the framework surface.\n\n\
+             ## Instructions\n\n\
+             ### Review checklist\n\n\
+             - Check the module layout.\n",
+        );
+
+        let out = s.run(&["--global", "--propose"]);
+        out.ran();
+        let pack_agent = s
+            .work()
+            .join(".armadai-proposal/agents/platodin-java-lead.md");
+        let written = std::fs::read_to_string(&pack_agent).unwrap_or_else(|e| {
+            panic!(
+                "the pack must carry the agent ({}): {e}\n{}\n{}",
+                pack_agent.display(),
+                out.stdout,
+                out.stderr
+            )
+        });
+
+        // Whole trimmed lines, never `contains`: a heading shifted two levels
+        // down still *contains* the shallower one as a substring, so
+        // `contains("### Scope")` stays true for `##### Scope` and the
+        // assertion could not fail (measured — it was the first version of
+        // this test).
+        let lines: Vec<&str> = written.lines().map(str::trim).collect();
+        for expected in [
+            "- model: claude-sonnet-5",
+            "- temperature: 0.4",
+            "- max_tokens: 8192",
+            "- tags: [coordinator, lead, analysis]",
+            "- stacks: [java, spring-boot, platodin]",
+            "## Instructions",
+            "### Scope",
+            "### Review checklist",
+        ] {
+            assert!(
+                lines.contains(&expected),
+                "the pack lost the line {expected:?}:\n{written}"
+            );
+        }
+        assert!(
+            !lines.contains(&"- tags: [imported]"),
+            "the source's own tags must not be overwritten:\n{written}"
+        );
+    }
+
     /// An empty library is not an error, and must not be reported as a
     /// project path the user never named.
     #[test]

--- a/crates/armadai/tests/audit_scopes.rs
+++ b/crates/armadai/tests/audit_scopes.rs
@@ -811,9 +811,13 @@ mod tests {
     /// all four files were read;
     /// `two_agents_of_one_name_in_one_root_are_still_a_collision` is the
     /// control that `C01` did not simply stop working.
-    #[test]
-    fn a_library_published_into_the_native_root_is_not_a_collision() {
-        let s = Sandbox::new();
+    /// The canonical #399 fixture: a healthy two-agent ArmadAI library, plus
+    /// the copies `armadai link --target claude` publishes into `~/.claude`.
+    /// Same stem, same `name:`, and a `description:` that *is* the first line
+    /// of the ArmadAI system prompt — because that is what `link` writes.
+    /// Both agents carry the same 10-line block, so `A06` and `--propose` have
+    /// something real to work on.
+    fn library_published_by_link(s: &Sandbox) {
         let block = shared_block();
         for name in ["dev-lead", "qa"] {
             let prompt = format!("You are the {name}.");
@@ -821,7 +825,6 @@ mod tests {
                 &format!("home/.config/armadai/agents/{name}.md"),
                 &armadai_agent(name, &prompt, &format!("\n{block}")),
             );
-            // What `armadai link --target claude` writes for that agent.
             s.write(
                 &format!("home/.claude/agents/{name}.md"),
                 &format!(
@@ -830,6 +833,12 @@ mod tests {
                 ),
             );
         }
+    }
+
+    #[test]
+    fn a_library_published_into_the_native_root_is_not_a_collision() {
+        let s = Sandbox::new();
+        library_published_by_link(&s);
 
         let out = s.run(&["--global"]);
         out.ran().line_with("Detected:", &["4 agent(s)"]);
@@ -843,6 +852,76 @@ mod tests {
             .has_no_line_with("A07", &["dev-lead"])
             .has_no_line_with("A07", &["qa"])
             .has_no_line_with("A06", &["dev-lead, dev-lead"]);
+    }
+
+    /// The same fixture, run through `--propose`, because that is where the
+    /// duplication survives the fix above.
+    ///
+    /// `A06`'s remedy — the line the report prints — is "extract the shared
+    /// block into **one** reusable prompt fragment". Since #399 the clusters
+    /// are per tree, and one fragment per cluster meant a single shared block
+    /// left the pack as `shared-conventions-1` (`apply_to: [dev-lead, qa]`)
+    /// **and** `shared-conventions-2` (`apply_to: [dev-lead-2, qa-2]`), bodies
+    /// byte-identical at 418 bytes. The pack was valid and installable; it just
+    /// shipped the promise twice, on the workflow this PR exists to repair —
+    /// and `master` never got that far, exiting 1 on the same input.
+    ///
+    /// Asserted on the directory and on the file bodies, never on the summary
+    /// count alone: the count is a number the generator prints about itself.
+    #[test]
+    fn a_global_propose_factors_one_shared_block_into_exactly_one_fragment() {
+        let s = Sandbox::new();
+        library_published_by_link(&s);
+
+        let out = s.run(&["--global", "--propose"]);
+        out.ran();
+        let prompts = s.work().join(".armadai-proposal/prompts");
+        let mut files: Vec<String> = std::fs::read_dir(&prompts)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "the pack must carry the shared fragment ({}): {e}\n{}\n{}",
+                    prompts.display(),
+                    out.stdout,
+                    out.stderr
+                )
+            })
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        files.sort();
+        assert_eq!(
+            files,
+            ["shared-conventions-1.md"],
+            "one shared block, one fragment:\n{}",
+            out.stdout
+        );
+
+        // And the bodies — not just the names — are distinct. Renumbering
+        // alone would satisfy the assertion above while still writing the
+        // same text twice under different names.
+        let bodies: Vec<String> = files
+            .iter()
+            .map(|f| {
+                let text = std::fs::read_to_string(prompts.join(f)).unwrap();
+                // Everything after the closing `---` of the frontmatter: the
+                // duplicate fragments differed only in `name:` and `apply_to:`.
+                text.splitn(3, "---\n").nth(2).unwrap().to_string()
+            })
+            .collect();
+        let mut unique = bodies.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), bodies.len(), "two fragments share a body");
+
+        // Every agent that carries the block is named once by the fragment
+        // that replaces it — the merge must not drop half of them.
+        let fragment = std::fs::read_to_string(prompts.join("shared-conventions-1.md")).unwrap();
+        for slug in ["dev-lead", "qa", "dev-lead-2", "qa-2"] {
+            let named = fragment
+                .lines()
+                .filter(|l| l.trim() == format!("- {slug}"))
+                .count();
+            assert_eq!(named, 1, "`apply_to` must name {slug} once:\n{fragment}");
+        }
     }
 
     /// The control the fix must not swallow: inside one tree, two files
@@ -919,6 +998,79 @@ mod tests {
         );
         out.has_no_line_with("C01", &["graphify"])
             .has_no_line_with("C03", &["graphify"]);
+    }
+
+    /// The *other* half of `C01`, and the one no test covered: an agent and a
+    /// skill sharing a name. Inside one tree it is a Warning ("confusing to
+    /// someone reading one tree"); across the two global roots it is one asset
+    /// and a neighbour, and must stay silent.
+    ///
+    /// Both directions in one case, because either alone is passed by a rule
+    /// that is simply broken: removing the space guard from that pairing left
+    /// 759 unit tests and 29 cases here green, while turning the silence into a
+    /// warning `master` also emitted.
+    #[test]
+    fn an_agent_and_a_skill_of_one_name_collide_inside_a_tree_only() {
+        let agent_md = "---\nname: graphify\ndescription: Builds a graph of the repo\ntools: Read\n---\n\
+             You build graphs.";
+        let skill_md =
+            "---\nname: graphify\ndescription: turns any input into a knowledge graph\n---\nBody.";
+
+        let across = Sandbox::new();
+        across.write("home/.claude/agents/graphify.md", agent_md);
+        across.write("home/.config/armadai/skills/graphify/SKILL.md", skill_md);
+        let out = across.run(&["--global"]);
+        out.ran()
+            .line_with("Detected:", &["1 agent(s), 1 skill(s)"]);
+        out.has_no_line_with("C01", &["graphify"]);
+
+        let inside = Sandbox::new();
+        inside.write("home/.claude/agents/graphify.md", agent_md);
+        inside.write("home/.claude/skills/graphify/SKILL.md", skill_md);
+        inside
+            .run(&["--global"])
+            .ran()
+            .line_with("C01", &["agent and skill share the name 'graphify'"]);
+    }
+
+    /// The two blind spots #399's fix opens, pinned so that closing them again
+    /// has to be a decision rather than an accident.
+    ///
+    /// Two *different* agents of one name, one per root (and the same for an
+    /// agent/skill pair), used to be reported and now are not. That is the
+    /// intended reading — "two routers, one entry each": `~/.claude/agents` is
+    /// enumerated by Claude Code and `~/.config/armadai/agents` by ArmadAI, and
+    /// neither resolver ever sees both files, so neither has an ambiguous
+    /// name to resolve. Nothing is silently lost either: `armadai link`
+    /// without `--force` refuses to overwrite an existing native file, so the
+    /// user is told at the moment the two would meet.
+    ///
+    /// Measured before the fix: `master` exited 1 on this exact fixture.
+    #[test]
+    fn two_different_agents_of_one_name_in_two_roots_are_not_a_collision() {
+        let s = Sandbox::new();
+        s.write(
+            "home/.claude/agents/dev-lead.md",
+            "---\nname: dev-lead\ndescription: Leads the Claude Code fleet\ntools: Read\n---\n\
+             You lead the native fleet.",
+        );
+        s.write(
+            "home/.config/armadai/agents/dev-lead.md",
+            &armadai_agent(
+                "dev-lead",
+                "You lead an entirely different ArmadAI fleet.",
+                "",
+            ),
+        );
+
+        let out = s.run(&["--global"]);
+        out.ran().line_with("Detected:", &["2 agent(s)"]);
+        assert!(
+            out.success,
+            "one name per resolver is not an ambiguity:\n{}\n{}",
+            out.stdout, out.stderr
+        );
+        out.has_no_line_with("C01", &["dev-lead"]);
     }
 
     /// `--propose` in global scope has no project root to write into, so it

--- a/crates/armadai/tests/audit_scopes.rs
+++ b/crates/armadai/tests/audit_scopes.rs
@@ -784,6 +784,143 @@ mod tests {
         );
     }
 
+    /// A block long enough for `A06`'s 8-line window, shared by both agents
+    /// of the fixture below — so the duplication rule has something real to
+    /// find and its silence cannot be mistaken for an empty corpus.
+    fn shared_block() -> String {
+        (1..=10)
+            .map(|i| format!("Shared convention line {i}.\n"))
+            .collect()
+    }
+
+    /// Issue #399. The global pass assembles two unrelated trees, and
+    /// `armadai link --target claude --output ~/.claude` publishes the ArmadAI
+    /// library into one of them — so the product's own main workflow made the
+    /// user's library collide with itself. Measured on a healthy two-agent
+    /// library: `2 critical, 1 warning` and **exit 1**, one `C01` per agent
+    /// the user had linked, plus `A06 … dev-lead, dev-lead, qa, qa` and two
+    /// `A07 agents 'dev-lead' and 'dev-lead'`.
+    ///
+    /// The fixture is what `link` actually writes: same stem, same `name:`,
+    /// and a `description:` that *is* the first line of the ArmadAI system
+    /// prompt — which is exactly why `A07` fired on every one of them.
+    ///
+    /// Four claims in one run, because a rule silenced too broadly would pass
+    /// three of them: the command succeeds, and none of `C01`, `A06`, `A07`
+    /// names the republished agents. The `Detected:` line is the control that
+    /// all four files were read;
+    /// `two_agents_of_one_name_in_one_root_are_still_a_collision` is the
+    /// control that `C01` did not simply stop working.
+    #[test]
+    fn a_library_published_into_the_native_root_is_not_a_collision() {
+        let s = Sandbox::new();
+        let block = shared_block();
+        for name in ["dev-lead", "qa"] {
+            let prompt = format!("You are the {name}.");
+            s.write(
+                &format!("home/.config/armadai/agents/{name}.md"),
+                &armadai_agent(name, &prompt, &format!("\n{block}")),
+            );
+            // What `armadai link --target claude` writes for that agent.
+            s.write(
+                &format!("home/.claude/agents/{name}.md"),
+                &format!(
+                    "---\nname: {name}\ndescription: \"{prompt}\"\n\
+                     model: claude-sonnet-4-5-20250929\n---\n\n{prompt}\n\n{block}"
+                ),
+            );
+        }
+
+        let out = s.run(&["--global"]);
+        out.ran().line_with("Detected:", &["4 agent(s)"]);
+        assert!(
+            out.success,
+            "a library the product itself published must not fail the audit:\n{}\n{}",
+            out.stdout, out.stderr
+        );
+        out.has_no_line_with("C01", &["dev-lead"])
+            .has_no_line_with("C01", &["qa"])
+            .has_no_line_with("A07", &["dev-lead"])
+            .has_no_line_with("A07", &["qa"])
+            .has_no_line_with("A06", &["dev-lead, dev-lead"]);
+    }
+
+    /// The control the fix must not swallow: inside one tree, two files
+    /// claiming one name really do make routing ambiguous, and the command
+    /// still fails. Claude Code recurses into `~/.claude/agents/`, so the
+    /// second file sits in a subdirectory with the same `name:` — the exact
+    /// shape `C01` exists for.
+    #[test]
+    fn two_agents_of_one_name_in_one_root_are_still_a_collision() {
+        let s = Sandbox::new();
+        for path in [
+            "home/.claude/agents/dev-lead.md",
+            "home/.claude/agents/backend/dev-lead.md",
+        ] {
+            s.write(
+                path,
+                "---\nname: dev-lead\ndescription: Leads the fleet\ntools: Read\n---\nYou lead.",
+            );
+        }
+
+        let out = s.run(&["--global"]);
+        out.ran()
+            .line_with("C01", &["dev-lead", "routing is ambiguous"]);
+        assert!(
+            !out.success,
+            "a real homonym inside one tree must still exit non-zero:\n{}",
+            out.stdout
+        );
+    }
+
+    /// The same control for skills, whose two trees are where the defect was
+    /// already reachable before #393: one name twice in `~/.claude/skills`
+    /// stays Critical.
+    #[test]
+    fn two_skills_of_one_name_in_one_root_are_still_a_collision() {
+        let s = Sandbox::new();
+        for dir in ["graphify", "graphify-copy"] {
+            s.write(
+                &format!("home/.claude/skills/{dir}/SKILL.md"),
+                "---\nname: graphify\ndescription: builds a knowledge graph\n---\nBody.",
+            );
+        }
+
+        let out = s.run(&["--global"]);
+        out.ran()
+            .line_with("C01", &["graphify", "routing is ambiguous"]);
+        assert!(
+            !out.success,
+            "a real skill homonym inside one tree must still exit non-zero:\n{}",
+            out.stdout
+        );
+    }
+
+    /// The skill half of #399, end to end: ArmadAI installs its skills under
+    /// `~/.config/armadai/skills` and Claude Code reads `~/.claude/skills`, so
+    /// one skill present in both used to produce `C01` Critical **and** `C03`
+    /// Warning — the second because a copy's description is, necessarily,
+    /// identical to the original's.
+    #[test]
+    fn a_skill_present_in_both_global_roots_is_not_a_collision() {
+        let s = Sandbox::new();
+        let skill =
+            "---\nname: graphify\ndescription: turns any input into a knowledge graph\n---\nBody.";
+        s.write("home/.claude/skills/graphify/SKILL.md", skill);
+        s.write("home/.config/armadai/skills/graphify/SKILL.md", skill);
+
+        let out = s.run(&["--global"]);
+        out.ran().line_with("Detected:", &["2 skill(s)"]);
+        assert!(
+            out.success,
+            "one skill installed from the library it lives in must not fail \
+             the audit:\n{}\n{}",
+            out.stdout, out.stderr
+        );
+        out.has_no_line_with("C01", &["graphify"])
+            .has_no_line_with("C03", &["graphify"]);
+    }
+
     /// `--propose` in global scope has no project root to write into, so it
     /// writes into the **current directory, whatever that is** — the same place
     /// project scope would.


### PR DESCRIPTION
Trois défauts mesurés de `armadai audit`, **un commit par issue**. Chaque
mesure a été **reproduite avant** correction, et chaque test ajouté a été
**tué par mutation** avant d'être gardé.

## `Closes #399` — C01/A06/A07/C03 ignoraient la racine

La passe globale assemble deux arbres sans lien (`~/.claude`,
`~/.config/armadai`) et `armadai link --target claude --output ~/.claude`
publie la bibliothèque ArmadAI dans le premier. Le workflow principal du
produit fabriquait donc une collision avec elle-même.

Mesuré sur une bibliothèque saine de 2 agents publiée par `link`, plus une
skill présente dans les deux racines :

| | avant | après |
|---|---|---|
| `armadai audit --global` | `3 critical, 2 warning(s), 4 info` — **exit 1** | `0 critical, 2 warning(s), 3 info` — **exit 0** |
| `A06` | `4 agents … : dev-lead, dev-lead, qa-specialist, qa-specialist` | 2 findings, un par arbre, chaque agent nommé une fois |

`ImportedAgent` et `ImportedSkill` gagnent un `space` : l'arbre d'où le
fichier a été lu. C'est le précédent de #393 (`format`) — on donne au type
importé le champ dont la règle a besoin, plutôt que de brancher la règle sur
la portée. `format` répond « que sait dire ce fichier », `space` répond « ces
deux fichiers sont-ils dans le même espace de résolution ». La portée reste
invisible aux règles.

**Contrôle négatif** : un homonyme dans la MÊME racine reste une vraie
collision et sort toujours en non-zéro — 4 contrôles, dont 2 sur le binaire
lancé.

Périmètre élargi par rapport au titre de l'issue : `C03` est touché lui aussi
(mesuré — une skill installée depuis la bibliothèque où elle vit produisait
`C01` **et** `C03`, sa description recopiée « chevauchant » la sienne).

## `Closes #400` — `--propose --global` appauvrissait une source déjà ArmadAI

Mesuré, source vs pack, sur un agent de bibliothèque : `temperature: 0.4`,
`max_tokens: 8192` et `stacks:` perdus, `tags: [coordinator, lead, analysis]`
écrasé par `[imported]`, `## Instructions` / `## Output Format` et leurs
quatre `###` aplatis en gras dans un unique `## System Prompt`.

Deux correctifs, parce que la perte a lieu à **deux** endroits — et c'est le
point sur lequel l'issue se trompe :

1. `reverse/armadai.rs` **jetait déjà** le bloc typé à l'import.
   `PartialMetadata` est l'intersection de ce que les deux formats savent
   exprimer. Aucune modification du seul `render_agent` n'aurait pu les
   rendre : `ImportedAgent` gagne `armadai_metadata`. Il reste hors de
   `PartialMetadata::extra` pour la raison mesurée par #391 (`A12` annoncerait
   `provider (76), model (76), tags (76)` et `scope` deviendrait 149 paires
   `C02` fantômes).
2. `render_agent` devient une fonction du format d'origine : on **convertit**
   un config natif, on **reproduit** un config ArmadAI.

`demote_headings` décale désormais les titres de deux niveaux au lieu de les
effacer en gras. L'aplatissement était **imposé** avant #392 (corrigé par
#394) ; le commentaire de la fonction demandait explicitement ce changement
« with its own before/after to measure ». Un pack natif conserve sa hiérarchie
(`# → ###`, `## → ####`, `### → #####`, plafonné à 6) et ne laisse toujours
survivre aucun `#`/`##`.

Le pack **reproduit aussi le `# H1`** d'une source ArmadAI. Une première
version de cette PR y renonçait, au motif que « le runtime apparie `apply_to`
au nom H1 (`prompt::prompts_for_agent`) » : la revue a mesuré que **cette
fonction n'existe pas**. Celle qui existe, `prompt::matching_prompts`, reçoit
de son unique appelant de production (`dependency_resolver`) le **stem du
fichier**, explicitement et avec commentaire ; `pack_validation` R1/R5 lisent
la liste de slugs du pack, qui est le stem de `agents/<slug>.md`. Les deux
côtés s'accordent quel que soit le H1, donc le titre lisible est une chose de
plus que « reproduire plutôt que convertir » rapporte. Un config natif garde
le slug en H1 : là, le `name:` qu'un routeur énumère **est** la clé de
routage.

Un point volontairement **non** corrigé, avec la mesure qui le dit :

- `orchestration` n'est pas réécrit : `parse_metadata` n'accepte que `direct`,
  `blackboard` et `ring`, donc un agent `Hierarchical` produirait un pack que
  le parser du produit refuse. Même catégorie que `## Pipeline`, que l'issue
  demandait à juste titre de laisser tranquille.

## `Closes #401` — `build_deep_auditor` codait `latest:pro` en dur

Sixième site de la classe nommée par #376 et fermée par #398 sur les cinq
chemins `run`. Passe maintenant par
`armadai_core::model_resolution::resolve_tier_placeholder`.

Mesuré sur cette machine : `claude` porte désormais `claude-sonnet-5` et
`gemini` `gemini-2.5-pro`, là où les deux portaient `latest:pro`.

**Latent sur Unix, actif sur Windows.** Sur Unix les deux sondes sont le
même programme : `--deep` n'est atteint qu'après le `which claude|gemini` de
`deep::cli_is_available`, donc le `which` de `create_provider` est d'accord et
rend le relais CLI, dont `honors_request_model()` vaut `false`. Sous
`#[cfg(windows)]`, `deep::cli_is_available` lance `where` alors que
`factory::cli_available` lance `which` sur **toutes** les plateformes : un CLI
installé passe la première sonde, échoue à la seconde, `create_provider`
bascule sur l'API — qui, elle, **honore** `request.model`. L'asymétrie des
sondes est préexistante et suivie à part (#420) ; le correctif est juste dans
les deux cas. L'assertion porte sur le constructeur parce que c'est toute la
surface qu'il y a.

**C'est bien le dernier** : vérifié sur l'ensemble des sites de production
appelant `Provider::complete`/`stream` (les cinq moteurs event-sourced,
`cli::run`, `cli::audit`) — seul celui-ci laissait encore passer un modèle
déclaré sans résolution.

## Tests

**25 tests ajoutés** — 17 unitaires et 8 sur la **sortie du binaire lancé**
(`tests/audit_scopes.rs`) — tous rouges avant correction. Le corps annonçait
« 11 dont 4 » ; la revue en a compté 17 (12 + 5) sur la première vague, et la
vague de correctifs en ajoute 8.

Les tests sur binaire sont nécessaires, et deux mutations le prouvent : câbler
les deux racines sur un seul `space` (#399) et effacer `armadai_metadata` dans
le pipeline de proposition (#400) laissent respectivement **265** et **269**
tests unitaires verts et ne font tomber que les tests de câblage.

Une mutation a par ailleurs révélé un piège dans un test que je venais
d'écrire : `contains("### Scope")` reste vrai pour `##### Scope`. Corrigé en
comparant des lignes entières — et la revue a montré que **treize autres
assertions** de `proposal.rs` avaient le même défaut, y compris dans le test
unitaire écrit pour la même issue. Toutes converties, et
`HEADING_SHIFT = 2 -> 3` fait maintenant tomber 5 tests là où il n'en faisait
tomber aucun.

### Vague post-revue

La revue a mesuré **cinq mutations qui laissaient 100 % de la suite verte**,
dont deux réintroduisant littéralement le défaut #400, plus une **régression
de sortie** : `--propose --global` livrait un même bloc partagé en **deux
fragments octet-identiques** (`shared-conventions-1` et `-2`, 418 octets), sur
la fixture canonique de #399. Toutes rejouées vertes avant, rouges après :

| mutation | avant | après |
|---|---|---|
| `HEADING_SHIFT = 3` | 0 rouge | 5 unitaires |
| décaler seulement les `###`+ | 0 unitaire | 6 unitaires |
| supprimer 7 des 15 écritures de `## Metadata` | 0 rouge | 1 unitaire |
| source sans `tags:` -> chemin « convert » | 0 rouge | 1 unitaire |
| garde d'espace retirée de l'appariement agent↔skill de `C01` | 0 rouge | 1 d'intégration |
| appel à `dedupe_fragments` retiré | — | 1 unitaire + 1 d'intégration |
| `dedupe_fragments` rend son entrée | — | 2 unitaires + 1 d'intégration |
| `render_agent` réécrit `agent.name` en H1 | — | 1 unitaire |
| garde d'espace retirée de `overlapping_pairs` (`C02`/`C05`) | — | 1 unitaire |

Chaque mutation jugée sur les **4** modes de test, pas un seul.

Gate local : `fmt` ; clippy `-D warnings` dans les **5** modes ; tests dans
les **4** modes ; gaveldrop **13 cases · 83/83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

