### PR TITLE
fix(parser): les cinq patterns d'orchestration, et une clé dupliquée qui ne se tait plus

### DIFF
--- a/crates/armadai-core/src/parser/markdown.rs
+++ b/crates/armadai-core/src/parser/markdown.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::{Context, bail};
 use pulldown_cmark::{Event, HeadingLevel, Parser, Tag, TagEnd};
 
+use super::metadata::{config_line, warn_duplicate_keys};
 use crate::agent::{Agent, PipelineConfig};
 use crate::orchestration::{AgentRingConfig, TriggerConfig};
 
@@ -103,7 +104,7 @@ fn parse_agent_content(content: &str, path: &Path) -> anyhow::Result<Agent> {
     let metadata_raw = sections
         .get("metadata")
         .context("Missing ## Metadata section")?;
-    let mut metadata = super::metadata::parse_metadata(metadata_raw)?;
+    let mut metadata = super::metadata::parse_metadata(metadata_raw, path)?;
 
     let system_prompt = sections
         .get("system prompt")
@@ -136,12 +137,12 @@ fn parse_agent_content(content: &str, path: &Path) -> anyhow::Result<Agent> {
 
     // Parse ## Triggers section (for Blackboard agents)
     if let Some(raw) = sections.get("triggers") {
-        metadata.triggers = Some(parse_trigger_config(raw));
+        metadata.triggers = Some(parse_trigger_config(raw, path));
     }
 
     // Parse ## Ring Config section (for Ring agents)
     if let Some(raw) = sections.get("ring config") {
-        metadata.ring_config = Some(parse_ring_config(raw));
+        metadata.ring_config = Some(parse_ring_config(raw, path));
     }
 
     Ok(Agent {
@@ -156,8 +157,28 @@ fn parse_agent_content(content: &str, path: &Path) -> anyhow::Result<Agent> {
     })
 }
 
+/// The canonical field a `## Triggers` key sets, or `None` when the parser
+/// ignores it. Mirrors the `match` below — see [`metadata_field`] for why the
+/// list is kept next to the parser that owns it.
+///
+/// [`metadata_field`]: super::metadata
+fn trigger_field(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "requires" => "requires",
+        "excludes" => "excludes",
+        "min_round" => "min_round",
+        "max_round" => "max_round",
+        "priority" => "priority",
+        _ => return None,
+    })
+}
+
 /// Parse a ## Triggers section into TriggerConfig.
-fn parse_trigger_config(raw: &str) -> TriggerConfig {
+///
+/// `source` only names the file in the duplicate-key warning (#396).
+fn parse_trigger_config(raw: &str, source: &Path) -> TriggerConfig {
+    warn_duplicate_keys(raw, source, "Triggers", trigger_field);
+
     let mut requires = Vec::new();
     let mut excludes = Vec::new();
     let mut min_round = 0u32;
@@ -165,15 +186,9 @@ fn parse_trigger_config(raw: &str) -> TriggerConfig {
     let mut priority = 50u8;
 
     for line in raw.lines() {
-        let line = line.trim().trim_start_matches('-').trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some((key, value)) = line.split_once(':') else {
+        let Some((key, value)) = config_line(line) else {
             continue;
         };
-        let key = key.trim().to_lowercase();
-        let value = value.trim();
 
         match key.as_str() {
             "requires" => requires = parse_string_list_inline(value),
@@ -194,22 +209,31 @@ fn parse_trigger_config(raw: &str) -> TriggerConfig {
     }
 }
 
+/// The canonical field a `## Ring Config` key sets, or `None` when the parser
+/// ignores it.
+fn ring_field(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "role" => "role",
+        "position" => "position",
+        "vote_weight" => "vote_weight",
+        _ => return None,
+    })
+}
+
 /// Parse a ## Ring Config section into AgentRingConfig.
-fn parse_ring_config(raw: &str) -> AgentRingConfig {
+///
+/// `source` only names the file in the duplicate-key warning (#396).
+fn parse_ring_config(raw: &str, source: &Path) -> AgentRingConfig {
+    warn_duplicate_keys(raw, source, "Ring Config", ring_field);
+
     let mut role = "specialist".to_string();
     let mut position = None;
     let mut vote_weight = 1.0f32;
 
     for line in raw.lines() {
-        let line = line.trim().trim_start_matches('-').trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some((key, value)) = line.split_once(':') else {
+        let Some((key, value)) = config_line(line) else {
             continue;
         };
-        let key = key.trim().to_lowercase();
-        let value = value.trim();
 
         match key.as_str() {
             "role" => role = value.to_string(),
@@ -886,6 +910,92 @@ test
         assert_eq!(triggers.min_round, 0);
         assert!(triggers.max_round.is_none());
         assert_eq!(triggers.priority, 50);
+    }
+
+    /// #396: `## Triggers` and `## Ring Config` overwrite in silence exactly
+    /// like `## Metadata`, and a `###` sub-block inside them is read since
+    /// #392 — so a "not in use" alternative changes Blackboard activation and
+    /// Ring vote weights. The printing of these warnings is measured on the
+    /// binary in `crates/armadai/tests/duplicate_metadata_key_warns.rs`.
+    #[test]
+    fn duplicate_trigger_keys_are_reported_with_their_values() {
+        let raw = "\
+- requires: [alpha]
+- priority: 10
+
+### Alternative triggers (not in use)
+- requires: [beta]
+- priority: 99
+- unrelated: repeated
+- unrelated: again
+";
+        assert_eq!(
+            super::super::metadata::duplicate_keys(raw, trigger_field),
+            vec![
+                ("requires", "[alpha]".to_string(), "[beta]".to_string()),
+                ("priority", "10".to_string(), "99".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_ring_keys_are_reported_with_their_values() {
+        let raw = "\
+- role: specialist
+- vote_weight: 1.0
+
+### Alternative ring (not in use)
+- role: coordinator
+- vote_weight: 9.0
+";
+        assert_eq!(
+            super::super::metadata::duplicate_keys(raw, ring_field),
+            vec![
+                ("role", "specialist".to_string(), "coordinator".to_string()),
+                ("vote_weight", "1.0".to_string(), "9.0".to_string()),
+            ]
+        );
+    }
+
+    /// The precedence in both sections is untouched: the last value still wins,
+    /// through the real `parse_agent_file` path.
+    #[test]
+    fn a_duplicated_trigger_and_ring_key_still_lets_the_last_value_win() {
+        let f = write_temp_agent(
+            r#"# Dup Agent
+
+## Metadata
+- provider: anthropic
+- model: test
+
+## System Prompt
+
+test
+
+## Triggers
+- requires: [alpha]
+- priority: 10
+
+### Alternative triggers (not in use)
+- requires: [beta]
+- priority: 99
+
+## Ring Config
+- role: specialist
+- vote_weight: 1.0
+
+### Alternative ring (not in use)
+- role: coordinator
+- vote_weight: 9.0
+"#,
+        );
+        let agent = parse_agent_file(f.path()).unwrap();
+        let triggers = agent.metadata.triggers.unwrap();
+        assert_eq!(triggers.requires, vec!["beta"]);
+        assert_eq!(triggers.priority, 99);
+        let ring = agent.metadata.ring_config.unwrap();
+        assert_eq!(ring.role, "coordinator");
+        assert!((ring.vote_weight - 9.0).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/crates/armadai-core/src/parser/markdown.rs
+++ b/crates/armadai-core/src/parser/markdown.rs
@@ -912,6 +912,57 @@ test
         assert_eq!(triggers.priority, 50);
     }
 
+    /// The same table-completeness check `## Metadata` gets, for the two
+    /// sections whose tables live here.
+    ///
+    /// Measured before this existed: dropping `excludes`, `min_round` and
+    /// `max_round` from `trigger_field` left the whole suite green, and so did
+    /// dropping `position` from `ring_field`. Three of five trigger spellings
+    /// and two of three ring spellings were exercised by any fixture; the rest
+    /// were promised only by a comment.
+    #[test]
+    fn every_trigger_and_ring_key_the_tables_know_is_reported_when_set_twice() {
+        for (section, keys, field) in [
+            (
+                "Triggers",
+                ["requires", "excludes", "min_round", "max_round", "priority"].as_slice(),
+                trigger_field as fn(&str) -> Option<&'static str>,
+            ),
+            (
+                "Ring Config",
+                ["role", "position", "vote_weight"].as_slice(),
+                ring_field as fn(&str) -> Option<&'static str>,
+            ),
+        ] {
+            for key in keys {
+                let raw = format!("- {key}: first\n- {key}: second\n");
+                let found = super::super::metadata::duplicate_keys(&raw, field);
+                assert_eq!(
+                    found.len(),
+                    1,
+                    "## {section} knows '{key}' but setting it twice reported {found:?}"
+                );
+            }
+        }
+    }
+
+    /// Control for the loop above: a key neither table knows must stay silent,
+    /// so the loop cannot be satisfied by a table that says yes to everything.
+    #[test]
+    fn a_key_neither_table_knows_is_never_reported() {
+        for key in ["unrelated", "note", "owner"] {
+            let raw = format!("- {key}: first\n- {key}: second\n");
+            assert!(
+                super::super::metadata::duplicate_keys(&raw, trigger_field).is_empty(),
+                "## Triggers does not read '{key}'"
+            );
+            assert!(
+                super::super::metadata::duplicate_keys(&raw, ring_field).is_empty(),
+                "## Ring Config does not read '{key}'"
+            );
+        }
+    }
+
     /// #396: `## Triggers` and `## Ring Config` overwrite in silence exactly
     /// like `## Metadata`, and a `###` sub-block inside them is read since
     /// #392 — so a "not in use" alternative changes Blackboard activation and

--- a/crates/armadai-core/src/parser/metadata.rs
+++ b/crates/armadai-core/src/parser/metadata.rs
@@ -60,15 +60,30 @@ pub fn parse_metadata(raw: &str) -> anyhow::Result<AgentMetadata> {
                     }
                 })
             }
+            // All five `OrchestrationPattern` variants are accepted (#415).
+            // Rejecting `hierarchical`/`auto` was not "ignoring a field": the
+            // `bail!` propagates out of `parse_agent_file`, so the whole agent
+            // file became unloadable and the agent vanished from `run`, `link`,
+            // `list`, the TUI and the audit at once — while `armadai.yaml`'s
+            // own `orchestration.pattern` accepted all five through serde's
+            // lowercase derive on the same enum.
+            //
+            // Widening cannot change how any run behaves: this per-agent field
+            // is descriptive only. Its sole readers are `tui/views/agent_detail`
+            // and `web/api`, both of which just display it; the pattern an
+            // orchestrated run actually uses comes from `armadai.yaml` or
+            // `--orchestrate`.
             "orchestration" => {
                 orchestration = Some(match value.to_lowercase().as_str() {
                     "direct" => OrchestrationPattern::Direct,
                     "blackboard" => OrchestrationPattern::Blackboard,
                     "ring" => OrchestrationPattern::Ring,
+                    "hierarchical" => OrchestrationPattern::Hierarchical,
+                    "auto" => OrchestrationPattern::Auto,
                     _ => {
                         anyhow::bail!(
-                            "Invalid orchestration: '{value}'. \
-                             Expected 'direct', 'blackboard', or 'ring'"
+                            "Invalid orchestration: '{value}'. Expected 'direct', \
+                             'blackboard', 'ring', 'hierarchical' or 'auto'"
                         )
                     }
                 })
@@ -213,6 +228,74 @@ mod tests {
 - mode: interactive
 ";
         assert!(parse_metadata(raw).is_err());
+    }
+
+    /// #415: every `OrchestrationPattern` variant must be declarable from a
+    /// `## Metadata` section. Before the fix, `hierarchical` and `auto` made
+    /// `parse_metadata` `bail!`, and since `parse_agent_file` propagates that
+    /// error the WHOLE agent file became unloadable — the agent vanished from
+    /// `run`, `link`, `list`, the TUI and the audit at once.
+    ///
+    /// Table-driven on purpose: it doubles as the negative control the
+    /// per-variant assertions need. A fix that maps every value to one variant
+    /// (say `Direct`) satisfies "hierarchical parses" but fails here.
+    #[test]
+    fn test_parse_orchestration_accepts_every_pattern() {
+        let cases = [
+            ("direct", OrchestrationPattern::Direct),
+            ("blackboard", OrchestrationPattern::Blackboard),
+            ("ring", OrchestrationPattern::Ring),
+            ("hierarchical", OrchestrationPattern::Hierarchical),
+            ("auto", OrchestrationPattern::Auto),
+        ];
+        for (value, expected) in cases {
+            let raw = format!(
+                "\
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- orchestration: {value}
+"
+            );
+            let meta = parse_metadata(&raw)
+                .unwrap_or_else(|e| panic!("`- orchestration: {value}` must parse, got: {e}"));
+            assert_eq!(
+                meta.orchestration,
+                Some(expected),
+                "`- orchestration: {value}` parsed to the wrong variant"
+            );
+        }
+    }
+
+    /// The value is matched case-insensitively, like `mode` above.
+    #[test]
+    fn test_parse_orchestration_is_case_insensitive() {
+        let raw = "\
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- orchestration: Hierarchical
+";
+        let meta = parse_metadata(raw).unwrap();
+        assert_eq!(meta.orchestration, Some(OrchestrationPattern::Hierarchical));
+    }
+
+    /// An unknown pattern is still rejected — and the message must enumerate
+    /// the five real variants. The old message listed three "as if the list
+    /// were complete" (#415), which is what sent an author down the wrong path.
+    #[test]
+    fn test_parse_orchestration_rejects_unknown_and_lists_all_five() {
+        let raw = "\
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- orchestration: mesh
+";
+        let err = parse_metadata(raw)
+            .expect_err("`- orchestration: mesh` is not a pattern and must be refused")
+            .to_string();
+        assert_eq!(
+            err,
+            "Invalid orchestration: 'mesh'. Expected 'direct', 'blackboard', \
+             'ring', 'hierarchical' or 'auto'"
+        );
     }
 
     #[test]

--- a/crates/armadai-core/src/parser/metadata.rs
+++ b/crates/armadai-core/src/parser/metadata.rs
@@ -87,9 +87,9 @@ pub(super) fn duplicate_keys(
 /// parsed, so it reaches the user in that second case too.
 ///
 /// One line per override, and the wording does not count: a key set three
-/// times yields two lines, and each said "twice" until it was measured — two
-/// lines both claiming "twice" for the same key. "again" is true of every
-/// link in the chain, which is what `duplicate_keys` actually reports.
+/// times yields two lines, and each said "twice" until the review measured it
+/// — two lines both claiming "twice" for the same key. "again" is true of
+/// every link in the chain, which is what `duplicate_keys` actually reports.
 ///
 /// The channel is `tracing::warn!` rather than the `LoadWarning` the core
 /// normally returns for the CLI to render (`agent_source.rs` documents that
@@ -460,6 +460,72 @@ mod tests {
                 "[gemini-2.5-pro]".to_string()
             )]
         );
+    }
+
+    /// Every spelling the table recognises must actually be reported.
+    ///
+    /// The doc-comment on [`metadata_field`] promises the table "lists exactly
+    /// the keys the `match` recognises", and until this test that promise was
+    /// prose: measured, dropping `orchestration` from the table left the whole
+    /// suite green, and so did dropping `cost_limit`, `rate_limit`, `scope`,
+    /// `tags` and `mode` in one go. Only 5 of the 17 spellings were exercised
+    /// by any fixture.
+    ///
+    /// This closes the table-to-warning direction for all of them. The other
+    /// direction — the parser reading a key the table omits — still has no
+    /// test: catching it needs a valid value per key and an assertion on the
+    /// parsed field, which is a fixture per key rather than a loop.
+    #[test]
+    fn every_metadata_key_the_table_knows_is_reported_when_set_twice() {
+        // Not `metadata_field`'s own output: a list written here on purpose,
+        // so deleting an arm from the table breaks this test instead of
+        // quietly shrinking both sides together.
+        for key in [
+            "provider",
+            "model",
+            "command",
+            "args",
+            "temperature",
+            "max_tokens",
+            "timeout",
+            "tags",
+            "stacks",
+            "scope",
+            "model_fallback",
+            "model_fallbacks",
+            "cost_limit",
+            "rate_limit",
+            "context_window",
+            "mode",
+            "orchestration",
+        ] {
+            let raw = format!("- {key}: first\n- {key}: second\n");
+            let found = duplicate_keys(&raw, metadata_field);
+            assert_eq!(
+                found.len(),
+                1,
+                "'{key}' is in the table but setting it twice reported {found:?}"
+            );
+            assert_eq!(
+                (found[0].1.as_str(), found[0].2.as_str()),
+                ("first", "second"),
+                "'{key}' reported the wrong pair: {found:?}"
+            );
+        }
+    }
+
+    /// A key the table does not know must stay silent — the pre-#396
+    /// behaviour, and the control that stops the loop above from being
+    /// satisfied by a table that says yes to everything.
+    #[test]
+    fn a_key_the_table_does_not_know_is_never_reported() {
+        for key in ["reviewer", "owner", "notes", "provider_hint"] {
+            let raw = format!("- {key}: first\n- {key}: second\n");
+            assert!(
+                duplicate_keys(&raw, metadata_field).is_empty(),
+                "'{key}' is not a parsed field, so a repeat changes nothing"
+            );
+        }
     }
 
     /// The case that hurts most: an unparsable value in the losing block makes

--- a/crates/armadai-core/src/parser/metadata.rs
+++ b/crates/armadai-core/src/parser/metadata.rs
@@ -1,10 +1,111 @@
+use std::path::Path;
+
 use anyhow::Context;
 
 use crate::agent::{AgentMetadata, AgentMode, default_temperature};
 use crate::orchestration::OrchestrationPattern;
 
+/// Split one line of a `- key: value` configuration section into its lowercased
+/// key and its trimmed value, or `None` for a line the parser skips.
+///
+/// `## Metadata`, `## Triggers` and `## Ring Config` all have this shape, and
+/// so does [`duplicate_keys`] — which has to see *exactly* the lines the
+/// parsers see, or it would report keys that never take effect and miss ones
+/// that do. One function, so the two passes cannot drift apart.
+pub(super) fn config_line(line: &str) -> Option<(String, &str)> {
+    let line = line.trim().trim_start_matches('-').trim();
+    if line.is_empty() {
+        return None;
+    }
+    let (key, value) = line.split_once(':')?;
+    Some((key.trim().to_lowercase(), value.trim()))
+}
+
+/// The canonical field a `## Metadata` key sets, or `None` when the parser
+/// ignores the key.
+///
+/// This must list exactly the keys the `match` in [`parse_metadata`]
+/// recognises. A key missing here simply gets no duplicate warning (the
+/// pre-#396 silence); a key listed here that the parser ignores would warn
+/// about a line that changes nothing. `model_fallback`/`model_fallbacks` are
+/// two spellings of one field, so a section using both collides with itself.
+fn metadata_field(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "provider" => "provider",
+        "model" => "model",
+        "command" => "command",
+        "args" => "args",
+        "temperature" => "temperature",
+        "max_tokens" => "max_tokens",
+        "timeout" => "timeout",
+        "tags" => "tags",
+        "stacks" => "stacks",
+        "scope" => "scope",
+        "model_fallback" | "model_fallbacks" => "model_fallback",
+        "cost_limit" => "cost_limit",
+        "rate_limit" => "rate_limit",
+        "context_window" => "context_window",
+        "mode" => "mode",
+        "orchestration" => "orchestration",
+        _ => return None,
+    })
+}
+
+/// Every override a `- key: value` section performs on itself, in the order it
+/// happens: `(canonical key, value being replaced, value replacing it)`.
+///
+/// A section that sets one key three times yields two entries, each naming the
+/// pair it supersedes, so the whole chain is visible rather than only its ends.
+pub(super) fn duplicate_keys(
+    raw: &str,
+    field: fn(&str) -> Option<&'static str>,
+) -> Vec<(&'static str, String, String)> {
+    let mut seen: std::collections::HashMap<&'static str, String> =
+        std::collections::HashMap::new();
+    let mut overrides = Vec::new();
+    for line in raw.lines() {
+        let Some((key, value)) = config_line(line) else {
+            continue;
+        };
+        let Some(field) = field(&key) else {
+            continue;
+        };
+        if let Some(previous) = seen.insert(field, value.to_string()) {
+            overrides.push((field, previous, value.to_string()));
+        }
+    }
+    overrides
+}
+
+/// Report every key a configuration section sets more than once (#396).
+///
+/// These sections are read line by line and the last value wins. Nothing here
+/// changes that — only the silence. Since #392 a `###` sub-block inside one of
+/// them is no longer truncated away, so a commented-out "alternative setup"
+/// block silently reconfigures the agent, and an unparsable value in one makes
+/// the whole file fail to load. The warning is emitted before the values are
+/// parsed, so it reaches the user in that second case too.
+pub(super) fn warn_duplicate_keys(
+    raw: &str,
+    source: &Path,
+    section: &str,
+    field: fn(&str) -> Option<&'static str>,
+) {
+    for (key, replaced, winner) in duplicate_keys(raw, field) {
+        tracing::warn!(
+            "{}: ## {section} sets '{key}' twice: '{replaced}' is overridden by \
+             '{winner}' (the last value wins)",
+            source.display()
+        );
+    }
+}
+
 /// Parse the Metadata section content (YAML-like list format) into AgentMetadata.
-pub fn parse_metadata(raw: &str) -> anyhow::Result<AgentMetadata> {
+///
+/// `source` is only used to name the file in diagnostics; it is never read.
+pub fn parse_metadata(raw: &str, source: &Path) -> anyhow::Result<AgentMetadata> {
+    warn_duplicate_keys(raw, source, "Metadata", metadata_field);
+
     let mut provider = None;
     let mut model = None;
     let mut command = None;
@@ -23,16 +124,9 @@ pub fn parse_metadata(raw: &str) -> anyhow::Result<AgentMetadata> {
     let mut orchestration = None;
 
     for line in raw.lines() {
-        let line = line.trim().trim_start_matches('-').trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let Some((key, value)) = line.split_once(':') else {
+        let Some((key, value)) = config_line(line) else {
             continue;
         };
-        let key = key.trim().to_lowercase();
-        let value = value.trim();
 
         match key.as_str() {
             "provider" => provider = Some(value.to_string()),
@@ -130,6 +224,12 @@ fn parse_string_list(value: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
+    /// Stand-in for the agent file these fixtures pretend to come from:
+    /// `parse_metadata` only uses `source` to name the file in diagnostics.
+    fn source() -> &'static Path {
+        Path::new("test-agent.md")
+    }
+
     #[test]
     fn test_parse_scope() {
         let raw = "\
@@ -139,7 +239,7 @@ mod tests {
 - tags: [review, quality]
 - scope: [src/**/*.rs, tests/]
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(meta.scope, vec!["src/**/*.rs", "tests/"]);
     }
 
@@ -149,7 +249,7 @@ mod tests {
 - provider: google
 - model: gemini-2.5-pro
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert!(meta.scope.is_empty());
     }
 
@@ -160,7 +260,7 @@ mod tests {
 - model: gemini-3.0-pro
 - model_fallback: [gemini-2.5-pro, gemini-2.5-flash]
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(
             meta.model_fallback,
             vec!["gemini-2.5-pro", "gemini-2.5-flash"]
@@ -174,7 +274,7 @@ mod tests {
 - model: claude-opus-4-6
 - model_fallbacks: [claude-sonnet-4-5-20250929]
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(meta.model_fallback, vec!["claude-sonnet-4-5-20250929"]);
     }
 
@@ -184,7 +284,7 @@ mod tests {
 - provider: google
 - model: gemini-2.5-pro
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert!(meta.model_fallback.is_empty());
     }
 
@@ -195,7 +295,7 @@ mod tests {
 - model: claude-sonnet-4-5-20250929
 - mode: guided
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(meta.mode, Some(AgentMode::Guided));
     }
 
@@ -206,7 +306,7 @@ mod tests {
 - model: claude-sonnet-4-5-20250929
 - mode: autonomous
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(meta.mode, Some(AgentMode::Autonomous));
     }
 
@@ -216,7 +316,7 @@ mod tests {
 - provider: anthropic
 - model: claude-sonnet-4-5-20250929
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert!(meta.mode.is_none());
     }
 
@@ -227,7 +327,152 @@ mod tests {
 - model: claude-sonnet-4-5-20250929
 - mode: interactive
 ";
-        assert!(parse_metadata(raw).is_err());
+        assert!(parse_metadata(raw, source()).is_err());
+    }
+
+    // -----------------------------------------------------------------
+    // #396 — a duplicated key overwrites in silence.
+    //
+    // These pin *which* duplicates are detected. That the warning actually
+    // reaches the user is a different property, and no unit test can hold it:
+    // it is measured on the real binary in
+    // `crates/armadai/tests/duplicate_metadata_key_warns.rs`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_duplicate_keys_reports_loser_and_winner_in_order() {
+        let raw = "\
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.2
+
+### Alternative setup (not in use)
+- provider: openai
+- temperature: 1.0
+";
+        assert_eq!(
+            duplicate_keys(raw, metadata_field),
+            vec![
+                ("provider", "anthropic".to_string(), "openai".to_string()),
+                ("temperature", "0.2".to_string(), "1.0".to_string()),
+            ],
+            "the overrides must be reported in the order they happen, each \
+             naming the value it replaces and the value that wins"
+        );
+    }
+
+    /// The parser's precedence is deliberately untouched: the LAST value still
+    /// wins. Without this, a fix that "made duplicates safe" by keeping the
+    /// first value would pass every warning assertion above.
+    #[test]
+    fn test_duplicate_key_still_lets_the_last_value_win() {
+        let raw = "\
+- provider: anthropic
+- temperature: 0.2
+- provider: openai
+- temperature: 1.0
+";
+        let meta = parse_metadata(raw, source()).unwrap();
+        assert_eq!(meta.provider, "openai");
+        assert_eq!(meta.temperature, 1.0);
+    }
+
+    /// Three settings of one key are two overrides, each naming its own pair —
+    /// not one entry collapsing the first value onto the last.
+    #[test]
+    fn test_duplicate_keys_reports_every_link_of_a_chain() {
+        let raw = "\
+- provider: anthropic
+- provider: openai
+- provider: google
+";
+        assert_eq!(
+            duplicate_keys(raw, metadata_field),
+            vec![
+                ("provider", "anthropic".to_string(), "openai".to_string()),
+                ("provider", "openai".to_string(), "google".to_string()),
+            ]
+        );
+    }
+
+    /// Keys the parser ignores must not warn: they configure nothing, and any
+    /// prose line carrying a colon would otherwise qualify.
+    #[test]
+    fn test_duplicate_keys_ignores_keys_the_parser_does_not_read() {
+        let raw = "\
+- provider: anthropic
+- reviewer: someone
+- reviewer: someone else
+- Rationale: kept at 0.2 for reproducibility
+- Rationale: or maybe not
+";
+        assert!(
+            duplicate_keys(raw, metadata_field).is_empty(),
+            "only recognised keys may be reported"
+        );
+    }
+
+    /// A section that says nothing twice reports nothing — including one whose
+    /// keys merely look alike.
+    #[test]
+    fn test_duplicate_keys_is_empty_without_a_duplicate() {
+        let raw = "\
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- model_fallback: [claude-opus-4-6]
+- temperature: 0.2
+- max_tokens: 4096
+";
+        assert!(duplicate_keys(raw, metadata_field).is_empty());
+    }
+
+    /// `model_fallback` and `model_fallbacks` are two spellings of one field,
+    /// so using both is a duplicate even though the literal keys differ — the
+    /// second silently replaces the first, exactly like a repeated spelling.
+    #[test]
+    fn test_duplicate_keys_sees_through_the_model_fallback_alias() {
+        let raw = "\
+- provider: anthropic
+- model_fallback: [claude-opus-4-6]
+- model_fallbacks: [gemini-2.5-pro]
+";
+        assert_eq!(
+            duplicate_keys(raw, metadata_field),
+            vec![(
+                "model_fallback",
+                "[claude-opus-4-6]".to_string(),
+                "[gemini-2.5-pro]".to_string()
+            )]
+        );
+    }
+
+    /// The case that hurts most: an unparsable value in the losing block makes
+    /// the whole file fail to load, and the duplicate is the reason why. Both
+    /// halves are pinned here — the parse still fails, and the override is
+    /// still detected.
+    ///
+    /// What this test does NOT prove is the *ordering* that makes the second
+    /// half useful (the warning must be emitted before the `?` bails, or the
+    /// user never sees it). Measured: moving the pass below the parse loop
+    /// leaves this test green and reddens
+    /// `link_names_the_duplicate_that_makes_an_agent_unloadable` in
+    /// `crates/armadai/tests/duplicate_metadata_key_warns.rs`, which is where
+    /// that property lives.
+    #[test]
+    fn test_duplicate_key_is_reported_even_when_the_second_value_is_fatal() {
+        let raw = "\
+- provider: anthropic
+- timeout: 300
+- timeout: to be decided
+";
+        assert!(
+            parse_metadata(raw, source()).is_err(),
+            "an unparsable timeout must still fail the parse"
+        );
+        assert_eq!(
+            duplicate_keys(raw, metadata_field),
+            vec![("timeout", "300".to_string(), "to be decided".to_string())]
+        );
     }
 
     /// #415: every `OrchestrationPattern` variant must be declarable from a
@@ -256,7 +501,7 @@ mod tests {
 - orchestration: {value}
 "
             );
-            let meta = parse_metadata(&raw)
+            let meta = parse_metadata(&raw, source())
                 .unwrap_or_else(|e| panic!("`- orchestration: {value}` must parse, got: {e}"));
             assert_eq!(
                 meta.orchestration,
@@ -274,7 +519,7 @@ mod tests {
 - model: claude-sonnet-4-5-20250929
 - orchestration: Hierarchical
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(meta.orchestration, Some(OrchestrationPattern::Hierarchical));
     }
 
@@ -288,7 +533,7 @@ mod tests {
 - model: claude-sonnet-4-5-20250929
 - orchestration: mesh
 ";
-        let err = parse_metadata(raw)
+        let err = parse_metadata(raw, source())
             .expect_err("`- orchestration: mesh` is not a pattern and must be refused")
             .to_string();
         assert_eq!(
@@ -311,7 +556,7 @@ mod tests {
 - cost_limit: 1.50
 - rate_limit: 10/min
 ";
-        let meta = parse_metadata(raw).unwrap();
+        let meta = parse_metadata(raw, source()).unwrap();
         assert_eq!(meta.provider, "anthropic");
         assert_eq!(meta.model.as_deref(), Some("claude-sonnet-4-5-20250929"));
         assert_eq!(meta.tags, vec!["dev", "test"]);

--- a/crates/armadai-core/src/parser/metadata.rs
+++ b/crates/armadai-core/src/parser/metadata.rs
@@ -85,6 +85,22 @@ pub(super) fn duplicate_keys(
 /// block silently reconfigures the agent, and an unparsable value in one makes
 /// the whole file fail to load. The warning is emitted before the values are
 /// parsed, so it reaches the user in that second case too.
+///
+/// One line per override, and the wording does not count: a key set three
+/// times yields two lines, and each said "twice" until it was measured — two
+/// lines both claiming "twice" for the same key. "again" is true of every
+/// link in the chain, which is what `duplicate_keys` actually reports.
+///
+/// The channel is `tracing::warn!` rather than the `LoadWarning` the core
+/// normally returns for the CLI to render (`agent_source.rs` documents that
+/// convention). The reason is the fatal case, which is this warning's whole
+/// point: when the duplicate makes the file unloadable, `parse_agent_file`
+/// returns `Err`, and a returned-warning channel has nowhere to put the
+/// explanation without widening the error type through every caller. The
+/// costs are real and measured — `link` parses each file twice (#419) and
+/// `tracing` does not deduplicate the way `load_all_agents` does, and
+/// `tracing::fmt` colours by `NO_COLOR` alone where `anstream` also detects a
+/// non-TTY, so a redirected stderr keeps its escape sequences.
 pub(super) fn warn_duplicate_keys(
     raw: &str,
     source: &Path,
@@ -93,7 +109,7 @@ pub(super) fn warn_duplicate_keys(
 ) {
     for (key, replaced, winner) in duplicate_keys(raw, field) {
         tracing::warn!(
-            "{}: ## {section} sets '{key}' twice: '{replaced}' is overridden by \
+            "{}: ## {section} sets '{key}' again: '{replaced}' is overridden by \
              '{winner}' (the last value wins)",
             source.display()
         );

--- a/crates/armadai/tests/duplicate_metadata_key_warns.rs
+++ b/crates/armadai/tests/duplicate_metadata_key_warns.rs
@@ -1,0 +1,265 @@
+//! Black-box regression for #396: `## Metadata`, `## Triggers` and
+//! `## Ring Config` are read line by line and the **last** value of a repeated
+//! key wins — silently.
+//!
+//! This is a wiring test on purpose, and it is the load-bearing one. The
+//! parser's unit tests prove which duplicates are *detected*; a warning that is
+//! computed but never printed leaves every one of them green. What matters here
+//! is that the real binary puts the sentence on stderr, so these assertions run
+//! `armadai` itself.
+//!
+//! Measured on `master` before the fix, on an agent whose `## Metadata` carries
+//! an `### Alternative setup (not in use)` block:
+//!
+//! ```text
+//! $ armadai inspect dup
+//!   Provider:       openai       # declared anthropic above
+//!   Model:          gpt-4o-mini  # declared claude-sonnet-4-5-20250929 above
+//!   Temperature:    1            # declared 0.2 above
+//! EXIT=0            # and not one word on stderr
+//! ```
+//!
+//! The values themselves are deliberately left alone: last-wins stays. Only the
+//! silence is fixed — see the commit message for why this warns instead of
+//! failing.
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use std::path::{Path, PathBuf};
+
+    /// Duplicates in all three sections at once, each pair with **different**
+    /// values so an assertion can name which one won: a fixture repeating the
+    /// same value would make the warning unfalsifiable.
+    const DUP_AGENT: &str = "\
+# dup
+
+## Metadata
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.2
+
+### Alternative setup (not in use)
+- provider: openai
+- model: gpt-4o-mini
+- temperature: 1.0
+
+## System Prompt
+You are dup.
+
+## Triggers
+- requires: [alpha]
+- priority: 10
+
+### Alternative triggers (not in use)
+- requires: [beta]
+- priority: 99
+
+## Ring Config
+- role: specialist
+- vote_weight: 1.0
+
+### Alternative ring (not in use)
+- role: coordinator
+- vote_weight: 9.0
+";
+
+    /// The hardest case of #396: the losing block holds a value that does not
+    /// parse, so the agent does not merely get misconfigured — it disappears.
+    /// `link` warns, skips it and still exits 0.
+    const FATAL_AGENT: &str = "\
+# fatal
+
+## Metadata
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- timeout: 300
+
+### Alternative setup (not in use)
+- timeout: to be decided
+
+## System Prompt
+You are fatal.
+";
+
+    /// Negative control. Every recognised key appears once; two `###` blocks
+    /// carry lines that are *not* recognised keys, plus prose with a colon in
+    /// it. None of that may produce a duplicate warning.
+    const CLEAN_AGENT: &str = "\
+# clean
+
+## Metadata
+- provider: anthropic
+- model: claude-sonnet-4-5-20250929
+- temperature: 0.2
+
+### Notes
+- reviewer: someone
+- reviewer: someone else
+- Rationale: kept at 0.2 for reproducibility
+
+## System Prompt
+You are clean.
+
+## Triggers
+- requires: [alpha]
+- priority: 10
+
+## Ring Config
+- role: specialist
+- vote_weight: 1.0
+";
+
+    fn isolated_library(dir: &Path, agents: &[(&str, &str)]) -> PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(config.join("agents")).unwrap();
+        for (name, body) in agents {
+            std::fs::write(config.join("agents").join(format!("{name}.md")), body).unwrap();
+        }
+        config
+    }
+
+    fn armadai(config: &Path, root: &Path) -> Command {
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(root).env("ARMADAI_CONFIG_DIR", config);
+        cmd
+    }
+
+    fn project(dir: &Path, config_yaml: &str) -> PathBuf {
+        let root = dir.join("project");
+        std::fs::create_dir_all(root.join(".armadai")).unwrap();
+        std::fs::write(root.join(".armadai/config.yaml"), config_yaml).unwrap();
+        root
+    }
+
+    /// The exact sentence, for one override. Asserting on the whole line — not
+    /// on `contains("duplicate")` — is what pins *which* value lost and which
+    /// won; a warning naming them the wrong way round must fail here.
+    fn expected(source: &Path, section: &str, key: &str, loser: &str, winner: &str) -> String {
+        format!(
+            "{}: ## {section} sets '{key}' twice: '{loser}' is overridden by \
+             '{winner}' (the last value wins)",
+            source.display()
+        )
+    }
+
+    #[test]
+    fn every_duplicated_metadata_key_is_named_on_stderr() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = isolated_library(dir.path(), &[("dup", DUP_AGENT)]);
+        let root = project(dir.path(), "agents:\n  - name: dup\n");
+        let source = config.join("agents/dup.md");
+
+        let output = armadai(&config, &root)
+            .args(["inspect", "dup"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "inspect must still succeed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        for (section, key, loser, winner) in [
+            ("Metadata", "provider", "anthropic", "openai"),
+            (
+                "Metadata",
+                "model",
+                "claude-sonnet-4-5-20250929",
+                "gpt-4o-mini",
+            ),
+            ("Metadata", "temperature", "0.2", "1.0"),
+            ("Triggers", "requires", "[alpha]", "[beta]"),
+            ("Triggers", "priority", "10", "99"),
+            ("Ring Config", "role", "specialist", "coordinator"),
+            ("Ring Config", "vote_weight", "1.0", "9.0"),
+        ] {
+            let line = expected(&source, section, key, loser, winner);
+            assert!(
+                stderr.contains(&line),
+                "missing warning:\n  {line}\ngot stderr:\n{stderr}"
+            );
+        }
+
+        // Which value wins is deliberately unchanged: this issue is about the
+        // silence, not the precedence. If that ever becomes a real decision,
+        // these three lines are what says it was one.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("openai"), "last-wins changed:\n{stdout}");
+        assert!(
+            stdout.contains("gpt-4o-mini"),
+            "last-wins changed:\n{stdout}"
+        );
+    }
+
+    /// A clean agent must produce no duplicate warning at all — including for
+    /// the repeated `reviewer:` key, which the parser ignores anyway, and for a
+    /// prose line that merely contains a colon.
+    #[test]
+    fn an_agent_without_duplicates_warns_about_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = isolated_library(dir.path(), &[("clean", CLEAN_AGENT)]);
+        let root = project(dir.path(), "agents:\n  - name: clean\n");
+
+        let output = armadai(&config, &root)
+            .args(["inspect", "clean"])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("twice"),
+            "no key is set twice in this agent, yet: {stderr}"
+        );
+    }
+
+    /// The disappearing-agent case. `link` keeps its old behaviour to the
+    /// letter — warn, link what did load, exit 0 — but the user now also learns
+    /// that a second `timeout:` is what broke the file.
+    #[test]
+    fn link_names_the_duplicate_that_makes_an_agent_unloadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = isolated_library(
+            dir.path(),
+            &[
+                ("fatal", FATAL_AGENT),
+                (
+                    "healthy",
+                    "# healthy\n\n## Metadata\n- provider: anthropic\n\
+                     - model: claude-sonnet-4-5-20250929\n\n## System Prompt\nYou are healthy.\n",
+                ),
+            ],
+        );
+        let root = project(dir.path(), "agents:\n  - name: fatal\n  - name: healthy\n");
+        let source = config.join("agents/fatal.md");
+
+        let output = armadai(&config, &root)
+            .args(["link", "--target", "claude", "--force"])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Unchanged, on purpose: warning is not failing.
+        assert!(output.status.success(), "link must still exit 0:\n{stderr}");
+        assert!(
+            stdout.contains("Linked 1 agent(s)"),
+            "the pre-existing skip behaviour must be untouched:\n{stdout}"
+        );
+
+        // `contains`, not a count: `link` currently emits this line TWICE,
+        // because it parses every agent file twice — once in
+        // `model_updater::auto_check_and_prompt` (cli/link.rs) and once in
+        // `agent_source::load_all_agents`. Measured: `list` and `inspect` print
+        // it once, `link` and `link --dry-run` twice. That double parse
+        // predates this fix and is a defect of its own; pinning a count here
+        // would make this test fail the day it is fixed, for a reason that has
+        // nothing to do with #396.
+        let line = expected(&source, "Metadata", "timeout", "300", "to be decided");
+        assert!(
+            stderr.contains(&line),
+            "the duplicate that broke the file must be named:\n  {line}\ngot:\n{stderr}"
+        );
+    }
+}

--- a/crates/armadai/tests/duplicate_metadata_key_warns.rs
+++ b/crates/armadai/tests/duplicate_metadata_key_warns.rs
@@ -137,7 +137,7 @@ You are clean.
     /// won; a warning naming them the wrong way round must fail here.
     fn expected(source: &Path, section: &str, key: &str, loser: &str, winner: &str) -> String {
         format!(
-            "{}: ## {section} sets '{key}' twice: '{loser}' is overridden by \
+            "{}: ## {section} sets '{key}' again: '{loser}' is overridden by \
              '{winner}' (the last value wins)",
             source.display()
         )
@@ -180,6 +180,18 @@ You are clean.
                 stderr.contains(&line),
                 "missing warning:\n  {line}\ngot stderr:\n{stderr}"
             );
+            // One line per override, not two. Nothing else pins the count:
+            // measured, emitting every warning twice left the whole suite
+            // green. `inspect` is the surface to assert it on — it parses
+            // each file once, where `link` parses twice (#419) and so prints
+            // each of these lines twice today. Pinning the count here says
+            // "one warning per override" without rusting the moment #419 is
+            // fixed.
+            assert_eq!(
+                stderr.matches(&line).count(),
+                1,
+                "warning repeated:\n  {line}\ngot stderr:\n{stderr}"
+            );
         }
 
         // Which value wins is deliberately unchanged: this issue is about the
@@ -209,7 +221,7 @@ You are clean.
         assert!(output.status.success());
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
-            !stderr.contains("twice"),
+            !stderr.contains("is overridden by"),
             "no key is set twice in this agent, yet: {stderr}"
         );
     }

--- a/crates/armadai/tests/orchestration_pattern_declarable.rs
+++ b/crates/armadai/tests/orchestration_pattern_declarable.rs
@@ -1,0 +1,159 @@
+//! Black-box regression for #415: `AgentMetadata.orchestration` is an
+//! `OrchestrationPattern` with **five** variants, but `parse_metadata`
+//! accepted only three and `bail!`ed on `hierarchical` and `auto`.
+//!
+//! This is a wiring test on purpose. The parser's own unit tests (in
+//! `armadai-core::parser::metadata`) prove the five values map to the five
+//! variants; they cannot prove the consequence, which is what actually hurt:
+//! `parse_agent_file` propagates the error, so the **whole file** became
+//! unloadable and the agent disappeared from every surface at once — silently
+//! for `list`, which drops it and still exits 0.
+//!
+//! Measured on `master` before the fix, on a library holding one agent per
+//! pattern:
+//!
+//! ```text
+//! $ armadai inspect coord      # - orchestration: hierarchical
+//! Error: Invalid orchestration: 'hierarchical'. Expected 'direct', 'blackboard', or 'ring'
+//! EXIT=1
+//! $ armadai inspect ringer     # - orchestration: ring
+//! Agent: Ringer …
+//! EXIT=0
+//! $ armadai list
+//!   3 agent(s) found.          # of the five declared
+//! EXIT=0
+//! ```
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use std::path::{Path, PathBuf};
+
+    /// The five variants of `OrchestrationPattern`, each paired with the agent
+    /// name used for it. Keeping all five here is the negative control the
+    /// count assertion needs: a fix that accepted *anything* would also pass
+    /// `five_patterns_are_all_listed`, so `an_unknown_pattern_is_still_refused`
+    /// below pins the other side.
+    const PATTERNS: &[(&str, &str)] = &[
+        ("directer", "direct"),
+        ("blacker", "blackboard"),
+        ("ringer", "ring"),
+        ("coord", "hierarchical"),
+        ("autoer", "auto"),
+    ];
+
+    fn agent_md(name: &str, pattern: &str) -> String {
+        format!(
+            "# {name}\n\n\
+             ## Metadata\n\
+             - provider: anthropic\n\
+             - model: claude-sonnet-4-5-20250929\n\
+             - orchestration: {pattern}\n\n\
+             ## System Prompt\n\
+             You are {name}.\n"
+        )
+    }
+
+    /// Isolate `~/.config/armadai`: `list`/`inspect` scan the global agent
+    /// library, which on a developer machine holds real agents.
+    fn isolated_library(dir: &Path, agents: &[(&str, &str)]) -> PathBuf {
+        let config = dir.join("config");
+        std::fs::create_dir_all(config.join("agents")).unwrap();
+        for (name, pattern) in agents {
+            std::fs::write(
+                config.join("agents").join(format!("{name}.md")),
+                agent_md(name, pattern),
+            )
+            .unwrap();
+        }
+        config
+    }
+
+    fn armadai(config: &Path, root: &Path) -> Command {
+        let mut cmd = Command::cargo_bin("armadai").unwrap();
+        cmd.current_dir(root).env("ARMADAI_CONFIG_DIR", config);
+        cmd
+    }
+
+    /// One agent per pattern in the library; every one of them must load.
+    /// The count is asserted exactly, not with `contains`: before the fix
+    /// `list` printed "3 agent(s) found." and exited 0, so an assertion that
+    /// merely looked for the surviving names would have stayed green.
+    #[test]
+    fn five_patterns_are_all_listed() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = isolated_library(dir.path(), PATTERNS);
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let output = armadai(&config, &root).arg("list").output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            stdout.contains(&format!("{} agent(s) found.", PATTERNS.len())),
+            "expected all {} declared agents to load, got:\n{stdout}",
+            PATTERNS.len()
+        );
+        for (name, pattern) in PATTERNS {
+            assert!(
+                stdout.to_lowercase().contains(name),
+                "the '{pattern}' agent is missing from `list`:\n{stdout}"
+            );
+        }
+    }
+
+    /// `inspect` is the surface #415 measured. Every pattern must exit 0 —
+    /// `hierarchical` and `auto` exited 1 before the fix.
+    #[test]
+    fn every_pattern_can_be_inspected() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = isolated_library(dir.path(), PATTERNS);
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+
+        for (name, pattern) in PATTERNS {
+            let output = armadai(&config, &root)
+                .args(["inspect", name])
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "`inspect {name}` (- orchestration: {pattern}) exited {:?}:\n{}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    /// The other side of the control: an invented pattern must still be
+    /// refused, and the message must enumerate the five real ones. The old
+    /// message listed three as if the list were complete.
+    #[test]
+    fn an_unknown_pattern_is_still_refused_with_all_five_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = isolated_library(dir.path(), &[("mesher", "mesh")]);
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let output = armadai(&config, &root)
+            .args(["inspect", "mesher"])
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "`- orchestration: mesh` is not a pattern and must be refused"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(
+                "Invalid orchestration: 'mesh'. Expected 'direct', 'blackboard', \
+                 'ring', 'hierarchical' or 'auto'"
+            ),
+            "the refusal must name all five patterns, got:\n{stderr}"
+        );
+    }
+}

--- a/crates/armadai/tests/orchestration_pattern_declarable.rs
+++ b/crates/armadai/tests/orchestration_pattern_declarable.rs
@@ -6,8 +6,9 @@
 //! `armadai-core::parser::metadata`) prove the five values map to the five
 //! variants; they cannot prove the consequence, which is what actually hurt:
 //! `parse_agent_file` propagates the error, so the **whole file** became
-//! unloadable and the agent disappeared from every surface at once — silently
-//! for `list`, which drops it and still exits 0.
+//! unloadable and the agent disappeared from every surface at once. `list`
+//! does warn on stderr, but drops the agent from stdout and still exits 0 —
+//! so a script reading stdout sees a shorter fleet and a success code.
 //!
 //! Measured on `master` before the fix, on a library holding one agent per
 //! pattern:

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -97,8 +97,12 @@ Two consequences worth knowing:
   twice, naming the file, the losing value and the winning one:
 
   ```text
-  agents/dup.md: ## Metadata sets 'provider' twice: 'anthropic' is overridden by 'openai' (the last value wins)
+  2026-08-28T05:56:43.104399Z  WARN armadai_core::parser::metadata: /abs/path/to/agents/dup.md: ## Metadata sets 'provider' again: 'anthropic' is overridden by 'openai' (the last value wins)
   ```
+
+  It goes through `tracing`, so it carries a timestamp, a level and a target,
+  and names the file by its absolute path — unlike the CLI's own indented
+  `warn:` lines. `RUST_LOG=off` silences it along with every other log line.
 
   Which value wins is unchanged — it is still the last. The warning is emitted before the
   values are parsed, so it also appears for the fatal case above, where it says *why* the file
@@ -135,8 +139,10 @@ Key-value pairs configuring the agent's technical behavior.
 
 `orchestration` documents the pattern an agent is designed for; it does **not**
 select the pattern a run uses. That comes from `armadai.yaml`'s `orchestration:`
-block or from `armadai run --orchestrate`. The value is surfaced in the TUI's
-agent detail view and in the web API, and is otherwise inert.
+block, or from `armadai run --orchestrate` — which accepts only `blackboard`
+and `ring`, so `hierarchical` and `auto` are selectable from `armadai.yaml`
+alone. The value is surfaced in the TUI's agent detail view and in the web API,
+and is otherwise inert.
 
 All five values are accepted. Until
 [#415](https://github.com/Dr0drigues/armadai/issues/415), only the first three

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -85,12 +85,25 @@ Two consequences worth knowing:
   `## Ring Config` are read **line by line**, so a `###` block inside them no longer hides its
   contents — it configures the agent. Measured on a fixture whose `## Metadata` carried an
   `### Alternative setup (not in use)` block: the agent switched provider from `anthropic` to
-  `openai` and temperature from `0.2` to `1.0`, with no warning (last value wins). The same
+  `openai` and temperature from `0.2` to `1.0` (last value wins). The same
   applies to `requires`/`priority` in `## Triggers`, to `role`/`vote_weight` in
   `## Ring Config`, and to `## Pipeline`, where an agent listed under a `###` heading now runs.
   Worse, an unparsable value there is fatal: `link` reports `warn: failed to parse …`, skips
   that agent, and still **exits 0** — so it disappears from the generated config silently.
   Keep commented-out alternatives out of these four sections, or in a fenced code block.
+
+  Since [#396](https://github.com/Dr0drigues/armadai/issues/396) this is no longer silent.
+  `## Metadata`, `## Triggers` and `## Ring Config` warn on stderr for every key they set
+  twice, naming the file, the losing value and the winning one:
+
+  ```text
+  agents/dup.md: ## Metadata sets 'provider' twice: 'anthropic' is overridden by 'openai' (the last value wins)
+  ```
+
+  Which value wins is unchanged — it is still the last. The warning is emitted before the
+  values are parsed, so it also appears for the fatal case above, where it says *why* the file
+  stopped loading. `## Pipeline` has no such warning: it is a list, not a set of keys, and
+  repeating an entry there is not a conflict.
 - **`---` and `===` under a line are headings too.** A paragraph followed by a line of dashes
   or equals signs is a setext H2/H1 in CommonMark, so it ends the section exactly as `##`
   would — and the text after it is lost from the prompt. This predates #392 and is unchanged

--- a/docs/wiki/agent-format.md
+++ b/docs/wiki/agent-format.md
@@ -118,7 +118,18 @@ Key-value pairs configuring the agent's technical behavior.
 | `cost_limit` | float | No | — | Max cost per execution in USD |
 | `rate_limit` | string | No | — | Rate limit: `"10/min"` |
 | `context_window` | int | No | — | Context window size override |
-| `orchestration` | string | No | — | Orchestration pattern: `blackboard`, `ring` |
+| `orchestration` | string | No | — | Orchestration pattern this agent is written for: `direct`, `blackboard`, `ring`, `hierarchical` or `auto`. Descriptive only — see below |
+
+`orchestration` documents the pattern an agent is designed for; it does **not**
+select the pattern a run uses. That comes from `armadai.yaml`'s `orchestration:`
+block or from `armadai run --orchestrate`. The value is surfaced in the TUI's
+agent detail view and in the web API, and is otherwise inert.
+
+All five values are accepted. Until
+[#415](https://github.com/Dr0drigues/armadai/issues/415), only the first three
+were, and the other two did not merely get ignored: the parse error made the
+**whole file** unloadable, so a `hierarchical` agent disappeared from `run`,
+`link`, `list`, the TUI and the audit at once — with `list` still exiting 0.
 
 ### What reaches the model
 


### PR DESCRIPTION
Deux défauts du parseur de métadonnées, un commit par issue. Ils vivent dans le même fichier (`crates/armadai-core/src/parser/metadata.rs`), d'où la PR unique.

## #415 — un agent hiérarchique était inchargeable

`AgentMetadata.orchestration` est un `OrchestrationPattern` à cinq variantes, mais `parse_metadata` n'en acceptait que trois. Ce n'était pas un champ ignoré : le `bail!` remonte jusqu'à `parse_agent_file`, donc **le fichier entier** devenait inchargeable et l'agent disparaissait de `run`, `link`, `list`, la TUI et l'audit d'un coup.

**Mesuré au binaire réel**, bibliothèque contenant un agent par pattern :

| | avant | après |
|---|---|---|
| `inspect directer` / `blacker` / `ringer` | exit 0 | exit 0 |
| `inspect coord` (`hierarchical`) | `Error: Invalid orchestration: 'hierarchical'. Expected 'direct', 'blackboard', or 'ring'`, exit **1** | exit 0 |
| `inspect autoer` (`auto`) | même erreur, exit **1** | exit 0 |
| `list` | `3 agent(s) found.`, exit **0** | `5 agent(s) found.` |

**Décision : accepter les cinq.** Trois mesures la justifient, et elles sont dans le message de commit :

1. `armadai.yaml` accepte déjà les cinq, via le derive serde `rename_all = "lowercase"` sur **le même enum**. Le parseur Markdown est un second lecteur écrit à la main qui a décroché ; le refus n'appliquait aucune règle propre.
2. Le champ par agent est **purement descriptif**. Ses seuls lecteurs sont `tui/views/agent_detail.rs` et `web/api.rs`, qui l'affichent, plus une assertion de test du linker. Rien sur le chemin `run` ne le lit — le pattern d'un run orchestré vient de `armadai.yaml` ou de `--orchestrate`. Élargir ne peut donc changer le comportement d'aucun run.
3. La sanction était hors de proportion : un champ décoratif rendait le fichier entier illisible.

Une valeur réellement inconnue reste refusée, avec un message qui nomme maintenant les cinq patterns au lieu de trois « comme si la liste était complète ». `docs/wiki/agent-format.md` n'en listait que **deux** (`blackboard`, `ring`) ; il en liste cinq et précise que le champ ne sélectionne pas le pattern d'un run.

## #396 — une clé dupliquée écrasait en silence

`## Metadata`, `## Triggers` et `## Ring Config` sont lues ligne par ligne, dernière valeur gagnante, sans un mot. #392 en a élargi l'exposition : un bloc `### Alternative setup (not in use)` était tronqué avant, il est lu maintenant.

**Mesuré au binaire réel** :

| | avant | après |
|---|---|---|
| `inspect dup` → provider | `openai` (déclaré `anthropic`), **silence** | `openai`, avec 7 avertissements |
| `inspect dup` → temperature | `1` (déclaré `0.2`), **silence** | `1`, avertie |
| `link` avec un `timeout` non parsable dans le bloc perdant | `warn: failed to parse …` puis `Linked 1 agent(s)`, exit 0 — **sans dire pourquoi** | idem, plus la ligne qui nomme le doublon |

**Décision : avertir, ne pas échouer, ne pas changer la précédence.**

- Échouer casserait des fichiers qui marchent aujourd'hui. Ce prix ne vaut que face à une population réelle : il n'y en a pas. Passé le vrai parseur sur **148 fichiers d'agents** (76 de la bibliothèque globale, 72 du dépôt ; sur 161 candidats trouvés, 13 n'atteignent jamais ce parseur — ce sont des docs qui citent `## Metadata`), la classe fait **0 occurrence**. J'ai refait ce comptage moi-même plutôt que de le croire ; l'issue annonçait 153 fichiers, j'en trouve un ensemble un peu différent, même conclusion.
- Changer la précédence serait une seconde décision, non demandée, et silencieuse pour qui compte sur le dernier-gagne aujourd'hui.
- Ce qui coûte, c'est le silence. L'avertissement l'enlève exactement.

### Sortie utilisateur ajoutée — à valider

```
<chemin>: ## Metadata sets 'provider' twice: 'anthropic' is overridden by 'openai' (the last value wins)
```

Sur stderr, via `tracing::warn!` (donc préfixée par l'horodatage et `WARN armadai_core::parser::metadata:` comme les autres avertissements du cœur). Elle nomme le fichier, la section, la clé, la valeur perdue et la valeur gardée. Elle est calculée **avant** l'analyse des valeurs, donc elle atteint aussi le cas fatal, où elle est la seule chose qui dise *pourquoi* le fichier a cessé de se charger.

Seules les clés que le parseur lit réellement sont suivies : une clé inconnue ne configure rien, et avertir sur sa répétition se déclencherait sur n'importe quelle ligne de prose contenant un `:`. `model_fallback`/`model_fallbacks` sont deux orthographes d'un même champ et se télescopent entre elles.

`config_line` factorise le découpage `- clé: valeur` que les trois parseurs avaient chacun en ligne, pour que la passe de doublons voie exactement les lignes qu'ils voient.

## Tests et mutations

TDD rouge → vert sur les deux lots ; **chaque test ajouté a été tué par au moins une mutation**, mesurée, avant d'être gardé.

La mesure la plus utile : mutation **N1**, où l'avertissement est calculé mais jamais imprimé (`tracing::warn!` → `format!`). **Les 51 tests unitaires du parseur restent verts** ; seuls les deux tests sur binaire tombent. C'est exactement le mode de défaillance que le dépôt collectionne, et la raison pour laquelle `crates/armadai/tests/duplicate_metadata_key_warns.rs` est le test porteur.

Autres mutations dont le verdict a orienté le code : **N6** (passe déplacée après l'analyse) ne rougit que le test `link`, pas l'unitaire correspondant — le commentaire de ce test le dit désormais explicitement plutôt que de revendiquer une propriété qu'il ne prouve pas.

## Défaut voisin mesuré, non corrigé

`link` imprime chaque avertissement **deux fois**, parce qu'il analyse chaque fichier d'agent deux fois : une fois dans `model_updater::auto_check_and_prompt` (`cli/link.rs:27`), une fois dans `agent_source::load_all_agents` (`cli/link.rs:58`). Mesuré : `list` → 1, `inspect` → 1, `link` → 2, `link --dry-run` → 2. Antérieur à cette PR, hors périmètre ; le test le documente et n'épingle pas de compte, pour ne pas casser le jour où ce sera corrigé.

## Gate

- `cargo fmt --all -- --check` : OK
- clippy `-D warnings` dans les **5 modes** : OK
- `cargo test --no-fail-fast` dans les **4 modes** : OK
- gaveldrop : **13 cases · 83/83**

Closes #396
Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
